### PR TITLE
fix: add monorepo tag prefix config to GoReleaser

### DIFF
--- a/.goreleaser-cfl.yml
+++ b/.goreleaser-cfl.yml
@@ -2,6 +2,9 @@ version: 2
 
 project_name: cfl
 
+monorepo:
+  tag_prefix: cfl-v
+
 before:
   hooks:
     - go mod tidy

--- a/.goreleaser-jtk.yml
+++ b/.goreleaser-jtk.yml
@@ -2,6 +2,9 @@ version: 2
 
 project_name: jtk
 
+monorepo:
+  tag_prefix: jtk-v
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
GoReleaser needs the monorepo tag_prefix configuration to correctly parse versions from tags like cfl-v0.9.100 and jtk-v0.1.100.