### PR TITLE
fix: parse automation API error format in shared error handler

### DIFF
--- a/shared/errors/errors.go
+++ b/shared/errors/errors.go
@@ -55,10 +55,24 @@ func (e *APIError) UnmarshalJSON(data []byte) error {
 			return nil
 		}
 
-		// Try as array (Confluence format)
+		// Try as array of strings (Confluence format)
 		var errList []string
 		if err := json.Unmarshal(aux.ErrorsRaw, &errList); err == nil {
 			e.ErrorList = errList
+			return nil
+		}
+
+		// Try as array of objects (Automation format: [{"title": "msg", "code": "..."}])
+		var errObjects []struct {
+			Title string `json:"title"`
+			Code  string `json:"code"`
+		}
+		if err := json.Unmarshal(aux.ErrorsRaw, &errObjects); err == nil {
+			for _, obj := range errObjects {
+				if obj.Title != "" {
+					e.ErrorList = append(e.ErrorList, obj.Title)
+				}
+			}
 			return nil
 		}
 	}

--- a/shared/errors/errors_test.go
+++ b/shared/errors/errors_test.go
@@ -40,6 +40,16 @@ func TestAPIError_UnmarshalJSON(t *testing.T) {
 			name: "Empty errors",
 			json: `{"statusCode": 401}`,
 		},
+		{
+			name:        "Automation format with array of error objects",
+			json:        `{"errors": [{"id": "abc", "status": 400, "code": "api.error.unknown", "title": "Can't create a rule with a UUID that already exists."}]}`,
+			wantErrList: []string{"Can't create a rule with a UUID that already exists."},
+		},
+		{
+			name:        "Automation format with multiple error objects",
+			json:        `{"errors": [{"title": "First error", "code": "err.1"}, {"title": "Second error", "code": "err.2"}]}`,
+			wantErrList: []string{"First error", "Second error"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -271,6 +281,30 @@ func TestParseAPIError_WithComplexJiraResponse(t *testing.T) {
 	errStr := err.Error()
 	if !strings.Contains(errStr, "Issue Does Not Exist") {
 		t.Errorf("Error should contain 'Issue Does Not Exist', got: %s", errStr)
+	}
+}
+
+func TestParseAPIError_WithAutomationResponse(t *testing.T) {
+	body := []byte(`{
+		"errors": [
+			{
+				"id": "4bb155c2-5897-4cc4-9180-241611a801cf",
+				"status": 400,
+				"code": "api.error.unknown",
+				"title": "Can't create a rule with a UUID that already exists."
+			}
+		]
+	}`)
+
+	err := ParseAPIError(http.StatusBadRequest, body)
+
+	if !errors.Is(err, ErrBadRequest) {
+		t.Errorf("Expected ErrBadRequest, got %v", err)
+	}
+
+	errStr := err.Error()
+	if !strings.Contains(errStr, "UUID that already exists") {
+		t.Errorf("Error should contain automation error title, got: %s", errStr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add third parsing case in `shared/errors/errors.go` UnmarshalJSON for Jira Automation API error format
- Automation API returns `{"errors": [{"title": "msg", "code": "..."}]}` which was silently dropped
- Now extracts `title` fields into `ErrorList`, surfacing actual error messages to users
- Affects all automation commands: `auto create`, `auto update`, `auto enable`, `auto disable`

## Test plan
- [x] New unmarshal tests for single and multiple automation error objects
- [x] End-to-end `ParseAPIError` test for automation response format
- [x] Existing Jira and Confluence format tests still pass
- [x] Build passes (`make build`)
- [x] All tests pass (shared, jtk, cfl)
- [x] Lint passes (`make lint`)

Closes #103