### PR TITLE
docs(jtk): true up README and CHANGELOG with command surface area

### DIFF
--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -9,26 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `projects create`, `update`, `delete`, `restore`, `types` commands for full project management ([#106](https://github.com/open-cli-collective/atlassian-cli/pull/106))
+- `automation create` command to create rules from JSON files ([#79](https://github.com/open-cli-collective/atlassian-cli/pull/79))
+- `automation enable`, `disable`, `update`, `export` commands for full automation rule management ([#76](https://github.com/open-cli-collective/atlassian-cli/pull/76))
+- `--full` flag on `issues get` and `comments list` to show full content without truncation ([#72](https://github.com/open-cli-collective/atlassian-cli/pull/72))
 - `init` command for guided setup wizard ([#48](https://github.com/open-cli-collective/atlassian-cli/pull/48))
 - `issues move` command to move issues between projects ([#51](https://github.com/open-cli-collective/atlassian-cli/pull/51))
-- `attachments` command for listing issue attachments ([#50](https://github.com/open-cli-collective/atlassian-cli/pull/50))
-- Wiki markup detection and automatic conversion ([#49](https://github.com/open-cli-collective/atlassian-cli/pull/49))
+- `attachments` commands: list, add, get, delete ([#50](https://github.com/open-cli-collective/atlassian-cli/pull/50))
+- Wiki markup detection and automatic conversion to ADF ([#49](https://github.com/open-cli-collective/atlassian-cli/pull/49))
+- `issues field-options` command to list allowed values for select fields ([#36](https://github.com/open-cli-collective/jira-ticket-cli/pull/36))
+- `issues types` command to list valid issue types per project ([#22](https://github.com/open-cli-collective/jira-ticket-cli/pull/22))
+- `users search` command for finding account IDs by name/email ([#34](https://github.com/open-cli-collective/jira-ticket-cli/pull/34))
+- Show required fields for transitions in `transitions list --fields` ([#35](https://github.com/open-cli-collective/jira-ticket-cli/pull/35))
+- Include custom fields in issue JSON output ([#37](https://github.com/open-cli-collective/jira-ticket-cli/pull/37))
 
 ### Changed
 
+- Consolidated markdown-to-ADF conversion into shared package ([#74](https://github.com/open-cli-collective/atlassian-cli/pull/74))
 - Improved init/config UX with huh forms and --force flag on clear ([#55](https://github.com/open-cli-collective/atlassian-cli/pull/55))
 - **Binary renamed to `jtk`** - The CLI binary is now `jtk` (short for jira-ticket-cli). Install via `brew install jira-ticket-cli`, run with `jtk`. ([#41](https://github.com/open-cli-collective/jira-ticket-cli/pull/41))
 - Module path migrated to `github.com/open-cli-collective/jira-ticket-cli` ([#39](https://github.com/open-cli-collective/jira-ticket-cli/pull/39))
 
-### Added
-
-- `jtk issues field-options` command to list allowed values for select fields ([#36](https://github.com/open-cli-collective/jira-ticket-cli/pull/36))
-- `jtk issues types` command to list valid issue types per project ([#22](https://github.com/open-cli-collective/jira-ticket-cli/pull/22))
-- `jtk users search` command for finding account IDs by name/email ([#34](https://github.com/open-cli-collective/jira-ticket-cli/pull/34))
-- Show required fields for transitions in `jtk transitions list` ([#35](https://github.com/open-cli-collective/jira-ticket-cli/pull/35))
-- Include custom fields in issue JSON output ([#37](https://github.com/open-cli-collective/jira-ticket-cli/pull/37))
-
 ### Fixed
 
+- `config show -o json` no longer appends trailing plain text after JSON body ([#124](https://github.com/open-cli-collective/atlassian-cli/pull/124))
+- `projects create` success message uses the input name instead of the empty API response name ([#121](https://github.com/open-cli-collective/atlassian-cli/pull/121))
+- `ProjectDetail.ID` uses `json.Number` to handle numeric API responses ([#116](https://github.com/open-cli-collective/atlassian-cli/pull/116))
+- Automation rule state endpoint uses correct payload format for Jira Cloud ([#110](https://github.com/open-cli-collective/atlassian-cli/pull/110))
+- `automation create` strips server-assigned fields and parses `ruleUuid` correctly ([#109](https://github.com/open-cli-collective/atlassian-cli/pull/109))
+- `--field` flag handles structured fields (e.g., `priority=High`) in create and update ([#107](https://github.com/open-cli-collective/atlassian-cli/pull/107))
+- Validate file input before making network calls ([#86](https://github.com/open-cli-collective/atlassian-cli/pull/86))
+- Automation API parsing aligned with Jira Cloud response format ([#87](https://github.com/open-cli-collective/atlassian-cli/pull/87))
 - Show user display name instead of account ID in assign command output ([#33](https://github.com/open-cli-collective/jira-ticket-cli/pull/33))
 - Convert number and textarea fields to correct API format when updating issues ([#32](https://github.com/open-cli-collective/jira-ticket-cli/pull/32))

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -225,8 +225,6 @@ jtk config clear --force
 
 List issues in a project.
 
-**Aliases:** `jtk issues ls`
-
 ```bash
 jtk issues list --project MYPROJECT
 jtk issues list --project MYPROJECT --sprint current
@@ -942,13 +940,19 @@ jtk automation disable 123
 
 ## Configuration
 
-Configuration is stored in `~/.config/jtk/config.json`:
+Configuration is stored in your system's config directory under `jira-ticket-cli/`:
+
+- **macOS:** `~/Library/Application Support/jira-ticket-cli/config.json`
+- **Linux:** `~/.config/jira-ticket-cli/config.json`
+
+Run `jtk config show` to see the path on your system.
 
 ```json
 {
   "url": "https://mycompany.atlassian.net",
   "email": "user@example.com",
-  "api_token": "your-api-token"
+  "api_token": "your-api-token",
+  "default_project": "MYPROJECT"
 }
 ```
 
@@ -961,6 +965,7 @@ Environment variables override config file values. Variables are checked in orde
 | URL | `JIRA_URL` → `ATLASSIAN_URL` → config file |
 | Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → config file |
 | API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → config file |
+| Default Project | `JIRA_DEFAULT_PROJECT` → config file |
 
 **Shared credentials:** If you use both `jtk` and `cfl` (Confluence CLI), set `ATLASSIAN_*` variables once:
 


### PR DESCRIPTION
## Summary

- Remove false `issues ls` alias from README (the `ls` alias belongs to `attachments list`, not `issues list`)
- Fix config path: was `~/.config/jtk/config.json`, actual is `~/Library/Application Support/jira-ticket-cli/config.json` (macOS) / `~/.config/jira-ticket-cli/config.json` (Linux)
- Add `JIRA_DEFAULT_PROJECT` env var to the env vars table
- Add `default_project` field to the config JSON example
- Bring CHANGELOG up to date with all changes from PRs #72 through #124

Closes #125

## Test plan

- [x] `make build-jtk` passes
- [x] `make test` passes
- [x] `make lint` passes
- [x] Verified `jtk issues ls` is not a real alias (falls through to parent help)
- [x] Verified config path via `jtk config show -o json | jq -r .path`
- [x] Verified `JIRA_DEFAULT_PROJECT` support via `config show` output