### PR TITLE
refactor: move URL normalization to shared package

### DIFF
--- a/shared/url/url.go
+++ b/shared/url/url.go
@@ -1,0 +1,38 @@
+// Package url provides URL normalization utilities for Atlassian CLI tools.
+package url
+
+import "strings"
+
+// NormalizeURL ensures the URL has an https scheme and no trailing slashes.
+// If the URL is empty, it returns an empty string.
+// If the URL has no scheme, https:// is prepended.
+// Any trailing slashes are removed.
+//
+// Examples:
+//
+//	NormalizeURL("example.atlassian.net") → "https://example.atlassian.net"
+//	NormalizeURL("https://example.com/") → "https://example.com"
+//	NormalizeURL("http://localhost:8080") → "http://localhost:8080"
+func NormalizeURL(u string) string {
+	if u == "" {
+		return ""
+	}
+
+	// Add https:// if no scheme
+	if !HasScheme(u) {
+		u = "https://" + u
+	}
+
+	// Remove trailing slashes
+	return TrimTrailingSlashes(u)
+}
+
+// HasScheme checks if a URL has an http or https scheme.
+func HasScheme(u string) bool {
+	return strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")
+}
+
+// TrimTrailingSlashes removes all trailing slashes from a URL.
+func TrimTrailingSlashes(u string) string {
+	return strings.TrimRight(u, "/")
+}

