### PR TITLE
fix(jtk): use correct payload format for automation rule state endpoint

### DIFF
--- a/tools/jtk/api/automation.go
+++ b/tools/jtk/api/automation.go
@@ -162,7 +162,7 @@ func (c *Client) SetAutomationRuleState(ruleID string, enabled bool) error {
 	}
 
 	urlStr := fmt.Sprintf("%s/rule/%s/state", base, url.PathEscape(ruleID))
-	_, err = c.put(urlStr, AutomationStateUpdate{RuleState: state})
+	_, err = c.put(urlStr, AutomationStateUpdate{Value: state})
 	if err != nil {
 		return fmt.Errorf("failed to set automation rule %s state to %s: %w", ruleID, state, err)
 	}

--- a/tools/jtk/api/automation_test.go
+++ b/tools/jtk/api/automation_test.go
@@ -270,7 +270,7 @@ func TestUpdateAutomationRule(t *testing.T) {
 
 func TestSetAutomationRuleState(t *testing.T) {
 	t.Run("enable", func(t *testing.T) {
-		var receivedBody AutomationStateUpdate
+		var rawBody json.RawMessage
 
 		client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/_edge/tenant_info" {
@@ -279,7 +279,7 @@ func TestSetAutomationRuleState(t *testing.T) {
 				return
 			}
 
-			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			_ = json.NewDecoder(r.Body).Decode(&rawBody)
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{}`))
 		}))
@@ -287,11 +287,12 @@ func TestSetAutomationRuleState(t *testing.T) {
 
 		err := client.SetAutomationRuleState("42", true)
 		require.NoError(t, err)
-		assert.Equal(t, "ENABLED", receivedBody.RuleState)
+		// Verify the JSON field name is "value" per the Automation REST API spec
+		assert.JSONEq(t, `{"value":"ENABLED"}`, string(rawBody))
 	})
 
 	t.Run("disable", func(t *testing.T) {
-		var receivedBody AutomationStateUpdate
+		var rawBody json.RawMessage
 
 		client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/_edge/tenant_info" {
@@ -300,7 +301,7 @@ func TestSetAutomationRuleState(t *testing.T) {
 				return
 			}
 
-			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			_ = json.NewDecoder(r.Body).Decode(&rawBody)
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{}`))
 		}))
@@ -308,7 +309,7 @@ func TestSetAutomationRuleState(t *testing.T) {
 
 		err := client.SetAutomationRuleState("42", false)
 		require.NoError(t, err)
-		assert.Equal(t, "DISABLED", receivedBody.RuleState)
+		assert.JSONEq(t, `{"value":"DISABLED"}`, string(rawBody))
 	})
 }
 

--- a/tools/jtk/api/automation_types.go
+++ b/tools/jtk/api/automation_types.go
@@ -145,6 +145,7 @@ func (r AutomationRuleSummaryResponse) NextURL() string {
 }
 
 // AutomationStateUpdate represents a request to enable or disable a rule.
+// The Automation REST API expects {"value": "ENABLED"} or {"value": "DISABLED"}.
 type AutomationStateUpdate struct {
-	RuleState string `json:"ruleState"`
+	Value string `json:"value"`
 }


### PR DESCRIPTION
## Summary

- Change `AutomationStateUpdate` JSON field from `"ruleState"` to `"value"` to match the [Automation REST API spec](https://developer.atlassian.com/cloud/automation/rest/)
- The API expects `{"value": "ENABLED"}` but the code was sending `{"ruleState": "ENABLED"}`, causing a 400 Bad Request

Closes #105

## Test plan

- [x] Test: enable sends `{"value": "ENABLED"}` (asserts raw JSON body)
- [x] Test: disable sends `{"value": "DISABLED"}` (asserts raw JSON body)
- [x] All existing automation tests pass