### PR TITLE
feat(cfl): add space create/view/update/delete commands

### DIFF
--- a/tools/cfl/CHANGELOG.md
+++ b/tools/cfl/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- `space view`, `space create`, `space update`, `space delete` commands for full space management ([#151](https://github.com/open-cli-collective/atlassian-cli/issues/151))
 - ADF-to-Markdown converter (`pkg/md.FromADF`) for rendering Atlassian Document Format pages as markdown ([#150](https://github.com/open-cli-collective/atlassian-cli/issues/150))
 - Bracket macros (`[TOC]`, `[INFO]...[/INFO]`, etc.) are now converted to proper ADF nodes in the default (cloud editor) upload path ([#137](https://github.com/open-cli-collective/atlassian-cli/pull/137), closes [#133](https://github.com/open-cli-collective/atlassian-cli/issues/133))
 - `config show`, `config test`, `config clear` commands ([#47](https://github.com/open-cli-collective/atlassian-cli/pull/47))

--- a/tools/cfl/CLAUDE.md
+++ b/tools/cfl/CLAUDE.md
@@ -33,7 +33,7 @@ api/                     → Confluence REST API client (pages, spaces, attachme
 internal/cmd/            → Cobra command implementations
   root/                  → Root command with global flags
   page/                  → page list|view|create|edit|delete
-  space/                 → space list
+  space/                 → space list|view|create|update|delete
   attachment/            → attachment list|upload|download
   init/                  → Configuration wizard
 internal/config/         → YAML config loading with env var overrides

--- a/tools/cfl/api/space_management.go
+++ b/tools/cfl/api/space_management.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// CreateSpaceRequest is the request body for creating a space (v2 API).
+type CreateSpaceRequest struct {
+	Key         string            `json:"key"`
+	Name        string            `json:"name"`
+	Description *SpaceDescription `json:"description,omitempty"`
+	Type        string            `json:"type,omitempty"`
+}
+
+// UpdateSpaceRequest is the request body for updating a space (v1 API).
+type UpdateSpaceRequest struct {
+	Key         string              `json:"key"`
+	Name        string              `json:"name,omitempty"`
+	Description *V1SpaceDescription `json:"description,omitempty"`
+}
+
+// V1SpaceDescription is the v1 API description format (includes representation field).
+type V1SpaceDescription struct {
+	Plain *V1DescriptionValue `json:"plain,omitempty"`
+}
+
+// V1DescriptionValue holds a description value with its representation type.
+type V1DescriptionValue struct {
+	Value          string `json:"value"`
+	Representation string `json:"representation"`
+}
+
+// v1SpaceResponse is the v1 API response for space operations.
+type v1SpaceResponse struct {
+	ID          int    `json:"id"`
+	Key         string `json:"key"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Description struct {
+		Plain struct {
+			Value          string `json:"value"`
+			Representation string `json:"representation"`
+		} `json:"plain"`
+	} `json:"description"`
+	Links struct {
+		WebUI string `json:"webui"`
+		Self  string `json:"self"`
+	} `json:"_links"`
+}
+
+// toSpace converts a v1 API response to a Space.
+func (r *v1SpaceResponse) toSpace() *Space {
+	space := &Space{
+		ID:   fmt.Sprintf("%d", r.ID),
+		Key:  r.Key,
+		Name: r.Name,
+		Type: r.Type,
+		Links: Links{
+			WebUI: r.Links.WebUI,
+		},
+	}
+	if r.Description.Plain.Value != "" {
+		space.Description = &SpaceDescription{
+			Plain: &DescriptionValue{
+				Value: r.Description.Plain.Value,
+			},
+		}
+	}
+	return space
+}
+
+// CreateSpace creates a new Confluence space.
+func (c *Client) CreateSpace(ctx context.Context, req *CreateSpaceRequest) (*Space, error) {
+	body, err := c.Post(ctx, "/api/v2/spaces", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var space Space
+	if err := json.Unmarshal(body, &space); err != nil {
+		return nil, fmt.Errorf("failed to parse create space response: %w", err)
+	}
+
+	return &space, nil
+}
+
+// UpdateSpace updates an existing Confluence space.
+// Uses the v1 REST API as v2 doesn't support space updates.
+func (c *Client) UpdateSpace(ctx context.Context, spaceKey string, req *UpdateSpaceRequest) (*Space, error) {
+	path := fmt.Sprintf("/rest/api/space/%s", spaceKey)
+	body, err := c.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var response v1SpaceResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse update space response: %w", err)
+	}
+
+	return response.toSpace(), nil
+}
+
+// DeleteSpace deletes a Confluence space.
+// Uses the v1 REST API as v2 doesn't support space deletion.
+// The API returns 202 Accepted as deletion is asynchronous.
+func (c *Client) DeleteSpace(ctx context.Context, spaceKey string) error {
+	path := fmt.Sprintf("/rest/api/space/%s", spaceKey)
+	_, err := c.Delete(ctx, path)
+	return err
+}

--- a/tools/cfl/api/space_management_test.go
+++ b/tools/cfl/api/space_management_test.go
@@ -1,0 +1,280 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_CreateSpace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v2/spaces", r.URL.Path)
+
+		var req CreateSpaceRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "TEST", req.Key)
+		assert.Equal(t, "Test Space", req.Name)
+		assert.Equal(t, "global", req.Type)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "123456",
+			"key": "TEST",
+			"name": "Test Space",
+			"type": "global",
+			"status": "current",
+			"_links": {"webui": "/spaces/TEST"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "token")
+	space, err := client.CreateSpace(context.Background(), &CreateSpaceRequest{
+		Key:  "TEST",
+		Name: "Test Space",
+		Type: "global",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "123456", space.ID)
+	assert.Equal(t, "TEST", space.Key)
+	assert.Equal(t, "Test Space", space.Name)
+	assert.Equal(t, "global", space.Type)
+	assert.Equal(t, "/spaces/TEST", space.Links.WebUI)
+}
+
+func TestClient_CreateSpace_WithDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req CreateSpaceRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.NotNil(t, req.Description)
+		assert.Equal(t, "A test space", req.Description.Plain.Value)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "123456",
+			"key": "TEST",
+			"name": "Test Space",
+			"type": "global",
+			"description": {"plain": {"value": "A test space"}}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "token")
+	space, err := client.CreateSpace(context.Background(), &CreateSpaceRequest{
+		Key:  "TEST",
+		Name: "Test Space",
+		Type: "global",
+		Description: &SpaceDescription{
+			Plain: &DescriptionValue{Value: "A test space"},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "TEST", space.Key)
+	assert.NotNil(t, space.Description)
+	assert.Equal(t, "A test space", space.Description.Plain.Value)
+}
+
+func TestClient_CreateSpace_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message": "Space key already exists"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "token")
+	_, err := client.CreateSpace(context.Background(), &CreateSpaceRequest{
+		Key:  "DUPE",
+		Name: "Duplicate",
+	})
+
+	require.Error(t, err)
+}
+
+func TestClient_UpdateSpace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/rest/api/space/TEST", r.URL.Path)
+
+		var req UpdateSpaceRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "TEST", req.Key)
+		assert.Equal(t, "Updated Name", req.Name)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": 123456,
+			"key": "TEST",
+			"name": "Updated Name",
+			"type": "global",
+			"description": {"plain": {"value": "Description", "representation": "plain"}},
+			"_links": {"webui": "/spaces/TEST", "self": "https://example.atlassian.net/wiki/rest/api/space/TEST"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "token")
+	space, err := client.UpdateSpace(context.Background(), "TEST", &UpdateSpaceRequest{
+		Key:  "TEST",
+		Name: "Updated Name",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "123456", space.ID)
+	assert.Equal(t, "TEST", space.Key)
+	assert.Equal(t, "Updated Name", space.Name)
+	assert.Equal(t, "global", space.Type)
+	assert.NotNil(t, space.Description)
+	assert.Equal(t, "Description", space.Description.Plain.Value)
+}
+
+func TestClient_UpdateSpace_WithDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req UpdateSpaceRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.NotNil(t, req.Description)
+		assert.Equal(t, "New description", req.Description.Plain.Value)
+		assert.Equal(t, "plain", req.Description.Plain.Representation)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": 123456,
+			"key": "TEST",
+			"name": "Test Space",
+			"type": "global",
+			"description": {"plain": {"value": "New description", "representation": "plain"}},
+			"_links": {"webui": "/spaces/TEST"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "token")
+	space, err := client.UpdateSpace(context.Background(), "TEST", &UpdateSpaceRequest{
+		Key:  "TEST",
+		Name: "Test Space",
+		Description: &V1SpaceDescription{
+			Plain: &V1DescriptionValue{
+				Value:          "New description",
+				Representation: "plain",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "New description", space.Description.Plain.Value)
+}
+
+func TestClient_UpdateSpace_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message": "Space not found"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "token")
+	_, err := client.UpdateSpace(context.Background(), "NOPE", &UpdateSpaceRequest{
+		Key:  "NOPE",
+		Name: "Updated",
+	})
+
+	require.Error(t, err)
+}
+
+func TestClient_UpdateSpace_NoDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": 123456,
+			"key": "TEST",
+			"name": "Test Space",
+			"type": "global",
+			"description": {"plain": {"value": "", "representation": "plain"}},
+			"_links": {"webui": "/spaces/TEST"}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "token")
+	space, err := client.UpdateSpace(context.Background(), "TEST", &UpdateSpaceRequest{
+		Key:  "TEST",
+		Name: "Test Space",
+	})
+
+	require.NoError(t, err)
+	assert.Nil(t, space.Description)
+}
+
+func TestClient_DeleteSpace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/rest/api/space/TEST", r.URL.Path)
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "token")
+	err := client.DeleteSpace(context.Background(), "TEST")
+
+	require.NoError(t, err)
+}
+
+func TestClient_DeleteSpace_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message": "Space not found"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "user@example.com", "token")
+	err := client.DeleteSpace(context.Background(), "NOPE")
+
+	require.Error(t, err)
+}
+
+func TestV1SpaceResponse_ToSpace(t *testing.T) {
+	response := &v1SpaceResponse{
+		ID:   123456,
+		Key:  "TEST",
+		Name: "Test Space",
+		Type: "global",
+	}
+	response.Description.Plain.Value = "A test space"
+	response.Description.Plain.Representation = "plain"
+	response.Links.WebUI = "/spaces/TEST"
+
+	space := response.toSpace()
+
+	assert.Equal(t, "123456", space.ID)
+	assert.Equal(t, "TEST", space.Key)
+	assert.Equal(t, "Test Space", space.Name)
+	assert.Equal(t, "global", space.Type)
+	assert.Equal(t, "/spaces/TEST", space.Links.WebUI)
+	assert.NotNil(t, space.Description)
+	assert.Equal(t, "A test space", space.Description.Plain.Value)
+}
+
+func TestV1SpaceResponse_ToSpace_EmptyDescription(t *testing.T) {
+	response := &v1SpaceResponse{
+		ID:   123456,
+		Key:  "TEST",
+		Name: "Test Space",
+		Type: "global",
+	}
+
+	space := response.toSpace()
+
+	assert.Nil(t, space.Description)
+}

--- a/tools/cfl/integration-tests.md
+++ b/tools/cfl/integration-tests.md
@@ -174,6 +174,61 @@ This document catalogs the manual integration test suite for `cfl`. These tests 
 | JSON output | `cfl space list --output json` | Valid JSON array |
 | Limit results | `cfl space list --limit 5` | Shows first 5 spaces |
 
+### space view
+
+| Test Case | Command | Expected Result |
+|-----------|---------|-----------------|
+| View space by key | `cfl space view confluence` | Key-value pairs: KEY, NAME, ID, TYPE, STATUS, DESCRIPTION |
+| JSON output | `cfl space view confluence -o json` | Valid JSON object with id, key, name, type, status, description |
+| Non-existent space | `cfl space view NONEXISTENT` | Error: Space with key 'NONEXISTENT' not found |
+| View personal space | `cfl space view ~accountid` | Shows personal space details (if accessible) |
+| Alias: get | `cfl space get confluence` | Same output as `space view` |
+
+### space create
+
+| Test Case | Command | Expected Result |
+|-----------|---------|-----------------|
+| Create global space | `cfl space create --key INTTEST --name "[Test] Integration" --description "Test space"` | Space created, shows KEY, NAME, URL |
+| Create with JSON output | `cfl space create --key INTTEST2 --name "[Test] Int2" -o json` | Valid JSON with id, key, name, type |
+| Missing key flag | `cfl space create --name "Test"` | Error: required flag(s) "key" not set |
+| Missing name flag | `cfl space create --key TST` | Error: required flag(s) "name" not set |
+| Duplicate key | `cfl space create --key INTTEST --name "Duplicate"` (after creating INTTEST) | Error: API rejects duplicate key |
+
+### space update
+
+| Test Case | Command | Expected Result |
+|-----------|---------|-----------------|
+| Update name | `cfl space update INTTEST --name "[Test] Updated Name"` | Shows updated key and name |
+| Update description | `cfl space update INTTEST --description "Updated description"` | Shows updated key and name |
+| Update both | `cfl space update INTTEST --name "[Test] Both" --description "Both updated"` | Both name and description changed |
+| JSON output | `cfl space update INTTEST --name "[Test] JSON" -o json` | Valid JSON with updated fields |
+| No flags provided | `cfl space update INTTEST` | Error: at least one of --name or --description required |
+| Non-existent space | `cfl space update NONEXISTENT --name "X"` | Error: not found |
+| Verify update | `cfl space view INTTEST` | Shows new name and description |
+
+### space delete
+
+| Test Case | Command | Expected Result |
+|-----------|---------|-----------------|
+| Delete with confirmation | `cfl space delete INTTEST` (type "y") | Space deleted after confirmation prompt |
+| Delete cancelled | `cfl space delete INTTEST` (type "n") | "Deletion cancelled" message |
+| Delete with --force | `cfl space delete INTTEST --force` | Space deleted without confirmation |
+| JSON output | `cfl space delete INTTEST --force -o json` | `{"status": "deleted", "space_key": "INTTEST", "name": "..."}` |
+| Non-existent space | `cfl space delete NONEXISTENT --force` | Error: not found |
+
+### Space CRUD End-to-End (sequential)
+
+| Step | Command | Expected Result |
+|------|---------|-----------------|
+| 1. Create | `cfl space create --key INTTEST --name "[Test] Integration" --description "Test space"` | Space created |
+| 2. Verify create | `cfl space view INTTEST` | Shows key=INTTEST, name="[Test] Integration" |
+| 3. Update name | `cfl space update INTTEST --name "[Test] Updated"` | Name updated |
+| 4. Verify update | `cfl space view INTTEST` | Shows new name |
+| 5. Update desc | `cfl space update INTTEST --description "New description"` | Description updated |
+| 6. List includes it | `cfl space list -o json \| jq '.[] \| select(.key == "INTTEST")'` | Space appears in list |
+| 7. Delete | `cfl space delete INTTEST --force` | "Deleted space INTTEST" |
+| 8. Verify gone | `cfl space view INTTEST` | Error: not found |
+
 ---
 
 ## Search Operations
@@ -567,6 +622,21 @@ Before GA release, run through this checklist:
 - [ ] JSON output is valid
 - [ ] Raw CQL works
 
+### Space CRUD
+- [ ] View space (table output)
+- [ ] View space (JSON output)
+- [ ] View non-existent space (expect error)
+- [ ] Create space with key, name, description
+- [ ] Create space (JSON output)
+- [ ] Create duplicate key (expect error)
+- [ ] Update space name
+- [ ] Update space description
+- [ ] Update with no flags (expect error)
+- [ ] Delete space (with confirmation, type "y")
+- [ ] Delete space (with confirmation, type "n" — cancelled)
+- [ ] Delete space (--force, no confirmation)
+- [ ] End-to-end lifecycle: create → view → update → delete → verify gone
+
 ### Edge Cases
 - [ ] Unicode in titles/content
 - [ ] Empty content
@@ -576,6 +646,8 @@ Before GA release, run through this checklist:
 
 ### Cleanup
 - [ ] Delete all [Test] prefixed pages
+- [ ] `cfl space delete INTTEST --force`
+- [ ] `cfl space delete INTTEST2 --force`
 - [ ] Verify no test data remains
 
 ---

--- a/tools/cfl/internal/cmd/space/create.go
+++ b/tools/cfl/internal/cmd/space/create.go
@@ -1,0 +1,96 @@
+package space
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+type createOptions struct {
+	*root.Options
+	key         string
+	name        string
+	description string
+	spaceType   string
+}
+
+func newCreateCmd(rootOpts *root.Options) *cobra.Command {
+	opts := &createOptions{Options: rootOpts}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new space",
+		Long:  `Create a new Confluence space.`,
+		Example: `  # Create a global space
+  cfl space create --key DEV --name "Development"
+
+  # Create with description
+  cfl space create --key DEV --name "Development" --description "Development team space"`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runCreate(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.key, "key", "k", "", "Space key (required)")
+	cmd.Flags().StringVarP(&opts.name, "name", "n", "", "Space name (required)")
+	cmd.Flags().StringVarP(&opts.description, "description", "d", "", "Space description")
+	cmd.Flags().StringVarP(&opts.spaceType, "type", "t", "global", "Space type (global, personal)")
+
+	_ = cmd.MarkFlagRequired("key")
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func runCreate(opts *createOptions) error {
+	if err := view.ValidateFormat(opts.Output); err != nil {
+		return err
+	}
+
+	cfg, err := opts.Config()
+	if err != nil {
+		return err
+	}
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	req := &api.CreateSpaceRequest{
+		Key:  opts.key,
+		Name: opts.name,
+		Type: opts.spaceType,
+	}
+
+	if opts.description != "" {
+		req.Description = &api.SpaceDescription{
+			Plain: &api.DescriptionValue{Value: opts.description},
+		}
+	}
+
+	space, err := client.CreateSpace(context.Background(), req)
+	if err != nil {
+		return fmt.Errorf("failed to create space: %w", err)
+	}
+
+	v := opts.View()
+
+	if opts.Output == "json" {
+		return v.JSON(space)
+	}
+
+	v.Success("Created space: %s", space.Name)
+	v.RenderKeyValue("Key", space.Key)
+	if space.Links.WebUI != "" {
+		v.RenderKeyValue("URL", cfg.URL+space.Links.WebUI)
+	}
+
+	return nil
+}

--- a/tools/cfl/internal/cmd/space/delete.go
+++ b/tools/cfl/internal/cmd/space/delete.go
@@ -1,0 +1,89 @@
+package space
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/atlassian-go/prompt"
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+type deleteOptions struct {
+	*root.Options
+	force bool
+}
+
+func newDeleteCmd(rootOpts *root.Options) *cobra.Command {
+	opts := &deleteOptions{Options: rootOpts}
+
+	cmd := &cobra.Command{
+		Use:   "delete <space-key>",
+		Short: "Delete a space",
+		Long:  `Delete a Confluence space by its key.`,
+		Example: `  # Delete a space
+  cfl space delete TEST
+
+  # Delete without confirmation
+  cfl space delete TEST --force`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runDelete(args[0], opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+func runDelete(spaceKey string, opts *deleteOptions) error {
+	if err := view.ValidateFormat(opts.Output); err != nil {
+		return err
+	}
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	space, err := client.GetSpaceByKey(context.Background(), spaceKey)
+	if err != nil {
+		return fmt.Errorf("failed to get space: %w", err)
+	}
+
+	v := opts.View()
+
+	if !opts.force {
+		fmt.Printf("About to delete space: %s (%s)\n", space.Name, space.Key)
+		fmt.Print("Are you sure? [y/N]: ")
+
+		confirmed, err := prompt.Confirm(opts.Stdin)
+		if err != nil {
+			return fmt.Errorf("failed to read confirmation: %w", err)
+		}
+		if !confirmed {
+			fmt.Println("Deletion cancelled.")
+			return nil
+		}
+	}
+
+	if err := client.DeleteSpace(context.Background(), spaceKey); err != nil {
+		return fmt.Errorf("failed to delete space: %w", err)
+	}
+
+	if opts.Output == "json" {
+		return v.JSON(map[string]string{
+			"status":    "deleted",
+			"space_key": spaceKey,
+			"name":      space.Name,
+		})
+	}
+
+	v.Success("Deleted space: %s (%s)", space.Name, spaceKey)
+
+	return nil
+}

--- a/tools/cfl/internal/cmd/space/space.go
+++ b/tools/cfl/internal/cmd/space/space.go
@@ -13,10 +13,14 @@ func Register(rootCmd *cobra.Command, opts *root.Options) {
 		Use:     "space",
 		Aliases: []string{"spaces"},
 		Short:   "Manage Confluence spaces",
-		Long:    `Commands for listing and viewing Confluence spaces.`,
+		Long:    `Commands for listing, viewing, creating, updating, and deleting Confluence spaces.`,
 	}
 
 	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newViewCmd(opts))
+	cmd.AddCommand(newCreateCmd(opts))
+	cmd.AddCommand(newUpdateCmd(opts))
+	cmd.AddCommand(newDeleteCmd(opts))
 
 	rootCmd.AddCommand(cmd)
 }

--- a/tools/cfl/internal/cmd/space/space_test.go
+++ b/tools/cfl/internal/cmd/space/space_test.go
@@ -1,0 +1,511 @@
+package space
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	"github.com/open-cli-collective/confluence-cli/internal/config"
+)
+
+// spaceListResponse returns a v2 list response with a single space.
+const spaceListResponse = `{
+	"results": [{
+		"id": "123456",
+		"key": "TEST",
+		"name": "Test Space",
+		"type": "global",
+		"status": "current",
+		"description": {"plain": {"value": "A test space"}}
+	}]
+}`
+
+// v1SpaceUpdateResponse returns a v1 API space response.
+const v1SpaceUpdateResponse = `{
+	"id": 123456,
+	"key": "TEST",
+	"name": "Updated Name",
+	"type": "global",
+	"description": {"plain": {"value": "Updated description", "representation": "plain"}},
+	"_links": {"webui": "/spaces/TEST"}
+}`
+
+// --- View tests ---
+
+func TestRunView_Table(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Contains(t, r.URL.Path, "/spaces")
+		assert.Equal(t, "TEST", r.URL.Query().Get("keys"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(spaceListResponse))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	rootOpts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &viewOptions{Options: rootOpts}
+	err := runView("TEST", opts)
+
+	require.NoError(t, err)
+	output := stdout.String()
+	assert.Contains(t, output, "TEST")
+	assert.Contains(t, output, "Test Space")
+	assert.Contains(t, output, "global")
+	assert.Contains(t, output, "A test space")
+}
+
+func TestRunView_JSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(spaceListResponse))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	rootOpts := &root.Options{
+		Output:  "json",
+		NoColor: true,
+		Stdout:  stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &viewOptions{Options: rootOpts}
+	err := runView("TEST", opts)
+
+	require.NoError(t, err)
+	var result map[string]interface{}
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Equal(t, "TEST", result["key"])
+}
+
+func TestRunView_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &viewOptions{Options: rootOpts}
+	err := runView("NONEXISTENT", opts)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// --- Create tests ---
+
+func TestRunCreate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v2/spaces", r.URL.Path)
+
+		var req api.CreateSpaceRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "TEST", req.Key)
+		assert.Equal(t, "Test Space", req.Name)
+		assert.Equal(t, "global", req.Type)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "123456",
+			"key": "TEST",
+			"name": "Test Space",
+			"type": "global",
+			"_links": {"webui": "/spaces/TEST"}
+		}`))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	rootOpts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+	rootOpts.SetConfig(&config.Config{URL: "https://example.atlassian.net/wiki"})
+
+	opts := &createOptions{
+		Options:   rootOpts,
+		key:       "TEST",
+		name:      "Test Space",
+		spaceType: "global",
+	}
+
+	err := runCreate(opts)
+
+	require.NoError(t, err)
+	output := stdout.String()
+	assert.Contains(t, output, "Created space")
+	assert.Contains(t, output, "Test Space")
+	assert.Contains(t, output, "TEST")
+}
+
+func TestRunCreate_JSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "123456",
+			"key": "TEST",
+			"name": "Test Space",
+			"type": "global"
+		}`))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	rootOpts := &root.Options{
+		Output:  "json",
+		NoColor: true,
+		Stdout:  stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+	rootOpts.SetConfig(&config.Config{URL: "https://example.atlassian.net/wiki"})
+
+	opts := &createOptions{
+		Options:   rootOpts,
+		key:       "TEST",
+		name:      "Test Space",
+		spaceType: "global",
+	}
+
+	err := runCreate(opts)
+
+	require.NoError(t, err)
+	var result map[string]interface{}
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Equal(t, "TEST", result["key"])
+}
+
+func TestRunCreate_WithDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req api.CreateSpaceRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.NotNil(t, req.Description)
+		assert.Equal(t, "A test space", req.Description.Plain.Value)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "123456",
+			"key": "TEST",
+			"name": "Test Space",
+			"type": "global"
+		}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+	rootOpts.SetConfig(&config.Config{URL: "https://example.atlassian.net/wiki"})
+
+	opts := &createOptions{
+		Options:     rootOpts,
+		key:         "TEST",
+		name:        "Test Space",
+		description: "A test space",
+		spaceType:   "global",
+	}
+
+	err := runCreate(opts)
+	require.NoError(t, err)
+}
+
+// --- Update tests ---
+
+func TestRunUpdate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/rest/api/space/TEST", r.URL.Path)
+
+		var req api.UpdateSpaceRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "TEST", req.Key)
+		assert.Equal(t, "Updated Name", req.Name)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(v1SpaceUpdateResponse))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	rootOpts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &updateOptions{
+		Options: rootOpts,
+		name:    "Updated Name",
+	}
+
+	err := runUpdate("TEST", opts)
+
+	require.NoError(t, err)
+	output := stdout.String()
+	assert.Contains(t, output, "Updated space")
+	assert.Contains(t, output, "Updated Name")
+}
+
+func TestRunUpdate_JSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(v1SpaceUpdateResponse))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	rootOpts := &root.Options{
+		Output:  "json",
+		NoColor: true,
+		Stdout:  stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &updateOptions{
+		Options: rootOpts,
+		name:    "Updated Name",
+	}
+
+	err := runUpdate("TEST", opts)
+
+	require.NoError(t, err)
+	var result map[string]interface{}
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Equal(t, "TEST", result["key"])
+}
+
+func TestRunUpdate_NoFlags(t *testing.T) {
+	rootOpts := newTestRootOptions()
+
+	opts := &updateOptions{
+		Options: rootOpts,
+	}
+
+	err := runUpdate("TEST", opts)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one of --name or --description is required")
+}
+
+func TestRunUpdate_WithDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req api.UpdateSpaceRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.NotNil(t, req.Description)
+		assert.Equal(t, "New description", req.Description.Plain.Value)
+		assert.Equal(t, "plain", req.Description.Plain.Representation)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(v1SpaceUpdateResponse))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &updateOptions{
+		Options:     rootOpts,
+		description: "New description",
+	}
+
+	err := runUpdate("TEST", opts)
+	require.NoError(t, err)
+}
+
+// --- Delete tests ---
+
+func TestRunDelete_Force(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			// GetSpaceByKey call
+			assert.Equal(t, "GET", r.Method)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(spaceListResponse))
+			return
+		}
+		// DeleteSpace call
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/rest/api/space/TEST", r.URL.Path)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	rootOpts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &deleteOptions{
+		Options: rootOpts,
+		force:   true,
+	}
+
+	err := runDelete("TEST", opts)
+
+	require.NoError(t, err)
+	output := stdout.String()
+	assert.Contains(t, output, "Deleted space")
+	assert.Contains(t, output, "Test Space")
+}
+
+func TestRunDelete_Force_JSON(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(spaceListResponse))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	rootOpts := &root.Options{
+		Output:  "json",
+		NoColor: true,
+		Stdout:  stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &deleteOptions{
+		Options: rootOpts,
+		force:   true,
+	}
+
+	err := runDelete("TEST", opts)
+
+	require.NoError(t, err)
+	var result map[string]string
+	err = json.Unmarshal(stdout.Bytes(), &result)
+	require.NoError(t, err)
+	assert.Equal(t, "deleted", result["status"])
+	assert.Equal(t, "TEST", result["space_key"])
+	assert.Equal(t, "Test Space", result["name"])
+}
+
+func TestRunDelete_NoForce_Declined(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(spaceListResponse))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	rootOpts.Stdin = strings.NewReader("n\n")
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &deleteOptions{
+		Options: rootOpts,
+		force:   false,
+	}
+
+	err := runDelete("TEST", opts)
+
+	require.NoError(t, err)
+}
+
+func TestRunDelete_NoForce_Accepted(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(spaceListResponse))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	rootOpts.Stdin = strings.NewReader("y\n")
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &deleteOptions{
+		Options: rootOpts,
+		force:   false,
+	}
+
+	err := runDelete("TEST", opts)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestRunDelete_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &deleteOptions{
+		Options: rootOpts,
+		force:   true,
+	}
+
+	err := runDelete("NONEXISTENT", opts)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/tools/cfl/internal/cmd/space/update.go
+++ b/tools/cfl/internal/cmd/space/update.go
@@ -1,0 +1,93 @@
+package space
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+type updateOptions struct {
+	*root.Options
+	name        string
+	description string
+}
+
+func newUpdateCmd(rootOpts *root.Options) *cobra.Command {
+	opts := &updateOptions{Options: rootOpts}
+
+	cmd := &cobra.Command{
+		Use:   "update <space-key>",
+		Short: "Update a space",
+		Long:  `Update the name or description of a Confluence space.`,
+		Example: `  # Update space name
+  cfl space update DEV --name "Development Team"
+
+  # Update space description
+  cfl space update DEV --description "Updated description"
+
+  # Update both
+  cfl space update DEV --name "Development Team" --description "Updated description"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runUpdate(args[0], opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.name, "name", "n", "", "New space name")
+	cmd.Flags().StringVarP(&opts.description, "description", "d", "", "New space description")
+
+	return cmd
+}
+
+func runUpdate(spaceKey string, opts *updateOptions) error {
+	if opts.name == "" && opts.description == "" {
+		return fmt.Errorf("at least one of --name or --description is required")
+	}
+
+	if err := view.ValidateFormat(opts.Output); err != nil {
+		return err
+	}
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	req := &api.UpdateSpaceRequest{
+		Key: spaceKey,
+	}
+
+	if opts.name != "" {
+		req.Name = opts.name
+	}
+
+	if opts.description != "" {
+		req.Description = &api.V1SpaceDescription{
+			Plain: &api.V1DescriptionValue{
+				Value:          opts.description,
+				Representation: "plain",
+			},
+		}
+	}
+
+	space, err := client.UpdateSpace(context.Background(), spaceKey, req)
+	if err != nil {
+		return fmt.Errorf("failed to update space: %w", err)
+	}
+
+	v := opts.View()
+
+	if opts.Output == "json" {
+		return v.JSON(space)
+	}
+
+	v.Success("Updated space: %s (%s)", space.Name, space.Key)
+
+	return nil
+}

--- a/tools/cfl/internal/cmd/space/view.go
+++ b/tools/cfl/internal/cmd/space/view.go
@@ -1,0 +1,73 @@
+package space
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+type viewOptions struct {
+	*root.Options
+}
+
+func newViewCmd(rootOpts *root.Options) *cobra.Command {
+	opts := &viewOptions{Options: rootOpts}
+
+	cmd := &cobra.Command{
+		Use:     "view <space-key>",
+		Aliases: []string{"get"},
+		Short:   "View space details",
+		Long:    `View details of a Confluence space by its key.`,
+		Example: `  # View a space
+  cfl space view DEV
+
+  # View as JSON
+  cfl space view DEV -o json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runView(args[0], opts)
+		},
+	}
+
+	return cmd
+}
+
+func runView(spaceKey string, opts *viewOptions) error {
+	if err := view.ValidateFormat(opts.Output); err != nil {
+		return err
+	}
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	space, err := client.GetSpaceByKey(context.Background(), spaceKey)
+	if err != nil {
+		return fmt.Errorf("failed to get space: %w", err)
+	}
+
+	v := opts.View()
+
+	if opts.Output == "json" {
+		return v.JSON(space)
+	}
+
+	v.RenderKeyValue("Key", space.Key)
+	v.RenderKeyValue("Name", space.Name)
+	v.RenderKeyValue("ID", space.ID)
+	v.RenderKeyValue("Type", space.Type)
+	if space.Status != "" {
+		v.RenderKeyValue("Status", space.Status)
+	}
+	if space.Description != nil && space.Description.Plain != nil && space.Description.Plain.Value != "" {
+		v.RenderKeyValue("Description", space.Description.Plain.Value)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `space view`, `space create`, `space update`, `space delete` commands for full Confluence space management
- API layer handles v2 (create) and v1 (update/delete) with v1→v2 response conversion
- 12 API tests + 15 command tests covering happy paths, error cases, and confirmation prompts
- Integration tests added for all space CRUD operations

Closes #151