### PR TITLE
feat(jtk): add --parent flag to issues create and update

### DIFF
--- a/tools/jtk/internal/cmd/issues/create.go
+++ b/tools/jtk/internal/cmd/issues/create.go
@@ -15,6 +15,7 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
 	var issueType string
 	var summary string
 	var description string
+	var parent string
 	var fields []string
 
 	cmd := &cobra.Command{
@@ -27,10 +28,13 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
   # Create with description
   jtk issues create --project MYPROJECT --type Bug --summary "Login fails" --description "Users cannot log in with SSO"
 
+  # Create as child of an epic
+  jtk issues create --project MYPROJECT --type Task --summary "Subtask" --parent MYPROJECT-100
+
   # Create with custom fields
   jtk issues create --project MYPROJECT --type Story --summary "New feature" --field priority=High`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCreate(opts, project, issueType, summary, description, fields)
+			return runCreate(opts, project, issueType, summary, description, parent, fields)
 		},
 	}
 
@@ -38,6 +42,7 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
 	cmd.Flags().StringVarP(&issueType, "type", "t", "Task", "Issue type (Task, Bug, Story, etc.)")
 	cmd.Flags().StringVarP(&summary, "summary", "s", "", "Issue summary (required)")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Issue description")
+	cmd.Flags().StringVar(&parent, "parent", "", "Parent issue key (epic or parent issue)")
 	cmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "Additional fields (key=value)")
 
 	_ = cmd.MarkFlagRequired("project")
@@ -46,7 +51,7 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
 	return cmd
 }
 
-func runCreate(opts *root.Options, project, issueType, summary, description string, fieldArgs []string) error {
+func runCreate(opts *root.Options, project, issueType, summary, description, parent string, fieldArgs []string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -87,6 +92,10 @@ func runCreate(opts *root.Options, project, issueType, summary, description stri
 			// Format value based on field type
 			extraFields[fieldID] = api.FormatFieldValue(field, value)
 		}
+	}
+
+	if parent != "" {
+		extraFields["parent"] = map[string]string{"key": parent}
 	}
 
 	req := api.BuildCreateRequest(project, issueType, summary, description, extraFields)

--- a/tools/jtk/internal/cmd/issues/create_test.go
+++ b/tools/jtk/internal/cmd/issues/create_test.go
@@ -47,7 +47,7 @@ func TestRunCreate_RequestBodyNoDoubleQuoting(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runCreate(opts, "MYPROJECT", "Task", "Fix login bug", "Users cannot log in with SSO credentials", nil)
+	err = runCreate(opts, "MYPROJECT", "Task", "Fix login bug", "Users cannot log in with SSO credentials", "", nil)
 	require.NoError(t, err)
 
 	// Parse the captured request body
@@ -109,7 +109,7 @@ func TestRunCreate_SummaryWithSpecialCharacters(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runCreate(opts, "PROJ", "Bug", `Error: "unexpected token" in parser`, "", nil)
+	err = runCreate(opts, "PROJ", "Bug", `Error: "unexpected token" in parser`, "", "", nil)
 	require.NoError(t, err)
 
 	var reqBody map[string]interface{}
@@ -141,6 +141,10 @@ func TestNewCreateCmd(t *testing.T) {
 	descFlag := cmd.Flags().Lookup("description")
 	require.NotNil(t, descFlag)
 	assert.Equal(t, "d", descFlag.Shorthand)
+
+	parentFlag := cmd.Flags().Lookup("parent")
+	require.NotNil(t, parentFlag)
+	assert.Equal(t, "", parentFlag.Shorthand, "parent flag should have no shorthand")
 }
 
 func TestCreateCmd_CobraExecution_NoDoubleQuoting(t *testing.T) {
@@ -194,4 +198,139 @@ func TestCreateCmd_CobraExecution_NoDoubleQuoting(t *testing.T) {
 	summary := fields["summary"].(string)
 	assert.Equal(t, "Fix login bug", summary)
 	assert.False(t, summary[0] == '"', "summary must not start with a literal quote")
+}
+
+func TestRunCreate_WithParent(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue" && r.Method == "POST" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-456", ID: "10456"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "PROJ", "Task", "Child task", "", "PROJ-100", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+
+	// Parent should be an object with "key" field
+	parentField := fields["parent"].(map[string]interface{})
+	assert.Equal(t, "PROJ-100", parentField["key"], "parent key should match")
+}
+
+func TestRunCreate_WithoutParent(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue" && r.Method == "POST" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-789", ID: "10789"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "PROJ", "Task", "Standalone task", "", "", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	assert.Nil(t, fields["parent"], "parent should not be present when empty")
+}
+
+func TestCreateCmd_CobraExecution_WithParent(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue" && r.Method == "POST" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-456", ID: "10456"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	cmd := newCreateCmd(opts)
+	cmd.SetArgs([]string{
+		"--project", "PROJ",
+		"--type", "Task",
+		"--summary", "Child task",
+		"--parent", "PROJ-100",
+	})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	parentField := fields["parent"].(map[string]interface{})
+	assert.Equal(t, "PROJ-100", parentField["key"])
 }

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -13,6 +13,7 @@ import (
 func newUpdateCmd(opts *root.Options) *cobra.Command {
 	var summary string
 	var description string
+	var parent string
 	var fields []string
 
 	cmd := &cobra.Command{
@@ -25,26 +26,30 @@ func newUpdateCmd(opts *root.Options) *cobra.Command {
   # Update description
   jtk issues update PROJ-123 --description "Updated description"
 
+  # Move issue under a different parent/epic
+  jtk issues update PROJ-123 --parent PROJ-100
+
   # Update custom fields
   jtk issues update PROJ-123 --field priority=High --field "Story Points"=5`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUpdate(opts, args[0], summary, description, fields)
+			return runUpdate(opts, args[0], summary, description, parent, fields)
 		},
 	}
 
 	cmd.Flags().StringVarP(&summary, "summary", "s", "", "New summary")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "New description")
