### PR TITLE
feat(issues): add --assignee flag to create and update commands

### DIFF
--- a/tools/jtk/internal/cmd/issues/create.go
+++ b/tools/jtk/internal/cmd/issues/create.go
@@ -15,6 +15,7 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
 	var issueType string
 	var summary string
 	var description string
+	var assignee string
 	var fields []string
 
 	cmd := &cobra.Command{
@@ -28,9 +29,15 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
   jtk issues create --project MYPROJECT --type Bug --summary "Login fails" --description "Users cannot log in with SSO"
 
   # Create with custom fields
-  jtk issues create --project MYPROJECT --type Story --summary "New feature" --field priority=High`,
+  jtk issues create --project MYPROJECT --type Story --summary "New feature" --field priority=High
+
+  # Create and assign to yourself
+  jtk issues create --project MYPROJECT --type Task --summary "My task" --assignee me
+
+  # Create and assign by email
+  jtk issues create --project MYPROJECT --type Task --summary "Their task" --assignee user@example.com`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCreate(opts, project, issueType, summary, description, fields)
+			return runCreate(opts, project, issueType, summary, description, assignee, fields)
 		},
 	}
 
@@ -38,6 +45,7 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
 	cmd.Flags().StringVarP(&issueType, "type", "t", "Task", "Issue type (Task, Bug, Story, etc.)")
 	cmd.Flags().StringVarP(&summary, "summary", "s", "", "Issue summary (required)")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Issue description")
+	cmd.Flags().StringVarP(&assignee, "assignee", "a", "", "Assignee (account ID, email, or 'me')")
 	cmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "Additional fields (key=value)")
 
 	_ = cmd.MarkFlagRequired("project")
@@ -46,7 +54,7 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
 	return cmd
 }
 
-func runCreate(opts *root.Options, project, issueType, summary, description string, fieldArgs []string) error {
+func runCreate(opts *root.Options, project, issueType, summary, description, assignee string, fieldArgs []string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -87,6 +95,15 @@ func runCreate(opts *root.Options, project, issueType, summary, description stri
 			// Format value based on field type
 			extraFields[fieldID] = api.FormatFieldValue(field, value)
 		}
+	}
+
+	// Resolve assignee
+	if assignee != "" {
+		accountID, err := resolveAssignee(client, assignee)
+		if err != nil {
+			return err
+		}
+		extraFields["assignee"] = map[string]string{"accountId": accountID}
 	}
 
 	req := api.BuildCreateRequest(project, issueType, summary, description, extraFields)

--- a/tools/jtk/internal/cmd/issues/create_test.go
+++ b/tools/jtk/internal/cmd/issues/create_test.go
@@ -1,0 +1,184 @@
+package issues
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+func TestNewCreateCmd(t *testing.T) {
+	opts := &root.Options{}
+	cmd := newCreateCmd(opts)
+
+	assert.Equal(t, "create", cmd.Use)
+
+	// Check that assignee flag exists
+	assigneeFlag := cmd.Flags().Lookup("assignee")
+	require.NotNil(t, assigneeFlag)
+	assert.Equal(t, "a", assigneeFlag.Shorthand)
+	assert.Equal(t, "", assigneeFlag.DefValue)
+}
+
+func TestRunCreate_WithAssigneeMe(t *testing.T) {
+	var capturedBody api.CreateIssueRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/myself":
+			json.NewEncoder(w).Encode(api.User{
+				AccountID:   "me-account-id",
+				DisplayName: "Current User",
+			})
+		case "/rest/api/3/issue":
+			assert.Equal(t, http.MethodPost, r.Method)
+			json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-1"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "PROJ", "Task", "My task", "", "me", nil)
+	require.NoError(t, err)
+
+	// Verify assignee was set in the request
+	assignee, ok := capturedBody.Fields["assignee"]
+	require.True(t, ok, "assignee field should be present")
+	assigneeMap, ok := assignee.(map[string]interface{})
+	require.True(t, ok, "assignee should be a map")
+	assert.Equal(t, "me-account-id", assigneeMap["accountId"])
+
+	assert.Contains(t, stdout.String(), "PROJ-1")
+}
+
+func TestRunCreate_WithAssigneeAccountID(t *testing.T) {
+	var capturedBody api.CreateIssueRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue" {
+			json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-2"})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "PROJ", "Task", "Their task", "", "5b10ac8d82e05b22cc7d4ef5", nil)
+	require.NoError(t, err)
+
+	assignee, ok := capturedBody.Fields["assignee"]
+	require.True(t, ok)
+	assigneeMap, ok := assignee.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "5b10ac8d82e05b22cc7d4ef5", assigneeMap["accountId"])
+}
+
+func TestRunCreate_WithoutAssignee(t *testing.T) {
+	var capturedBody api.CreateIssueRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue" {
+			json.NewDecoder(r.Body).Decode(&capturedBody)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-3"})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "PROJ", "Task", "Unassigned task", "", "", nil)
+	require.NoError(t, err)
+
+	_, hasAssignee := capturedBody.Fields["assignee"]
+	assert.False(t, hasAssignee, "assignee should not be present when not specified")
+}
+
+func TestRunCreate_WithAssigneeJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/myself":
+			json.NewEncoder(w).Encode(api.User{AccountID: "me-id"})
+		case "/rest/api/3/issue":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-4"})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "json",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "PROJ", "Task", "JSON task", "", "me", nil)
+	require.NoError(t, err)
+
+	var result api.Issue
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Equal(t, "PROJ-4", result.Key)
+}

