### PR TITLE
docs: true-up READMEs after recent feature additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,40 +210,55 @@ cfl page list --space DEV
 Manage Jira issues, sprints, and boards from the command line.
 
 ```bash
-# List issues in a project
+# Issues
 jtk issues list --project PROJ
-
-# Create an issue
-jtk issues create --project PROJ --type Task --summary "Fix bug"
-
-# View issue details
 jtk issues get PROJ-123
-
-# Search with JQL
+jtk issues create --project PROJ --type Task --summary "Fix bug"
+jtk issues update PROJ-123 --field priority=High
 jtk issues search "project = PROJ AND status = 'In Progress'"
+jtk issues assign PROJ-123 <account-id>
+jtk issues move PROJ-123 --to-project OTHERPROJ
 
-# List transitions and move issue
+# Projects
+jtk projects list
+jtk projects get PROJ
+jtk projects create --key PROJ --name "My Project" --lead <account-id>
+jtk projects update PROJ --name "New Name"
+jtk projects delete PROJ
+
+# Transitions
 jtk transitions list PROJ-123
 jtk transitions do PROJ-123 "Done"
 
-# Manage comments
+# Comments
 jtk comments list PROJ-123
-jtk comments add PROJ-123 "This is fixed"
+jtk comments add PROJ-123 --body "This is fixed"
 
-# View current sprint
+# Sprints
+jtk sprints list --board 123
 jtk sprints current --board 123
+jtk sprints issues 456
+jtk sprints add 456 PROJ-123
 
-# Manage attachments
+# Boards
+jtk boards list
+jtk boards get 123
+
+# Attachments
 jtk attachments list PROJ-123
 jtk attachments add PROJ-123 --file screenshot.png
 jtk attachments get 12345 --output ./downloads/
 
-# Search users
+# Users
 jtk users search "john"
+jtk me
 
-# Manage automation rules
+# Automation rules
 jtk automation list
+jtk automation get 123
 jtk automation export 123 > rule-backup.json
+jtk automation create --file rule.json
+jtk automation enable 123
 ```
 
 **Full documentation:** [tools/jtk/README.md](tools/jtk/README.md)
@@ -349,7 +364,17 @@ go test ./tools/cfl/...
 atlassian-cli/
 ├── go.work              # Go workspace file
 ├── Makefile             # Build automation
-├── shared/              # Shared packages (auth, client, errors)
+├── shared/              # Shared packages
+│   ├── adf/             # Atlassian Document Format helpers
+│   ├── auth/            # Authentication (API token, env vars)
+│   ├── client/          # HTTP client with retry and error handling
+│   ├── config/          # Configuration loading
+│   ├── errors/          # Unified error parsing (Jira, Confluence, Automation)
+│   ├── exitcode/        # Exit code constants
+│   ├── prompt/          # Interactive prompts
+│   ├── url/             # URL utilities
+│   ├── version/         # Build-time version info
+│   └── view/            # Output formatting (table, JSON, plain)
 └── tools/
     ├── cfl/             # Confluence CLI
     │   ├── api/         # API client

