### PR TITLE
feat(fields): add issuelink type support in FormatFieldValue

### DIFF
--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `--field parent=PROJ-123` and issuelink-type custom fields now format correctly instead of producing a `"data was not an object"` API error ([#140](https://github.com/open-cli-collective/atlassian-cli/pull/140))
 - `config show -o json` no longer appends trailing plain text after JSON body ([#124](https://github.com/open-cli-collective/atlassian-cli/pull/124))
 - `projects create` success message uses the input name instead of the empty API response name ([#121](https://github.com/open-cli-collective/atlassian-cli/pull/121))
 - `ProjectDetail.ID` uses `json.Number` to handle numeric API responses ([#116](https://github.com/open-cli-collective/atlassian-cli/pull/116))

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -80,6 +80,7 @@ func ResolveFieldID(fields []Field, nameOrID string) (string, error) {
 //   - array fields: wraps value as [{"value": "..."}] or []string{...}
 //   - user fields: wraps value as {"accountId": "..."}
 //   - number fields: converts string to float64
+//   - issuelink fields (e.g., parent): wraps value as {"key": "..."} or {"id": "..."}
 //   - textarea custom fields: converts to ADF document
 func FormatFieldValue(field *Field, value string) interface{} {
 	if field == nil {
@@ -88,6 +89,15 @@ func FormatFieldValue(field *Field, value string) interface{} {
 
 	if field.Schema.Custom == "com.atlassian.jira.plugin.system.customfieldtypes:textarea" {
 		return NewADFDocument(value)
+	}
+
+	// The parent field requires {"key": "..."} format but Jira reports an empty
+	// schema type for it, so handle it before the type switch.
+	if field.ID == "parent" {
+		if _, err := strconv.Atoi(value); err == nil {
+			return map[string]string{"id": value}
+		}
+		return map[string]string{"key": value}
 	}
 
 	switch field.Schema.Type {
@@ -105,6 +115,12 @@ func FormatFieldValue(field *Field, value string) interface{} {
 			return n
 		}
 		return value
+	case "issuelink":
+		// Issue link fields (e.g., parent) need {"key": "..."} or {"id": "..."} format
+		if _, err := strconv.Atoi(value); err == nil {
+			return map[string]string{"id": value}
+		}
+		return map[string]string{"key": value}
 	case "priority", "resolution", "status", "issuetype", "securitylevel":
 		if _, err := strconv.Atoi(value); err == nil {
 			return map[string]string{"id": value}

--- a/tools/jtk/api/fields_test.go
+++ b/tools/jtk/api/fields_test.go
@@ -355,6 +355,54 @@ func TestFormatFieldValue(t *testing.T) {
 			value: "Confidential",
 			want:  map[string]string{"name": "Confidential"},
 		},
+		{
+			name: "parent field by issue key - wraps in key map",
+			field: &Field{
+				ID:   "parent",
+				Name: "Parent",
+				Schema: FieldSchema{
+					Type: "",
+				},
+			},
+			value: "PROJ-123",
+			want:  map[string]string{"key": "PROJ-123"},
+		},
+		{
+			name: "parent field by numeric ID - wraps in id map",
+			field: &Field{
+				ID:   "parent",
+				Name: "Parent",
+				Schema: FieldSchema{
+					Type: "",
+				},
+			},
+			value: "10001",
+			want:  map[string]string{"id": "10001"},
+		},
+		{
+			name: "issuelink custom field by key - wraps in key map",
+			field: &Field{
+				ID:   "customfield_10050",
+				Name: "Blocked By",
+				Schema: FieldSchema{
+					Type: "issuelink",
+				},
+			},
+			value: "PROJ-456",
+			want:  map[string]string{"key": "PROJ-456"},
+		},
+		{
+			name: "issuelink custom field by ID - wraps in id map",
+			field: &Field{
+				ID:   "customfield_10050",
+				Name: "Blocked By",
+				Schema: FieldSchema{
+					Type: "issuelink",
+				},
+			},
+			value: "20001",
+			want:  map[string]string{"id": "20001"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## [#135]

Handles `parent` and `issuelink` field types in `FormatFieldValue` so that `--field parent=PROJ-123` and other issuelink-type fields work correctly via the `--field` flag.

### Changes

- **Parent field check** — Jira reports the parent field with an empty schema type, so a pre-switch check on field ID wraps the value as `{"key": "..."}` or `{"id": "..."}`
- **`issuelink` type case** — custom issuelink fields (e.g., "Blocked By") that do report their schema type are also handled
- **Tests** — four new test cases: parent by key, parent by ID, custom issuelink by key, custom issuelink by ID

### Why

`FormatFieldValue` handles every other common Jira field type (option, user, number, priority, etc.) but had no handling for issuelink fields. The `parent` field is particularly problematic because Jira reports an empty schema type for it, so it falls through to the default string path and produces a confusing `"data was not an object"` API error.

The dedicated `--parent` flag (#139) bypasses `FormatFieldValue` entirely, but `--field parent=PROJ-123` and any custom issuelink fields still hit this gap.

### Test plan

- [x] All existing tests pass
- [x] New unit tests: parent field (empty schema type, matched by ID) and custom issuelink field (matched by schema type), both key and numeric ID variants
- [x] Manual: `jtk issues create --field parent=an internal ticket` — parent set correctly (previously failed with "data was not an object")
- [x] Manual: verified parent via `jtk issues get` after create

Closes #135