+	cmd.Flags().StringVar(&parent, "parent", "", "Parent issue key (epic or parent issue)")
 	cmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "Fields to update (key=value)")
 
 	return cmd
 }
 
-func runUpdate(opts *root.Options, issueKey, summary, description string, fieldArgs []string) error {
+func runUpdate(opts *root.Options, issueKey, summary, description, parent string, fieldArgs []string) error {
 	v := opts.View()
 
 	// Validate that at least one field is being updated before making API calls
-	if summary == "" && description == "" && len(fieldArgs) == 0 {
+	if summary == "" && description == "" && parent == "" && len(fieldArgs) == 0 {
 		return fmt.Errorf("no fields specified to update")
 	}
 
@@ -61,6 +66,10 @@ func runUpdate(opts *root.Options, issueKey, summary, description string, fieldA
 
 	if description != "" {
 		fields["description"] = api.NewADFDocument(description)
+	}
+
+	if parent != "" {
+		fields["parent"] = map[string]string{"key": parent}
 	}
 
 	// Parse additional fields

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -43,7 +43,7 @@ func TestRunUpdate_RequestBodyNoDoubleQuoting(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(opts, "PROJ-123", "Updated summary", "Updated description", nil)
+	err = runUpdate(opts, "PROJ-123", "Updated summary", "Updated description", "", nil)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, capturedBody)
@@ -87,6 +87,10 @@ func TestNewUpdateCmd(t *testing.T) {
 	descFlag := cmd.Flags().Lookup("description")
 	require.NotNil(t, descFlag)
 	assert.Equal(t, "d", descFlag.Shorthand)
+
+	parentFlag := cmd.Flags().Lookup("parent")
+	require.NotNil(t, parentFlag)
+	assert.Equal(t, "", parentFlag.Shorthand, "parent flag should have no shorthand")
 }
 
 func TestRunUpdate_SummaryOnly(t *testing.T) {
@@ -117,7 +121,7 @@ func TestRunUpdate_SummaryOnly(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(opts, "PROJ-123", "New summary", "", nil)
+	err = runUpdate(opts, "PROJ-123", "New summary", "", "", nil)
 	require.NoError(t, err)
 
 	var reqBody map[string]interface{}
@@ -127,6 +131,7 @@ func TestRunUpdate_SummaryOnly(t *testing.T) {
 	fields := reqBody["fields"].(map[string]interface{})
 	assert.Equal(t, "New summary", fields["summary"])
 	assert.Nil(t, fields["description"], "description should not be present when empty")
+	assert.Nil(t, fields["parent"], "parent should not be present when empty")
 }
 
 func TestRunUpdate_NoFieldsError(t *testing.T) {
@@ -136,7 +141,139 @@ func TestRunUpdate_NoFieldsError(t *testing.T) {
 		Stderr: &bytes.Buffer{},
 	}
 
-	err := runUpdate(opts, "PROJ-123", "", "", nil)
+	err := runUpdate(opts, "PROJ-123", "", "", "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no fields specified")
+}
+
+func TestRunUpdate_ParentOnly(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runUpdate(opts, "PROJ-456", "", "", "PROJ-100", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	parentField := fields["parent"].(map[string]interface{})
+	assert.Equal(t, "PROJ-100", parentField["key"], "parent key should match")
+	assert.Nil(t, fields["summary"], "summary should not be present when empty")
+	assert.Nil(t, fields["description"], "description should not be present when empty")
+}
+
+func TestRunUpdate_ParentWithSummary(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runUpdate(opts, "PROJ-456", "Updated title", "", "PROJ-200", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	assert.Equal(t, "Updated title", fields["summary"])
+	parentField := fields["parent"].(map[string]interface{})
+	assert.Equal(t, "PROJ-200", parentField["key"])
+}
+
+func TestUpdateCmd_CobraExecution_WithParent(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	cmd := newUpdateCmd(opts)
+	cmd.SetArgs([]string{
+		"PROJ-456",
+		"--parent", "PROJ-100",
+	})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	parentField := fields["parent"].(map[string]interface{})
+	assert.Equal(t, "PROJ-100", parentField["key"])
 }


### PR DESCRIPTION
## Summary
- Adds `--parent` flag to `jtk issues create` and `jtk issues update` for setting parent/epic relationships
- Sends parent as `{"parent": {"key": "PROJ-100"}}` object (required by Jira REST API v3), unlike `--field parent=PROJ-100` which sends it as a plain string
- Includes tests for both commands verifying the request body format via httptest

Closes #135

## Test plan
- [x] Unit tests for create with parent, create without parent, create via Cobra with parent
- [x] Unit tests for update with parent only, update with parent + summary
- [x] Existing tests updated for new function signatures
- [x] Full jtk test suite passes