### PR TITLE
fix(issues): interpret \n escape sequences in --description flag

### DIFF
--- a/tools/jtk/internal/cmd/issues/create.go
+++ b/tools/jtk/internal/cmd/issues/create.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/text"
 )
 
 func newCreateCmd(opts *root.Options) *cobra.Command {
@@ -114,7 +115,7 @@ func runCreate(opts *root.Options, project, issueType, summary, description, par
 		extraFields["assignee"] = map[string]string{"accountId": accountID}
 	}
 
-	req := api.BuildCreateRequest(project, issueType, summary, description, extraFields)
+	req := api.BuildCreateRequest(project, issueType, summary, text.InterpretEscapes(description), extraFields)
 
 	issue, err := client.CreateIssue(req)
 	if err != nil {

--- a/tools/jtk/internal/cmd/issues/create_test.go
+++ b/tools/jtk/internal/cmd/issues/create_test.go
@@ -478,6 +478,55 @@ func TestRunCreate_WithAssigneeEmail(t *testing.T) {
 	assert.Equal(t, "found-account-id", assigneeField["accountId"])
 }
 
+func TestRunCreate_DescriptionEscapeSequences(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue" && r.Method == "POST" {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(api.Issue{Key: "TEST-10", ID: "10010"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	// Simulate what the shell passes when user types: --description "First paragraph.\n\nSecond paragraph."
+	// The shell delivers literal backslash-n, not actual newlines.
+	err = runCreate(opts, "PROJ", "Task", "Test", `First paragraph.\n\nSecond paragraph.`, "", "", nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, capturedBody)
+	var reqBody map[string]interface{}
+	err = json.Unmarshal(capturedBody, &reqBody)
+	require.NoError(t, err)
+
+	fields := reqBody["fields"].(map[string]interface{})
+	desc := fields["description"].(map[string]interface{})
+	assert.Equal(t, "doc", desc["type"])
+
+	// With escape interpretation, the description should produce multiple paragraphs
+	// (not a single paragraph with literal \n text)
+	content := desc["content"].([]interface{})
+	assert.GreaterOrEqual(t, len(content), 2, "escaped newlines should produce multiple ADF nodes, not one paragraph with literal \\n")
+}
+
 func TestRunCreate_WithoutAssignee(t *testing.T) {
 	var capturedBody []byte
 

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/text"
 )
 
 func newUpdateCmd(opts *root.Options) *cobra.Command {
@@ -70,7 +71,7 @@ func runUpdate(opts *root.Options, issueKey, summary, description, parent, assig
 	}
 
 	if description != "" {
-		fields["description"] = api.NewADFDocument(description)
+		fields["description"] = api.NewADFDocument(text.InterpretEscapes(description))
 	}
 
 	if parent != "" {

--- a/tools/jtk/internal/text/escapes.go
+++ b/tools/jtk/internal/text/escapes.go
@@ -1,0 +1,34 @@
+package text
+
+import "strings"
+
+// InterpretEscapes processes C-style escape sequences in a string.
+// This handles the common case where CLI users pass literal \n, \t, or \\
+// in flag values and expect them to be interpreted as actual control characters.
+func InterpretEscapes(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	for i := 0; i < len(s); i++ {
+		if s[i] != '\\' || i+1 >= len(s) {
+			b.WriteByte(s[i])
+			continue
+		}
+
+		switch s[i+1] {
+		case 'n':
+			b.WriteByte('\n')
+		case 't':
+			b.WriteByte('\t')
+		case '\\':
+			b.WriteByte('\\')
+		default:
+			// Not a recognized escape — keep both characters
+			b.WriteByte(s[i])
+			b.WriteByte(s[i+1])
+		}
+		i++ // skip the character after backslash
+	}
+
+	return b.String()
+}

--- a/tools/jtk/internal/text/escapes_test.go
+++ b/tools/jtk/internal/text/escapes_test.go
@@ -1,0 +1,33 @@
+package text
+
+import "testing"
+
+func TestInterpretEscapes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no escapes", "hello world", "hello world"},
+		{"single newline", `first\nsecond`, "first\nsecond"},
+		{"double newline", `first\n\nsecond`, "first\n\nsecond"},
+		{"tab", `col1\tcol2`, "col1\tcol2"},
+		{"escaped backslash", `path\\to\\file`, `path\to\file`},
+		{"mixed escapes", `line1\n\tindented\n\\done`, "line1\n\tindented\n\\done"},
+		{"trailing backslash", `ends with\`, `ends with\`},
+		{"unknown escape", `\x is unknown`, `\x is unknown`},
+		{"empty string", "", ""},
+		{"only newlines", `\n\n\n`, "\n\n\n"},
+		{"markdown with escapes", `# Title\n\nParagraph\n\n- Item 1\n- Item 2`, "# Title\n\nParagraph\n\n- Item 1\n- Item 2"},
+		{"already real newlines", "real\nnewlines", "real\nnewlines"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InterpretEscapes(tt.input)
+			if got != tt.want {
+				t.Errorf("InterpretEscapes(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #161

- Adds `internal/text.InterpretEscapes()` to convert C-style escape sequences (`\n`, `\t`, `\\`) in CLI flag values to actual control characters
- Applies escape interpretation to `--description` in both `jtk issues create` and `jtk issues update`
- Users can now use `--description "First paragraph.\n\nSecond paragraph."` and get proper paragraph breaks in Jira

## Test plan

- [x] New unit tests for `InterpretEscapes` covering all edge cases (trailing backslash, unknown escapes, already-real newlines, empty string)
- [x] New integration test `TestRunCreate_DescriptionEscapeSequences` verifying escaped newlines produce multiple ADF nodes
- [x] All existing tests pass (`go test ./tools/jtk/...`)
- [x] Lint clean (`golangci-lint run`)