### PR TITLE
feat(jtk): add --assignee flag to issues create and update

### DIFF
--- a/tools/jtk/internal/cmd/issues/assignee.go
+++ b/tools/jtk/internal/cmd/issues/assignee.go
@@ -1,0 +1,33 @@
+package issues
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// resolveAssignee resolves an assignee value to a Jira account ID.
+// Accepts "me" (current user), an email address (searched via API), or a raw account ID.
+func resolveAssignee(client *api.Client, assignee string) (string, error) {
+	if strings.EqualFold(assignee, "me") {
+		user, err := client.GetCurrentUser()
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve current user: %w", err)
+		}
+		return user.AccountID, nil
+	}
+
+	if strings.Contains(assignee, "@") {
+		users, err := client.SearchUsers(assignee, 1)
+		if err != nil {
+			return "", fmt.Errorf("failed to search for user %q: %w", assignee, err)
+		}
+		if len(users) == 0 {
+			return "", fmt.Errorf("no user found matching %q", assignee)
+		}
+		return users[0].AccountID, nil
+	}
+
+	return assignee, nil
+}

--- a/tools/jtk/internal/cmd/issues/assignee_test.go
+++ b/tools/jtk/internal/cmd/issues/assignee_test.go
@@ -1,0 +1,122 @@
+package issues
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestResolveAssignee_RawAccountID(t *testing.T) {
+	client, err := api.New(api.ClientConfig{
+		URL:      "http://unused",
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	id, err := resolveAssignee(client, "61292e4c4f29230069621c5f")
+	require.NoError(t, err)
+	assert.Equal(t, "61292e4c4f29230069621c5f", id)
+}
+
+func TestResolveAssignee_Me(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/myself" {
+			json.NewEncoder(w).Encode(api.User{
+				AccountID:   "me-account-id",
+				DisplayName: "Current User",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	id, err := resolveAssignee(client, "me")
+	require.NoError(t, err)
+	assert.Equal(t, "me-account-id", id)
+}
+
+func TestResolveAssignee_MeCaseInsensitive(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/myself" {
+			json.NewEncoder(w).Encode(api.User{
+				AccountID:   "me-account-id",
+				DisplayName: "Current User",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	id, err := resolveAssignee(client, "Me")
+	require.NoError(t, err)
+	assert.Equal(t, "me-account-id", id)
+}
+
+func TestResolveAssignee_Email(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/user/search" {
+			json.NewEncoder(w).Encode([]api.User{
+				{AccountID: "email-account-id", DisplayName: "Email User"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	id, err := resolveAssignee(client, "user@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "email-account-id", id)
+}
+
+func TestResolveAssignee_EmailNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/user/search" {
+			json.NewEncoder(w).Encode([]api.User{})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	_, err = resolveAssignee(client, "nobody@example.com")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no user found")
+}

--- a/tools/jtk/internal/cmd/issues/create.go
+++ b/tools/jtk/internal/cmd/issues/create.go
@@ -16,6 +16,7 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
 	var summary string
 	var description string
 	var parent string
+	var assignee string
 	var fields []string
 
 	cmd := &cobra.Command{
@@ -31,10 +32,16 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
   # Create as child of an epic
   jtk issues create --project MYPROJECT --type Task --summary "Subtask" --parent MYPROJECT-100
 
+  # Assign to yourself
+  jtk issues create --project MYPROJECT --type Task --summary "My task" --assignee me
+
+  # Assign by email
+  jtk issues create --project MYPROJECT --type Task --summary "Their task" --assignee user@example.com
+
   # Create with custom fields
   jtk issues create --project MYPROJECT --type Story --summary "New feature" --field priority=High`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCreate(opts, project, issueType, summary, description, parent, fields)
+			return runCreate(opts, project, issueType, summary, description, parent, assignee, fields)
 		},
 	}
 
@@ -43,6 +50,7 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
 	cmd.Flags().StringVarP(&summary, "summary", "s", "", "Issue summary (required)")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Issue description")
 	cmd.Flags().StringVar(&parent, "parent", "", "Parent issue key (epic or parent issue)")
+	cmd.Flags().StringVarP(&assignee, "assignee", "a", "", "Assignee (account ID, email, or \"me\")")
 	cmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "Additional fields (key=value)")
 
 	_ = cmd.MarkFlagRequired("project")
@@ -51,7 +59,7 @@ func newCreateCmd(opts *root.Options) *cobra.Command {
 	return cmd
 }
 
-func runCreate(opts *root.Options, project, issueType, summary, description, parent string, fieldArgs []string) error {
+func runCreate(opts *root.Options, project, issueType, summary, description, parent, assignee string, fieldArgs []string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -96,6 +104,14 @@ func runCreate(opts *root.Options, project, issueType, summary, description, par
 
 	if parent != "" {
 		extraFields["parent"] = map[string]string{"key": parent}
+	}
+
+	if assignee != "" {
+		accountID, err := resolveAssignee(client, assignee)
+		if err != nil {
+			return err
+		}
+		extraFields["assignee"] = map[string]string{"accountId": accountID}
 	}
 
 	req := api.BuildCreateRequest(project, issueType, summary, description, extraFields)

--- a/tools/jtk/internal/cmd/issues/create_test.go
+++ b/tools/jtk/internal/cmd/issues/create_test.go
@@ -47,7 +47,7 @@ func TestRunCreate_RequestBodyNoDoubleQuoting(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runCreate(opts, "MYPROJECT", "Task", "Fix login bug", "Users cannot log in with SSO credentials", "", nil)
+	err = runCreate(opts, "MYPROJECT", "Task", "Fix login bug", "Users cannot log in with SSO credentials", "", "", nil)
 	require.NoError(t, err)
 
 	// Parse the captured request body
@@ -109,7 +109,7 @@ func TestRunCreate_SummaryWithSpecialCharacters(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runCreate(opts, "PROJ", "Bug", `Error: "unexpected token" in parser`, "", "", nil)
+	err = runCreate(opts, "PROJ", "Bug", `Error: "unexpected token" in parser`, "", "", "", nil)
 	require.NoError(t, err)
 
 	var reqBody map[string]interface{}
@@ -145,6 +145,10 @@ func TestNewCreateCmd(t *testing.T) {
 	parentFlag := cmd.Flags().Lookup("parent")
 	require.NotNil(t, parentFlag)
 	assert.Equal(t, "", parentFlag.Shorthand, "parent flag should have no shorthand")
+
+	assigneeFlag := cmd.Flags().Lookup("assignee")
+	require.NotNil(t, assigneeFlag)
+	assert.Equal(t, "a", assigneeFlag.Shorthand)
 }
 
 func TestCreateCmd_CobraExecution_NoDoubleQuoting(t *testing.T) {
@@ -229,7 +233,7 @@ func TestRunCreate_WithParent(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runCreate(opts, "PROJ", "Task", "Child task", "", "PROJ-100", nil)
+	err = runCreate(opts, "PROJ", "Task", "Child task", "", "PROJ-100", "", nil)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, capturedBody)
@@ -273,7 +277,7 @@ func TestRunCreate_WithoutParent(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runCreate(opts, "PROJ", "Task", "Standalone task", "", "", nil)
+	err = runCreate(opts, "PROJ", "Task", "Standalone task", "", "", "", nil)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, capturedBody)
@@ -333,4 +337,184 @@ func TestCreateCmd_CobraExecution_WithParent(t *testing.T) {
 	fields := reqBody["fields"].(map[string]interface{})
 	parentField := fields["parent"].(map[string]interface{})
 	assert.Equal(t, "PROJ-100", parentField["key"])
+}
+
+func TestRunCreate_WithAssigneeAccountID(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue" && r.Method == "POST" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-500", ID: "10500"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "PROJ", "Task", "Assigned task", "", "", "61292e4c4f29230069621c5f", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	assigneeField := fields["assignee"].(map[string]interface{})
+	assert.Equal(t, "61292e4c4f29230069621c5f", assigneeField["accountId"])
+}
+
+func TestRunCreate_WithAssigneeMe(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/myself" && r.Method == "GET" {
+			json.NewEncoder(w).Encode(api.User{
+				AccountID:   "myself-account-id",
+				DisplayName: "Test User",
+			})
+			return
+		}
+		if r.URL.Path == "/rest/api/3/issue" && r.Method == "POST" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-501", ID: "10501"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "PROJ", "Task", "My task", "", "", "me", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	assigneeField := fields["assignee"].(map[string]interface{})
+	assert.Equal(t, "myself-account-id", assigneeField["accountId"])
+}
+
+func TestRunCreate_WithAssigneeEmail(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/user/search" && r.Method == "GET" {
+			json.NewEncoder(w).Encode([]api.User{
+				{AccountID: "found-account-id", DisplayName: "Found User"},
+			})
+			return
+		}
+		if r.URL.Path == "/rest/api/3/issue" && r.Method == "POST" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-502", ID: "10502"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "PROJ", "Task", "Their task", "", "", "user@example.com", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	assigneeField := fields["assignee"].(map[string]interface{})
+	assert.Equal(t, "found-account-id", assigneeField["accountId"])
+}
+
+func TestRunCreate_WithoutAssignee(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue" && r.Method == "POST" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "PROJ-503", ID: "10503"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "PROJ", "Task", "Unassigned task", "", "", "", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	assert.Nil(t, fields["assignee"], "assignee should not be present when empty")
 }

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -14,6 +14,7 @@ func newUpdateCmd(opts *root.Options) *cobra.Command {
 	var summary string
 	var description string
 	var parent string
+	var assignee string
 	var fields []string
 
 	cmd := &cobra.Command{
@@ -29,27 +30,31 @@ func newUpdateCmd(opts *root.Options) *cobra.Command {
   # Move issue under a different parent/epic
   jtk issues update PROJ-123 --parent PROJ-100
 
+  # Reassign an issue
+  jtk issues update PROJ-123 --assignee user@example.com
+
   # Update custom fields
   jtk issues update PROJ-123 --field priority=High --field "Story Points"=5`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUpdate(opts, args[0], summary, description, parent, fields)
+			return runUpdate(opts, args[0], summary, description, parent, assignee, fields)
 		},
 	}
 
 	cmd.Flags().StringVarP(&summary, "summary", "s", "", "New summary")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "New description")
 	cmd.Flags().StringVar(&parent, "parent", "", "Parent issue key (epic or parent issue)")
+	cmd.Flags().StringVarP(&assignee, "assignee", "a", "", "Assignee (account ID, email, or \"me\")")
 	cmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "Fields to update (key=value)")
 
 	return cmd
 }
 
-func runUpdate(opts *root.Options, issueKey, summary, description, parent string, fieldArgs []string) error {
+func runUpdate(opts *root.Options, issueKey, summary, description, parent, assignee string, fieldArgs []string) error {
 	v := opts.View()
 
 	// Validate that at least one field is being updated before making API calls
-	if summary == "" && description == "" && parent == "" && len(fieldArgs) == 0 {
+	if summary == "" && description == "" && parent == "" && assignee == "" && len(fieldArgs) == 0 {
 		return fmt.Errorf("no fields specified to update")
 	}
 
@@ -70,6 +75,14 @@ func runUpdate(opts *root.Options, issueKey, summary, description, parent string
 
 	if parent != "" {
 		fields["parent"] = map[string]string{"key": parent}
+	}
+
+	if assignee != "" {
+		accountID, err := resolveAssignee(client, assignee)
+		if err != nil {
+			return err
+		}
+		fields["assignee"] = map[string]string{"accountId": accountID}
 	}
 
 	// Parse additional fields

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -43,7 +43,7 @@ func TestRunUpdate_RequestBodyNoDoubleQuoting(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(opts, "PROJ-123", "Updated summary", "Updated description", "", nil)
+	err = runUpdate(opts, "PROJ-123", "Updated summary", "Updated description", "", "", nil)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, capturedBody)
@@ -91,6 +91,10 @@ func TestNewUpdateCmd(t *testing.T) {
 	parentFlag := cmd.Flags().Lookup("parent")
 	require.NotNil(t, parentFlag)
 	assert.Equal(t, "", parentFlag.Shorthand, "parent flag should have no shorthand")
+
+	assigneeFlag := cmd.Flags().Lookup("assignee")
+	require.NotNil(t, assigneeFlag)
+	assert.Equal(t, "a", assigneeFlag.Shorthand)
 }
 
 func TestRunUpdate_SummaryOnly(t *testing.T) {
@@ -121,7 +125,7 @@ func TestRunUpdate_SummaryOnly(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(opts, "PROJ-123", "New summary", "", "", nil)
+	err = runUpdate(opts, "PROJ-123", "New summary", "", "", "", nil)
 	require.NoError(t, err)
 
 	var reqBody map[string]interface{}
@@ -141,7 +145,7 @@ func TestRunUpdate_NoFieldsError(t *testing.T) {
 		Stderr: &bytes.Buffer{},
 	}
 
-	err := runUpdate(opts, "PROJ-123", "", "", "", nil)
+	err := runUpdate(opts, "PROJ-123", "", "", "", "", nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no fields specified")
 }
@@ -174,7 +178,7 @@ func TestRunUpdate_ParentOnly(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(opts, "PROJ-456", "", "", "PROJ-100", nil)
+	err = runUpdate(opts, "PROJ-456", "", "", "PROJ-100", "", nil)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, capturedBody)
@@ -217,7 +221,7 @@ func TestRunUpdate_ParentWithSummary(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(opts, "PROJ-456", "Updated title", "", "PROJ-200", nil)
+	err = runUpdate(opts, "PROJ-456", "Updated title", "", "PROJ-200", "", nil)
 	require.NoError(t, err)
 
 	require.NotEmpty(t, capturedBody)
@@ -276,4 +280,141 @@ func TestUpdateCmd_CobraExecution_WithParent(t *testing.T) {
 	fields := reqBody["fields"].(map[string]interface{})
 	parentField := fields["parent"].(map[string]interface{})
 	assert.Equal(t, "PROJ-100", parentField["key"])
+}
+
+func TestRunUpdate_AssigneeOnly(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runUpdate(opts, "PROJ-789", "", "", "", "61292e4c4f29230069621c5f", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	assigneeField := fields["assignee"].(map[string]interface{})
+	assert.Equal(t, "61292e4c4f29230069621c5f", assigneeField["accountId"])
+	assert.Nil(t, fields["summary"], "summary should not be present when empty")
+}
+
+func TestRunUpdate_AssigneeMe(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/myself" && r.Method == "GET" {
+			json.NewEncoder(w).Encode(api.User{
+				AccountID:   "myself-account-id",
+				DisplayName: "Test User",
+			})
+			return
+		}
+		if r.Method == "PUT" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runUpdate(opts, "PROJ-789", "", "", "", "me", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	assigneeField := fields["assignee"].(map[string]interface{})
+	assert.Equal(t, "myself-account-id", assigneeField["accountId"])
+}
+
+func TestUpdateCmd_CobraExecution_WithAssignee(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	cmd := newUpdateCmd(opts)
+	cmd.SetArgs([]string{
+		"PROJ-789",
+		"--assignee", "61292e4c4f29230069621c5f",
+	})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	assigneeField := fields["assignee"].(map[string]interface{})
+	assert.Equal(t, "61292e4c4f29230069621c5f", assigneeField["accountId"])
 }


### PR DESCRIPTION
## Summary
- Adds `--assignee`/`-a` flag to `jtk issues create` and `jtk issues update`
- Accepts three formats: raw account ID, email address (resolved via user search API), or `"me"` (resolved via `/myself` endpoint)
- Sends assignee as `{"assignee": {"accountId": "..."}}` in the Jira API request body
- Shared `resolveAssignee` helper handles all resolution logic

Closes #136

## Test plan
- [x] Unit tests for `resolveAssignee`: raw ID passthrough, "me" resolution, "Me" case-insensitive, email resolution, email not found error
- [x] Create tests: with account ID, with "me", with email, without assignee (nil check)
- [x] Update tests: assignee only, assignee with "me", Cobra integration with --assignee
- [x] Flag registration tests for both commands (shorthand `-a`)
- [x] Full jtk test suite passes