### PR TITLE
docs: update README, CHANGELOG, and integration tests

### DIFF
--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `users get <account-id>` subcommand to look up a user by account ID ([#189](https://github.com/open-cli-collective/atlassian-cli/pull/189))
+- `--assignee none` on `issues update` and `--field assignee=null` to unassign issues ([#187](https://github.com/open-cli-collective/atlassian-cli/pull/187))
+- `--field` flag accumulates repeated values for the same key, enabling multi-checkbox and multi-select custom fields ([#186](https://github.com/open-cli-collective/atlassian-cli/pull/186))
+- `--fields` flag on `issues list` and `issues search` for explicit field selection ([#180](https://github.com/open-cli-collective/atlassian-cli/pull/180))
+- Auto-pagination for `issues list` and `issues search` — `--max` returns up to N results across pages ([#182](https://github.com/open-cli-collective/atlassian-cli/pull/182))
 - Automation rule builder module for constructing rule JSON programmatically with a fluent Go API ([#174](https://github.com/open-cli-collective/atlassian-cli/pull/174))
 - Service account support with bearer auth (`--auth-method bearer`) for scoped API tokens ([#171](https://github.com/open-cli-collective/atlassian-cli/pull/171))
 - Cursor-based pagination with `--next-page-token` and lightweight fields (`--full`) for `issues list` and `issues search` ([#168](https://github.com/open-cli-collective/atlassian-cli/pull/168))
@@ -42,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `\n`, `\t`, `\\` escape sequences now work in `comments add --body` ([#188](https://github.com/open-cli-collective/atlassian-cli/pull/188))
+- `issues search` and `issues list` with `-o json` now return all fields including custom fields by default ([#180](https://github.com/open-cli-collective/atlassian-cli/pull/180))
+- Wiki markup conversion no longer mangles hyphens and tildes ([#178](https://github.com/open-cli-collective/atlassian-cli/pull/178))
 - `--field parent=PROJ-123` and issuelink-type custom fields now format correctly instead of producing a `"data was not an object"` API error ([#140](https://github.com/open-cli-collective/atlassian-cli/pull/140))
 - `config show -o json` no longer appends trailing plain text after JSON body ([#124](https://github.com/open-cli-collective/atlassian-cli/pull/124))
 - `projects create` success message uses the input name instead of the empty API response name ([#121](https://github.com/open-cli-collective/atlassian-cli/pull/121))

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -10,10 +10,11 @@ A command-line interface for managing Jira Cloud tickets.
 - Manage sprints and boards
 - Add comments and perform transitions
 - Manage attachments
+- Manage custom fields (create, delete, restore, contexts, options)
 - Manage automation rules (list, export, create, enable/disable)
 - Manage dashboards and gadgets
 - Create and manage issue links
-- Search users
+- Search and look up users
 - Multiple output formats (table, JSON, plain)
 - Shell completion for bash, zsh, fish, and PowerShell
 
@@ -243,13 +244,20 @@ List issues in a project.
 jtk issues list --project MYPROJECT
 jtk issues list --project MYPROJECT --sprint current
 jtk issues list --project MYPROJECT -o json
+
+# Auto-pagination: fetch up to 200 results across multiple pages
+jtk issues list --project MYPROJECT --max 200
+
+# Explicit field selection
+jtk issues list --project MYPROJECT --fields summary,status,customfield_10005 -o json
 ```
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--project` | `-p` | | Project key |
 | `--sprint` | `-s` | | Filter by sprint: sprint ID or `current` |
-| `--max` | `-m` | `25` | Page size (number of results per page) |
+| `--max` | `-m` | `25` | Maximum number of results to return |
+| `--fields` | | `*all` | Comma-separated list of fields to include in JSON output |
 | `--full` | | `false` | Include all fields (e.g. description) |
 | `--next-page-token` | | | Token for next page of results |
 
@@ -304,6 +312,12 @@ Update an existing issue.
 jtk issues update PROJ-123 --summary "New summary"
 jtk issues update PROJ-123 --field priority=High
 jtk issues update PROJ-123 --description "Updated description" --field labels=urgent
+
+# Unassign an issue
+jtk issues update PROJ-123 --assignee none
+
+# Multi-value fields: repeat --field with the same key to accumulate values
+jtk issues update PROJ-123 --field customfield_10050=Option1 --field customfield_10050=Option2
 ```
 
 | Flag | Short | Default | Description |
@@ -311,9 +325,9 @@ jtk issues update PROJ-123 --description "Updated description" --field labels=ur
 | `--summary` | `-s` | | New summary |
 | `--description` | `-d` | | New description (supports `\n`, `\t`, `\\` escape sequences) |
 | `--parent` | | | Parent issue key (epic or parent issue) |
-| `--assignee` | `-a` | | Assignee (account ID, email, or `"me"`) |
+| `--assignee` | `-a` | | Assignee (account ID, email, `"me"`, or `"none"` to unassign) |
 | `--type` | `-t` | | New issue type (uses Jira Cloud bulk move API) |
-| `--field` | `-f` | | Field to update in `key=value` format (can be repeated) |
+| `--field` | `-f` | | Field to update in `key=value` format (can be repeated; repeating the same key accumulates values for multi-select fields) |
 
 **Arguments:**
 - `<issue-key>` - The issue key (**required**)
@@ -327,12 +341,19 @@ Search issues using JQL.
 ```bash
 jtk issues search --jql "project = MYPROJECT AND status = 'In Progress'"
 jtk issues search --jql "assignee = currentUser()" -o json
+
+# Auto-pagination: fetch up to 200 results across multiple pages
+jtk issues search --jql "project = MYPROJECT" --max 200
+
+# Explicit field selection
+jtk issues search --jql "project = MYPROJECT" --fields summary,status -o json
 ```
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--jql` | | | JQL query string (**required**) |
-| `--max` | `-m` | `25` | Page size (number of results per page) |
+| `--max` | `-m` | `25` | Maximum number of results to return |
+| `--fields` | | `*all` | Comma-separated list of fields to include in JSON output |
 | `--full` | | `false` | Include all fields (e.g. description) |
 | `--next-page-token` | | | Token for next page of results |
 
@@ -409,6 +430,174 @@ jtk issues field-options customfield_10001 --issue PROJ-123
 
 **Arguments:**
 - `<field-name-or-id>` - Field name or ID (**required**)
+
+---
+
+### `jtk fields`
+
+Manage custom fields, their contexts, and options.
+
+**Aliases:** `jtk field`, `jtk f`
+
+#### `jtk fields list`
+
+List all fields (system and custom).
+
+```bash
+jtk fields list
+jtk fields list --custom
+jtk fields list -o json
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--custom` | `false` | Show only custom fields |
+
+#### `jtk fields create`
+
+Create a new custom field.
+
+```bash
+jtk fields create --name "My Select Field" --type com.atlassian.jira.plugin.system.customfieldtypes:select
+jtk fields create --name "My Text Field" --type com.atlassian.jira.plugin.system.customfieldtypes:textarea --description "A text area field"
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--name` | | Field name (**required**) |
+| `--type` | | Field type (**required**) |
+| `--description` | | Field description |
+
+#### `jtk fields delete <field-id>`
+
+Trash a custom field (can be restored).
+
+```bash
+jtk fields delete customfield_10001
+jtk fields delete customfield_10001 --force
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--force` | `false` | Skip confirmation prompt |
+
+**Arguments:**
+- `<field-id>` - The field ID (**required**)
+
+#### `jtk fields restore <field-id>`
+
+Restore a trashed custom field.
+
+```bash
+jtk fields restore customfield_10001
+```
+
+**Arguments:**
+- `<field-id>` - The field ID (**required**)
+
+#### `jtk fields contexts list <field-id>`
+
+List contexts for a custom field.
+
+```bash
+jtk fields contexts list customfield_10001
+jtk fields contexts list customfield_10001 -o json
+```
+
+**Arguments:**
+- `<field-id>` - The field ID (**required**)
+
+#### `jtk fields contexts create <field-id>`
+
+Create a context for a custom field.
+
+```bash
+jtk fields contexts create customfield_10001 --name "My Context"
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--name` | | Context name (**required**) |
+
+**Arguments:**
+- `<field-id>` - The field ID (**required**)
+
+#### `jtk fields contexts delete <field-id> <context-id>`
+
+Delete a context from a custom field.
+
+```bash
+jtk fields contexts delete customfield_10001 10100
+jtk fields contexts delete customfield_10001 10100 --force
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--force` | `false` | Skip confirmation prompt |
+
+**Arguments:**
+- `<field-id>` - The field ID (**required**)
+- `<context-id>` - The context ID (**required**)
+
+#### `jtk fields options list <field-id>`
+
+List options for a select/multi-select custom field.
+
+```bash
+jtk fields options list customfield_10001
+jtk fields options list customfield_10001 -o json
+```
+
+**Arguments:**
+- `<field-id>` - The field ID (**required**)
+
+#### `jtk fields options add <field-id>`
+
+Add an option to a select/multi-select custom field.
+
+```bash
+jtk fields options add customfield_10001 --value "New Option"
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--value` | | Option value (**required**) |
+
+**Arguments:**
+- `<field-id>` - The field ID (**required**)
+
+#### `jtk fields options update <field-id>`
+
+Update an existing option value.
+
+```bash
+jtk fields options update customfield_10001 --option 10200 --value "Updated Value"
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--option` | | Option ID to update (**required**) |
+| `--value` | | New option value (**required**) |
+
+**Arguments:**
+- `<field-id>` - The field ID (**required**)
+
+#### `jtk fields options delete <field-id>`
+
+Delete an option from a select/multi-select custom field.
+
+```bash
+jtk fields options delete customfield_10001 --option 10200
+jtk fields options delete customfield_10001 --option 10200 --force
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--option` | | Option ID to delete (**required**) |
+| `--force` | `false` | Skip confirmation prompt |
+
+**Arguments:**
+- `<field-id>` - The field ID (**required**)
 
 ---
 
@@ -590,11 +779,12 @@ Add a comment to an issue.
 
 ```bash
 jtk comments add PROJ-123 --body "This is my comment"
+jtk comments add PROJ-123 --body "Line one\nLine two\n\tIndented line"
 ```
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--body` | `-b` | | Comment text (**required**) |
+| `--body` | `-b` | | Comment text (supports `\n`, `\t`, `\\` escape sequences) (**required**) |
 
 **Arguments:**
 - `<issue-key>` - The issue key (**required**)
@@ -909,6 +1099,20 @@ jtk users search "john" --max 20
 
 **Arguments:**
 - `<query>` - Search query (matches display name, email, etc.) (**required**)
+
+---
+
+### `jtk users get <account-id>`
+
+Get details for a specific user by account ID.
+
+```bash
+jtk users get 5b10ac8d82e05b22cc7d4ef5
+jtk users get 5b10ac8d82e05b22cc7d4ef5 -o json
+```
+
+**Arguments:**
+- `<account-id>` - The Atlassian account ID (**required**)
 
 ---
 

--- a/tools/jtk/integration-tests.md
+++ b/tools/jtk/integration-tests.md
@@ -82,6 +82,9 @@ jtk fields list --custom
 
 # $SELECT_FIELD — pick a select/multiselect custom field with options
 # (same as $CUSTOM_FIELD if it's a select type)
+
+# $MULTI_FIELD — pick a multi-select or multi-checkbox custom field (optional)
+# Used for multi-value --field tests. Skip those tests if unavailable.
 ```
 
 ### Test Data Conventions
@@ -154,6 +157,26 @@ jtk fields list --custom
 | 2 | `jtk issues search --jql "project = $PROJECT" --max 2 -o json` | Valid JSON array |
 | 3 | `jtk issues search --jql "project = $PROJECT AND summary ~ 'xyznonexistent999'"` | `No issues found` |
 | 4 | `jtk issues search --jql "invalid jql ((("` | `bad request: Error in the JQL Query: ...` |
+
+### Auto-pagination (issues search / issues list)
+
+> These tests require a project with more than 100 issues. If your project has fewer, lower the `--max` value and adjust expected counts accordingly.
+
+| # | Command | Expected Output |
+|---|---------|-----------------|
+| 1 | `jtk issues search --jql "project = $PROJECT" --max 200 -o json \| jq '.issues \| length'` | Number >= 101 (proves multi-page fetch) |
+| 2 | `jtk issues search --jql "project = $PROJECT" --max 200 -o json \| jq '.pagination'` | `total` matches count, `pageSize` <= 100 |
+| 3 | `jtk issues search --jql "project = $PROJECT" --max 200` | Table output with > 100 rows |
+| 4 | `jtk issues list -p $PROJECT --max 200 -o json \| jq '.issues \| length'` | Same multi-page behavior for list |
+
+### `--fields` flag (issues search / issues list)
+
+| # | Command | Expected Output |
+|---|---------|-----------------|
+| 1 | `jtk issues search --jql "project = $PROJECT" --max 1 -o json \| jq '.issues[0].fields \| keys'` | Includes `customfield_*` keys (default `*all`) |
+| 2 | `jtk issues search --jql "project = $PROJECT" --max 1 --fields summary,status -o json \| jq '.issues[0].fields \| keys'` | Only `summary`, `status` |
+| 3 | `jtk issues list -p $PROJECT --max 1 -o json \| jq '.issues[0].fields \| keys'` | Same `*all` default |
+| 4 | `jtk issues list -p $PROJECT --max 1 --fields summary,customfield_10005 -o json \| jq '.issues[0].fields \| keys'` | Only requested fields |
 
 ### issues types
 
@@ -282,11 +305,21 @@ jtk fields list --custom
 
 ## 7. Users (Read-Only)
 
+### users search
+
 | # | Command | Expected Output |
 |---|---------|-----------------|
 | 1 | `jtk users search "YOUR_NAME"` | Table with columns: ACCOUNT_ID, NAME, EMAIL, ACTIVE |
 | 2 | `jtk users search "YOUR_NAME" -o json` | Valid JSON array |
 | 3 | `jtk users search "xyznonexistent999"` | `No users found matching 'xyznonexistent999'` |
+
+### users get
+
+| # | Command | Expected Output |
+|---|---------|-----------------|
+| 1 | `jtk users get $ACCOUNT_ID` | Table with Account ID, Display Name, Email, Active |
+| 2 | `jtk users get $ACCOUNT_ID -o json` | Valid JSON with `accountId`, `displayName`, `emailAddress`, `active` |
+| 3 | `jtk users get 000000000000000000000000` | Error: 404 (user not found) |
 
 ---
 
@@ -374,12 +407,18 @@ Run these steps in order. Each step depends on the previous.
    ```
    Expected: `✓ Assigned issue $TEST_ISSUE to YOUR_NAME`
 
-6. **Add comment:**
+6. **Add comment with escape sequences:**
    ```bash
-   jtk comments add $TEST_ISSUE -b "Test comment from integration testing"
+   jtk comments add $TEST_ISSUE -b "Line one\nLine two\n\tIndented line"
    ```
    Expected: `✓ Added comment XXXXX to $TEST_ISSUE`
    Capture the comment ID → `$COMMENT_ID`
+
+6b. **Verify escape sequences rendered:**
+   ```bash
+   jtk comments list $TEST_ISSUE --full
+   ```
+   Expected: Comment body shows actual newlines and tab, not literal `\n` or `\t`
 
 7. **List comments:**
    ```bash
@@ -409,11 +448,24 @@ Run these steps in order. Each step depends on the previous.
     ```
     Expected: Status shows the new value
 
-11. **Unassign:**
+11. **Unassign (via assign command):**
     ```bash
     jtk issues assign $TEST_ISSUE --unassign
     ```
     Expected: `✓ Unassigned issue $TEST_ISSUE`
+
+11b. **Re-assign, then unassign via update --assignee none:**
+    ```bash
+    jtk issues assign $TEST_ISSUE $ACCOUNT_ID
+    jtk issues update $TEST_ISSUE --assignee none
+    ```
+    Expected: First command assigns, second command shows `✓ Updated issue $TEST_ISSUE`
+
+11c. **Verify unassignment:**
+    ```bash
+    jtk issues get $TEST_ISSUE -o json | jq '.fields.assignee'
+    ```
+    Expected: `null`
 
 12. **Delete comment:**
     ```bash
@@ -426,6 +478,29 @@ Run these steps in order. Each step depends on the previous.
     jtk issues delete $TEST_ISSUE --force
     ```
     Expected: `✓ Deleted issue $TEST_ISSUE`
+
+### Multi-value `--field` flag
+
+> Requires a multi-select or multi-checkbox custom field (`$MULTI_FIELD`) on the project. Skip if unavailable.
+
+1. **Create issue with multi-value field:**
+   ```bash
+   jtk issues create -p $PROJECT -t $ISSUE_TYPE -s "[Test] Multi-Value Field" \
+     --field $MULTI_FIELD=Option1 --field $MULTI_FIELD=Option2
+   ```
+   Expected: `✓ Created issue $PROJECT-XXXX`
+   Capture the issue key → `$MV_ISSUE`
+
+2. **Verify both values set:**
+   ```bash
+   jtk issues get $MV_ISSUE -o json | jq ".fields.$MULTI_FIELD"
+   ```
+   Expected: JSON array containing both Option1 and Option2
+
+3. **Cleanup:**
+   ```bash
+   jtk issues delete $MV_ISSUE --force
+   ```
 
 ### Error cases
 
@@ -963,6 +1038,8 @@ Verify each alias produces the same output as the full command:
 - [ ] `issues list` (table, JSON, plain, error)
 - [ ] `issues get` (table, JSON, 404)
 - [ ] `issues search` (results, JSON, no results, bad JQL)
+- [ ] Auto-pagination (search multi-page, list multi-page)
+- [ ] `--fields` flag (default `*all`, explicit fields for search and list)
 - [ ] `issues types` (table, JSON, 404)
 - [ ] `issues fields` (all, custom, JSON)
 - [ ] `issues field-options` (with --issue, JSON)
@@ -988,6 +1065,7 @@ Verify each alias produces the same output as the full command:
 
 #### Users Read-Only (Section 7)
 - [ ] `users search` (results, JSON, no results)
+- [ ] `users get` (table, JSON, 404)
 
 #### Automation Read-Only (Section 8)
 - [ ] `auto list` (all, filtered, JSON)
@@ -1000,7 +1078,9 @@ Verify each alias produces the same output as the full command:
 - [ ] `fields options list` (table, JSON)
 
 #### Issue Mutations (Section 10)
-- [ ] Create → get → update → assign → comment → transition → unassign → delete comment → delete issue
+- [ ] Create → get → update → assign → comment (with escape sequences) → transition → unassign → delete comment → delete issue
+- [ ] Unassign via `--assignee none` on `issues update`
+- [ ] Multi-value `--field` flag (create issue with repeated `--field` same key)
 - [ ] Error cases (missing flags, 404)
 
 #### Link Mutations (Section 11)
@@ -1069,6 +1149,8 @@ Verify each alias produces the same output as the full command:
 - [ ] `issues list` (table, JSON, plain, error)
 - [ ] `issues get` (table, JSON, 404)
 - [ ] `issues search` (results, JSON, no results, bad JQL)
+- [ ] Auto-pagination (search multi-page, list multi-page)
+- [ ] `--fields` flag (default `*all`, explicit fields for search and list)
 - [ ] `issues types` (table, JSON, 404)
 - [ ] `issues fields` (all, custom, JSON)
 - [ ] `issues field-options` (with --issue, JSON)
@@ -1084,6 +1166,7 @@ Verify each alias produces the same output as the full command:
 
 #### Users Read-Only (Section 7)
 - [ ] `users search` (results, JSON, no results)
+- [ ] `users get` (table, JSON, 404)
 
 #### Fields Read-Only (Section 9)
 - [ ] `fields list` (all, custom, JSON)
@@ -1091,7 +1174,9 @@ Verify each alias produces the same output as the full command:
 - [ ] `fields options list` (table, JSON)
 
 #### Issue Mutations (Section 10)
-- [ ] Create → get → update → assign → comment → transition → unassign → delete comment → delete issue
+- [ ] Create → get → update → assign → comment (with escape sequences) → transition → unassign → delete comment → delete issue
+- [ ] Unassign via `--assignee none` on `issues update`
+- [ ] Multi-value `--field` flag (create issue with repeated `--field` same key)
 - [ ] Error cases (missing flags, 404)
 
 #### Link Mutations (Section 11)


### PR DESCRIPTION
## Summary
- **README**: Document `--fields` flag and auto-pagination on `issues list`/`issues search`, add `jtk fields` command group section, add `users get` subcommand, document `--assignee none` for unassignment, multi-value `--field` flag, and escape sequences in `comments add --body`
- **CHANGELOG**: Add entries for PRs #178, #180, #182, #186, #187, #188, #189
- **integration-tests**: Add test cases for auto-pagination, `--fields` flag, `users get`, `--assignee none`, multi-value `--field`, and escape sequences in comment body; update both auth pass checklists

## Test plan
- [ ] Verify only `.md` files changed (`git diff --stat`)
- [ ] Visual review of README against `jtk <cmd> --help` output
- [ ] Confirm `docs:` prefix -- no release triggered

Closes #183