--- a/tools/jtk/internal/cmd/issues/resolve_assignee.go
+++ b/tools/jtk/internal/cmd/issues/resolve_assignee.go
@@ -1,0 +1,41 @@
+package issues
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// resolveAssignee resolves an assignee value to a Jira account ID.
+// It accepts:
+//   - "me" — resolves to the authenticated user's account ID
+//   - an email address (contains @) — searches users and matches by email
+//   - a raw account ID — returned as-is
+func resolveAssignee(client *api.Client, value string) (string, error) {
+	if strings.EqualFold(value, "me") {
+		user, err := client.GetCurrentUser()
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve 'me': %w", err)
+		}
+		return user.AccountID, nil
+	}
+
+	if strings.Contains(value, "@") {
+		users, err := client.SearchUsers(value, 50)
+		if err != nil {
+			return "", fmt.Errorf("failed to search users: %w", err)
+		}
+
+		// Look for exact email match
+		for _, u := range users {
+			if strings.EqualFold(u.EmailAddress, value) {
+				return u.AccountID, nil
+			}
+		}
+
+		return "", fmt.Errorf("no user found with email %q", value)
+	}
+
+	return value, nil
+}

--- a/tools/jtk/internal/cmd/issues/resolve_assignee_test.go
+++ b/tools/jtk/internal/cmd/issues/resolve_assignee_test.go
@@ -1,0 +1,129 @@
+package issues
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestResolveAssignee_RawAccountID(t *testing.T) {
+	client, err := api.New(api.ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	accountID, err := resolveAssignee(client, "5b10ac8d82e05b22cc7d4ef5")
+	require.NoError(t, err)
+	assert.Equal(t, "5b10ac8d82e05b22cc7d4ef5", accountID)
+}
+
+func TestResolveAssignee_Me(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/myself", r.URL.Path)
+		json.NewEncoder(w).Encode(api.User{
+			AccountID:   "abc123",
+			DisplayName: "Test User",
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	accountID, err := resolveAssignee(client, "me")
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", accountID)
+}
+
+func TestResolveAssignee_MeCaseInsensitive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(api.User{
+			AccountID: "abc123",
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	accountID, err := resolveAssignee(client, "ME")
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", accountID)
+}
+
+func TestResolveAssignee_Email(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/rest/api/3/user/search", r.URL.Path)
+		assert.Equal(t, "jane@example.com", r.URL.Query().Get("query"))
+		json.NewEncoder(w).Encode([]api.User{
+			{AccountID: "other123", DisplayName: "Other User", EmailAddress: "other@example.com"},
+			{AccountID: "jane456", DisplayName: "Jane Doe", EmailAddress: "jane@example.com"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	accountID, err := resolveAssignee(client, "jane@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "jane456", accountID)
+}
+
+func TestResolveAssignee_EmailNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]api.User{})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	_, err = resolveAssignee(client, "nobody@example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no user found with email")
+}
+
+func TestResolveAssignee_EmailNoExactMatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]api.User{
+			{AccountID: "other123", DisplayName: "Other User", EmailAddress: "similar@example.com"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	_, err = resolveAssignee(client, "exact@example.com")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no user found with email")
+}

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -13,6 +13,7 @@ import (
 func newUpdateCmd(opts *root.Options) *cobra.Command {
 	var summary string
 	var description string
+	var assignee string
 	var fields []string
 
 	cmd := &cobra.Command{
@@ -26,21 +27,26 @@ func newUpdateCmd(opts *root.Options) *cobra.Command {
   jtk issues update PROJ-123 --description "Updated description"
 
   # Update custom fields
-  jtk issues update PROJ-123 --field priority=High --field "Story Points"=5`,
+  jtk issues update PROJ-123 --field priority=High --field "Story Points"=5
+
+  # Reassign an issue
+  jtk issues update PROJ-123 --assignee me
+  jtk issues update PROJ-123 --assignee user@example.com`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUpdate(opts, args[0], summary, description, fields)
+			return runUpdate(opts, args[0], summary, description, assignee, fields)
 		},
 	}
 
 	cmd.Flags().StringVarP(&summary, "summary", "s", "", "New summary")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "New description")
+	cmd.Flags().StringVarP(&assignee, "assignee", "a", "", "Assignee (account ID, email, or 'me')")
 	cmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "Fields to update (key=value)")
 
 	return cmd
 }
 
-func runUpdate(opts *root.Options, issueKey, summary, description string, fieldArgs []string) error {
+func runUpdate(opts *root.Options, issueKey, summary, description, assignee string, fieldArgs []string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -56,6 +62,15 @@ func runUpdate(opts *root.Options, issueKey, summary, description string, fieldA
 
 	if description != "" {
 		fields["description"] = api.NewADFDocument(description)
+	}
+
+	// Resolve assignee
+	if assignee != "" {
+		accountID, err := resolveAssignee(client, assignee)
+		if err != nil {
+			return err
+		}
+		fields["assignee"] = map[string]string{"accountId": accountID}
 	}
 
 	// Parse additional fields

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -1,0 +1,172 @@
+package issues
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+func TestNewUpdateCmd(t *testing.T) {
+	opts := &root.Options{}
+	cmd := newUpdateCmd(opts)
+
+	assert.Equal(t, "update <issue-key>", cmd.Use)
+
+	// Check that assignee flag exists
+	assigneeFlag := cmd.Flags().Lookup("assignee")
+	require.NotNil(t, assigneeFlag)
+	assert.Equal(t, "a", assigneeFlag.Shorthand)
+	assert.Equal(t, "", assigneeFlag.DefValue)
+}
+
+func TestRunUpdate_WithAssigneeMe(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/myself":
+			json.NewEncoder(w).Encode(api.User{
+				AccountID:   "me-account-id",
+				DisplayName: "Current User",
+			})
+		case "/rest/api/3/issue/PROJ-123":
+			assert.Equal(t, http.MethodPut, r.Method)
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &capturedBody)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runUpdate(opts, "PROJ-123", "", "", "me", nil)
+	require.NoError(t, err)
+
+	// Verify assignee was set in the request
+	fields, ok := capturedBody["fields"].(map[string]interface{})
+	require.True(t, ok)
+	assignee, ok := fields["assignee"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "me-account-id", assignee["accountId"])
+
+	assert.Contains(t, stdout.String(), "PROJ-123")
+}
+
+func TestRunUpdate_WithAssigneeEmail(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/user/search":
+			json.NewEncoder(w).Encode([]api.User{
+				{AccountID: "jane456", DisplayName: "Jane Doe", EmailAddress: "jane@example.com"},
+			})
+		case "/rest/api/3/issue/PROJ-456":
+			body, _ := io.ReadAll(r.Body)
+			json.Unmarshal(body, &capturedBody)
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runUpdate(opts, "PROJ-456", "", "", "jane@example.com", nil)
+	require.NoError(t, err)
+
+	fields, ok := capturedBody["fields"].(map[string]interface{})
+	require.True(t, ok)
+	assignee, ok := fields["assignee"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "jane456", assignee["accountId"])
+}
+
+func TestRunUpdate_AssigneeOnly(t *testing.T) {
+	// Verify that assignee alone counts as "fields specified"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/myself":
+			json.NewEncoder(w).Encode(api.User{AccountID: "me-id"})
+		case "/rest/api/3/issue/PROJ-789":
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	// Should not error with "no fields specified" since assignee is a field
+	err = runUpdate(opts, "PROJ-789", "", "", "me", nil)
+	require.NoError(t, err)
+}
+
+func TestRunUpdate_NoFieldsError(t *testing.T) {
+	client, err := api.New(api.ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runUpdate(opts, "PROJ-999", "", "", "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no fields specified to update")
+}


### PR DESCRIPTION
## [#136]

Adds an `--assignee` / `-a` flag to `issues create` and `issues update` that accepts:

- **Account ID**: `--assignee 5b10ac8d82e05b22cc7d4ef5`
- **Email address** (resolved via user search): `--assignee user@example.com`
- **`me`** (resolved to authenticated user): `--assignee me`

### Usage

```bash
# Create and assign to yourself
jtk issues create --project MYPROJECT --type Task --summary "My task" --assignee me

# Create and assign by email
jtk issues create --project MYPROJECT --type Task --summary "Their task" --assignee user@example.com

# Reassign an existing issue
jtk issues update PROJ-456 --assignee user@example.com
```

### Implementation

- `resolve_assignee.go` — shared helper that resolves `me` → `GetCurrentUser()`, email → `SearchUsers()` with exact match, or passes through raw account IDs
- `create.go` / `update.go` — adds `--assignee` flag, resolves it, and sets `{"accountId": "..."}` in the fields map

### Test plan

- [x] `resolveAssignee` with raw account ID (passthrough)
- [x] `resolveAssignee` with `me` / `ME` (case-insensitive)
- [x] `resolveAssignee` with email (exact match from search results)
- [x] `resolveAssignee` with email that has no match / no exact match (error)
- [x] `runCreate` with `--assignee me` (verifies request body)
- [x] `runCreate` with `--assignee <account-id>` (verifies request body)
- [x] `runCreate` without `--assignee` (no assignee in request)
- [x] `runCreate` with `--assignee` and JSON output
- [x] `runUpdate` with `--assignee me` (verifies request body)
- [x] `runUpdate` with `--assignee <email>` (verifies request body)
- [x] `runUpdate` with only `--assignee` (no "no fields" error)
- [x] `runUpdate` with no fields at all (error)
- [ ] Manual: `jtk issues create --project ... --assignee me` against live Jira

Closes #136