### PR TITLE
fix: skip changelog generation in GoReleaser

### DIFF
--- a/.github/workflows/release-cfl.yml
+++ b/.github/workflows/release-cfl.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean --config .goreleaser-cfl.yml
+          args: release --clean --skip=changelog --config .goreleaser-cfl.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.github/workflows/release-jtk.yml
+++ b/.github/workflows/release-jtk.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean --config .goreleaser-jtk.yml
+          args: release --clean --skip=changelog --config .goreleaser-jtk.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
Changelog generation fails in monorepo because it compares semver tags (v0.9.100) but actual git tags have prefixes (cfl-v0.9.100). Skip changelog until we find a better solution.