### PR TITLE
fix: use positional arg for wingetcreate submit

### DIFF
--- a/.github/workflows/release-jtk.yml
+++ b/.github/workflows/release-jtk.yml
@@ -147,4 +147,4 @@ jobs:
 
       - name: Submit manifests
         run: |
-          ./wingetcreate.exe submit --path manifests --token ${{ secrets.WINGET_GITHUB_TOKEN }}
+          ./wingetcreate.exe submit manifests --token ${{ secrets.WINGET_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `wingetcreate submit` takes the manifest path as a positional argument, not `--path`
- The `--path` flag doesn't exist and causes `Option 'path' is unknown` error
- One-line fix: `submit --path manifests` → `submit manifests`

## Test plan

- [ ] Merge, push `jtk-v0.1.19` tag, verify winget job passes

Relates to #88