### PR TITLE
feat(jtk): add wiki markup detection and conversion

### DIFF
--- a/tools/jtk/api/markdown.go
+++ b/tools/jtk/api/markdown.go
@@ -14,9 +14,17 @@ import (
 // MarkdownToADF converts markdown text to an Atlassian Document Format document.
 // Supports: headings (h1-h6), paragraphs, bold, italic, strikethrough, code,
 // code blocks, bullet lists, numbered lists, links, blockquotes, and tables.
+//
+// If the input contains Jira wiki markup (h1., {{code}}, [text|url], etc.),
+// it will be automatically converted to markdown first.
 func MarkdownToADF(markdown string) *ADFDocument {
 	if markdown == "" {
 		return nil
+	}
+
+	// Auto-detect and convert wiki markup to markdown
+	if IsWikiMarkup(markdown) {
+		markdown = WikiToMarkdown(markdown)
 	}
 
 	source := []byte(markdown)

--- a/tools/jtk/api/wiki.go
+++ b/tools/jtk/api/wiki.go
@@ -1,0 +1,324 @@
+package api
+
+import (
+	"regexp"
+	"strings"
+)
+
+// wikiPatterns defines regex patterns for Jira wiki markup detection
+var wikiPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?m)^h[1-6]\.\s`),                  // h1. h2. etc
+	regexp.MustCompile(`\{\{[^}]+\}\}`),                    // {{monospace}}
+	regexp.MustCompile(`\{code[^}]*\}[\s\S]*?\{code\}`),    // {code}...{code}
+	regexp.MustCompile(`\{noformat\}[\s\S]*?\{noformat\}`), // {noformat}...{noformat}
+	regexp.MustCompile(`\{quote\}[\s\S]*?\{quote\}`),       // {quote}...{quote}
+	regexp.MustCompile(`\[([^\]|]+)\|([^\]]+)\]`),          // [text|url]
+	regexp.MustCompile(`\![^\s!]+\!`),                      // !image.png!
+	regexp.MustCompile(`(?m)^bq\.\s`),                      // bq. blockquote
+	regexp.MustCompile(`(?m)^\*+\s`),                       // * bullet (could be markdown too)
+	regexp.MustCompile(`(?m)^#+\s+[^#]`),                   // # numbered list (not markdown heading)
+}
+
+// IsWikiMarkup detects if text contains Jira wiki markup patterns.
+// Returns true if wiki markup is detected, false if it appears to be
+// plain text or markdown.
+func IsWikiMarkup(text string) bool {
+	// Quick check for obvious wiki patterns
+	for _, pattern := range wikiPatterns {
+		if pattern.MatchString(text) {
+			// For bullet patterns, verify it's not markdown
+			if strings.HasPrefix(pattern.String(), `(?m)^\*+\s`) {
+				// Check if it looks more like wiki (no blank line before)
+				continue
+			}
+			// For # pattern, make sure it's numbered list not markdown heading
+			if strings.HasPrefix(pattern.String(), `(?m)^#+\s+[^#]`) {
+				// In wiki markup, # is numbered list; in markdown it's heading
+				// Check context to decide
+				if looksLikeWikiNumberedList(text) {
+					return true
+				}
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// looksLikeWikiNumberedList checks if # usage looks like wiki numbered lists
+func looksLikeWikiNumberedList(text string) bool {
+	lines := strings.Split(text, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		// Wiki numbered lists: # item, ## nested item
+		// Markdown headings: # Title (usually followed by content, not lists)
+		if strings.HasPrefix(trimmed, "# ") || strings.HasPrefix(trimmed, "## ") {
+			// If the line after # is short and there are multiple such lines,
+			// it's likely a wiki numbered list
+			rest := strings.TrimLeft(trimmed, "# ")
+			if len(rest) < 80 && !strings.Contains(rest, "#") {
+				// Count consecutive # lines
+				count := 0
+				for _, l := range lines {
+					if strings.HasPrefix(strings.TrimSpace(l), "#") {
+						count++
+					}
+				}
+				if count >= 2 {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// WikiToMarkdown converts Jira wiki markup to markdown format.
+// This enables users to paste wiki-formatted text and have it properly
+// converted to ADF for Jira Cloud.
+func WikiToMarkdown(wiki string) string {
+	if wiki == "" {
+		return ""
+	}
+
+	result := wiki
+
+	// Convert headings: h1. Title -> # Title
+	result = convertWikiHeadings(result)
+
+	// Convert code blocks: {code:java}...{code} -> ```java...```
+	result = convertWikiCodeBlocks(result)
+
+	// Convert noformat blocks: {noformat}...{noformat} -> ```...```
+	result = convertWikiNoformat(result)
+
+	// Convert quote blocks: {quote}...{quote} -> > ...
+	result = convertWikiQuoteBlocks(result)
+
+	// Convert monospace: {{text}} -> `text`
+	result = convertWikiMonospace(result)
+
+	// Convert links: [text|url] -> [text](url)
+	result = convertWikiLinks(result)
+
+	// Convert images: !image.png! -> ![](image.png)
+	result = convertWikiImages(result)
+
+	// Convert text formatting
+	result = convertWikiTextFormatting(result)
+
+	// Convert blockquotes: bq. text -> > text
+	result = convertWikiBlockquotes(result)
+
+	// Convert lists
+	result = convertWikiLists(result)
+
+	// Convert horizontal rules: ---- -> ---
+	result = convertWikiHorizontalRules(result)
+
+	return result
+}
+
+// convertWikiHeadings converts h1. through h6. to markdown headings
+func convertWikiHeadings(text string) string {
+	// h1. Title -> # Title
+	for i := 1; i <= 6; i++ {
+		pattern := regexp.MustCompile(`(?m)^h` + string(rune('0'+i)) + `\.\s*(.*)$`)
+		prefix := strings.Repeat("#", i)
+		text = pattern.ReplaceAllString(text, prefix+" $1")
+	}
+	return text
+}
+
+// convertWikiCodeBlocks converts {code}...{code} to fenced code blocks
+func convertWikiCodeBlocks(text string) string {
+	// {code:language}content{code} or {code}content{code}
+	// Use negative lookbehind to avoid matching {code inside {{code}}
+	// Since Go regex doesn't support lookbehind, we use a workaround:
+	// Match from start of line or after non-{ character
+	pattern := regexp.MustCompile(`(?s)(^|[^{])\{code(?::([a-zA-Z0-9]+))?\}(.*?)\{code\}`)
+	return pattern.ReplaceAllStringFunc(text, func(match string) string {
+		submatches := pattern.FindStringSubmatch(match)
+		prefix := ""
+		lang := ""
+		content := ""
+		if len(submatches) >= 4 {
+			prefix = submatches[1]
+			lang = submatches[2]
+			content = submatches[3]
+		}
+		// Trim leading/trailing newlines from content
+		content = strings.TrimPrefix(content, "\n")
+		content = strings.TrimSuffix(content, "\n")
+		return prefix + "```" + lang + "\n" + content + "\n```"
+	})
+}
+
+// convertWikiNoformat converts {noformat}...{noformat} to fenced code blocks
+func convertWikiNoformat(text string) string {
+	pattern := regexp.MustCompile(`(?s)\{noformat\}(.*?)\{noformat\}`)
+	return pattern.ReplaceAllStringFunc(text, func(match string) string {
+		submatches := pattern.FindStringSubmatch(match)
+		content := ""
+		if len(submatches) >= 2 {
+			content = submatches[1]
+		}
+		content = strings.TrimPrefix(content, "\n")
+		content = strings.TrimSuffix(content, "\n")
+		return "```\n" + content + "\n```"
+	})
+}
+
+// convertWikiQuoteBlocks converts {quote}...{quote} to markdown blockquotes
+func convertWikiQuoteBlocks(text string) string {
+	pattern := regexp.MustCompile(`(?s)\{quote\}(.*?)\{quote\}`)
+	return pattern.ReplaceAllStringFunc(text, func(match string) string {
+		submatches := pattern.FindStringSubmatch(match)
+		content := ""
+		if len(submatches) >= 2 {
+			content = submatches[1]
+		}
+		content = strings.TrimSpace(content)
+		// Add > prefix to each line
+		lines := strings.Split(content, "\n")
+		for i, line := range lines {
+			lines[i] = "> " + line
+		}
+		return strings.Join(lines, "\n")
+	})
+}
+
+// convertWikiMonospace converts {{text}} to `text`
+func convertWikiMonospace(text string) string {
+	pattern := regexp.MustCompile(`\{\{([^}]+)\}\}`)
+	return pattern.ReplaceAllString(text, "`$1`")
+}
+
+// convertWikiLinks converts [text|url] to [text](url)
+func convertWikiLinks(text string) string {
+	// [link text|http://example.com] -> [link text](http://example.com)
+	pattern := regexp.MustCompile(`\[([^\]|]+)\|([^\]]+)\]`)
+	return pattern.ReplaceAllString(text, "[$1]($2)")
+}
+
+// convertWikiImages converts !image.png! to ![](image.png)
+func convertWikiImages(text string) string {
+	// !image.png! -> ![](image.png)
+	// !image.png|alt=text! -> ![text](image.png)
+	pattern := regexp.MustCompile(`!([^\s!|]+)(?:\|([^!]+))?!`)
+	return pattern.ReplaceAllStringFunc(text, func(match string) string {
+		submatches := pattern.FindStringSubmatch(match)
+		if len(submatches) < 2 {
+			return match
+		}
+		src := submatches[1]
+		alt := ""
+		if len(submatches) >= 3 && submatches[2] != "" {
+			// Parse alt=text or other attributes
+			attrs := submatches[2]
+			if strings.HasPrefix(attrs, "alt=") {
+				alt = strings.TrimPrefix(attrs, "alt=")
+			}
+		}
+		return "![" + alt + "](" + src + ")"
+	})
+}
+
+// convertWikiTextFormatting converts wiki text formatting to markdown
+func convertWikiTextFormatting(text string) string {
+	// Bold: *text* -> **text** (but not if already markdown **)
+	// Need to be careful not to convert markdown ** to ****
+	// Wiki uses single *, markdown uses double **
+	// Only convert if it's clearly wiki style (word boundaries)
+
+	// Strikethrough: -text- -> ~~text~~
+	strikePattern := regexp.MustCompile(`(?:^|[^-])-([^\s-][^-]*[^\s-]|[^\s-])-(?:[^-]|$)`)
+	text = strikePattern.ReplaceAllStringFunc(text, func(match string) string {
+		// Extract the content between dashes
+		innerPattern := regexp.MustCompile(`-([^-]+)-`)
+		inner := innerPattern.FindStringSubmatch(match)
+		if len(inner) >= 2 {
+			prefix := ""
+			suffix := ""
+			if len(match) > 0 && match[0] != '-' {
+				prefix = string(match[0])
+			}
+			if len(match) > 0 && match[len(match)-1] != '-' {
+				suffix = string(match[len(match)-1])
+			}
+			return prefix + "~~" + inner[1] + "~~" + suffix
+		}
+		return match
+	})
+
+	// Underline: +text+ -> <u>text</u> (no markdown equivalent, use HTML)
+	underlinePattern := regexp.MustCompile(`\+([^\s+][^+]*[^\s+]|[^\s+])\+`)
+	text = underlinePattern.ReplaceAllString(text, "<u>$1</u>")
+
+	// Subscript: ~text~ -> <sub>text</sub>
+	subPattern := regexp.MustCompile(`~([^\s~][^~]*[^\s~]|[^\s~])~`)
+	text = subPattern.ReplaceAllString(text, "<sub>$1</sub>")
+
+	// Superscript: ^text^ -> <sup>text</sup>
+	supPattern := regexp.MustCompile(`\^([^\s^][^^]*[^\s^]|[^\s^])\^`)
+	text = supPattern.ReplaceAllString(text, "<sup>$1</sup>")
+
+	// Citation: ??text?? -> <cite>text</cite>
+	citePattern := regexp.MustCompile(`\?\?([^?]+)\?\?`)
+	text = citePattern.ReplaceAllString(text, "<cite>$1</cite>")
+
+	return text
+}
+
+// convertWikiBlockquotes converts bq. lines to markdown blockquotes
+func convertWikiBlockquotes(text string) string {
+	// bq. text -> > text
+	pattern := regexp.MustCompile(`(?m)^bq\.\s*(.*)$`)
+	return pattern.ReplaceAllString(text, "> $1")
+}
+
+// convertWikiLists converts wiki lists to markdown lists
+func convertWikiLists(text string) string {
+	lines := strings.Split(text, "\n")
+	result := make([]string, 0, len(lines))
+
+	for _, line := range lines {
+		converted := convertWikiListLine(line)
+		result = append(result, converted)
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// convertWikiListLine converts a single wiki list line to markdown
+func convertWikiListLine(line string) string {
+	trimmed := strings.TrimLeft(line, " \t")
+	indent := line[:len(line)-len(trimmed)]
+
+	// Bullet lists: * item, ** nested -> - item, - nested (with indent)
+	if strings.HasPrefix(trimmed, "* ") {
+		return indent + "- " + trimmed[2:]
+	}
+	if strings.HasPrefix(trimmed, "** ") {
+		return indent + "  - " + trimmed[3:]
+	}
+	if strings.HasPrefix(trimmed, "*** ") {
+		return indent + "    - " + trimmed[4:]
+	}
+
+	// Note: We intentionally do NOT convert wiki # numbered lists here
+	// because # at the start of a line is ambiguous between:
+	// - Wiki numbered list: # item
+	// - Markdown heading: # Title
+	// Users should use "1. item" for numbered lists to avoid ambiguity.
+
+	return line
+}
+
+// convertWikiHorizontalRules converts ---- to ---
+func convertWikiHorizontalRules(text string) string {
+	// Wiki uses ---- for horizontal rule, markdown uses ---
+	pattern := regexp.MustCompile(`(?m)^----+$`)
+	return pattern.ReplaceAllString(text, "---")
+}

--- a/tools/jtk/api/wiki_test.go
+++ b/tools/jtk/api/wiki_test.go
@@ -1,0 +1,268 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsWikiMarkup(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "h1 heading",
+			input:    "h1. This is a heading",
+			expected: true,
+		},
+		{
+			name:     "h2 heading",
+			input:    "h2. Another heading",
+			expected: true,
+		},
+		{
+			name:     "monospace",
+			input:    "Some {{inline code}} here",
+			expected: true,
+		},
+		{
+			name:     "code block",
+			input:    "{code:java}\npublic class Test {}\n{code}",
+			expected: true,
+		},
+		{
+			name:     "wiki link",
+			input:    "Check out [this link|https://example.com]",
+			expected: true,
+		},
+		{
+			name:     "wiki image",
+			input:    "See !screenshot.png!",
+			expected: true,
+		},
+		{
+			name:     "blockquote",
+			input:    "bq. This is a quote",
+			expected: true,
+		},
+		{
+			name:     "noformat block",
+			input:    "{noformat}some text{noformat}",
+			expected: true,
+		},
+		{
+			name:     "quote block",
+			input:    "{quote}quoted text{quote}",
+			expected: true,
+		},
+		{
+			name:     "plain markdown",
+			input:    "# Heading\n\nSome **bold** text",
+			expected: false,
+		},
+		{
+			name:     "markdown link",
+			input:    "Check [this](https://example.com)",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: false,
+		},
+		{
+			name:     "plain text",
+			input:    "Just some plain text without any formatting",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsWikiMarkup(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestWikiToMarkdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "h1 heading",
+			input:    "h1. Main Title",
+			expected: "# Main Title",
+		},
+		{
+			name:     "h2 heading",
+			input:    "h2. Section",
+			expected: "## Section",
+		},
+		{
+			name:     "h3 heading",
+			input:    "h3. Subsection",
+			expected: "### Subsection",
+		},
+		{
+			name:     "multiple headings",
+			input:    "h1. Title\nh2. Section\nh3. Subsection",
+			expected: "# Title\n## Section\n### Subsection",
+		},
+		{
+			name:     "monospace",
+			input:    "Use {{git status}} to check",
+			expected: "Use `git status` to check",
+		},
+		{
+			name:     "code block without language",
+			input:    "{code}\nfunc main() {}\n{code}",
+			expected: "```\nfunc main() {}\n```",
+		},
+		{
+			name:     "code block with language",
+			input:    "{code:go}\nfunc main() {}\n{code}",
+			expected: "```go\nfunc main() {}\n```",
+		},
+		{
+			name:     "noformat block",
+			input:    "{noformat}\nsome preformatted text\n{noformat}",
+			expected: "```\nsome preformatted text\n```",
+		},
+		{
+			name:     "wiki link",
+			input:    "See [Google|https://google.com] for more",
+			expected: "See [Google](https://google.com) for more",
+		},
+		{
+			name:     "wiki image",
+			input:    "Screenshot: !image.png!",
+			expected: "Screenshot: ![](image.png)",
+		},
+		{
+			name:     "wiki image with alt",
+			input:    "!diagram.png|alt=Architecture!",
+			expected: "![Architecture](diagram.png)",
+		},
+		{
+			name:     "blockquote line",
+			input:    "bq. This is quoted",
+			expected: "> This is quoted",
+		},
+		{
+			name:     "quote block",
+			input:    "{quote}\nFirst line\nSecond line\n{quote}",
+			expected: "> First line\n> Second line",
+		},
+		{
+			name:     "bullet list",
+			input:    "* Item 1\n* Item 2\n* Item 3",
+			expected: "- Item 1\n- Item 2\n- Item 3",
+		},
+		{
+			name:     "nested bullet list",
+			input:    "* Item 1\n** Nested 1\n** Nested 2\n* Item 2",
+			expected: "- Item 1\n  - Nested 1\n  - Nested 2\n- Item 2",
+		},
+		{
+			name:     "horizontal rule",
+			input:    "Before\n----\nAfter",
+			expected: "Before\n---\nAfter",
+		},
+		{
+			name:     "complex document",
+			input:    "h1. Guide\n\nThis is about {{code}}.\n\n{code:python}\nprint('hello')\n{code}\n\nSee [docs|https://example.com].",
+			expected: "# Guide\n\nThis is about `code`.\n\n```python\nprint('hello')\n```\n\nSee [docs](https://example.com).",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WikiToMarkdown(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestWikiToMarkdownPreservesMarkdown(t *testing.T) {
+	// Markdown input should pass through mostly unchanged
+	// (some edge cases may have minor differences)
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "markdown heading",
+			input: "# Title",
+		},
+		{
+			name:  "markdown bold",
+			input: "Some **bold** text",
+		},
+		{
+			name:  "markdown code",
+			input: "Use `code` here",
+		},
+		{
+			name:  "markdown link",
+			input: "[Google](https://google.com)",
+		},
+		{
+			name:  "markdown list",
+			input: "- Item 1\n- Item 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WikiToMarkdown(tt.input)
+			assert.Equal(t, tt.input, result)
+		})
+	}
+}
+
+func TestMarkdownToADFWithWikiMarkup(t *testing.T) {
+	// Test that wiki markup is properly converted when passed to MarkdownToADF
+	tests := []struct {
+		name      string
+		input     string
+		checkType string
+		checkAttr interface{}
+	}{
+		{
+			name:      "wiki h1 becomes ADF heading",
+			input:     "h1. Hello World",
+			checkType: "heading",
+			checkAttr: 1,
+		},
+		{
+			name:      "wiki h2 becomes ADF heading",
+			input:     "h2. Section Title",
+			checkType: "heading",
+			checkAttr: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := MarkdownToADF(tt.input)
+			assert.NotNil(t, doc)
+			assert.Equal(t, "doc", doc.Type)
+			assert.NotEmpty(t, doc.Content)
+
+			if tt.checkType == "heading" {
+				assert.Equal(t, "heading", doc.Content[0].Type)
+				assert.Equal(t, tt.checkAttr, doc.Content[0].Attrs["level"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `IsWikiMarkup()` function to detect Jira wiki markup patterns
- Add `WikiToMarkdown()` function to convert wiki markup to markdown
- Update `MarkdownToADF()` to auto-detect and convert wiki markup first

**Supported patterns:**
- Headings: `h1.` through `h6.`
- Code blocks: `{code}...{code}` and `{code:lang}...{code}`
- Monospace: `{{text}}`
- Links: `[text|url]`
- Images: `!image.png!` and `!image.png|alt=text!`
- Blockquotes: `bq.` and `{quote}...{quote}`
- Bullet lists: `* item`, `** nested`
- Noformat: `{noformat}...{noformat}`
- Horizontal rules: `----`

Ports wiki markup handling from jira-ticket-cli PR #63.

Closes #37

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes
- [x] Unit tests for `IsWikiMarkup()` with wiki and non-wiki content
- [x] Unit tests for `WikiToMarkdown()` with various patterns
- [x] Integration test with `MarkdownToADF()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)