--- a/tools/jtk/CLAUDE.md
+++ b/tools/jtk/CLAUDE.md
@@ -35,28 +35,36 @@ make clean
 
 ```
 jira-ticket-cli/
-├── cmd/jtk/main.go  # Entry point - registers commands, calls Execute()
+├── cmd/jtk/main.go              # Entry point - registers commands, calls Execute()
 ├── api/                          # Public Go library (importable)
 │   ├── client.go                # Client struct, New(), HTTP helpers
 │   ├── types.go                 # All data types (Issue, Sprint, Board, etc.)
 │   ├── errors.go                # Error types: APIError, ErrNotFound
 │   ├── issues.go                # Issue CRUD operations
+│   ├── projects.go              # Project CRUD operations
 │   ├── sprints.go               # Sprint operations
 │   ├── boards.go                # Board operations
 │   ├── comments.go              # Comment operations
 │   ├── transitions.go           # Issue transition operations
+│   ├── attachments.go           # Attachment operations
+│   ├── automation.go            # Automation rule operations
+│   ├── automation_types.go      # Automation API types
 │   ├── fields.go                # Field metadata
 │   ├── users.go                 # User operations
 │   └── search.go                # JQL search
 ├── internal/
 │   ├── cmd/                     # Cobra commands (one package per resource)
 │   │   ├── root/                # Root command, Options struct, global flags
-│   │   ├── issues/              # issues list, get, create, update, search, assign
+│   │   ├── issues/              # issues list, get, create, update, delete, search, assign, fields, field-options, types, move
+│   │   ├── projects/            # projects list, get, create, update, delete, restore, types
 │   │   ├── transitions/         # transitions list, do
-│   │   ├── comments/            # comments list, add
+│   │   ├── comments/            # comments list, add, delete
+│   │   ├── attachments/         # attachments list, add, get, delete
+│   │   ├── automation/          # automation list, get, export, create, update, enable, disable
 │   │   ├── boards/              # boards list, get
-│   │   ├── sprints/             # sprints list, current, issues
-│   │   ├── configcmd/           # config set
+│   │   ├── sprints/             # sprints list, current, issues, add
+│   │   ├── users/               # users search
+│   │   ├── configcmd/           # config show, test, clear
 │   │   ├── me/                  # me (current user info)
 │   │   └── completion/          # Shell completion
 │   ├── config/                  # JSON config loading

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -6,10 +6,11 @@ A command-line interface for managing Jira Cloud tickets.
 
 - Manage Jira issues from the command line
 - List, create, update, search, and delete issues
+- Manage projects (create, update, delete, restore)
 - Manage sprints and boards
 - Add comments and perform transitions
 - Manage attachments
-- Manage automation rules
+- Manage automation rules (list, export, create, enable/disable)
 - Search users
 - Multiple output formats (table, JSON, plain)
 - Shell completion for bash, zsh, fish, and PowerShell
@@ -687,6 +688,122 @@ jtk boards get 123
 
 **Arguments:**
 - `<board-id>` - The board ID (**required**)
+
+---
+
+### `jtk projects list`
+
+List Jira projects.
+
+**Aliases:** `jtk project list`, `jtk proj list`, `jtk p list`
+
+```bash
+jtk projects list
+jtk projects list --query "my project"
+jtk projects list --max 10
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--query` | `-q` | | Filter projects by name |
+| `--max` | `-m` | `50` | Maximum number of results |
+
+---
+
+### `jtk projects get <project-key>`
+
+Get details for a specific project.
+
+```bash
+jtk projects get MYPROJECT
+jtk projects get 10001
+```
+
+**Arguments:**
+- `<project-key>` - Project key or numeric ID (**required**)
+
+---
+
+### `jtk projects create`
+
+Create a new Jira project.
+
+```bash
+jtk projects create --key MYPROJ --name "My Project" --lead <account-id>
+jtk projects create --key BIZ --name "Business" --type business --lead <account-id> --description "Business project"
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--key` | `-k` | | Project key (**required**) |
+| `--name` | `-n` | | Project name (**required**) |
+| `--type` | `-t` | `software` | Project type: `software`, `service_desk`, `business` |
+| `--lead` | `-l` | | Lead account ID (**required**) |
+| `--description` | `-d` | | Project description |
+
+> Tip: Use `jtk users search` to find account IDs, or `jtk me` to get your own.
+
+---
+
+### `jtk projects update <project-key>`
+
+Update a project's metadata. Only specified fields are changed.
+
+```bash
+jtk projects update MYPROJ --name "New Name"
+jtk projects update MYPROJ --description "Updated description"
+jtk projects update MYPROJ --lead <account-id>
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--name` | `-n` | | New project name |
+| `--description` | `-d` | | New project description |
+| `--lead` | `-l` | | New lead account ID |
+
+**Arguments:**
+- `<project-key>` - Project key (**required**)
+
+---
+
+### `jtk projects delete <project-key>`
+
+Soft-delete a project (moves it to trash). Can be restored with `jtk projects restore`.
+
+```bash
+jtk projects delete MYPROJ
+jtk projects delete MYPROJ --force
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--force` | `false` | Skip confirmation prompt |
+
+**Arguments:**
+- `<project-key>` - Project key (**required**)
+
+---
+
+### `jtk projects restore <project-key>`
+
+Restore a project from the trash.
+
+```bash
+jtk projects restore MYPROJ
+```
+
+**Arguments:**
+- `<project-key>` - Project key (**required**)
+
+---
+
+### `jtk projects types`
+
+List available project types for creating new projects.
+
+```bash
+jtk projects types
+```
 
 ---
 


### PR DESCRIPTION
Closes #111

## Summary

- **Root README**: Expand jtk examples section with projects, boards, me, sprints, and full automation commands; update `shared/` project structure tree to list all packages
- **jtk README**: Add complete `jtk projects` command reference (list, get, create, update, delete, restore, types); update features list
- **jtk CLAUDE.md**: Update architecture tree with projects, automation, attachments, and users packages; update subcommand listings to match current codebase

## Test plan

- [ ] Verify all documented commands match actual CLI output (`jtk projects --help`, etc.)
- [ ] Verify project structure tree matches `ls shared/`
- [ ] Spot-check flag names and defaults against source code