### PR TITLE
fix: add missing package doc comments to entry points

### DIFF
--- a/tools/cfl/cmd/cfl/main.go
+++ b/tools/cfl/cmd/cfl/main.go
@@ -1,4 +1,4 @@
-// Package main is the entry point for the cfl CLI.
+// Package main is the entry point for the cfl (Confluence) CLI.
 package main
 
 import (

--- a/tools/jtk/cmd/jtk/main.go
+++ b/tools/jtk/cmd/jtk/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point for the jtk CLI.
 package main
 
 import (


### PR DESCRIPTION
## Summary

- Adds missing package doc comment to `tools/jtk/cmd/jtk/main.go`
- Normalizes existing doc comment in `tools/cfl/cmd/cfl/main.go`

Smoke-tests both release workflows to verify the naming fix from #97 works end-to-end.