### PR TITLE
fix(jtk): handle structured fields in --field flag

### DIFF
--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -114,6 +114,12 @@ func FormatFieldValue(field *Field, value string) interface{} {
 			return n
 		}
 		return value
+	case "priority", "resolution", "status", "issuetype", "securitylevel":
+		// System fields that accept {"name": "..."} or {"id": "..."} format
+		if _, err := strconv.Atoi(value); err == nil {
+			return map[string]string{"id": value}
+		}
+		return map[string]string{"name": value}
 	default:
 		return value
 	}

--- a/tools/jtk/api/fields_test.go
+++ b/tools/jtk/api/fields_test.go
@@ -277,6 +277,84 @@ func TestFormatFieldValue(t *testing.T) {
 			value: "not-a-number",
 			want:  "not-a-number",
 		},
+		{
+			name: "priority field by name - wraps in name map",
+			field: &Field{
+				ID:   "priority",
+				Name: "Priority",
+				Schema: FieldSchema{
+					Type:   "priority",
+					System: "priority",
+				},
+			},
+			value: "High",
+			want:  map[string]string{"name": "High"},
+		},
+		{
+			name: "priority field by ID - wraps in id map",
+			field: &Field{
+				ID:   "priority",
+				Name: "Priority",
+				Schema: FieldSchema{
+					Type:   "priority",
+					System: "priority",
+				},
+			},
+			value: "2",
+			want:  map[string]string{"id": "2"},
+		},
+		{
+			name: "resolution field - wraps in name map",
+			field: &Field{
+				ID:   "resolution",
+				Name: "Resolution",
+				Schema: FieldSchema{
+					Type:   "resolution",
+					System: "resolution",
+				},
+			},
+			value: "Done",
+			want:  map[string]string{"name": "Done"},
+		},
+		{
+			name: "issuetype field - wraps in name map",
+			field: &Field{
+				ID:   "issuetype",
+				Name: "Issue Type",
+				Schema: FieldSchema{
+					Type:   "issuetype",
+					System: "issuetype",
+				},
+			},
+			value: "Bug",
+			want:  map[string]string{"name": "Bug"},
+		},
+		{
+			name: "status field - wraps in name map",
+			field: &Field{
+				ID:   "status",
+				Name: "Status",
+				Schema: FieldSchema{
+					Type:   "status",
+					System: "status",
+				},
+			},
+			value: "In Progress",
+			want:  map[string]string{"name": "In Progress"},
+		},
+		{
+			name: "securitylevel field - wraps in name map",
+			field: &Field{
+				ID:   "security",
+				Name: "Security Level",
+				Schema: FieldSchema{
+					Type:   "securitylevel",
+					System: "security",
+				},
+			},
+			value: "Confidential",
+			want:  map[string]string{"name": "Confidential"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/tools/jtk/internal/cmd/issues/create.go
+++ b/tools/jtk/internal/cmd/issues/create.go
@@ -71,14 +71,21 @@ func runCreate(opts *root.Options, project, issueType, summary, description stri
 
 			key, value := parts[0], parts[1]
 
-			// Try to resolve field name to ID
-			fieldID, err := api.ResolveFieldID(allFields, key)
-			if err != nil {
-				// Use the key as-is if not found
+			// Try to resolve field name to ID and get field info
+			var fieldID string
+			var field *api.Field
+			if resolved := api.FindFieldByName(allFields, key); resolved != nil {
+				fieldID = resolved.ID
+				field = resolved
+			} else if resolved := api.FindFieldByID(allFields, key); resolved != nil {
+				fieldID = resolved.ID
+				field = resolved
+			} else {
 				fieldID = key
 			}
 
-			extraFields[fieldID] = value
+			// Format value based on field type
+			extraFields[fieldID] = api.FormatFieldValue(field, value)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fix `--field priority=High` sending plain strings instead of structured objects like `{"name": "High"}`
- Align `create.go` field parsing with `update.go` which already used `FormatFieldValue`
- Add handling for system field types: `priority`, `resolution`, `issuetype`, `status`, `securitylevel`
- Numeric values auto-detected and sent as `{"id": "2"}`, names as `{"name": "High"}`

## Test plan
- [x] New unit tests for all 5 system field types (name and ID variants)
- [x] Existing `FormatFieldValue` tests still pass
- [x] Build passes (`make build-jtk`)
- [x] All tests pass (`go test ./tools/jtk/...`)
- [x] Lint passes (`make lint`)

Closes #102