### PR TITLE
fix: validate file input before network calls in jtk and cfl

### DIFF
--- a/tools/cfl/internal/cmd/page/create.go
+++ b/tools/cfl/internal/cmd/page/create.go
@@ -92,6 +92,14 @@ Content format:
 }
 
 func runCreate(opts *createOptions) error {
+	// Validate file exists before making any network calls so we fail
+	// fast on bad input without needing config or API access.
+	if opts.file != "" {
+		if _, err := os.Stat(opts.file); err != nil {
+			return fmt.Errorf("failed to read file: %w", err)
+		}
+	}
+
 	cfg, err := opts.Config()
 	if err != nil {
 		return err

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -92,6 +92,14 @@ Content format:
 }
 
 func runEdit(opts *editOptions) error {
+	// Validate file exists before making any network calls so we fail
+	// fast on bad input without needing config or API access.
+	if opts.file != "" {
+		if _, err := os.Stat(opts.file); err != nil {
+			return fmt.Errorf("failed to read file: %w", err)
+		}
+	}
+
 	cfg, err := opts.Config()
 	if err != nil {
 		return err

--- a/tools/jtk/internal/cmd/automation/update.go
+++ b/tools/jtk/internal/cmd/automation/update.go
@@ -49,20 +49,20 @@ field mappings and workflow configuration.`,
 func runUpdate(opts *root.Options, ruleID, filePath string) error {
 	v := opts.View()
 
-	client, err := opts.APIClient()
-	if err != nil {
-		return err
-	}
-
-	// Read the JSON file
+	// Read and validate file before creating the API client so we fail
+	// fast on bad input without needing network access.
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to read file %s: %w", filePath, err)
 	}
 
-	// Validate it's valid JSON
 	if !json.Valid(data) {
 		return fmt.Errorf("file %s does not contain valid JSON", filePath)
+	}
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
 	}
 
 	// Fetch current rule to show what we're updating

--- a/tools/jtk/internal/cmd/automation/update_test.go
+++ b/tools/jtk/internal/cmd/automation/update_test.go
@@ -1,0 +1,46 @@
+package automation
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+func TestRunUpdate(t *testing.T) {
+	t.Run("invalid JSON file", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "bad.json")
+		err := os.WriteFile(filePath, []byte(`not valid json`), 0644)
+		require.NoError(t, err)
+
+		var stdout, stderr bytes.Buffer
+		opts := &root.Options{
+			Output: "table",
+			Stdout: &stdout,
+			Stderr: &stderr,
+		}
+
+		err = runUpdate(opts, "12345", filePath)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not contain valid JSON")
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		opts := &root.Options{
+			Output: "table",
+			Stdout: &stdout,
+			Stderr: &stderr,
+		}
+
+		err := runUpdate(opts, "12345", "/nonexistent/path/rule.json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read file")
+	})
+}


### PR DESCRIPTION
## Summary

- **jtk auto update**: Move file read and JSON validation before `opts.APIClient()` — same fix applied to `auto create` in 2cef041
- **cfl page create/edit**: Add early file existence check before config loading and API client creation when `--file` is provided
- Add `update_test.go` with invalid JSON and file-not-found test cases

Without these fixes, passing a bad file path gives confusing config/network errors instead of a clear "failed to read file" message.

## Test plan

- [x] `go test ./tools/jtk/...` passes
- [x] `go test ./tools/cfl/...` passes
- [ ] **Release pipeline test**: This is a `fix:` commit touching Go code in both `tools/jtk/` and `tools/cfl/` — merging will trigger auto-release for **both tools**, validating the release build fixes from #85

Fixes #82
Fixes #83