### PR TITLE
fix: run go mod tidy in correct directory for each tool

### DIFF
--- a/.goreleaser-cfl.yml
+++ b/.goreleaser-cfl.yml
@@ -4,7 +4,7 @@ project_name: cfl
 
 before:
   hooks:
-    - go mod tidy
+    - go mod tidy -C tools/cfl
     - go test ./tools/cfl/...
 
 builds:

--- a/.goreleaser-jtk.yml
+++ b/.goreleaser-jtk.yml
@@ -4,7 +4,7 @@ project_name: jtk
 
 before:
   hooks:
-    - go mod tidy
+    - go mod tidy -C tools/jtk
     - go test ./tools/jtk/...
 
 builds:


### PR DESCRIPTION
The go mod tidy hook needs to specify the tool directory since go.mod files are in tools/cfl/ and tools/jtk/, not the repo root.