### PR TITLE
feat(cfl): add config show/test/clear commands

### DIFF
--- a/tools/cfl/cmd/cfl/main.go
+++ b/tools/cfl/cmd/cfl/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/attachment"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/completion"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/configcmd"
 	initcmd "github.com/open-cli-collective/confluence-cli/internal/cmd/init"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/page"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
@@ -21,6 +22,7 @@ func main() {
 
 	root.RegisterCommands(cmd, opts,
 		initcmd.Register,
+		configcmd.Register,
 		page.Register,
 		space.Register,
 		attachment.Register,

--- a/tools/cfl/internal/cmd/configcmd/clear.go
+++ b/tools/cfl/internal/cmd/configcmd/clear.go
@@ -1,0 +1,104 @@
+package configcmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	sharedconfig "github.com/open-cli-collective/atlassian-go/config"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	"github.com/open-cli-collective/confluence-cli/internal/config"
+)
+
+type clearOptions struct {
+	*root.Options
+	force bool
+	stdin io.Reader // For testing
+}
+
+func newClearCmd(opts *root.Options) *cobra.Command {
+	clearOpts := &clearOptions{
+		Options: opts,
+		stdin:   os.Stdin,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "clear",
+		Short: "Clear stored configuration",
+		Long: `Remove the cfl configuration file.
+
+Note: Environment variables (CFL_*, ATLASSIAN_*) will still be used if set.`,
+		Example: `  # Clear configuration (with confirmation)
+  cfl config clear
+
+  # Clear without confirmation
+  cfl config clear --force`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runClear(clearOpts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&clearOpts.force, "force", "f", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runClear(opts *clearOptions) error {
+	configPath := config.DefaultConfigPath()
+
+	// Check if config file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		fmt.Printf("No configuration file found at %s\n", configPath)
+		return nil
+	}
+
+	// Confirm unless --force
+	if !opts.force {
+		fmt.Printf("This will remove: %s\n", configPath)
+		fmt.Print("Are you sure? [y/N]: ")
+
+		var response string
+		_, err := fmt.Fscanln(opts.stdin, &response)
+		if err != nil && err.Error() != "unexpected newline" {
+			return err
+		}
+
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response != "y" && response != "yes" {
+			fmt.Println("Cancelled.")
+			return nil
+		}
+	}
+
+	// Remove the file
+	if err := os.Remove(configPath); err != nil {
+		return fmt.Errorf("failed to remove config file: %w", err)
+	}
+
+	fmt.Printf("Configuration file removed: %s\n", configPath)
+
+	// Check for active environment variables
+	envVars := []string{}
+	if sharedconfig.GetEnvWithFallback("CFL_URL", "ATLASSIAN_URL") != "" {
+		envVars = append(envVars, "URL")
+	}
+	if sharedconfig.GetEnvWithFallback("CFL_EMAIL", "ATLASSIAN_EMAIL") != "" {
+		envVars = append(envVars, "Email")
+	}
+	if sharedconfig.GetEnvWithFallback("CFL_API_TOKEN", "ATLASSIAN_API_TOKEN") != "" {
+		envVars = append(envVars, "API Token")
+	}
+
+	if len(envVars) > 0 {
+		fmt.Println()
+		fmt.Printf("Note: The following are still configured via environment variables: %s\n",
+			strings.Join(envVars, ", "))
+		fmt.Println("These will continue to be used. Unset them if you want to fully clear configuration.")
+	}
+
+	return nil
+}

--- a/tools/cfl/internal/cmd/configcmd/clear_test.go
+++ b/tools/cfl/internal/cmd/configcmd/clear_test.go
@@ -1,0 +1,132 @@
+package configcmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+func TestRunClear_FileNotFound(t *testing.T) {
+	// Use a temp directory that doesn't have a config file
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+
+	rootOpts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+
+	opts := &clearOptions{
+		Options: rootOpts,
+		force:   true,
+		stdin:   strings.NewReader(""),
+	}
+
+	err := runClear(opts)
+	require.NoError(t, err)
+}
+
+func TestRunClear_WithForce(t *testing.T) {
+	// Create a temp config file
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+
+	configDir := filepath.Join(tempDir, "cfl")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+	configPath := filepath.Join(configDir, "config.yml")
+	err := os.WriteFile(configPath, []byte("url: https://test.atlassian.net"), 0600)
+	require.NoError(t, err)
+
+	rootOpts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+
+	opts := &clearOptions{
+		Options: rootOpts,
+		force:   true,
+		stdin:   strings.NewReader(""),
+	}
+
+	err = runClear(opts)
+	require.NoError(t, err)
+
+	// Verify file is deleted
+	_, err = os.Stat(configPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestRunClear_WithConfirmation(t *testing.T) {
+	// Create a temp config file
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+
+	configDir := filepath.Join(tempDir, "cfl")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+	configPath := filepath.Join(configDir, "config.yml")
+	err := os.WriteFile(configPath, []byte("url: https://test.atlassian.net"), 0600)
+	require.NoError(t, err)
+
+	rootOpts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+
+	opts := &clearOptions{
+		Options: rootOpts,
+		force:   false,
+		stdin:   strings.NewReader("y\n"),
+	}
+
+	err = runClear(opts)
+	require.NoError(t, err)
+
+	// Verify file is deleted
+	_, err = os.Stat(configPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestRunClear_Cancelled(t *testing.T) {
+	// Create a temp config file
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+
+	configDir := filepath.Join(tempDir, "cfl")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+	configPath := filepath.Join(configDir, "config.yml")
+	err := os.WriteFile(configPath, []byte("url: https://test.atlassian.net"), 0600)
+	require.NoError(t, err)
+
+	rootOpts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+
+	opts := &clearOptions{
+		Options: rootOpts,
+		force:   false,
+		stdin:   strings.NewReader("n\n"),
+	}
+
+	err = runClear(opts)
+	require.NoError(t, err)
+
+	// Verify file still exists
+	_, err = os.Stat(configPath)
+	assert.NoError(t, err)
+}

--- a/tools/cfl/internal/cmd/configcmd/config.go
+++ b/tools/cfl/internal/cmd/configcmd/config.go
@@ -1,0 +1,23 @@
+// Package configcmd provides the config command for cfl.
+package configcmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+// Register adds the config command to the root command.
+func Register(rootCmd *cobra.Command, opts *root.Options) {
+	configCmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage cfl configuration",
+		Long:  `Commands for viewing, testing, and managing cfl configuration.`,
+	}
+
+	configCmd.AddCommand(newShowCmd(opts))
+	configCmd.AddCommand(newTestCmd(opts))
+	configCmd.AddCommand(newClearCmd(opts))
+
+	rootCmd.AddCommand(configCmd)
+}

--- a/tools/cfl/internal/cmd/configcmd/show.go
+++ b/tools/cfl/internal/cmd/configcmd/show.go
@@ -1,0 +1,106 @@
+package configcmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	sharedconfig "github.com/open-cli-collective/atlassian-go/config"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	"github.com/open-cli-collective/confluence-cli/internal/config"
+)
+
+func newShowCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Show current configuration",
+		Long: `Display the current cfl configuration with masked credentials.
+
+Shows the source of each value (environment variable, config file, or not set).`,
+		Example: `  # Show current configuration
+  cfl config show`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runShow(opts)
+		},
+	}
+}
+
+func runShow(opts *root.Options) error {
+	configPath := config.DefaultConfigPath()
+	v := opts.View()
+
+	// Load config file (if exists)
+	fileCfg, fileErr := config.Load(configPath)
+	if fileErr != nil {
+		fileCfg = &config.Config{}
+	}
+
+	// Check environment variables
+	envURL := sharedconfig.GetEnvWithFallback("CFL_URL", "ATLASSIAN_URL")
+	envEmail := sharedconfig.GetEnvWithFallback("CFL_EMAIL", "ATLASSIAN_EMAIL")
+	envToken := sharedconfig.GetEnvWithFallback("CFL_API_TOKEN", "ATLASSIAN_API_TOKEN")
+	envSpace := os.Getenv("CFL_DEFAULT_SPACE")
+
+	// Determine effective values and sources
+	url, urlSource := getValueAndSource(envURL, fileCfg.URL, getEnvVarName("CFL_URL", "ATLASSIAN_URL"))
+	email, emailSource := getValueAndSource(envEmail, fileCfg.Email, getEnvVarName("CFL_EMAIL", "ATLASSIAN_EMAIL"))
+	token, tokenSource := getValueAndSource(envToken, fileCfg.APIToken, getEnvVarName("CFL_API_TOKEN", "ATLASSIAN_API_TOKEN"))
+	space, spaceSource := getValueAndSource(envSpace, fileCfg.DefaultSpace, "CFL_DEFAULT_SPACE")
+
+	// Display
+	v.RenderKeyValue("URL", formatValueWithSource(url, urlSource))
+	v.RenderKeyValue("Email", formatValueWithSource(email, emailSource))
+	v.RenderKeyValue("API Token", formatValueWithSource(maskToken(token), tokenSource))
+	v.RenderKeyValue("Default Space", formatValueWithSource(space, spaceSource))
+
+	fmt.Println()
+	fmt.Printf("Config file: %s\n", configPath)
+	if fileErr != nil {
+		fmt.Printf("  (file not found or unreadable)\n")
+	}
+
+	return nil
+}
+
+// getValueAndSource returns the effective value and its source.
+func getValueAndSource(envValue, fileValue, envVarName string) (string, string) {
+	if envValue != "" {
+		return envValue, envVarName
+	}
+	if fileValue != "" {
+		return fileValue, "config"
+	}
+	return "", "not set"
+}
+
+// getEnvVarName returns the name of the environment variable that is set.
+func getEnvVarName(primary, fallback string) string {
+	if os.Getenv(primary) != "" {
+		return primary
+	}
+	if os.Getenv(fallback) != "" {
+		return fallback
+	}
+	return primary // Default to primary if neither is set
+}
+
+// formatValueWithSource formats a value with its source indicator.
+func formatValueWithSource(value, source string) string {
+	if value == "" {
+		return fmt.Sprintf("(source: %s)", source)
+	}
+	return fmt.Sprintf("%s  (source: %s)", value, source)
+}
+
+// maskToken masks the API token for display, showing first 4 and last 4 chars.
+func maskToken(token string) string {
+	if token == "" {
+		return ""
+	}
+	if len(token) <= 8 {
+		return "********"
+	}
+	return token[:4] + "********" + token[len(token)-4:]
+}

--- a/tools/cfl/internal/cmd/configcmd/show_test.go
+++ b/tools/cfl/internal/cmd/configcmd/show_test.go
@@ -1,0 +1,121 @@
+package configcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{
+			name:  "normal token",
+			token: "abcd1234567890wxyz",
+			want:  "abcd********wxyz",
+		},
+		{
+			name:  "short token",
+			token: "abc",
+			want:  "********",
+		},
+		{
+			name:  "exactly 8 chars",
+			token: "12345678",
+			want:  "********",
+		},
+		{
+			name:  "9 chars",
+			token: "123456789",
+			want:  "1234********6789",
+		},
+		{
+			name:  "empty token",
+			token: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maskToken(tt.token)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetValueAndSource(t *testing.T) {
+	tests := []struct {
+		name       string
+		envValue   string
+		fileValue  string
+		envVarName string
+		wantValue  string
+		wantSource string
+	}{
+		{
+			name:       "env takes precedence",
+			envValue:   "from-env",
+			fileValue:  "from-file",
+			envVarName: "CFL_URL",
+			wantValue:  "from-env",
+			wantSource: "CFL_URL",
+		},
+		{
+			name:       "file used when env empty",
+			envValue:   "",
+			fileValue:  "from-file",
+			envVarName: "CFL_URL",
+			wantValue:  "from-file",
+			wantSource: "config",
+		},
+		{
+			name:       "not set when both empty",
+			envValue:   "",
+			fileValue:  "",
+			envVarName: "CFL_URL",
+			wantValue:  "",
+			wantSource: "not set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotValue, gotSource := getValueAndSource(tt.envValue, tt.fileValue, tt.envVarName)
+			assert.Equal(t, tt.wantValue, gotValue)
+			assert.Equal(t, tt.wantSource, gotSource)
+		})
+	}
+}
+
+func TestFormatValueWithSource(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  string
+		source string
+		want   string
+	}{
+		{
+			name:   "value with source",
+			value:  "https://example.com",
+			source: "config",
+			want:   "https://example.com  (source: config)",
+		},
+		{
+			name:   "empty value",
+			value:  "",
+			source: "not set",
+			want:   "(source: not set)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatValueWithSource(tt.value, tt.source)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/tools/cfl/internal/cmd/configcmd/test.go
+++ b/tools/cfl/internal/cmd/configcmd/test.go
@@ -1,0 +1,60 @@
+package configcmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+func newTestCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "test",
+		Short: "Test connectivity with current configuration",
+		Long: `Test the connection to Confluence using the current configuration.
+
+This verifies that:
+- The URL is reachable
+- The credentials are valid
+- You have permission to access the API`,
+		Example: `  # Test current configuration
+  cfl config test`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runTest(opts)
+		},
+	}
+}
+
+func runTest(opts *root.Options) error {
+	// Try to get the API client - this validates config
+	client, err := opts.APIClient()
+	if err != nil {
+		return fmt.Errorf("configuration error: %w", err)
+	}
+
+	fmt.Print("Testing connection... ")
+
+	// Try to list spaces (limit 1) to verify connectivity
+	_, err = client.ListSpaces(context.Background(), nil)
+	if err != nil {
+		fmt.Println("failed!")
+		fmt.Println()
+		fmt.Println("Troubleshooting:")
+		fmt.Println("  - Verify your URL is correct (should include https://)")
+		fmt.Println("  - Check your email and API token")
+		fmt.Println("  - Ensure your API token hasn't expired")
+		fmt.Println("  - Verify you have permission to access Confluence")
+		fmt.Println()
+		fmt.Println("To regenerate an API token:")
+		fmt.Println("  https://id.atlassian.com/manage-profile/security/api-tokens")
+		return fmt.Errorf("connection test failed: %w", err)
+	}
+
+	fmt.Println("success!")
+	fmt.Println()
+	fmt.Println("Your cfl configuration is working correctly.")
+
+	return nil
+}

--- a/tools/cfl/internal/cmd/configcmd/test_test.go
+++ b/tools/cfl/internal/cmd/configcmd/test_test.go
@@ -1,0 +1,71 @@
+package configcmd
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+func newTestRootOptions() *root.Options {
+	return &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+}
+
+func TestRunTest_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/spaces")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	err := runTest(rootOpts)
+	require.NoError(t, err)
+}
+
+func TestRunTest_AuthFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message": "Unauthorized"}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "bad-token")
+	rootOpts.SetAPIClient(client)
+
+	err := runTest(rootOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection test failed")
+}
+
+func TestRunTest_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message": "Server error"}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	err := runTest(rootOpts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection test failed")
+}


### PR DESCRIPTION
## Summary
- Add `cfl config show` command to display current configuration with source info
- Add `cfl config test` command to verify API connectivity
- Add `cfl config clear` command to remove configuration file with confirmation

Ports config management commands from confluence-cli PR #106.

Closes #40

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes
- [ ] Manual testing of `cfl config show`
- [ ] Manual testing of `cfl config test`
- [ ] Manual testing of `cfl config clear`

🤖 Generated with [Claude Code](https://claude.com/claude-code)