### PR TITLE
fix(ci): replace deprecated homebrew_casks.binary with binaries

### DIFF
--- a/.goreleaser-cfl.yml
+++ b/.goreleaser-cfl.yml
@@ -68,7 +68,7 @@ homebrew_casks:
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     homepage: https://github.com/open-cli-collective/atlassian-cli
     description: "Command-line interface for Atlassian Confluence"
-    binary: cfl
+    binaries: [cfl]
     hooks:
       post:
         install: |

--- a/.goreleaser-jtk.yml
+++ b/.goreleaser-jtk.yml
@@ -70,7 +70,7 @@ homebrew_casks:
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     homepage: https://github.com/open-cli-collective/atlassian-cli
     description: "Command-line interface for Jira Cloud"
-    binary: jtk
+    binaries: [jtk]
     hooks:
       post:
         install: |


### PR DESCRIPTION
## Summary
- Replace deprecated `binary` field with `binaries` array in `homebrew_casks` section of both `.goreleaser-cfl.yml` and `.goreleaser-jtk.yml`
- Deprecation warning observed in cfl-v1.0.23 release: https://github.com/open-cli-collective/atlassian-cli/actions/runs/21965207011/job/63453113559
- See https://goreleaser.com/deprecations#homebrew_casksbinary

## Test plan
- [ ] CI passes
- [ ] Next release build shows no `homebrew_casks.binary` deprecation warning

Closes #153