### PR TITLE
refactor: remove duplicate truncate function in jtk

### DIFF
--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -89,20 +91,6 @@ func runGet(opts *root.Options, issueKey string) error {
 	return nil
 }
 
-func formatAssignee(name string) string {
-	if name == "" {
-		return "Unassigned"
-	}
-	return name
-}
-
-func truncate(s string, max int) string {
-	if len(s) <= max {
-		return s
-	}
-	return s[:max-3] + "..."
-}
-
 func orDash(s string) string {
 	if s == "" {
 		return "-"
@@ -110,17 +98,24 @@ func orDash(s string) string {
 	return s
 }
 
+func formatAssignee(name string) string {
+	if name == "" {
+		return "Unassigned"
+	}
+	return name
+}
+
 func formatIssueRow(key, summary, status, assignee, issueType string) []string {
 	return []string{
 		key,
-		truncate(summary, 50),
+		view.Truncate(summary, 50),
 		orDash(status),
 		formatAssignee(assignee),
 		orDash(issueType),
 	}
 }
 
-// Helper to safely extract string fields
+// safeString extracts string from an interface value
 func safeString(v interface{}) string {
 	if v == nil {
 		return ""

--- a/tools/jtk/internal/cmd/issues/types.go
+++ b/tools/jtk/internal/cmd/issues/types.go
@@ -3,6 +3,8 @@ package issues
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -59,7 +61,7 @@ func runTypes(opts *root.Options, project string) error {
 		if t.Subtask {
 			subtask = "yes"
 		}
-		rows = append(rows, []string{t.ID, t.Name, subtask, truncate(t.Description, 60)})
+		rows = append(rows, []string{t.ID, t.Name, subtask, view.Truncate(t.Description, 60)})
 	}
 
 	return v.Table(headers, rows)


### PR DESCRIPTION
## Summary
Replace local truncate() function with shared view.Truncate() in jtk issues package.

## Changes
- Update get.go and types.go to import shared view package
- Replace `truncate(s, n)` calls with `view.Truncate(s, n)`
- Remove the local truncate() function definition

## Test plan
- [x] All jtk tests pass
- [x] Lint passes

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)