### PR TITLE
fix: create temporary semver tag for GoReleaser in monorepo

### DIFF
--- a/.github/workflows/release-cfl.yml
+++ b/.github/workflows/release-cfl.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Create temporary semver tag for GoReleaser
+        run: |
+          git tag v${{ steps.get_version.outputs.version }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -37,7 +41,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
-          # Use semver-compatible tag for GoReleaser (strips cfl- prefix)
           GORELEASER_CURRENT_TAG: v${{ steps.get_version.outputs.version }}
 
   chocolatey:

--- a/.github/workflows/release-jtk.yml
+++ b/.github/workflows/release-jtk.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Create temporary semver tag for GoReleaser
+        run: |
+          git tag v${{ steps.get_version.outputs.version }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -37,7 +41,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
-          # Use semver-compatible tag for GoReleaser (strips jtk- prefix)
           GORELEASER_CURRENT_TAG: v${{ steps.get_version.outputs.version }}
 
   chocolatey:


### PR DESCRIPTION
GoReleaser validates that the tag exists in git. Since we use prefixed tags (cfl-v*, jtk-v*) but GoReleaser expects plain semver (v*), we create a temporary local tag before running GoReleaser.