### PR TITLE
fix: use git for changelog instead of github API

### DIFF
--- a/.github/workflows/release-cfl.yml
+++ b/.github/workflows/release-cfl.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean --skip=changelog --config .goreleaser-cfl.yml
+          args: release --clean --config .goreleaser-cfl.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.github/workflows/release-jtk.yml
+++ b/.github/workflows/release-jtk.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean --skip=changelog --config .goreleaser-jtk.yml
+          args: release --clean --config .goreleaser-jtk.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser-cfl.yml
+++ b/.goreleaser-cfl.yml
@@ -79,7 +79,7 @@ checksum:
 
 changelog:
   sort: asc
-  use: github
+  use: git
   filters:
     exclude:
       - '^docs:'

--- a/.goreleaser-jtk.yml
+++ b/.goreleaser-jtk.yml
@@ -84,7 +84,7 @@ checksum:
 
 changelog:
   sort: asc
-  use: github
+  use: git
   filters:
     exclude:
       - '^docs:'


### PR DESCRIPTION
GitHub API changelog fails because tag comparison uses semver tags but git has prefixed tags. Using git log instead.