### PR TITLE
feat(jtk): add issue move command

### DIFF
--- a/tools/jtk/api/move.go
+++ b/tools/jtk/api/move.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// MoveIssuesRequest represents a request to move issues between projects
+type MoveIssuesRequest struct {
+	SendBulkNotification   bool                            `json:"sendBulkNotification"`
+	TargetToSourcesMapping map[string]MoveIssuesSourceSpec `json:"targetToSourcesMapping"`
+}
+
+// MoveIssuesSourceSpec specifies which issues to move and how to map fields
+type MoveIssuesSourceSpec struct {
+	IssueIdsOrKeys        []string               `json:"issueIdsOrKeys"`
+	InferFieldDefaults    bool                   `json:"inferFieldDefaults"`
+	InferStatusDefaults   bool                   `json:"inferStatusDefaults"`
+	TargetStatus          []StatusMapping        `json:"targetStatus,omitempty"`
+	TargetMandatoryFields map[string]interface{} `json:"targetMandatoryFields,omitempty"`
+}
+
+// StatusMapping maps source status to target status
+type StatusMapping struct {
+	SourceStatusID string `json:"sourceStatusId"`
+	TargetStatusID string `json:"targetStatusId"`
+}
+
+// MoveIssuesResponse represents the response from a bulk move operation
+type MoveIssuesResponse struct {
+	TaskID string `json:"taskId"`
+}
+
+// MoveTaskStatus represents the status of a move task
+type MoveTaskStatus struct {
+	TaskID      string          `json:"taskId"`
+	Status      string          `json:"status"` // ENQUEUED, RUNNING, COMPLETE, FAILED, CANCELLED
+	SubmittedAt string          `json:"submittedAt"`
+	StartedAt   string          `json:"startedAt,omitempty"`
+	FinishedAt  string          `json:"finishedAt,omitempty"`
+	Progress    int             `json:"progress"`
+	Result      *MoveTaskResult `json:"result,omitempty"`
+}
+
+// MoveTaskResult contains the result of a completed move task
+type MoveTaskResult struct {
+	Successful []string          `json:"successful,omitempty"`
+	Failed     []MoveFailedIssue `json:"failed,omitempty"`
+}
+
+// MoveFailedIssue represents an issue that failed to move
+type MoveFailedIssue struct {
+	IssueKey string   `json:"issueKey"`
+	Errors   []string `json:"errors"`
+}
+
+// MoveIssues moves issues to a target project/issue type (Jira Cloud only)
+// This is an asynchronous operation that returns a task ID
+func (c *Client) MoveIssues(req MoveIssuesRequest) (*MoveIssuesResponse, error) {
+	urlStr := fmt.Sprintf("%s/bulk/issues/move", c.BaseURL)
+
+	body, err := c.post(urlStr, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp MoveIssuesResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse move response: %w", err)
+	}
+
+	return &resp, nil
+}
+
+// GetMoveTaskStatus gets the status of a move task
+func (c *Client) GetMoveTaskStatus(taskID string) (*MoveTaskStatus, error) {
+	if taskID == "" {
+		return nil, fmt.Errorf("task ID is required")
+	}
+
+	// Status endpoint is /bulk/queue/{taskId}
+	urlStr := fmt.Sprintf("%s/bulk/queue/%s", c.BaseURL, taskID)
+
+	body, err := c.get(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var status MoveTaskStatus
+	if err := json.Unmarshal(body, &status); err != nil {
+		return nil, fmt.Errorf("failed to parse task status: %w", err)
+	}
+
+	return &status, nil
+}
+
+// GetProjectIssueTypes returns the issue types available in a project
+func (c *Client) GetProjectIssueTypes(projectKey string) ([]IssueType, error) {
+	if projectKey == "" {
+		return nil, fmt.Errorf("project key is required")
+	}
+
+	urlStr := fmt.Sprintf("%s/project/%s", c.BaseURL, projectKey)
+
+	body, err := c.get(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var project struct {
+		IssueTypes []IssueType `json:"issueTypes"`
+	}
+	if err := json.Unmarshal(body, &project); err != nil {
+		return nil, fmt.Errorf("failed to parse project: %w", err)
+	}
+
+	return project.IssueTypes, nil
+}
+
+// GetProjectStatuses returns the statuses available in a project
+func (c *Client) GetProjectStatuses(projectKey string) ([]ProjectStatus, error) {
+	if projectKey == "" {
+		return nil, fmt.Errorf("project key is required")
+	}
+
+	urlStr := fmt.Sprintf("%s/project/%s/statuses", c.BaseURL, projectKey)
+
+	body, err := c.get(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var statuses []ProjectStatus
+	if err := json.Unmarshal(body, &statuses); err != nil {
+		return nil, fmt.Errorf("failed to parse statuses: %w", err)
+	}
+
+	return statuses, nil
+}
+
+// ProjectStatus represents an issue type's available statuses
+type ProjectStatus struct {
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	Subtask  bool     `json:"subtask"`
+	Statuses []Status `json:"statuses"`
+}
+
+// BuildMoveRequest creates a move request for a simple move operation
+func BuildMoveRequest(issueKeys []string, targetProject, targetIssueTypeID string, notify bool) MoveIssuesRequest {
+	// Target key format: "PROJECT_KEY,ISSUE_TYPE_ID" (comma-separated per Jira API docs)
+	targetKey := fmt.Sprintf("%s,%s", targetProject, targetIssueTypeID)
+
+	return MoveIssuesRequest{
+		SendBulkNotification: notify,
+		TargetToSourcesMapping: map[string]MoveIssuesSourceSpec{
+			targetKey: {
+				IssueIdsOrKeys:      issueKeys,
+				InferFieldDefaults:  true,
+				InferStatusDefaults: true,
+			},
+		},
+	}
+}

--- a/tools/jtk/api/move_test.go
+++ b/tools/jtk/api/move_test.go
@@ -1,0 +1,230 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMoveRequest(t *testing.T) {
+	req := BuildMoveRequest([]string{"PROJ-1", "PROJ-2"}, "TARGET", "10001", true)
+
+	assert.True(t, req.SendBulkNotification)
+	assert.Len(t, req.TargetToSourcesMapping, 1)
+
+	// Key format should be "PROJECT,ISSUE_TYPE_ID" (comma-separated)
+	spec, exists := req.TargetToSourcesMapping["TARGET,10001"]
+	assert.True(t, exists, "target key should use comma separator")
+	assert.Equal(t, []string{"PROJ-1", "PROJ-2"}, spec.IssueIdsOrKeys)
+	assert.True(t, spec.InferFieldDefaults)
+	assert.True(t, spec.InferStatusDefaults)
+}
+
+func TestBuildMoveRequest_NoNotify(t *testing.T) {
+	req := BuildMoveRequest([]string{"PROJ-1"}, "TARGET", "10001", false)
+
+	assert.False(t, req.SendBulkNotification)
+}
+
+func TestGetMoveTaskStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/bulk/queue/task-123", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"taskId": "task-123",
+			"status": "COMPLETE",
+			"submittedAt": "2024-01-15T10:30:00.000+0000",
+			"startedAt": "2024-01-15T10:30:01.000+0000",
+			"finishedAt": "2024-01-15T10:30:05.000+0000",
+			"progress": 100,
+			"result": {
+				"successful": ["TARGET-1", "TARGET-2"],
+				"failed": []
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	status, err := client.GetMoveTaskStatus("task-123")
+	require.NoError(t, err)
+	assert.Equal(t, "task-123", status.TaskID)
+	assert.Equal(t, "COMPLETE", status.Status)
+	assert.Equal(t, 100, status.Progress)
+	require.NotNil(t, status.Result)
+	assert.Equal(t, []string{"TARGET-1", "TARGET-2"}, status.Result.Successful)
+	assert.Empty(t, status.Result.Failed)
+}
+
+func TestGetMoveTaskStatus_EmptyID(t *testing.T) {
+	client, _ := New(ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+
+	_, err := client.GetMoveTaskStatus("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "task ID is required")
+}
+
+func TestGetMoveTaskStatus_WithFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"taskId": "task-456",
+			"status": "COMPLETE",
+			"progress": 100,
+			"submittedAt": "2024-01-15T10:30:00.000+0000",
+			"result": {
+				"successful": ["TARGET-1"],
+				"failed": [
+					{"issueKey": "PROJ-2", "errors": ["Field X is required", "Invalid status"]}
+				]
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	status, err := client.GetMoveTaskStatus("task-456")
+	require.NoError(t, err)
+	require.NotNil(t, status.Result)
+	assert.Len(t, status.Result.Successful, 1)
+	assert.Len(t, status.Result.Failed, 1)
+	assert.Equal(t, "PROJ-2", status.Result.Failed[0].IssueKey)
+	assert.Equal(t, []string{"Field X is required", "Invalid status"}, status.Result.Failed[0].Errors)
+}
+
+func TestMoveIssues(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/rest/api/3/bulk/issues/move", r.URL.Path)
+
+		var req MoveIssuesRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+
+		assert.True(t, req.SendBulkNotification)
+		assert.Contains(t, req.TargetToSourcesMapping, "TARGET,10001")
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"taskId": "new-task-id"}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	req := BuildMoveRequest([]string{"PROJ-1"}, "TARGET", "10001", true)
+	resp, err := client.MoveIssues(req)
+	require.NoError(t, err)
+	assert.Equal(t, "new-task-id", resp.TaskID)
+}
+
+func TestGetProjectIssueTypes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/project/PROJ", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"issueTypes": [
+				{"id": "10001", "name": "Task", "subtask": false},
+				{"id": "10002", "name": "Bug", "subtask": false},
+				{"id": "10003", "name": "Sub-task", "subtask": true}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	types, err := client.GetProjectIssueTypes("PROJ")
+	require.NoError(t, err)
+	assert.Len(t, types, 3)
+	assert.Equal(t, "Task", types[0].Name)
+	assert.False(t, types[0].Subtask)
+	assert.True(t, types[2].Subtask)
+}
+
+func TestGetProjectIssueTypes_EmptyProject(t *testing.T) {
+	client, _ := New(ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+
+	_, err := client.GetProjectIssueTypes("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "project key is required")
+}
+
+func TestGetProjectStatuses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/project/PROJ/statuses", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{
+				"id": "10001",
+				"name": "Task",
+				"subtask": false,
+				"statuses": [
+					{"id": "1", "name": "To Do"},
+					{"id": "2", "name": "In Progress"},
+					{"id": "3", "name": "Done"}
+				]
+			}
+		]`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	statuses, err := client.GetProjectStatuses("PROJ")
+	require.NoError(t, err)
+	assert.Len(t, statuses, 1)
+	assert.Equal(t, "Task", statuses[0].Name)
+	assert.Len(t, statuses[0].Statuses, 3)
+	assert.Equal(t, "To Do", statuses[0].Statuses[0].Name)
+}
+
+func TestGetProjectStatuses_EmptyProject(t *testing.T) {
+	client, _ := New(ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+
+	_, err := client.GetProjectStatuses("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "project key is required")
+}

--- a/tools/jtk/internal/cmd/issues/issues.go
+++ b/tools/jtk/internal/cmd/issues/issues.go
@@ -25,6 +25,8 @@ func Register(parent *cobra.Command, opts *root.Options) {
 	cmd.AddCommand(newFieldsCmd(opts))
 	cmd.AddCommand(newFieldOptionsCmd(opts))
 	cmd.AddCommand(newTypesCmd(opts))
+	cmd.AddCommand(newMoveCmd(opts))
+	cmd.AddCommand(newMoveStatusCmd(opts))
 
 	parent.AddCommand(cmd)
 }

--- a/tools/jtk/internal/cmd/issues/move.go
+++ b/tools/jtk/internal/cmd/issues/move.go
@@ -1,0 +1,253 @@
+package issues
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+func newMoveCmd(opts *root.Options) *cobra.Command {
+	var targetProject string
+	var targetType string
+	var notify bool
+	var wait bool
+
+	cmd := &cobra.Command{
+		Use:   "move <issue-key>...",
+		Short: "Move issues to another project (Cloud only)",
+		Long: `Move one or more issues to a different project and/or issue type.
+
+This command uses the Jira Cloud bulk move API and is not available
+on Jira Server or Data Center.
+
+The operation is asynchronous - by default it waits for completion.
+Use --no-wait to return immediately with the task ID.
+
+Limitations:
+- Maximum 1000 issues per request
+- Subtasks must be moved with their parent or separately
+- Some field values may need to be remapped manually`,
+		Example: `  # Move a single issue to another project
+  jtk issues move PROJ-123 --to-project NEWPROJ
+
+  # Move to specific issue type
+  jtk issues move PROJ-123 --to-project NEWPROJ --to-type Task
+
+  # Move multiple issues
+  jtk issues move PROJ-123 PROJ-124 PROJ-125 --to-project NEWPROJ
+
+  # Move without waiting for completion
+  jtk issues move PROJ-123 --to-project NEWPROJ --no-wait
+
+  # Move without notifications
+  jtk issues move PROJ-123 --to-project NEWPROJ --no-notify`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMove(opts, args, targetProject, targetType, notify, wait)
+		},
+	}
+
+	cmd.Flags().StringVar(&targetProject, "to-project", "", "Target project key (required)")
+	cmd.Flags().StringVar(&targetType, "to-type", "", "Target issue type (default: same as source)")
+	cmd.Flags().BoolVar(&notify, "notify", true, "Send notifications for the move")
+	cmd.Flags().BoolVar(&wait, "wait", true, "Wait for the move to complete")
+
+	_ = cmd.MarkFlagRequired("to-project")
+
+	return cmd
+}
+
+func runMove(opts *root.Options, issueKeys []string, targetProject, targetType string, notify, wait bool) error {
+	v := opts.View()
+
+	if len(issueKeys) > 1000 {
+		return fmt.Errorf("cannot move more than 1000 issues at once (got %d)", len(issueKeys))
+	}
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	// Get target project's issue types to validate or default the type
+	issueTypes, err := client.GetProjectIssueTypes(targetProject)
+	if err != nil {
+		return fmt.Errorf("failed to get target project issue types: %w", err)
+	}
+
+	if len(issueTypes) == 0 {
+		return fmt.Errorf("target project %s has no issue types", targetProject)
+	}
+
+	// Find target issue type
+	var targetIssueType *api.IssueType
+	if targetType == "" {
+		// Get the source issue's type to use as default
+		issue, err := client.GetIssue(issueKeys[0])
+		if err != nil {
+			return fmt.Errorf("failed to get source issue: %w", err)
+		}
+
+		sourceTypeName := issue.Fields.IssueType.Name
+		for i := range issueTypes {
+			if strings.EqualFold(issueTypes[i].Name, sourceTypeName) {
+				targetIssueType = &issueTypes[i]
+				break
+			}
+		}
+
+		if targetIssueType == nil {
+			// Fall back to first non-subtask type
+			for i := range issueTypes {
+				if !issueTypes[i].Subtask {
+					targetIssueType = &issueTypes[i]
+					break
+				}
+			}
+		}
+	} else {
+		// Find by name
+		for i := range issueTypes {
+			if strings.EqualFold(issueTypes[i].Name, targetType) {
+				targetIssueType = &issueTypes[i]
+				break
+			}
+		}
+	}
+
+	if targetIssueType == nil {
+		v.Error("Issue type not found in target project")
+		v.Info("Available types in %s:", targetProject)
+		for _, t := range issueTypes {
+			if !t.Subtask {
+				v.Info("  - %s", t.Name)
+			}
+		}
+		return fmt.Errorf("issue type not found: %s", targetType)
+	}
+
+	v.Info("Moving %d issue(s) to %s (%s)...", len(issueKeys), targetProject, targetIssueType.Name)
+
+	// Build and execute the move request
+	req := api.BuildMoveRequest(issueKeys, targetProject, targetIssueType.ID, notify)
+
+	resp, err := client.MoveIssues(req)
+	if err != nil {
+		// Check if this is a Server/DC instance
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+			return fmt.Errorf("move operation failed - this feature is only available on Jira Cloud")
+		}
+		return fmt.Errorf("failed to initiate move: %w", err)
+	}
+
+	if !wait {
+		v.Success("Move initiated (Task ID: %s)", resp.TaskID)
+		v.Info("Check status with: jtk issues move-status %s", resp.TaskID)
+		return nil
+	}
+
+	// Wait for completion
+	v.Info("Waiting for move to complete...")
+
+	for {
+		status, err := client.GetMoveTaskStatus(resp.TaskID)
+		if err != nil {
+			return fmt.Errorf("failed to get task status: %w", err)
+		}
+
+		switch status.Status {
+		case "COMPLETE":
+			if status.Result != nil && len(status.Result.Failed) > 0 {
+				v.Warning("Move completed with errors")
+				for _, failed := range status.Result.Failed {
+					v.Error("  %s: %s", failed.IssueKey, strings.Join(failed.Errors, ", "))
+				}
+				if len(status.Result.Successful) > 0 {
+					v.Success("Successfully moved: %s", strings.Join(status.Result.Successful, ", "))
+				}
+				return fmt.Errorf("some issues failed to move")
+			}
+			v.Success("Moved %d issue(s) to %s", len(issueKeys), targetProject)
+			return nil
+
+		case "FAILED":
+			return fmt.Errorf("move failed")
+
+		case "CANCELLED":
+			return fmt.Errorf("move was cancelled")
+
+		case "ENQUEUED", "RUNNING":
+			// Still in progress
+			time.Sleep(1 * time.Second)
+
+		default:
+			return fmt.Errorf("unknown task status: %s", status.Status)
+		}
+	}
+}
+
+func newMoveStatusCmd(opts *root.Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "move-status <task-id>",
+		Short: "Check status of a move operation",
+		Long:  "Check the status of an asynchronous move operation by task ID.",
+		Example: `  # Check move task status
+  jtk issues move-status abc123`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMoveStatus(opts, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func runMoveStatus(opts *root.Options, taskID string) error {
+	v := opts.View()
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	status, err := client.GetMoveTaskStatus(taskID)
+	if err != nil {
+		return err
+	}
+
+	if opts.Output == "json" {
+		return v.JSON(status)
+	}
+
+	v.Println("Task ID:     %s", status.TaskID)
+	v.Println("Status:      %s", status.Status)
+	v.Println("Progress:    %d%%", status.Progress)
+	v.Println("Submitted:   %s", status.SubmittedAt)
+
+	if status.StartedAt != "" {
+		v.Println("Started:     %s", status.StartedAt)
+	}
+	if status.FinishedAt != "" {
+		v.Println("Finished:    %s", status.FinishedAt)
+	}
+
+	if status.Result != nil {
+		v.Println("")
+		if len(status.Result.Successful) > 0 {
+			v.Success("Successful: %s", strings.Join(status.Result.Successful, ", "))
+		}
+		if len(status.Result.Failed) > 0 {
+			v.Error("Failed:")
+			for _, failed := range status.Result.Failed {
+				v.Error("  %s: %s", failed.IssueKey, strings.Join(failed.Errors, ", "))
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `jtk issues move <issue-key>... --to-project <project>` to move issues between projects
- Add `jtk issues move-status <task-id>` to check async task status
- Uses Jira Cloud bulk move API (not available on Server/Data Center)
- Supports `--to-type`, `--notify`, `--wait` flags
- Max 1000 issues per request

## Test plan
- [x] Unit tests for BuildMoveRequest with comma-separated key format
- [x] Unit tests for GetMoveTaskStatus (success, empty ID, with failures)
- [x] Unit tests for MoveIssues API call
- [x] Unit tests for GetProjectIssueTypes (success, empty project)
- [x] Unit tests for GetProjectStatuses (success, empty project)
- [x] All tests passing locally
- [x] Lint passing

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)