--- a/shared/url/url_test.go
+++ b/shared/url/url_test.go
@@ -1,0 +1,111 @@
+package url
+
+import "testing"
+
+func TestNormalizeURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "domain only",
+			input: "example.atlassian.net",
+			want:  "https://example.atlassian.net",
+		},
+		{
+			name:  "with https scheme",
+			input: "https://example.atlassian.net",
+			want:  "https://example.atlassian.net",
+		},
+		{
+			name:  "with http scheme",
+			input: "http://localhost:8080",
+			want:  "http://localhost:8080",
+		},
+		{
+			name:  "with trailing slash",
+			input: "https://example.com/",
+			want:  "https://example.com",
+		},
+		{
+			name:  "with multiple trailing slashes",
+			input: "https://example.com///",
+			want:  "https://example.com",
+		},
+		{
+			name:  "domain with trailing slash",
+			input: "example.atlassian.net/",
+			want:  "https://example.atlassian.net",
+		},
+		{
+			name:  "with path",
+			input: "https://example.com/wiki",
+			want:  "https://example.com/wiki",
+		},
+		{
+			name:  "with path and trailing slash",
+			input: "https://example.com/wiki/",
+			want:  "https://example.com/wiki",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeURL(tt.input)
+			if got != tt.want {
+				t.Errorf("NormalizeURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasScheme(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"https://example.com", true},
+		{"http://example.com", true},
+		{"example.com", false},
+		{"ftp://example.com", false},
+		{"", false},
+		{"httpx://example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := HasScheme(tt.input)
+			if got != tt.want {
+				t.Errorf("HasScheme(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrimTrailingSlashes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://example.com/", "https://example.com"},
+		{"https://example.com///", "https://example.com"},
+		{"https://example.com", "https://example.com"},
+		{"https://example.com/path/", "https://example.com/path"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := TrimTrailingSlashes(tt.input)
+			if got != tt.want {
+				t.Errorf("TrimTrailingSlashes(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/jtk/api/client.go
+++ b/tools/jtk/api/client.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
+	neturl "net/url"
 
 	"github.com/open-cli-collective/atlassian-go/client"
 	"github.com/open-cli-collective/atlassian-go/errors"
+	"github.com/open-cli-collective/atlassian-go/url"
 )
 
 // Client is a Jira API client
@@ -39,11 +40,7 @@ func New(cfg ClientConfig) (*Client, error) {
 	}
 
 	// Normalize URL: ensure https and no trailing slash
-	baseURL := cfg.URL
-	if !hasScheme(baseURL) {
-		baseURL = "https://" + baseURL
-	}
-	baseURL = trimTrailingSlash(baseURL)
+	baseURL := url.NormalizeURL(cfg.URL)
 
 	// Create shared client with verbose option
 	var opts *client.Options
@@ -65,19 +62,6 @@ var (
 	ErrEmailRequired    = fmt.Errorf("email is required")
 	ErrAPITokenRequired = fmt.Errorf("API token is required")
 )
-
-// hasScheme checks if a URL has an http or https scheme
-func hasScheme(u string) bool {
-	return len(u) >= 7 && (u[:7] == "http://" || (len(u) >= 8 && u[:8] == "https://"))
-}
-
-// trimTrailingSlash removes trailing slashes from a URL
-func trimTrailingSlash(u string) string {
-	for len(u) > 0 && u[len(u)-1] == '/' {
-		u = u[:len(u)-1]
-	}
-	return u
-}
 
 // get performs a GET request to the specified URL
 func (c *Client) get(urlStr string) ([]byte, error) {
@@ -105,7 +89,7 @@ func buildURL(base string, params map[string]string) string {
 		return base
 	}
 
-	u, _ := url.Parse(base)
+	u, _ := neturl.Parse(base)
 	q := u.Query()
 	for k, v := range params {
 		if v != "" {

--- a/tools/jtk/internal/cmd/configcmd/configcmd.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	sharedurl "github.com/open-cli-collective/atlassian-go/url"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
 )
@@ -50,7 +52,7 @@ func newSetCmd(opts *root.Options) *cobra.Command {
 			}
 
 			if url != "" {
-				cfg.URL = config.NormalizeURL(url)
+				cfg.URL = sharedurl.NormalizeURL(url)
 				cfg.Domain = "" // Clear deprecated field when URL is set
 			}
 			if email != "" {

--- a/tools/jtk/internal/config/config.go
+++ b/tools/jtk/internal/config/config.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+
+	"github.com/open-cli-collective/atlassian-go/url"
 )
 
 const (
@@ -98,17 +99,17 @@ func Clear() error {
 // Precedence: JIRA_URL → ATLASSIAN_URL → config url → JIRA_DOMAIN (legacy) → config domain (legacy)
 func GetURL() string {
 	if v := os.Getenv("JIRA_URL"); v != "" {
-		return NormalizeURL(v)
+		return url.NormalizeURL(v)
 	}
 	if v := os.Getenv("ATLASSIAN_URL"); v != "" {
-		return NormalizeURL(v)
+		return url.NormalizeURL(v)
 	}
 	cfg, err := Load()
 	if err != nil {
 		return ""
 	}
 	if cfg.URL != "" {
-		return NormalizeURL(cfg.URL)
+		return url.NormalizeURL(cfg.URL)
 	}
 	// Backwards compatibility: construct URL from domain
 	if v := os.Getenv("JIRA_DOMAIN"); v != "" {
@@ -131,19 +132,6 @@ func GetDomain() string {
 		return ""
 	}
 	return cfg.Domain
-}
-
-// NormalizeURL ensures the URL has a scheme and no trailing slash.
-func NormalizeURL(u string) string {
-	if u == "" {
-		return ""
-	}
-	// Add https:// if no scheme
-	if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
-		u = "https://" + u
-	}
-	// Remove trailing slash
-	return strings.TrimSuffix(u, "/")
 }
 
 // GetEmail returns the email from config or environment.

--- a/tools/jtk/internal/config/config_test.go
+++ b/tools/jtk/internal/config/config_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/atlassian-go/url"
 )
 
 // setupTestConfig creates a temporary config directory for testing
@@ -197,7 +199,7 @@ func TestNormalizeURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			assert.Equal(t, tt.want, NormalizeURL(tt.input))
+			assert.Equal(t, tt.want, url.NormalizeURL(tt.input))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Create `shared/url` package with `NormalizeURL`, `HasScheme`, and `TrimTrailingSlashes` functions
- Update jtk to use shared URL normalization in config, API client, and config command
- Remove duplicate `NormalizeURL` from `jtk/internal/config`
- Remove duplicate `hasScheme` and `trimTrailingSlash` from `jtk/api`

## Notes
cfl's `NormalizeURL` is different (adds `/wiki` suffix for Confluence) so it remains in place as a method on `Config`.

## Test plan
- [x] All existing tests pass
- [x] New unit tests for shared/url package
- [x] Lint passes

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)