### PR TITLE
fix: specify GORELEASER_CURRENT_TAG for monorepo releases

### DIFF
--- a/.github/workflows/release-cfl.yml
+++ b/.github/workflows/release-cfl.yml
@@ -37,6 +37,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
   chocolatey:
     needs: goreleaser

--- a/.github/workflows/release-jtk.yml
+++ b/.github/workflows/release-jtk.yml
@@ -37,6 +37,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
   chocolatey:
     needs: goreleaser


### PR DESCRIPTION
## Summary

Fix GoReleaser release workflows for monorepo by specifying which tag to use.

## Problem

When multiple tags exist on the same commit (e.g., `cfl-v0.9.100` and `jtk-v0.1.100`), GoReleaser picks one based on its own heuristics, which can result in the wrong tag being used for a release.

## Solution

Set `GORELEASER_CURRENT_TAG` environment variable to `${{ github.ref_name }}`, which is the tag that triggered the workflow.

## Test plan

- [ ] Re-push release tags after merge
- [ ] Verify both cfl and jtk releases complete successfully