### PR TITLE
fix: use semver-compatible tag for GoReleaser in monorepo

### DIFF
--- a/.github/workflows/release-cfl.yml
+++ b/.github/workflows/release-cfl.yml
@@ -37,7 +37,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+          # Use semver-compatible tag for GoReleaser (strips cfl- prefix)
+          GORELEASER_CURRENT_TAG: v${{ steps.get_version.outputs.version }}
 
   chocolatey:
     needs: goreleaser

--- a/.github/workflows/release-jtk.yml
+++ b/.github/workflows/release-jtk.yml
@@ -37,7 +37,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+          # Use semver-compatible tag for GoReleaser (strips jtk- prefix)
+          GORELEASER_CURRENT_TAG: v${{ steps.get_version.outputs.version }}
 
   chocolatey:
     needs: goreleaser

--- a/.goreleaser-cfl.yml
+++ b/.goreleaser-cfl.yml
@@ -2,9 +2,6 @@ version: 2
 
 project_name: cfl
 
-monorepo:
-  tag_prefix: cfl-v
-
 before:
   hooks:
     - go mod tidy

--- a/.goreleaser-jtk.yml
+++ b/.goreleaser-jtk.yml
@@ -2,9 +2,6 @@ version: 2
 
 project_name: jtk
 
-monorepo:
-  tag_prefix: jtk-v
-
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
GoReleaser can't parse prefixed tags like cfl-v0.9.100 as semver. This works around the limitation by setting GORELEASER_CURRENT_TAG to v{version} instead of the full prefixed tag.