### PR TITLE
fix: support scoped conventional commits in auto-release workflows

### DIFF
--- a/.github/workflows/auto-release-cfl.yml
+++ b/.github/workflows/auto-release-cfl.yml
@@ -11,8 +11,8 @@ on:
 jobs:
   create-tag:
     runs-on: ubuntu-latest
-    # Only create release for feat: or fix: commits
-    if: startsWith(github.event.head_commit.message, 'feat:') || startsWith(github.event.head_commit.message, 'fix:')
+    # Only create release for feat or fix commits (supports scoped conventional commits like feat(cfl):)
+    if: startsWith(github.event.head_commit.message, 'feat') || startsWith(github.event.head_commit.message, 'fix')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/auto-release-jtk.yml
+++ b/.github/workflows/auto-release-jtk.yml
@@ -11,8 +11,8 @@ on:
 jobs:
   create-tag:
     runs-on: ubuntu-latest
-    # Only create release for feat: or fix: commits
-    if: startsWith(github.event.head_commit.message, 'feat:') || startsWith(github.event.head_commit.message, 'fix:')
+    # Only create release for feat or fix commits (supports scoped conventional commits like feat(jtk):)
+    if: startsWith(github.event.head_commit.message, 'feat') || startsWith(github.event.head_commit.message, 'fix')
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Fix auto-release workflows to match scoped conventional commits (`feat(cfl):`, `feat(jtk):`)
- Previously only matched non-scoped format (`feat:`, `fix:`)
- 9 feature commits were stuck without releases due to this bug

## Changes

Updated the `if` condition in both workflow files from:
```yaml
startsWith(github.event.head_commit.message, 'feat:')
```
to:
```yaml
startsWith(github.event.head_commit.message, 'feat')
```

## Test plan

- [ ] After merge, verify auto-release workflows run (not skip) on GitHub Actions
- [ ] Confirm tags are created: `git fetch --tags && git tag | grep -E '^(cfl|jtk)-v'`
- [ ] Check GitHub releases page for new releases
- [ ] Run `brew update && brew upgrade cfl jtk` to confirm Homebrew works

Closes #59