### PR TITLE
fix: update ldflags to use shared atlassian-go/version package

### DIFF
--- a/.goreleaser-cfl.yml
+++ b/.goreleaser-cfl.yml
@@ -23,9 +23,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/open-cli-collective/confluence-cli/internal/version.Version={{.Version}}
-      - -X github.com/open-cli-collective/confluence-cli/internal/version.Commit={{.Commit}}
-      - -X github.com/open-cli-collective/confluence-cli/internal/version.Date={{.Date}}
+      - -X github.com/open-cli-collective/atlassian-go/version.Version={{.Version}}
+      - -X github.com/open-cli-collective/atlassian-go/version.Commit={{.Commit}}
+      - -X github.com/open-cli-collective/atlassian-go/version.BuildDate={{.Date}}
 
 archives:
   - id: default

--- a/.goreleaser-jtk.yml
+++ b/.goreleaser-jtk.yml
@@ -23,9 +23,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/open-cli-collective/jira-ticket-cli/internal/version.Version={{.Version}}
-      - -X github.com/open-cli-collective/jira-ticket-cli/internal/version.Commit={{.Commit}}
-      - -X github.com/open-cli-collective/jira-ticket-cli/internal/version.BuildDate={{.Date}}
+      - -X github.com/open-cli-collective/atlassian-go/version.Version={{.Version}}
+      - -X github.com/open-cli-collective/atlassian-go/version.Commit={{.Commit}}
+      - -X github.com/open-cli-collective/atlassian-go/version.BuildDate={{.Date}}
 
 archives:
   - id: default


### PR DESCRIPTION
The version package moved to the shared atlassian-go module. Update ldflags to inject version into the correct package path.