### PR TITLE
fix: fix release builds for monorepo

### DIFF
--- a/.github/workflows/release-cfl.yml
+++ b/.github/workflows/release-cfl.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
+          cache-dependency-path: tools/cfl/go.sum
 
       - name: Create temporary semver tag for GoReleaser
         run: |
@@ -42,6 +43,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: v${{ steps.get_version.outputs.version }}
+
+      - name: Fix release tag
+        run: |
+          VERSION=${{ steps.get_version.outputs.version }}
+          gh release edit "v${VERSION}" --tag "cfl-v${VERSION}"
+          git push origin :refs/tags/v${VERSION}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   chocolatey:
     needs: goreleaser

--- a/.github/workflows/release-jtk.yml
+++ b/.github/workflows/release-jtk.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.24'
+          cache-dependency-path: tools/jtk/go.sum
 
       - name: Create temporary semver tag for GoReleaser
         run: |
@@ -42,6 +43,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: v${{ steps.get_version.outputs.version }}
+
+      - name: Fix release tag
+        run: |
+          VERSION=${{ steps.get_version.outputs.version }}
+          gh release edit "v${VERSION}" --tag "jtk-v${VERSION}"
+          git push origin :refs/tags/v${VERSION}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   chocolatey:
     needs: goreleaser

--- a/.goreleaser-jtk.yml
+++ b/.goreleaser-jtk.yml
@@ -57,12 +57,11 @@ nfpms:
       - src: tools/jtk/LICENSE
         dst: /usr/share/licenses/jtk/LICENSE
 
-# Homebrew cask — primary name 'jtk', alias 'jira-ticket-cli'
-# Both cask files are auto-generated and stay in sync on every release.
+# Homebrew cask with auto-quarantine removal for unsigned binaries
+# Note: 'jira-ticket-cli' alias cask must be maintained manually in homebrew-tap
+# (alternative_names requires GoReleaser Pro)
 homebrew_casks:
   - name: jtk
-    alternative_names:
-      - jira-ticket-cli
     repository:
       owner: open-cli-collective
       name: homebrew-tap
@@ -81,10 +80,6 @@ homebrew_casks:
         jtk config set --domain DOMAIN --email EMAIL --token TOKEN
 
       Get your API token from: https://id.atlassian.com/manage-profile/security/api-tokens
-
-      Note: 'jira-ticket-cli' is an alias for this cask. Both install paths are supported:
-        brew install open-cli-collective/tap/jtk
-        brew install open-cli-collective/tap/jira-ticket-cli
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
## Summary

- Remove GoReleaser Pro-only `alternative_names` field from `.goreleaser-jtk.yml` — caused immediate YAML parse failure on every jtk release since `cbe3071`
- Add post-GoReleaser "Fix release tag" step to both release workflows — retags releases from temp `v{version}` to `{tool}-v{version}` so chocolatey/winget can find them
- Fix Go dependency cache path in both workflows (`go.sum` is at `tools/{tool}/go.sum`, not repo root)

All release builds (20+ runs) have been broken since the monorepo consolidation on Feb 2. These three fixes address the three distinct failure modes.

## Test plan

- [ ] Merge this PR (commit message starts with `fix:`, touches workflow files)
- [ ] Verify auto-release creates a tag for jtk
- [ ] Verify GoReleaser step passes (no more `alternative_names` parse error)
- [ ] Verify "Fix release tag" step retags the release to `jtk-v{version}`
- [ ] Verify chocolatey/winget jobs can find the release (no more "release not found")
- [ ] After confirming, do stale tag/release cleanup (#84)

Fixes #82
Fixes #83