### PR TITLE
refactor: remove error re-exports in jtk

### DIFF
--- a/tools/jtk/api/errors.go
+++ b/tools/jtk/api/errors.go
@@ -6,16 +6,6 @@ import (
 	sharederrors "github.com/open-cli-collective/atlassian-go/errors"
 )
 
-// Re-export common errors from shared module
-var (
-	ErrNotFound     = sharederrors.ErrNotFound
-	ErrUnauthorized = sharederrors.ErrUnauthorized
-	ErrForbidden    = sharederrors.ErrForbidden
-	ErrBadRequest   = sharederrors.ErrBadRequest
-	ErrRateLimited  = sharederrors.ErrRateLimited
-	ErrServerError  = sharederrors.ErrServerError
-)
-
 // Jira-specific validation errors
 var (
 	ErrIssueKeyRequired   = errors.New("issue key is required")
@@ -24,18 +14,3 @@ var (
 
 // APIError is an alias for the shared APIError type
 type APIError = sharederrors.APIError
-
-// IsNotFound checks if an error is a not found error
-func IsNotFound(err error) bool {
-	return sharederrors.IsNotFound(err)
-}
-
-// IsUnauthorized checks if an error is an unauthorized error
-func IsUnauthorized(err error) bool {
-	return sharederrors.IsUnauthorized(err)
-}
-
-// IsForbidden checks if an error is a forbidden error
-func IsForbidden(err error) bool {
-	return sharederrors.IsForbidden(err)
-}

--- a/tools/jtk/api/errors_test.go
+++ b/tools/jtk/api/errors_test.go
@@ -74,57 +74,57 @@ func TestParseAPIError(t *testing.T) {
 			name:       "401 unauthorized",
 			statusCode: http.StatusUnauthorized,
 			body:       `{}`,
-			wantErr:    ErrUnauthorized,
+			wantErr:    sharederrors.ErrUnauthorized,
 		},
 		{
 			name:       "401 with message",
 			statusCode: http.StatusUnauthorized,
 			body:       `{"errorMessages": ["Bad credentials"]}`,
-			wantErr:    ErrUnauthorized,
+			wantErr:    sharederrors.ErrUnauthorized,
 			wantMsg:    "Bad credentials",
 		},
 		{
 			name:       "403 forbidden",
 			statusCode: http.StatusForbidden,
 			body:       `{}`,
-			wantErr:    ErrForbidden,
+			wantErr:    sharederrors.ErrForbidden,
 		},
 		{
 			name:       "404 not found",
 			statusCode: http.StatusNotFound,
 			body:       `{}`,
-			wantErr:    ErrNotFound,
+			wantErr:    sharederrors.ErrNotFound,
 		},
 		{
 			name:       "404 with message",
 			statusCode: http.StatusNotFound,
 			body:       `{"errorMessages": ["Issue Does Not Exist"]}`,
-			wantErr:    ErrNotFound,
+			wantErr:    sharederrors.ErrNotFound,
 			wantMsg:    "Issue Does Not Exist",
 		},
 		{
 			name:       "400 bad request",
 			statusCode: http.StatusBadRequest,
 			body:       `{}`,
-			wantErr:    ErrBadRequest,
+			wantErr:    sharederrors.ErrBadRequest,
 		},
 		{
 			name:       "429 rate limited",
 			statusCode: http.StatusTooManyRequests,
 			body:       `{}`,
-			wantErr:    ErrRateLimited,
+			wantErr:    sharederrors.ErrRateLimited,
 		},
 		{
 			name:       "500 server error",
 			statusCode: http.StatusInternalServerError,
 			body:       `{}`,
-			wantErr:    ErrServerError,
+			wantErr:    sharederrors.ErrServerError,
 		},
 		{
 			name:       "502 server error",
 			statusCode: http.StatusBadGateway,
 			body:       `{}`,
-			wantErr:    ErrServerError,
+			wantErr:    sharederrors.ErrServerError,
 		},
 	}
 
@@ -155,20 +155,20 @@ func TestParseAPIError_418_NonStandard(t *testing.T) {
 }
 
 func TestIsNotFound(t *testing.T) {
-	assert.True(t, IsNotFound(ErrNotFound))
-	assert.True(t, IsNotFound(fmt.Errorf("wrapped: %w", ErrNotFound)))
-	assert.False(t, IsNotFound(ErrUnauthorized))
-	assert.False(t, IsNotFound(nil))
+	assert.True(t, sharederrors.IsNotFound(sharederrors.ErrNotFound))
+	assert.True(t, sharederrors.IsNotFound(fmt.Errorf("wrapped: %w", sharederrors.ErrNotFound)))
+	assert.False(t, sharederrors.IsNotFound(sharederrors.ErrUnauthorized))
+	assert.False(t, sharederrors.IsNotFound(nil))
 }
 
 func TestIsUnauthorized(t *testing.T) {
-	assert.True(t, IsUnauthorized(ErrUnauthorized))
-	assert.False(t, IsUnauthorized(ErrNotFound))
-	assert.False(t, IsUnauthorized(nil))
+	assert.True(t, sharederrors.IsUnauthorized(sharederrors.ErrUnauthorized))
+	assert.False(t, sharederrors.IsUnauthorized(sharederrors.ErrNotFound))
+	assert.False(t, sharederrors.IsUnauthorized(nil))
 }
 
 func TestIsForbidden(t *testing.T) {
-	assert.True(t, IsForbidden(ErrForbidden))
-	assert.False(t, IsForbidden(ErrNotFound))
-	assert.False(t, IsForbidden(nil))
+	assert.True(t, sharederrors.IsForbidden(sharederrors.ErrForbidden))
+	assert.False(t, sharederrors.IsForbidden(sharederrors.ErrNotFound))
+	assert.False(t, sharederrors.IsForbidden(nil))
 }


### PR DESCRIPTION
## Summary
- Remove unnecessary error variable re-exports (`ErrNotFound`, `ErrUnauthorized`, etc.) from jtk's API package
- Remove wrapper functions (`IsNotFound`, `IsUnauthorized`, `IsForbidden`) 
- Keep tool-specific errors: `ErrIssueKeyRequired`, `ErrProjectKeyRequired`
- Update tests to use `sharederrors` directly

Callers can now import the shared errors package directly for clearer dependency chains.

## Test plan
- [x] Run `make test` - all tests pass

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)