### PR TITLE
feat(jtk): add attachments command

### DIFF
--- a/tools/jtk/api/attachments.go
+++ b/tools/jtk/api/attachments.go
@@ -1,0 +1,279 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	sharederrors "github.com/open-cli-collective/atlassian-go/errors"
+)
+
+// Attachment represents a Jira attachment
+type Attachment struct {
+	ID       FlexibleID `json:"id"`
+	Filename string     `json:"filename"`
+	Author   User       `json:"author"`
+	Created  string     `json:"created"`
+	Size     int64      `json:"size"`
+	MimeType string     `json:"mimeType"`
+	Content  string     `json:"content"` // URL to download the attachment
+	Self     string     `json:"self"`
+}
+
+// FlexibleID handles Jira API inconsistency where IDs can be strings or numbers
+type FlexibleID string
+
+// UnmarshalJSON handles both string and number JSON values for IDs
+func (f *FlexibleID) UnmarshalJSON(data []byte) error {
+	// Check for null
+	if string(data) == "null" {
+		return fmt.Errorf("id cannot be null")
+	}
+
+	// Try string first
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*f = FlexibleID(s)
+		return nil
+	}
+
+	// Try number
+	var n int64
+	if err := json.Unmarshal(data, &n); err == nil {
+		*f = FlexibleID(fmt.Sprintf("%d", n))
+		return nil
+	}
+
+	return fmt.Errorf("id must be string or number, got: %s", string(data))
+}
+
+// String returns the ID as a string
+func (f FlexibleID) String() string {
+	return string(f)
+}
+
+// GetIssueAttachments returns all attachments for an issue
+func (c *Client) GetIssueAttachments(issueKey string) ([]Attachment, error) {
+	if issueKey == "" {
+		return nil, fmt.Errorf("issue key is required")
+	}
+
+	urlStr := fmt.Sprintf("%s/issue/%s?fields=attachment", c.BaseURL, issueKey)
+	body, err := c.get(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Fields struct {
+			Attachment []Attachment `json:"attachment"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse attachments: %w", err)
+	}
+
+	return result.Fields.Attachment, nil
+}
+
+// GetAttachment returns metadata for a specific attachment
+func (c *Client) GetAttachment(attachmentID string) (*Attachment, error) {
+	if attachmentID == "" {
+		return nil, fmt.Errorf("attachment ID is required")
+	}
+
+	urlStr := fmt.Sprintf("%s/attachment/%s", c.BaseURL, attachmentID)
+	body, err := c.get(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var attachment Attachment
+	if err := json.Unmarshal(body, &attachment); err != nil {
+		return nil, fmt.Errorf("failed to parse attachment: %w", err)
+	}
+
+	return &attachment, nil
+}
+
+// AddAttachment uploads a file as an attachment to an issue
+func (c *Client) AddAttachment(issueKey, filePath string) ([]Attachment, error) {
+	if issueKey == "" {
+		return nil, fmt.Errorf("issue key is required")
+	}
+	if filePath == "" {
+		return nil, fmt.Errorf("file path is required")
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	// Create multipart form
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+
+	// Write the file in a goroutine to avoid blocking
+	errChan := make(chan error, 1)
+	go func() {
+		defer pw.Close()
+		defer writer.Close()
+
+		part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+		if err != nil {
+			errChan <- fmt.Errorf("failed to create form file: %w", err)
+			return
+		}
+
+		if _, err := io.Copy(part, file); err != nil {
+			errChan <- fmt.Errorf("failed to copy file content: %w", err)
+			return
+		}
+		errChan <- nil
+	}()
+
+	urlStr := fmt.Sprintf("%s/issue/%s/attachments", c.BaseURL, issueKey)
+
+	req, err := http.NewRequest(http.MethodPost, urlStr, pr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", c.GetAuthHeader())
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+	// Required header for attachment uploads
+	req.Header.Set("X-Atlassian-Token", "no-check")
+
+	if c.Verbose {
+		fmt.Printf("→ POST %s\n", urlStr)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Wait for the write goroutine to finish
+	if writeErr := <-errChan; writeErr != nil {
+		return nil, writeErr
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if c.Verbose {
+		fmt.Printf("← %d %s\n", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, sharederrors.ParseAPIError(resp.StatusCode, respBody)
+	}
+
+	var attachments []Attachment
+	if err := json.Unmarshal(respBody, &attachments); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return attachments, nil
+}
+
+// DeleteAttachment deletes an attachment by ID
+func (c *Client) DeleteAttachment(attachmentID string) error {
+	if attachmentID == "" {
+		return fmt.Errorf("attachment ID is required")
+	}
+
+	urlStr := fmt.Sprintf("%s/attachment/%s", c.BaseURL, attachmentID)
+	_, err := c.delete(urlStr)
+	return err
+}
+
+// DownloadAttachment downloads an attachment to the specified output path
+func (c *Client) DownloadAttachment(attachment *Attachment, outputPath string) error {
+	if attachment == nil {
+		return fmt.Errorf("attachment is required")
+	}
+	if attachment.Content == "" {
+		return fmt.Errorf("attachment has no content URL")
+	}
+
+	// Create the request
+	req, err := http.NewRequest(http.MethodGet, attachment.Content, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", c.GetAuthHeader())
+
+	if c.Verbose {
+		fmt.Printf("→ GET %s\n", attachment.Content)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if c.Verbose {
+		fmt.Printf("← %d %s\n", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return sharederrors.ParseAPIError(resp.StatusCode, body)
+	}
+
+	// Determine output file path
+	outFile := outputPath
+	if isDirectory(outputPath) {
+		outFile = filepath.Join(outputPath, attachment.Filename)
+	}
+
+	// Create the output file
+	file, err := os.Create(outFile)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer file.Close()
+
+	// Copy the content
+	if _, err := io.Copy(file, resp.Body); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}
+
+// isDirectory checks if a path is a directory
+func isDirectory(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+// FormatFileSize returns a human-readable file size
+func FormatFileSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/tools/jtk/api/attachments_test.go
+++ b/tools/jtk/api/attachments_test.go
@@ -1,0 +1,295 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlexibleID_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected FlexibleID
+		wantErr  bool
+	}{
+		{
+			name:     "string ID",
+			input:    `"12345"`,
+			expected: FlexibleID("12345"),
+		},
+		{
+			name:     "number ID",
+			input:    `12345`,
+			expected: FlexibleID("12345"),
+		},
+		{
+			name:     "large number ID",
+			input:    `9876543210`,
+			expected: FlexibleID("9876543210"),
+		},
+		{
+			name:    "invalid type",
+			input:   `true`,
+			wantErr: true,
+		},
+		{
+			name:    "null",
+			input:   `null`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var id FlexibleID
+			err := json.Unmarshal([]byte(tt.input), &id)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, id)
+				assert.Equal(t, string(tt.expected), id.String())
+			}
+		})
+	}
+}
+
+func TestGetIssueAttachments(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/issue/PROJ-123", r.URL.Path)
+		assert.Equal(t, "attachment", r.URL.Query().Get("fields"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"fields": {
+				"attachment": [
+					{
+						"id": "10001",
+						"filename": "test.txt",
+						"size": 1024,
+						"created": "2024-01-15T10:30:00.000+0000",
+						"author": {"displayName": "Test User"},
+						"mimeType": "text/plain",
+						"content": "https://example.com/attachments/10001"
+					}
+				]
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	attachments, err := client.GetIssueAttachments("PROJ-123")
+	require.NoError(t, err)
+	require.Len(t, attachments, 1)
+
+	att := attachments[0]
+	assert.Equal(t, "10001", att.ID.String())
+	assert.Equal(t, "test.txt", att.Filename)
+	assert.Equal(t, int64(1024), att.Size)
+	assert.Equal(t, "Test User", att.Author.DisplayName)
+}
+
+func TestGetIssueAttachments_EmptyIssueKey(t *testing.T) {
+	client, _ := New(ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+
+	_, err := client.GetIssueAttachments("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "issue key is required")
+}
+
+func TestGetAttachment(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/attachment/10001", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "10001",
+			"filename": "document.pdf",
+			"size": 2048,
+			"mimeType": "application/pdf",
+			"content": "https://example.com/attachments/10001"
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	att, err := client.GetAttachment("10001")
+	require.NoError(t, err)
+	assert.Equal(t, "10001", att.ID.String())
+	assert.Equal(t, "document.pdf", att.Filename)
+	assert.Equal(t, int64(2048), att.Size)
+}
+
+func TestGetAttachment_EmptyID(t *testing.T) {
+	client, _ := New(ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+
+	_, err := client.GetAttachment("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "attachment ID is required")
+}
+
+func TestDeleteAttachment(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/rest/api/3/attachment/10001", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	err = client.DeleteAttachment("10001")
+	assert.NoError(t, err)
+}
+
+func TestDeleteAttachment_EmptyID(t *testing.T) {
+	client, _ := New(ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+
+	err := client.DeleteAttachment("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "attachment ID is required")
+}
+
+func TestDownloadAttachment(t *testing.T) {
+	content := []byte("Test file content")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "downloaded.txt")
+
+	att := &Attachment{
+		Filename: "test.txt",
+		Content:  server.URL + "/attachment/content",
+	}
+
+	err = client.DownloadAttachment(att, outPath)
+	require.NoError(t, err)
+
+	downloaded, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, downloaded)
+}
+
+func TestDownloadAttachment_ToDirectory(t *testing.T) {
+	content := []byte("Test file content")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+
+	att := &Attachment{
+		Filename: "original.txt",
+		Content:  server.URL + "/attachment/content",
+	}
+
+	err = client.DownloadAttachment(att, tmpDir)
+	require.NoError(t, err)
+
+	// Should use original filename
+	downloaded, err := os.ReadFile(filepath.Join(tmpDir, "original.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, content, downloaded)
+}
+
+func TestDownloadAttachment_NilAttachment(t *testing.T) {
+	client, _ := New(ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+
+	err := client.DownloadAttachment(nil, "/tmp/test.txt")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "attachment is required")
+}
+
+func TestDownloadAttachment_NoContentURL(t *testing.T) {
+	client, _ := New(ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+
+	att := &Attachment{Filename: "test.txt"}
+	err := client.DownloadAttachment(att, "/tmp/test.txt")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no content URL")
+}
+
+func TestFormatFileSize(t *testing.T) {
+	tests := []struct {
+		bytes    int64
+		expected string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1572864, "1.5 MB"},
+		{1073741824, "1.0 GB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := FormatFileSize(tt.bytes)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/tools/jtk/cmd/jtk/main.go
+++ b/tools/jtk/cmd/jtk/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/exitcode"
 
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/attachments"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/boards"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/comments"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/completion"
@@ -35,6 +36,7 @@ func run() error {
 	issues.Register(rootCmd, opts)
 	transitions.Register(rootCmd, opts)
 	comments.Register(rootCmd, opts)
+	attachments.Register(rootCmd, opts)
 	boards.Register(rootCmd, opts)
 	sprints.Register(rootCmd, opts)
 	users.Register(rootCmd, opts)

--- a/tools/jtk/internal/cmd/attachments/attachments.go
+++ b/tools/jtk/internal/cmd/attachments/attachments.go
@@ -1,0 +1,242 @@
+package attachments
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+// Register registers the attachments commands
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:     "attachments",
+		Aliases: []string{"attachment", "att"},
+		Short:   "Manage issue attachments",
+		Long:    "Commands for listing, adding, downloading, and deleting issue attachments.",
+	}
+
+	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newAddCmd(opts))
+	cmd.AddCommand(newGetCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
+
+	parent.AddCommand(cmd)
+}
+
+func newListCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list <issue-key>",
+		Aliases: []string{"ls"},
+		Short:   "List attachments on an issue",
+		Long:    "List all attachments on a Jira issue.",
+		Example: `  # List attachments
+  jtk attachments list PROJ-123
+
+  # Output as JSON
+  jtk attachments list PROJ-123 -o json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(opts, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func runList(opts *root.Options, issueKey string) error {
+	v := opts.View()
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	attachments, err := client.GetIssueAttachments(issueKey)
+	if err != nil {
+		return err
+	}
+
+	if len(attachments) == 0 {
+		v.Info("No attachments found on %s", issueKey)
+		return nil
+	}
+
+	headers := []string{"ID", "FILENAME", "SIZE", "CREATED", "AUTHOR"}
+	rows := make([][]string, 0, len(attachments))
+
+	for _, att := range attachments {
+		rows = append(rows, []string{
+			att.ID.String(),
+			att.Filename,
+			api.FormatFileSize(att.Size),
+			att.Created[:10], // Date only
+			att.Author.DisplayName,
+		})
+	}
+
+	data := make([]map[string]interface{}, 0, len(attachments))
+	for _, att := range attachments {
+		data = append(data, map[string]interface{}{
+			"id":       att.ID.String(),
+			"filename": att.Filename,
+			"size":     att.Size,
+			"mimeType": att.MimeType,
+			"created":  att.Created,
+			"author":   att.Author.DisplayName,
+			"content":  att.Content,
+		})
+	}
+
+	return v.Render(headers, rows, data)
+}
+
+func newAddCmd(opts *root.Options) *cobra.Command {
+	var files []string
+
+	cmd := &cobra.Command{
+		Use:   "add <issue-key>",
+		Short: "Add attachments to an issue",
+		Long:  "Upload one or more files as attachments to a Jira issue.",
+		Example: `  # Add a single file
+  jtk attachments add PROJ-123 --file screenshot.png
+
+  # Add multiple files
+  jtk attachments add PROJ-123 --file doc.pdf --file image.png`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAdd(opts, args[0], files)
+		},
+	}
+
+	cmd.Flags().StringArrayVarP(&files, "file", "f", nil, "File(s) to attach (can be specified multiple times)")
+	_ = cmd.MarkFlagRequired("file")
+
+	return cmd
+}
+
+func runAdd(opts *root.Options, issueKey string, files []string) error {
+	v := opts.View()
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	for _, filePath := range files {
+		// Expand path
+		absPath, err := filepath.Abs(filePath)
+		if err != nil {
+			return fmt.Errorf("invalid file path %s: %w", filePath, err)
+		}
+
+		// Check file exists
+		if _, err := os.Stat(absPath); os.IsNotExist(err) {
+			return fmt.Errorf("file not found: %s", filePath)
+		}
+
+		attachments, err := client.AddAttachment(issueKey, absPath)
+		if err != nil {
+			return fmt.Errorf("failed to upload %s: %w", filepath.Base(filePath), err)
+		}
+
+		for _, att := range attachments {
+			v.Success("Uploaded %s (ID: %s, Size: %s)", att.Filename, att.ID.String(), api.FormatFileSize(att.Size))
+		}
+	}
+
+	return nil
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	var outputPath string
+
+	cmd := &cobra.Command{
+		Use:     "get <attachment-id>",
+		Aliases: []string{"download"},
+		Short:   "Download an attachment",
+		Long:    "Download an attachment by its ID.",
+		Example: `  # Download to current directory
+  jtk attachments get 12345
+
+  # Download to specific directory
+  jtk attachments get 12345 --output ./downloads/
+
+  # Download with custom filename
+  jtk attachments get 12345 --output ./downloads/renamed.pdf`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGet(opts, args[0], outputPath)
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputPath, "output", "o", ".", "Output path (directory or filename)")
+
+	return cmd
+}
+
+func runGet(opts *root.Options, attachmentID, outputPath string) error {
+	v := opts.View()
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	// Get attachment metadata
+	attachment, err := client.GetAttachment(attachmentID)
+	if err != nil {
+		return fmt.Errorf("failed to get attachment: %w", err)
+	}
+
+	// Download the file
+	if err := client.DownloadAttachment(attachment, outputPath); err != nil {
+		return fmt.Errorf("failed to download attachment: %w", err)
+	}
+
+	// Determine actual output path for message
+	actualPath := outputPath
+	if info, err := os.Stat(outputPath); err == nil && info.IsDir() {
+		actualPath = filepath.Join(outputPath, attachment.Filename)
+	}
+
+	v.Success("Downloaded %s (%s)", actualPath, api.FormatFileSize(attachment.Size))
+	return nil
+}
+
+func newDeleteCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete <attachment-id>",
+		Aliases: []string{"rm"},
+		Short:   "Delete an attachment",
+		Long:    "Delete an attachment by its ID.",
+		Example: `  # Delete an attachment
+  jtk attachments delete 12345`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDelete(opts, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func runDelete(opts *root.Options, attachmentID string) error {
+	v := opts.View()
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	if err := client.DeleteAttachment(attachmentID); err != nil {
+		return fmt.Errorf("failed to delete attachment: %w", err)
+	}
+
+	v.Success("Deleted attachment %s", attachmentID)
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `jtk attachments list <issue>` to list attachments on an issue
- Add `jtk attachments add <issue> --file <path>` to upload files
- Add `jtk attachments get <id>` to download attachments
- Add `jtk attachments delete <id>` to remove attachments
- Add FlexibleID type to handle Jira API inconsistency (IDs as strings or numbers)

## Test plan
- [x] Unit tests for FlexibleID unmarshaling (string, number, null, invalid)
- [x] Unit tests for GetIssueAttachments API method
- [x] Unit tests for GetAttachment API method
- [x] Unit tests for DeleteAttachment API method
- [x] Unit tests for DownloadAttachment (file and directory output)
- [x] Unit tests for FormatFileSize helper
- [x] All tests passing locally
- [x] Lint passing

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)