### PR TITLE
feat(cfl): improve init and config test UX

### DIFF
--- a/tools/cfl/api/client.go
+++ b/tools/cfl/api/client.go
@@ -2,7 +2,11 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/client"
 )
@@ -33,4 +37,26 @@ func (c *Client) GetBaseURL() string {
 // GetAuthHeader returns the authorization header value.
 func (c *Client) GetAuthHeader() string {
 	return c.AuthHeader
+}
+
+// GetCurrentUser returns the currently authenticated user.
+// Uses the legacy REST API endpoint /rest/api/user/current.
+func (c *Client) GetCurrentUser(ctx context.Context) (*User, error) {
+	// The base URL includes /wiki suffix for Confluence Cloud
+	// The legacy API endpoint is at /wiki/rest/api/user/current
+	// Strip /wiki suffix to avoid duplication, then add it back with the endpoint
+	baseURL := strings.TrimSuffix(c.BaseURL, "/wiki")
+	url := baseURL + "/wiki/rest/api/user/current"
+
+	body, err := c.Get(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current user: %w", err)
+	}
+
+	var user User
+	if err := json.Unmarshal(body, &user); err != nil {
+		return nil, fmt.Errorf("failed to decode user response: %w", err)
+	}
+
+	return &user, nil
 }

--- a/tools/cfl/api/types.go
+++ b/tools/cfl/api/types.go
@@ -173,3 +173,12 @@ func (e *ErrorResponse) Error() string {
 	}
 	return e.Message
 }
+
+// User represents a Confluence user.
+type User struct {
+	AccountID   string `json:"accountId"`
+	AccountType string `json:"accountType,omitempty"`
+	Email       string `json:"email,omitempty"`
+	PublicName  string `json:"publicName,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+}

--- a/tools/cfl/internal/cmd/configcmd/test.go
+++ b/tools/cfl/internal/cmd/configcmd/test.go
@@ -54,7 +54,35 @@ func runTest(opts *root.Options) error {
 
 	fmt.Println("success!")
 	fmt.Println()
-	fmt.Println("Your cfl configuration is working correctly.")
+
+	// Get current user details
+	user, err := client.GetCurrentUser(context.Background())
+	if err != nil {
+		// User details failed but connection worked - show basic success
+		fmt.Println("Your cfl configuration is working correctly.")
+		return nil
+	}
+
+	fmt.Println("Authentication successful")
+	fmt.Println("API access verified")
+	fmt.Println()
+
+	// Display user info - try DisplayName first, fall back to PublicName
+	displayName := user.DisplayName
+	if displayName == "" {
+		displayName = user.PublicName
+	}
+
+	if displayName != "" {
+		if user.Email != "" {
+			fmt.Printf("Authenticated as: %s (%s)\n", displayName, user.Email)
+		} else {
+			fmt.Printf("Authenticated as: %s\n", displayName)
+		}
+	}
+	if user.AccountID != "" {
+		fmt.Printf("Account ID: %s\n", user.AccountID)
+	}
 
 	return nil
 }

--- a/tools/cfl/internal/cmd/configcmd/test_test.go
+++ b/tools/cfl/internal/cmd/configcmd/test_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,12 @@ func newTestRootOptions() *root.Options {
 
 func TestRunTest_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Contains(t, r.URL.Path, "/spaces")
+		if strings.Contains(r.URL.Path, "/user/current") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"accountId": "123", "displayName": "Test User", "email": "test@example.com"}`))
+			return
+		}
+		// Spaces endpoint
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"results": []}`))
 	}))
@@ -36,6 +42,8 @@ func TestRunTest_Success(t *testing.T) {
 
 	err := runTest(rootOpts)
 	require.NoError(t, err)
+	// Note: Output goes to real stdout via fmt.Print, not opts.Stdout
+	// Just verifying no error is sufficient for this test
 }
 
 func TestRunTest_AuthFailure(t *testing.T) {

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -59,6 +59,12 @@ To generate an API token:
 func runInit(prefillURL, prefillEmail string, noVerify bool) error {
 	configPath := config.DefaultConfigPath()
 
+	// Load existing config for pre-population
+	existingCfg, _ := config.Load(configPath)
+	if existingCfg == nil {
+		existingCfg = &config.Config{}
+	}
+
 	// Check if config already exists
 	if _, err := os.Stat(configPath); err == nil {
 		var overwrite bool
@@ -78,12 +84,26 @@ func runInit(prefillURL, prefillEmail string, noVerify bool) error {
 
 	cfg := &config.Config{}
 
-	// Use prefilled values or prompt
+	// Pre-fill from existing config, then override with CLI flags
+	// Priority: CLI flag > existing config value
 	if prefillURL != "" {
 		cfg.URL = prefillURL
+	} else if existingCfg.URL != "" {
+		cfg.URL = existingCfg.URL
 	}
+
 	if prefillEmail != "" {
 		cfg.Email = prefillEmail
+	} else if existingCfg.Email != "" {
+		cfg.Email = existingCfg.Email
+	}
+
+	if existingCfg.APIToken != "" {
+		cfg.APIToken = existingCfg.APIToken
+	}
+
+	if existingCfg.DefaultSpace != "" {
+		cfg.DefaultSpace = existingCfg.DefaultSpace
 	}
 
 	// Build the form


### PR DESCRIPTION
## Summary

Improves cfl's init command to reuse existing values and enhances config test output to match jtk's more informative style.

### Changes

- **init command**: Pre-populate form with existing config values when re-running init, so users can selectively update fields
- **config test**: Show authenticated user details on success (display name, email, account ID) instead of just "success!"
- **API client**: Add `GetCurrentUser()` method using legacy `/rest/api/user/current` endpoint
- **Types**: Add `User` type with AccountID, DisplayName, Email fields

## Test plan

- [x] `make build-cfl` succeeds
- [x] `make test` in tools/cfl passes
- [x] `make lint` in tools/cfl passes
- [ ] Manual test: `cfl init` pre-populates existing values
- [ ] Manual test: `cfl config test` shows user details

Closes #54