### PR TITLE
fix(jtk): use input name in projects create success message

### DIFF
--- a/tools/jtk/internal/cmd/projects/create.go
+++ b/tools/jtk/internal/cmd/projects/create.go
@@ -72,7 +72,7 @@ func runCreate(opts *root.Options, key, name, projectType, lead, description str
 		return v.JSON(project)
 	}
 
-	v.Success("Created project %s (%s)", project.Key, project.Name)
+	v.Success("Created project %s (%s)", project.Key, name)
 
 	return nil
 }

--- a/tools/jtk/internal/cmd/projects/projects_test.go
+++ b/tools/jtk/internal/cmd/projects/projects_test.go
@@ -157,12 +157,14 @@ func TestNewCreateCmd(t *testing.T) {
 }
 
 func TestRunCreate(t *testing.T) {
+	// Jira's create endpoint returns an empty name, so the success message
+	// should use the input name, not the response name.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(api.ProjectDetail{
 			ID:   json.Number("10001"),
 			Key:  "TST",
-			Name: "Test Project",
+			Name: "",
 		})
 	}))
 	defer server.Close()
@@ -177,6 +179,7 @@ func TestRunCreate(t *testing.T) {
 	err = runCreate(opts, "TST", "Test Project", "software", "abc123", "")
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Created project TST")
+	assert.Contains(t, stdout.String(), "Test Project")
 }
 
 func TestNewDeleteCmd(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #119

Jira's project create endpoint (`POST /rest/api/3/project`) returns only `id` and `key` in the response — the `name` field is empty. This caused the success message to show `Created project ZT4 ()` instead of `Created project ZT4 (Integration Test Project)`.

**Fix:** Use the input `name` parameter instead of `project.Name` from the API response.

**Test:** Updated `TestRunCreate` to simulate the real Jira behavior (empty name in response) and verify the success message still contains the input name.