### PR TITLE
fix(jtk): strip server-assigned fields and parse ruleUuid in auto create

### DIFF
--- a/tools/jtk/internal/cmd/automation/create.go
+++ b/tools/jtk/internal/cmd/automation/create.go
@@ -56,6 +56,20 @@ func runCreate(opts *root.Options, filePath string) error {
 		return fmt.Errorf("file %s does not contain valid JSON", filePath)
 	}
 
+	// Strip server-assigned fields that would cause conflicts on create.
+	// The API rejects requests containing a UUID that already exists.
+	var ruleMap map[string]interface{}
+	if err := json.Unmarshal(data, &ruleMap); err != nil {
+		return fmt.Errorf("failed to parse rule JSON: %w", err)
+	}
+	for _, key := range []string{"uuid", "id", "ruleKey", "created", "updated"} {
+		delete(ruleMap, key)
+	}
+	data, err = json.Marshal(ruleMap)
+	if err != nil {
+		return fmt.Errorf("failed to re-encode rule JSON: %w", err)
+	}
+
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -71,9 +85,10 @@ func runCreate(opts *root.Options, filePath string) error {
 		// Legacy/documented response fields.
 		ID      json.Number `json:"id"`
 		RuleKey string      `json:"ruleKey"`
-		// Observed Cloud response field.
-		UUID string `json:"uuid"`
-		Name string `json:"name"`
+		// Observed Cloud response fields.
+		UUID     string `json:"uuid"`
+		RuleUUID string `json:"ruleUuid"`
+		Name     string `json:"name"`
 	}
 	if err := json.Unmarshal(respBody, &created); err != nil {
 		// Even if we can't parse the response, the rule was created.
@@ -82,6 +97,9 @@ func runCreate(opts *root.Options, filePath string) error {
 	}
 
 	identifier := created.UUID
+	if identifier == "" {
+		identifier = created.RuleUUID
+	}
 	if identifier == "" {
 		identifier = created.RuleKey
 	}

--- a/tools/jtk/internal/cmd/automation/create_test.go
+++ b/tools/jtk/internal/cmd/automation/create_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 func TestRunCreate(t *testing.T) {
-	t.Run("successful create", func(t *testing.T) {
-		var receivedBody json.RawMessage
+	t.Run("strips server-assigned fields", func(t *testing.T) {
+		var receivedBody map[string]interface{}
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/_edge/tenant_info" {
@@ -30,7 +30,7 @@ func TestRunCreate(t *testing.T) {
 			if r.Method == http.MethodPost {
 				_ = json.NewDecoder(r.Body).Decode(&receivedBody)
 				w.WriteHeader(http.StatusCreated)
-				_, _ = w.Write([]byte(`{"id":99,"ruleKey":"new-uuid","name":"Test Rule"}`))
+				_, _ = w.Write([]byte(`{"id":99,"ruleUuid":"new-uuid-456","name":"Test Rule"}`))
 				return
 			}
 
@@ -53,17 +53,115 @@ func TestRunCreate(t *testing.T) {
 		}
 		opts.SetAPIClient(client)
 
-		// Write test JSON to temp file
+		// Write test JSON with server-assigned fields that should be stripped
 		dir := t.TempDir()
 		filePath := filepath.Join(dir, "rule.json")
-		err = os.WriteFile(filePath, []byte(`{"name":"Test Rule","state":"DISABLED"}`), 0644)
+		inputJSON := `{
+			"uuid": "existing-uuid",
+			"id": 42,
+			"ruleKey": "old-rule-key",
+			"created": "2024-01-01T00:00:00Z",
+			"updated": "2024-06-01T00:00:00Z",
+			"name": "Test Rule",
+			"state": "DISABLED"
+		}`
+		err = os.WriteFile(filePath, []byte(inputJSON), 0644)
 		require.NoError(t, err)
 
 		err = runCreate(opts, filePath)
 		require.NoError(t, err)
+
+		// Verify server-assigned fields were stripped
+		assert.Nil(t, receivedBody["uuid"], "uuid should be stripped")
+		assert.Nil(t, receivedBody["id"], "id should be stripped")
+		assert.Nil(t, receivedBody["ruleKey"], "ruleKey should be stripped")
+		assert.Nil(t, receivedBody["created"], "created should be stripped")
+		assert.Nil(t, receivedBody["updated"], "updated should be stripped")
+
+		// Verify non-server fields are preserved
+		assert.Equal(t, "Test Rule", receivedBody["name"])
+		assert.Equal(t, "DISABLED", receivedBody["state"])
+
+		// Verify output shows the new UUID from response
 		assert.Contains(t, stdout.String(), "Test Rule")
-		assert.Contains(t, stdout.String(), "new-uuid")
-		assert.JSONEq(t, `{"name":"Test Rule","state":"DISABLED"}`, string(receivedBody))
+		assert.Contains(t, stdout.String(), "new-uuid-456")
+	})
+
+	t.Run("response with ruleUuid field", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/_edge/tenant_info" {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+				return
+			}
+
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"ruleUuid":"rule-uuid-789","name":"New Rule"}`))
+		}))
+		defer server.Close()
+
+		client, err := api.New(api.ClientConfig{
+			URL:      server.URL,
+			Email:    "test@example.com",
+			APIToken: "token",
+		})
+		require.NoError(t, err)
+
+		var stdout, stderr bytes.Buffer
+		opts := &root.Options{
+			Output: "table",
+			Stdout: &stdout,
+			Stderr: &stderr,
+		}
+		opts.SetAPIClient(client)
+
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "rule.json")
+		err = os.WriteFile(filePath, []byte(`{"name":"New Rule","state":"DISABLED"}`), 0644)
+		require.NoError(t, err)
+
+		err = runCreate(opts, filePath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout.String(), "rule-uuid-789")
+	})
+
+	t.Run("response prefers uuid over ruleUuid", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/_edge/tenant_info" {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+				return
+			}
+
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"uuid":"preferred-uuid","ruleUuid":"fallback-uuid","name":"Both UUIDs"}`))
+		}))
+		defer server.Close()
+
+		client, err := api.New(api.ClientConfig{
+			URL:      server.URL,
+			Email:    "test@example.com",
+			APIToken: "token",
+		})
+		require.NoError(t, err)
+
+		var stdout, stderr bytes.Buffer
+		opts := &root.Options{
+			Output: "table",
+			Stdout: &stdout,
+			Stderr: &stderr,
+		}
+		opts.SetAPIClient(client)
+
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "rule.json")
+		err = os.WriteFile(filePath, []byte(`{"name":"Both UUIDs","state":"DISABLED"}`), 0644)
+		require.NoError(t, err)
+
+		err = runCreate(opts, filePath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout.String(), "preferred-uuid")
+		assert.NotContains(t, stdout.String(), "fallback-uuid")
 	})
 
 	t.Run("invalid JSON file", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Strip `uuid`, `id`, `ruleKey`, `created`, `updated` from exported rule JSON before POSTing to the Automation API, preventing "UUID already exists" rejection
- Add `ruleUuid` to the create response parser so the success message shows the correct identifier

Closes #104

## Test plan

- [x] Test: server-assigned fields are stripped from the request body
- [x] Test: response with only `ruleUuid` field shows correct UUID
- [x] Test: response with both `uuid` and `ruleUuid` prefers `uuid`
- [x] Existing tests (invalid JSON, file not found) still pass