### PR TITLE
refactor: standardize config/client creation pattern in cfl

### DIFF
--- a/tools/cfl/cmd/cfl/main.go
+++ b/tools/cfl/cmd/cfl/main.go
@@ -7,11 +7,27 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/exitcode"
 
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/attachment"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/completion"
+	initcmd "github.com/open-cli-collective/confluence-cli/internal/cmd/init"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/page"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/search"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/space"
 )
 
 func main() {
-	cmd := root.NewCmdRoot()
+	cmd, opts := root.NewCmd()
+
+	root.RegisterCommands(cmd, opts,
+		initcmd.Register,
+		page.Register,
+		space.Register,
+		attachment.Register,
+		search.Register,
+		completion.Register,
+	)
+
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(exitcode.GeneralError)

--- a/tools/cfl/internal/cmd/attachment/attachment.go
+++ b/tools/cfl/internal/cmd/attachment/attachment.go
@@ -3,10 +3,12 @@ package attachment
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
-// NewCmdAttachment creates the attachment command.
-func NewCmdAttachment() *cobra.Command {
+// Register adds attachment commands to the root command.
+func Register(rootCmd *cobra.Command, opts *root.Options) {
 	cmd := &cobra.Command{
 		Use:     "attachment",
 		Aliases: []string{"attachments", "att"},
@@ -14,10 +16,10 @@ func NewCmdAttachment() *cobra.Command {
 		Long:    `Commands for listing, uploading, and downloading Confluence page attachments.`,
 	}
 
-	cmd.AddCommand(NewCmdList())
-	cmd.AddCommand(NewCmdUpload())
-	cmd.AddCommand(NewCmdDownload())
-	cmd.AddCommand(NewCmdDelete())
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newUploadCmd(opts))
+	cmd.AddCommand(newDownloadCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
 
-	return cmd
+	rootCmd.AddCommand(cmd)
 }

--- a/tools/cfl/internal/cmd/attachment/download.go
+++ b/tools/cfl/internal/cmd/attachment/download.go
@@ -7,23 +7,19 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/open-cli-collective/atlassian-go/view"
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/confluence-cli/api"
-	"github.com/open-cli-collective/confluence-cli/internal/config"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
 type downloadOptions struct {
-	output     string
+	*root.Options
 	outputFile string
-	noColor    bool
 	force      bool
 }
 
-// NewCmdDownload creates the attachment download command.
-func NewCmdDownload() *cobra.Command {
-	opts := &downloadOptions{}
+func newDownloadCmd(rootOpts *root.Options) *cobra.Command {
+	opts := &downloadOptions{Options: rootOpts}
 
 	cmd := &cobra.Command{
 		Use:   "download <attachment-id>",
@@ -35,10 +31,8 @@ func NewCmdDownload() *cobra.Command {
   # Download to a specific file
   cfl attachment download abc123 -O document.pdf`,
 		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.output, _ = cmd.Flags().GetString("output")
-			opts.noColor, _ = cmd.Flags().GetBool("no-color")
-			return runDownload(args[0], opts, nil)
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runDownload(args[0], opts)
 		},
 	}
 
@@ -48,66 +42,49 @@ func NewCmdDownload() *cobra.Command {
 	return cmd
 }
 
-func runDownload(attachmentID string, opts *downloadOptions, client *api.Client) error {
-	// Create API client if not provided (allows injection for testing)
-	if client == nil {
-		cfg, err := config.LoadWithEnv(config.DefaultConfigPath())
-		if err != nil {
-			return fmt.Errorf("failed to load config: %w (run 'cfl init' to configure)", err)
-		}
-
-		if err := cfg.Validate(); err != nil {
-			return fmt.Errorf("invalid config: %w (run 'cfl init' to configure)", err)
-		}
-
-		client = api.NewClient(cfg.URL, cfg.Email, cfg.APIToken)
+func runDownload(attachmentID string, opts *downloadOptions) error {
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
 	}
 
-	// Get attachment info first to get the filename
 	attachment, err := client.GetAttachment(context.Background(), attachmentID)
 	if err != nil {
 		return fmt.Errorf("failed to get attachment info: %w", err)
 	}
 
-	// Determine output filename
 	outputPath := opts.outputFile
 	if outputPath == "" {
-		// Sanitize filename to prevent path traversal attacks
 		outputPath = filepath.Base(attachment.Title)
 		if outputPath == "" || outputPath == "." || outputPath == ".." {
 			return fmt.Errorf("invalid attachment filename: %q", attachment.Title)
 		}
 	}
 
-	// Check if file already exists (unless --force is used)
 	if !opts.force {
 		if _, err := os.Stat(outputPath); err == nil {
 			return fmt.Errorf("file already exists: %s (use --force to overwrite)", outputPath)
 		}
 	}
 
-	// Download the attachment
 	reader, err := client.DownloadAttachment(context.Background(), attachmentID)
 	if err != nil {
 		return fmt.Errorf("failed to download attachment: %w", err)
 	}
 	defer func() { _ = reader.Close() }()
 
-	// Create output file
 	outFile, err := os.Create(outputPath)
 	if err != nil {
 		return fmt.Errorf("failed to create output file: %w", err)
 	}
 	defer func() { _ = outFile.Close() }()
 
-	// Copy content
 	bytesWritten, err := io.Copy(outFile, reader)
 	if err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
 
-	// Render output
-	v := view.New(view.Format(opts.output), opts.noColor)
+	v := opts.View()
 
 	v.Success("Downloaded: %s", outputPath)
 	v.RenderKeyValue("Size", formatFileSize(bytesWritten))

--- a/tools/cfl/internal/cmd/attachment/download_test.go
+++ b/tools/cfl/internal/cmd/attachment/download_test.go
@@ -1,6 +1,7 @@
 package attachment
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
 // TestSanitizeAttachmentFilename validates that filepath.Base correctly
@@ -100,7 +102,7 @@ func mockDownloadServer(t *testing.T) *httptest.Server {
 		case "/api/v2/attachments/att123":
 			// Get attachment metadata
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{
+			_, _ = w.Write([]byte(`{
 				"id": "att123",
 				"title": "document.pdf",
 				"mediaType": "application/pdf",
@@ -111,12 +113,21 @@ func mockDownloadServer(t *testing.T) *httptest.Server {
 			// Download content
 			w.Header().Set("Content-Type", "application/pdf")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("fake pdf content"))
+			_, _ = w.Write([]byte("fake pdf content"))
 		default:
 			t.Errorf("unexpected request: %s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
+}
+
+func newDownloadTestRootOptions() *root.Options {
+	return &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
 }
 
 func TestRunDownload_Success(t *testing.T) {
@@ -126,15 +137,18 @@ func TestRunDownload_Success(t *testing.T) {
 	// Use temp directory for download
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	defer os.Chdir(origDir)
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(origDir) }()
 
+	rootOpts := newDownloadTestRootOptions()
 	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
 	opts := &downloadOptions{
-		noColor: true,
+		Options: rootOpts,
 	}
 
-	err := runDownload("att123", opts, client)
+	err := runDownload("att123", opts)
 	require.NoError(t, err)
 
 	// Verify file was created
@@ -150,13 +164,16 @@ func TestRunDownload_CustomOutputFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "custom-name.pdf")
 
+	rootOpts := newDownloadTestRootOptions()
 	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
 	opts := &downloadOptions{
+		Options:    rootOpts,
 		outputFile: outputPath,
-		noColor:    true,
 	}
 
-	err := runDownload("att123", opts, client)
+	err := runDownload("att123", opts)
 	require.NoError(t, err)
 
 	// Verify file was created with custom name
@@ -171,21 +188,24 @@ func TestRunDownload_FileExists_NoForce(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	defer os.Chdir(origDir)
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(origDir) }()
 
 	// Create existing file
 	existingFile := filepath.Join(tmpDir, "document.pdf")
 	err := os.WriteFile(existingFile, []byte("existing content"), 0644)
 	require.NoError(t, err)
 
+	rootOpts := newDownloadTestRootOptions()
 	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
 	opts := &downloadOptions{
-		noColor: true,
+		Options: rootOpts,
 		force:   false,
 	}
 
-	err = runDownload("att123", opts, client)
+	err = runDownload("att123", opts)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "file already exists")
 	assert.Contains(t, err.Error(), "--force")
@@ -201,21 +221,24 @@ func TestRunDownload_FileExists_WithForce(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	defer os.Chdir(origDir)
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(origDir) }()
 
 	// Create existing file
 	existingFile := filepath.Join(tmpDir, "document.pdf")
 	err := os.WriteFile(existingFile, []byte("existing content"), 0644)
 	require.NoError(t, err)
 
+	rootOpts := newDownloadTestRootOptions()
 	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
 	opts := &downloadOptions{
-		noColor: true,
+		Options: rootOpts,
 		force:   true,
 	}
 
-	err = runDownload("att123", opts, client)
+	err = runDownload("att123", opts)
 	require.NoError(t, err)
 
 	// Verify file was overwritten
@@ -226,16 +249,19 @@ func TestRunDownload_FileExists_WithForce(t *testing.T) {
 func TestRunDownload_AttachmentNotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"message": "Attachment not found"}`))
+		_, _ = w.Write([]byte(`{"message": "Attachment not found"}`))
 	}))
 	defer server.Close()
 
+	rootOpts := newDownloadTestRootOptions()
 	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
 	opts := &downloadOptions{
-		noColor: true,
+		Options: rootOpts,
 	}
 
-	err := runDownload("nonexistent", opts, client)
+	err := runDownload("nonexistent", opts)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get attachment info")
 }
@@ -245,7 +271,7 @@ func TestRunDownload_DownloadFailed(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v2/attachments/att123":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{
+			_, _ = w.Write([]byte(`{
 				"id": "att123",
 				"title": "document.pdf",
 				"downloadLink": "/download/error"
@@ -258,15 +284,18 @@ func TestRunDownload_DownloadFailed(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	defer os.Chdir(origDir)
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(origDir) }()
 
+	rootOpts := newDownloadTestRootOptions()
 	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
 	opts := &downloadOptions{
-		noColor: true,
+		Options: rootOpts,
 	}
 
-	err := runDownload("att123", opts, client)
+	err := runDownload("att123", opts)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to download attachment")
 }
@@ -285,7 +314,7 @@ func TestRunDownload_InvalidFilename(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(`{
+				_, _ = w.Write([]byte(`{
 					"id": "att123",
 					"title": "` + tt.filename + `",
 					"downloadLink": "/download/file"
@@ -293,12 +322,15 @@ func TestRunDownload_InvalidFilename(t *testing.T) {
 			}))
 			defer server.Close()
 
+			rootOpts := newDownloadTestRootOptions()
 			client := api.NewClient(server.URL, "test@example.com", "token")
+			rootOpts.SetAPIClient(client)
+
 			opts := &downloadOptions{
-				noColor: true,
+				Options: rootOpts,
 			}
 
-			err := runDownload("att123", opts, client)
+			err := runDownload("att123", opts)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "invalid attachment filename")
 		})
@@ -312,29 +344,32 @@ func TestRunDownload_PathTraversalPrevented(t *testing.T) {
 		case "/api/v2/attachments/att123":
 			w.WriteHeader(http.StatusOK)
 			// Malicious filename attempting path traversal
-			w.Write([]byte(`{
+			_, _ = w.Write([]byte(`{
 				"id": "att123",
 				"title": "../../../etc/passwd",
 				"downloadLink": "/download/file"
 			}`))
 		case "/download/file":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("file content"))
+			_, _ = w.Write([]byte("file content"))
 		}
 	}))
 	defer server.Close()
 
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	defer os.Chdir(origDir)
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(origDir) }()
 
+	rootOpts := newDownloadTestRootOptions()
 	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
 	opts := &downloadOptions{
-		noColor: true,
+		Options: rootOpts,
 	}
 
-	err := runDownload("att123", opts, client)
+	err := runDownload("att123", opts)
 	require.NoError(t, err)
 
 	// File should be saved as just "passwd" (the base name), not a path traversal

--- a/tools/cfl/internal/cmd/completion/bash.go
+++ b/tools/cfl/internal/cmd/completion/bash.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCmdBash creates the bash completion command.
-func NewCmdBash() *cobra.Command {
+// newBashCmd creates the bash completion command.
+func newBashCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "bash",
 		Short: "Generate bash completion script",

--- a/tools/cfl/internal/cmd/completion/completion.go
+++ b/tools/cfl/internal/cmd/completion/completion.go
@@ -3,10 +3,12 @@ package completion
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
-// NewCmdCompletion creates the completion command.
-func NewCmdCompletion() *cobra.Command {
+// Register adds the completion command to the root command.
+func Register(rootCmd *cobra.Command, _ *root.Options) {
 	cmd := &cobra.Command{
 		Use:   "completion",
 		Short: "Generate shell completion scripts",
@@ -16,10 +18,10 @@ These scripts enable tab-completion for commands, flags, and arguments.
 See each sub-command's help for installation instructions.`,
 	}
 
-	cmd.AddCommand(NewCmdBash())
-	cmd.AddCommand(NewCmdZsh())
-	cmd.AddCommand(NewCmdFish())
-	cmd.AddCommand(NewCmdPowerShell())
+	cmd.AddCommand(newBashCmd())
+	cmd.AddCommand(newZshCmd())
+	cmd.AddCommand(newFishCmd())
+	cmd.AddCommand(newPowerShellCmd())
 
-	return cmd
+	rootCmd.AddCommand(cmd)
 }

--- a/tools/cfl/internal/cmd/completion/completion_test.go
+++ b/tools/cfl/internal/cmd/completion/completion_test.go
@@ -7,30 +7,45 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
-// createTestRootCmd creates a minimal root command for testing.
+// createTestRootCmd creates a minimal root command for testing with completion registered.
 func createTestRootCmd() *cobra.Command {
-	return &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:   "cfl",
 		Short: "Test CLI",
 	}
+
+	opts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+
+	Register(rootCmd, opts)
+	return rootCmd
 }
 
-func TestNewCmdCompletion(t *testing.T) {
-	cmd := NewCmdCompletion()
+func TestCompletionCommand(t *testing.T) {
+	rootCmd := createTestRootCmd()
 
-	assert.Equal(t, "completion", cmd.Use)
-	assert.NotEmpty(t, cmd.Short)
-	assert.NotEmpty(t, cmd.Long)
+	// Find the completion command
+	completionCmd, _, err := rootCmd.Find([]string{"completion"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "completion", completionCmd.Use)
+	assert.NotEmpty(t, completionCmd.Short)
+	assert.NotEmpty(t, completionCmd.Long)
 
 	// Should have 4 subcommands
-	assert.Len(t, cmd.Commands(), 4)
+	assert.Len(t, completionCmd.Commands(), 4)
 }
 
 func TestBashCompletion(t *testing.T) {
 	root := createTestRootCmd()
-	root.AddCommand(NewCmdCompletion())
 
 	buf := new(bytes.Buffer)
 	root.SetOut(buf)
@@ -47,7 +62,6 @@ func TestBashCompletion(t *testing.T) {
 
 func TestZshCompletion(t *testing.T) {
 	root := createTestRootCmd()
-	root.AddCommand(NewCmdCompletion())
 
 	buf := new(bytes.Buffer)
 	root.SetOut(buf)
@@ -64,7 +78,6 @@ func TestZshCompletion(t *testing.T) {
 
 func TestFishCompletion(t *testing.T) {
 	root := createTestRootCmd()
-	root.AddCommand(NewCmdCompletion())
 
 	buf := new(bytes.Buffer)
 	root.SetOut(buf)
@@ -81,7 +94,6 @@ func TestFishCompletion(t *testing.T) {
 
 func TestPowerShellCompletion(t *testing.T) {
 	root := createTestRootCmd()
-	root.AddCommand(NewCmdCompletion())
 
 	buf := new(bytes.Buffer)
 	root.SetOut(buf)
@@ -110,7 +122,6 @@ func TestCompletionRejectsExtraArgs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			root := createTestRootCmd()
-			root.AddCommand(NewCmdCompletion())
 
 			root.SetArgs([]string{"completion", tc.shell, "unexpected-arg"})
 

--- a/tools/cfl/internal/cmd/completion/fish.go
+++ b/tools/cfl/internal/cmd/completion/fish.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCmdFish creates the fish completion command.
-func NewCmdFish() *cobra.Command {
+// newFishCmd creates the fish completion command.
+func newFishCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "fish",
 		Short: "Generate fish completion script",

--- a/tools/cfl/internal/cmd/completion/powershell.go
+++ b/tools/cfl/internal/cmd/completion/powershell.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCmdPowerShell creates the PowerShell completion command.
-func NewCmdPowerShell() *cobra.Command {
+// newPowerShellCmd creates the PowerShell completion command.
+func newPowerShellCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "powershell",
 		Short: "Generate PowerShell completion script",

--- a/tools/cfl/internal/cmd/completion/zsh.go
+++ b/tools/cfl/internal/cmd/completion/zsh.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCmdZsh creates the zsh completion command.
-func NewCmdZsh() *cobra.Command {
+// newZshCmd creates the zsh completion command.
+func newZshCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "zsh",
 		Short: "Generate zsh completion script",

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -10,11 +10,17 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	"github.com/open-cli-collective/confluence-cli/internal/config"
 )
 
-// NewCmdInit creates the init command.
-func NewCmdInit() *cobra.Command {
+// Register adds the init command to the root command.
+func Register(rootCmd *cobra.Command, _ *root.Options) {
+	rootCmd.AddCommand(newInitCmd())
+}
+
+// newInitCmd creates the init command.
+func newInitCmd() *cobra.Command {
 	var (
 		url      string
 		email    string

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -12,14 +12,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/view"
-
 	"github.com/open-cli-collective/confluence-cli/api"
-	"github.com/open-cli-collective/confluence-cli/internal/config"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	"github.com/open-cli-collective/confluence-cli/pkg/md"
 )
 
 type editOptions struct {
+	*root.Options
 	pageID   string
 	title    string
 	file     string
@@ -27,14 +26,10 @@ type editOptions struct {
 	markdown *bool // nil = auto-detect, true = force markdown, false = force storage format
 	legacy   bool  // Use legacy editor (storage format) instead of cloud editor (ADF)
 	parent   string
-	output   string
-	noColor  bool
-	stdin    io.Reader // For testing; defaults to os.Stdin
 }
 
-// NewCmdEdit creates the page edit command.
-func NewCmdEdit() *cobra.Command {
-	opts := &editOptions{}
+func newEditCmd(rootOpts *root.Options) *cobra.Command {
+	opts := &editOptions{Options: rootOpts}
 
 	cmd := &cobra.Command{
 		Use:   "edit <page-id>",
@@ -76,20 +71,13 @@ Content format:
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.pageID = args[0]
-			opts.output, _ = cmd.Flags().GetString("output")
-			opts.noColor, _ = cmd.Flags().GetBool("no-color")
-
-			// Handle markdown flag
 			if cmd.Flags().Changed("no-markdown") {
 				noMd, _ := cmd.Flags().GetBool("no-markdown")
 				useMd := !noMd
 				opts.markdown = &useMd
 			}
-
-			// Handle legacy flag
 			opts.legacy, _ = cmd.Flags().GetBool("legacy")
-
-			return runEdit(opts, nil)
+			return runEdit(opts)
 		},
 	}
 
@@ -103,26 +91,17 @@ Content format:
 	return cmd
 }
 
-func runEdit(opts *editOptions, client *api.Client) error {
-	// Track base URL for output (only available when loading config)
-	var baseURL string
-
-	// Create API client if not provided (allows injection for testing)
-	if client == nil {
-		cfg, err := config.LoadWithEnv(config.DefaultConfigPath())
-		if err != nil {
-			return fmt.Errorf("failed to load config: %w (run 'cfl init' to configure)", err)
-		}
-
-		if err := cfg.Validate(); err != nil {
-			return fmt.Errorf("invalid config: %w (run 'cfl init' to configure)", err)
-		}
-
-		baseURL = cfg.URL
-		client = api.NewClient(cfg.URL, cfg.Email, cfg.APIToken)
+func runEdit(opts *editOptions) error {
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
 	}
 
-	// Get existing page
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
 	existingPage, err := client.GetPage(context.Background(), opts.pageID, &api.GetPageOptions{
 		BodyFormat: "storage",
 	})
@@ -130,29 +109,30 @@ func runEdit(opts *editOptions, client *api.Client) error {
 		return fmt.Errorf("failed to get page: %w", err)
 	}
 
-	// Determine new title (use existing if not specified)
 	newTitle := opts.title
 	if newTitle == "" {
 		newTitle = existingPage.Title
 	}
 
-	// Get new content
 	var newContent string
 	hasNewContent := false
 
-	// Check if content is provided via file, stdin, or editor flag
-	if opts.file != "" || opts.editor || opts.stdin != nil || !isTerminal() {
+	hasStdinData := opts.Stdin != nil && opts.Stdin != os.Stdin
+	if !hasStdinData {
+		stat, _ := os.Stdin.Stat()
+		hasStdinData = (stat.Mode() & os.ModeCharDevice) == 0
+	}
+
+	if opts.file != "" || opts.editor || hasStdinData {
 		content, isMarkdown, err := getEditContent(opts, existingPage)
 		if err != nil {
 			return err
 		}
 
-		// Validate content is not empty
 		if strings.TrimSpace(content) == "" {
 			return fmt.Errorf("page content cannot be empty")
 		}
 
-		// Convert content based on legacy flag
 		newContent, err = convertEditContent(content, isMarkdown, opts.legacy)
 		if err != nil {
 			return err
@@ -160,14 +140,12 @@ func runEdit(opts *editOptions, client *api.Client) error {
 		hasNewContent = true
 	}
 
-	// If no new content and no new title and no parent move, open editor by default
 	if !hasNewContent && opts.title == "" && opts.parent == "" {
-		content, isMarkdown, err := getEditContent(&editOptions{editor: true, markdown: opts.markdown}, existingPage)
+		content, isMarkdown, err := getEditContent(&editOptions{Options: opts.Options, editor: true, markdown: opts.markdown}, existingPage)
 		if err != nil {
 			return err
 		}
 
-		// Validate content is not empty
 		if strings.TrimSpace(content) == "" {
 			return fmt.Errorf("page content cannot be empty")
 		}
@@ -179,7 +157,6 @@ func runEdit(opts *editOptions, client *api.Client) error {
 		hasNewContent = true
 	}
 
-	// Build update request
 	req := &api.UpdatePageRequest{
 		ID:     opts.pageID,
 		Status: "current",
@@ -190,11 +167,9 @@ func runEdit(opts *editOptions, client *api.Client) error {
 		},
 	}
 
-	// Only update body if we have new content
 	if hasNewContent {
 		if opts.legacy {
-			// Warn about potential editor switch
-			v := view.New(view.Format(opts.output), opts.noColor)
+			v := opts.View()
 			v.Warning("Using --legacy flag. If this page uses the cloud editor, it may switch to the legacy editor.")
 
 			req.Body = &api.Body{
@@ -212,48 +187,37 @@ func runEdit(opts *editOptions, client *api.Client) error {
 			}
 		}
 	} else {
-		// Keep existing body when only updating title
 		req.Body = existingPage.Body
 	}
 
-	// Update page
 	page, err := client.UpdatePage(context.Background(), opts.pageID, req)
 	if err != nil {
 		return fmt.Errorf("failed to update page: %w", err)
 	}
 
-	// Move page to new parent if specified
 	if opts.parent != "" {
 		if err := client.MovePage(context.Background(), opts.pageID, opts.parent); err != nil {
 			return fmt.Errorf("failed to move page to new parent: %w", err)
 		}
 	}
 
-	// Render output
-	v := view.New(view.Format(opts.output), opts.noColor)
+	v := opts.View()
 
-	if opts.output == "json" {
+	if opts.Output == "json" {
 		return v.JSON(page)
 	}
 
 	v.Success("Updated page: %s", page.Title)
 	v.RenderKeyValue("ID", page.ID)
 	v.RenderKeyValue("Version", strconv.Itoa(page.Version.Number))
-	v.RenderKeyValue("URL", baseURL+page.Links.WebUI)
+	v.RenderKeyValue("URL", cfg.URL+page.Links.WebUI)
 
 	return nil
-}
-
-// isTerminal checks if stdin is a terminal
-func isTerminal() bool {
-	stat, _ := os.Stdin.Stat()
-	return (stat.Mode() & os.ModeCharDevice) != 0
 }
 
 // convertEditContent converts content based on markdown flag and legacy mode.
 func convertEditContent(content string, isMarkdown, legacy bool) (string, error) {
 	if legacy {
-		// Legacy mode: convert to storage format (XHTML)
 		if isMarkdown {
 			converted, err := md.ToConfluenceStorage([]byte(content))
 			if err != nil {
@@ -264,7 +228,6 @@ func convertEditContent(content string, isMarkdown, legacy bool) (string, error)
 		return content, nil
 	}
 
-	// Default: cloud editor using ADF
 	if isMarkdown {
 		adfContent, err := md.ToADF([]byte(content))
 		if err != nil {
@@ -277,13 +240,10 @@ func convertEditContent(content string, isMarkdown, legacy bool) (string, error)
 
 // getEditContent reads content for editing and returns (content, isMarkdown, error).
 func getEditContent(opts *editOptions, existingPage *api.Page) (string, bool, error) {
-	// Determine if we should use markdown based on explicit flag or file extension
 	useMarkdown := func(filename string) bool {
-		// If explicitly set via flag, use that
 		if opts.markdown != nil {
 			return *opts.markdown
 		}
-		// Auto-detect based on file extension
 		if filename != "" {
 			ext := strings.ToLower(filepath.Ext(filename))
 			switch ext {
@@ -293,11 +253,9 @@ func getEditContent(opts *editOptions, existingPage *api.Page) (string, bool, er
 				return true
 			}
 		}
-		// Default to markdown for stdin and editor
 		return true
 	}
 
-	// Read from file
 	if opts.file != "" {
 		data, err := os.ReadFile(opts.file)
 		if err != nil {
@@ -306,16 +264,16 @@ func getEditContent(opts *editOptions, existingPage *api.Page) (string, bool, er
 		return string(data), useMarkdown(opts.file), nil
 	}
 
-	// Check if stdin has data (use injected stdin for testing)
-	if opts.stdin != nil {
-		data, err := io.ReadAll(opts.stdin)
+	if opts.Stdin != nil && opts.Stdin != os.Stdin {
+		data, err := io.ReadAll(opts.Stdin)
 		if err != nil {
 			return "", false, fmt.Errorf("failed to read stdin: %w", err)
 		}
 		return string(data), useMarkdown(""), nil
 	}
 
-	if !isTerminal() {
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
 		data, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return "", false, fmt.Errorf("failed to read stdin: %w", err)
@@ -323,48 +281,38 @@ func getEditContent(opts *editOptions, existingPage *api.Page) (string, bool, er
 		return string(data), useMarkdown(""), nil
 	}
 
-	// Open editor with existing content
 	isMarkdown := useMarkdown("")
 	content, err := openEditorForEdit(existingPage, isMarkdown)
 	return content, isMarkdown, err
 }
 
 func openEditorForEdit(existingPage *api.Page, isMarkdown bool) (string, error) {
-	// Determine file extension
 	ext := ".html"
 	if isMarkdown {
 		ext = ".md"
 	}
 
-	// Get existing content
 	existingContent := ""
 	if existingPage.Body != nil && existingPage.Body.Storage != nil {
 		existingContent = existingPage.Body.Storage.Value
 	}
 
-	// For markdown mode, convert storage format to markdown for editing
-	// Note: This is a best-effort conversion - complex formatting may not survive round-trip
 	editContent := existingContent
 	if isMarkdown && existingContent != "" {
-		// For now, just use the storage format - a proper implementation would convert to markdown
-		// Users can use --no-markdown flag if they want to edit raw storage format
 		editContent = "<!-- Edit your content below. This is Confluence storage format. -->\n<!-- Use --no-markdown flag to edit raw storage format -->\n\n" + existingContent
 	}
 
-	// Create temp file
 	tmpfile, err := os.CreateTemp("", "cfl-edit-*"+ext)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
 	defer func() { _ = os.Remove(tmpfile.Name()) }()
 
-	// Write existing content
 	if _, err := tmpfile.WriteString(editContent); err != nil {
 		return "", err
 	}
 	_ = tmpfile.Close()
 
-	// Get editor
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
 		editor = os.Getenv("VISUAL")
@@ -373,7 +321,6 @@ func openEditorForEdit(existingPage *api.Page, isMarkdown bool) (string, error) 
 		editor = "vi"
 	}
 
-	// Open editor
 	cmd := exec.Command(editor, tmpfile.Name())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -383,7 +330,6 @@ func openEditorForEdit(existingPage *api.Page, isMarkdown bool) (string, error) 
 		return "", fmt.Errorf("editor failed: %w", err)
 	}
 
-	// Read content
 	data, err := os.ReadFile(tmpfile.Name())
 	if err != nil {
 		return "", fmt.Errorf("failed to read edited content: %w", err)

--- a/tools/cfl/internal/cmd/page/page.go
+++ b/tools/cfl/internal/cmd/page/page.go
@@ -3,10 +3,12 @@ package page
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
-// NewCmdPage creates the page command.
-func NewCmdPage() *cobra.Command {
+// Register adds page commands to the root command.
+func Register(rootCmd *cobra.Command, opts *root.Options) {
 	cmd := &cobra.Command{
 		Use:     "page",
 		Aliases: []string{"pages"},
@@ -14,12 +16,12 @@ func NewCmdPage() *cobra.Command {
 		Long:    `Commands for creating, viewing, editing, and listing Confluence pages.`,
 	}
 
-	cmd.AddCommand(NewCmdList())
-	cmd.AddCommand(NewCmdView())
-	cmd.AddCommand(NewCmdCreate())
-	cmd.AddCommand(NewCmdEdit())
-	cmd.AddCommand(NewCmdDelete())
-	cmd.AddCommand(NewCmdCopy())
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newViewCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newEditCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+	cmd.AddCommand(newCopyCmd(opts))
 
-	return cmd
+	rootCmd.AddCommand(cmd)
 }

--- a/tools/cfl/internal/cmd/root/root.go
+++ b/tools/cfl/internal/cmd/root/root.go
@@ -2,20 +2,95 @@
 package root
 
 import (
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/version"
+	"github.com/open-cli-collective/atlassian-go/view"
 
-	"github.com/open-cli-collective/confluence-cli/internal/cmd/attachment"
-	"github.com/open-cli-collective/confluence-cli/internal/cmd/completion"
-	initcmd "github.com/open-cli-collective/confluence-cli/internal/cmd/init"
-	"github.com/open-cli-collective/confluence-cli/internal/cmd/page"
-	"github.com/open-cli-collective/confluence-cli/internal/cmd/search"
-	"github.com/open-cli-collective/confluence-cli/internal/cmd/space"
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/config"
 )
 
-// NewCmdRoot creates the root command for cfl.
-func NewCmdRoot() *cobra.Command {
+// Options contains global options for commands
+type Options struct {
+	Output  string
+	NoColor bool
+	Stdin   io.Reader
+	Stdout  io.Writer
+	Stderr  io.Writer
+
+	// testClient is used for testing; if set, APIClient() returns this instead
+	testClient *api.Client
+
+	// cachedConfig stores loaded config for reuse
+	cachedConfig *config.Config
+}
+
+// View returns a configured View instance
+func (o *Options) View() *view.View {
+	v := view.NewWithFormat(o.Output, o.NoColor)
+	v.Out = o.Stdout
+	v.Err = o.Stderr
+	return v
+}
+
+// Config loads and returns the config, caching it for reuse.
+// If a test client is set and no config is cached, returns an empty config
+// (since tests inject their own client and typically don't need real config).
+func (o *Options) Config() (*config.Config, error) {
+	if o.cachedConfig != nil {
+		return o.cachedConfig, nil
+	}
+	// If test client is set, return empty config since tests inject their own client
+	if o.testClient != nil {
+		o.cachedConfig = &config.Config{}
+		return o.cachedConfig, nil
+	}
+	cfg, err := config.LoadWithEnv(config.DefaultConfigPath())
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w (run 'cfl init' to configure)", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w (run 'cfl init' to configure)", err)
+	}
+	o.cachedConfig = cfg
+	return cfg, nil
+}
+
+// SetConfig sets a test config (for testing only)
+func (o *Options) SetConfig(cfg *config.Config) {
+	o.cachedConfig = cfg
+}
+
+// APIClient creates a new API client from config
+func (o *Options) APIClient() (*api.Client, error) {
+	if o.testClient != nil {
+		return o.testClient, nil
+	}
+	cfg, err := o.Config()
+	if err != nil {
+		return nil, err
+	}
+	return api.NewClient(cfg.URL, cfg.Email, cfg.APIToken), nil
+}
+
+// SetAPIClient sets a test client (for testing only)
+func (o *Options) SetAPIClient(client *api.Client) {
+	o.testClient = client
+}
+
+// NewCmd creates the root command and returns the options struct
+func NewCmd() (*cobra.Command, *Options) {
+	opts := &Options{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
 	cmd := &cobra.Command{
 		Use:   "cfl",
 		Short: "A command-line interface for Atlassian Confluence",
@@ -30,21 +105,20 @@ Get started by running: cfl init`,
 		Version:       version.Version,
 	}
 
-	// Global flags
+	// Global flags - bound to opts struct
 	cmd.PersistentFlags().StringP("config", "c", "", "config file (default: ~/.config/cfl/config.yml)")
-	cmd.PersistentFlags().StringP("output", "o", "table", "output format: table, json, plain")
-	cmd.PersistentFlags().Bool("no-color", false, "disable colored output")
+	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "table", "output format: table, json, plain")
+	cmd.PersistentFlags().BoolVar(&opts.NoColor, "no-color", false, "disable colored output")
 
 	// Set version template
 	cmd.SetVersionTemplate("cfl version {{.Version}} (commit: " + version.Commit + ", built: " + version.BuildDate + ")\n")
 
-	// Subcommands
-	cmd.AddCommand(initcmd.NewCmdInit())
-	cmd.AddCommand(page.NewCmdPage())
-	cmd.AddCommand(space.NewCmdSpace())
-	cmd.AddCommand(attachment.NewCmdAttachment())
-	cmd.AddCommand(search.NewCmdSearch())
-	cmd.AddCommand(completion.NewCmdCompletion())
+	return cmd, opts
+}
 
-	return cmd
+// RegisterCommands registers subcommands with the root command
+func RegisterCommands(root *cobra.Command, opts *Options, registrars ...func(*cobra.Command, *Options)) {
+	for _, register := range registrars {
+		register(root, opts)
+	}
 }

--- a/tools/cfl/internal/cmd/space/space.go
+++ b/tools/cfl/internal/cmd/space/space.go
@@ -3,10 +3,12 @@ package space
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
-// NewCmdSpace creates the space command.
-func NewCmdSpace() *cobra.Command {
+// Register adds space commands to the root command.
+func Register(rootCmd *cobra.Command, opts *root.Options) {
 	cmd := &cobra.Command{
 		Use:     "space",
 		Aliases: []string{"spaces"},
@@ -14,7 +16,7 @@ func NewCmdSpace() *cobra.Command {
 		Long:    `Commands for listing and viewing Confluence spaces.`,
 	}
 
-	cmd.AddCommand(NewCmdList())
+	cmd.AddCommand(newListCmd(opts))
 
-	return cmd
+	rootCmd.AddCommand(cmd)
 }


### PR DESCRIPTION
## Summary
- Adopt jtk's Options pattern throughout cfl
- Add Options struct with APIClient(), Config(), and View() methods
- Add Register functions to all command packages
- Remove duplicate config loading from all command files (~15 lines repeated in 10+ files)
- Embed *root.Options in command-specific options structs

## Test plan
- [x] All existing tests pass
- [x] Lint passes
- [x] Build succeeds

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)