### PR TITLE
fix: auto-release workflows trigger on shared/ changes

### DIFF
--- a/.github/workflows/auto-release-cfl.yml
+++ b/.github/workflows/auto-release-cfl.yml
@@ -7,6 +7,9 @@ on:
       - 'tools/cfl/**/*.go'
       - 'tools/cfl/go.mod'
       - 'tools/cfl/go.sum'
+      - 'shared/**/*.go'
+      - 'shared/**/go.mod'
+      - 'shared/**/go.sum'
 
 jobs:
   create-tag:

--- a/.github/workflows/auto-release-jtk.yml
+++ b/.github/workflows/auto-release-jtk.yml
@@ -7,6 +7,9 @@ on:
       - 'tools/jtk/**/*.go'
       - 'tools/jtk/go.mod'
       - 'tools/jtk/go.sum'
+      - 'shared/**/*.go'
+      - 'shared/**/go.mod'
+      - 'shared/**/go.sum'
 
 jobs:
   create-tag:


### PR DESCRIPTION
## Summary

- Add `shared/**/*.go`, `shared/**/go.mod`, `shared/**/go.sum` path filters to both `auto-release-cfl.yml` and `auto-release-jtk.yml`
- Aligns auto-release path triggers with `ci.yml`, which already correctly includes `shared/**`

## Test plan

- [ ] Verify CI passes (workflow-only change, no Go code affected)
- [ ] After merge, confirm next `shared/` change with a `feat:` or `fix:` prefix triggers auto-release for both tools

Closes #91