### PR TITLE
fix: set release title in release workflows

### DIFF
--- a/.github/workflows/release-cfl.yml
+++ b/.github/workflows/release-cfl.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Fix release tag
         run: |
           VERSION=${{ steps.get_version.outputs.version }}
-          gh release edit "v${VERSION}" --tag "cfl-v${VERSION}"
+          gh release edit "v${VERSION}" --tag "cfl-v${VERSION}" --title "cfl v${VERSION}"
           git push origin :refs/tags/v${VERSION}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-jtk.yml
+++ b/.github/workflows/release-jtk.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Fix release tag
         run: |
           VERSION=${{ steps.get_version.outputs.version }}
-          gh release edit "v${VERSION}" --tag "jtk-v${VERSION}"
+          gh release edit "v${VERSION}" --tag "jtk-v${VERSION}" --title "jtk v${VERSION}"
           git push origin :refs/tags/v${VERSION}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes #84

### Cleanup (already done)
- Deleted 7 misnamed `v*` releases
- Deleted 7 stale `v*` temp tags leaked by GoReleaser
- Deleted 8 orphaned `{tool}-v*` tags from failed releases
- Renamed 6 valid releases from `v*` to `{tool} v*` format

### Root cause fix (this PR)
The "Fix release tag" step in both release workflows used `gh release edit --tag` to reassign the release from the temp `v*` tag to the correct `{tool}-v*` tag. But `--tag` only changes the tag — it doesn't change the release **name**. Added `--title "{tool} v${VERSION}"` so future releases are correctly named.

## Test plan
- [ ] Next jtk or cfl release should show `{tool} v{VERSION}` as the release name
- [ ] `gh release list` should show consistent naming