### PR TITLE
feat: add --compact flag to strip metadata from JSON output

### DIFF
--- a/shared/view/view.go
+++ b/shared/view/view.go
@@ -42,6 +42,7 @@ func ValidateFormat(format string) error {
 type View struct {
 	Format  Format
 	NoColor bool
+	Compact bool
 	Out     io.Writer
 	Err     io.Writer
 }
@@ -118,7 +119,13 @@ func (v *View) tableAsJSON(headers []string, rows [][]string) error {
 }
 
 // JSON renders data as formatted JSON.
+// When Compact is true, null fields, avatar URLs, self-links, and
+// Atlassian metadata keys (_links, _expandable) are stripped to
+// reduce output size for agent/LLM consumers.
 func (v *View) JSON(data any) error {
+	if v.Compact {
+		data = compactData(data)
+	}
 	enc := json.NewEncoder(v.Out)
 	enc.SetIndent("", "  ")
 	return enc.Encode(data)
@@ -260,6 +267,60 @@ func (v *View) RenderKeyValue(key, value string) {
 // RenderText renders plain text.
 func (v *View) RenderText(text string) {
 	_, _ = fmt.Fprintln(v.Out, text)
+}
+
+// compactData converts data to a generic map/slice structure and strips
+// verbose metadata that inflates output without adding useful content.
+// Removes: null-valued fields, avatarUrls, self-link URLs, _links, _expandable.
+func compactData(data any) any {
+	// Round-trip through JSON to get a generic map/slice structure.
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return data
+	}
+	var generic any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return data
+	}
+	return pruneValue(generic)
+}
+
+// Metadata keys stripped unconditionally in compact mode.
+var compactStripKeys = map[string]bool{
+	"avatarUrls":  true,
+	"_links":      true,
+	"_expandable": true,
+}
+
+func pruneValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		pruned := make(map[string]any, len(val))
+		for k, child := range val {
+			if child == nil {
+				continue
+			}
+			if compactStripKeys[k] {
+				continue
+			}
+			// Strip "self" keys that hold API URLs (e.g., "https://...atlassian.net/rest/...")
+			if k == "self" {
+				if s, ok := child.(string); ok && strings.Contains(s, "/rest/") {
+					continue
+				}
+			}
+			pruned[k] = pruneValue(child)
+		}
+		return pruned
+	case []any:
+		result := make([]any, len(val))
+		for i, item := range val {
+			result[i] = pruneValue(item)
+		}
+		return result
+	default:
+		return v
+	}
 }
 
 // Truncate truncates a string to the specified length, adding "..." if truncated.

--- a/shared/view/view.go
+++ b/shared/view/view.go
@@ -271,7 +271,11 @@ func (v *View) RenderText(text string) {
 
 // compactData converts data to a generic map/slice structure and strips
 // verbose metadata that inflates output without adding useful content.
-// Removes: null-valued fields, avatarUrls, self-link URLs, _links, _expandable.
+// Removes: null-valued fields, avatarUrls, self-link URLs, _links, _expandable,
+// and any maps/slices left empty after pruning.
+//
+// Uses a JSON round-trip (marshal → unmarshal → walk) for simplicity over a
+// reflection-based approach. The extra allocation is negligible for CLI output.
 func compactData(data any) any {
 	// Round-trip through JSON to get a generic map/slice structure.
 	raw, err := json.Marshal(data)
@@ -309,17 +313,35 @@ func pruneValue(v any) any {
 					continue
 				}
 			}
-			pruned[k] = pruneValue(child)
+			pv := pruneValue(child)
+			// Drop fields left empty after pruning (e.g., a user object
+			// that only had avatarUrls + self becomes {})
+			if isEmpty(pv) {
+				continue
+			}
+			pruned[k] = pv
 		}
 		return pruned
 	case []any:
-		result := make([]any, len(val))
-		for i, item := range val {
-			result[i] = pruneValue(item)
+		result := make([]any, 0, len(val))
+		for _, item := range val {
+			result = append(result, pruneValue(item))
 		}
 		return result
 	default:
 		return v
+	}
+}
+
+// isEmpty returns true for empty maps and empty slices.
+func isEmpty(v any) bool {
+	switch val := v.(type) {
+	case map[string]any:
+		return len(val) == 0
+	case []any:
+		return len(val) == 0
+	default:
+		return false
 	}
 }
 

--- a/shared/view/view.go
+++ b/shared/view/view.go
@@ -307,16 +307,20 @@ func pruneValue(v any) any {
 			if compactStripKeys[k] {
 				continue
 			}
-			// Strip "self" keys that hold API URLs (e.g., "https://...atlassian.net/rest/...")
+			// Strip "self" keys that hold API URLs. Covers both Jira v3 (/rest/...)
+			// and Confluence v2 (/wiki/api/v2/...) endpoints.
 			if k == "self" {
-				if s, ok := child.(string); ok && strings.Contains(s, "/rest/") {
+				if s, ok := child.(string); ok && (strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")) {
 					continue
 				}
 			}
 			pv := pruneValue(child)
-			// Drop fields left empty after pruning (e.g., a user object
-			// that only had avatarUrls + self becomes {})
-			if isEmpty(pv) {
+			// Drop fields that became empty due to pruning (e.g., a user
+			// object that only had avatarUrls + self becomes {}).
+			// Preserve originally-empty collections: [] means "no items"
+			// and {} means "empty object" — both are semantically distinct
+			// from an absent field.
+			if wasNonEmpty(child) && isEmpty(pv) {
 				continue
 			}
 			pruned[k] = pv
@@ -325,11 +329,27 @@ func pruneValue(v any) any {
 	case []any:
 		result := make([]any, 0, len(val))
 		for _, item := range val {
-			result = append(result, pruneValue(item))
+			pv := pruneValue(item)
+			if wasNonEmpty(item) && isEmpty(pv) {
+				continue
+			}
+			result = append(result, pv)
 		}
 		return result
 	default:
 		return v
+	}
+}
+
+// wasNonEmpty returns true if the value is a map or slice with at least one element.
+func wasNonEmpty(v any) bool {
+	switch val := v.(type) {
+	case map[string]any:
+		return len(val) > 0
+	case []any:
+		return len(val) > 0
+	default:
+		return false
 	}
 }
 

--- a/shared/view/view_test.go
+++ b/shared/view/view_test.go
@@ -567,6 +567,232 @@ func TestView_RenderKeyValue(t *testing.T) {
 	})
 }
 
+func TestView_JSON_Compact(t *testing.T) {
+	t.Parallel()
+
+	t.Run("strips null fields", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		data := map[string]any{
+			"key":         "MON-123",
+			"summary":     "Fix bug",
+			"description": nil,
+			"labels":      nil,
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := result["description"]; ok {
+			t.Error("compact should strip null 'description'")
+		}
+		if _, ok := result["labels"]; ok {
+			t.Error("compact should strip null 'labels'")
+		}
+		if result["key"] != "MON-123" {
+			t.Error("compact should preserve non-null fields")
+		}
+	})
+
+	t.Run("strips avatarUrls", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		data := map[string]any{
+			"displayName": "Alice",
+			"avatarUrls": map[string]any{
+				"48x48": "https://avatar.example.com/48",
+				"32x32": "https://avatar.example.com/32",
+			},
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := result["avatarUrls"]; ok {
+			t.Error("compact should strip avatarUrls")
+		}
+		if result["displayName"] != "Alice" {
+			t.Error("compact should preserve displayName")
+		}
+	})
+
+	t.Run("strips self links", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		data := map[string]any{
+			"id":   "123",
+			"self": "https://example.atlassian.net/rest/api/3/issue/123",
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := result["self"]; ok {
+			t.Error("compact should strip self API links")
+		}
+	})
+
+	t.Run("preserves self when not API URL", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		data := map[string]any{
+			"self": "this is not a URL",
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := result["self"]; !ok {
+			t.Error("compact should preserve non-URL 'self' values")
+		}
+	})
+
+	t.Run("strips _links and _expandable", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		data := map[string]any{
+			"title":       "My Page",
+			"_links":      map[string]any{"webui": "/spaces/ENG/pages/123"},
+			"_expandable": map[string]any{"body": ""},
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := result["_links"]; ok {
+			t.Error("compact should strip _links")
+		}
+		if _, ok := result["_expandable"]; ok {
+			t.Error("compact should strip _expandable")
+		}
+		if result["title"] != "My Page" {
+			t.Error("compact should preserve title")
+		}
+	})
+
+	t.Run("recurses into nested objects and arrays", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		data := map[string]any{
+			"fields": map[string]any{
+				"assignee": map[string]any{
+					"displayName": "Bob",
+					"avatarUrls":  map[string]any{"48x48": "https://avatar.example.com"},
+					"self":        "https://example.atlassian.net/rest/api/3/user/bob",
+				},
+				"customfield_10001": nil,
+			},
+			"items": []any{
+				map[string]any{"id": "1", "self": "https://example.atlassian.net/rest/api/3/item/1"},
+				map[string]any{"id": "2", "extra": nil},
+			},
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		fields := result["fields"].(map[string]any)
+		assignee := fields["assignee"].(map[string]any)
+		if assignee["displayName"] != "Bob" {
+			t.Error("should preserve nested displayName")
+		}
+		if _, ok := assignee["avatarUrls"]; ok {
+			t.Error("should strip nested avatarUrls")
+		}
+		if _, ok := assignee["self"]; ok {
+			t.Error("should strip nested self links")
+		}
+		if _, ok := fields["customfield_10001"]; ok {
+			t.Error("should strip nested null fields")
+		}
+
+		items := result["items"].([]any)
+		item0 := items[0].(map[string]any)
+		if _, ok := item0["self"]; ok {
+			t.Error("should strip self in array items")
+		}
+		item1 := items[1].(map[string]any)
+		if _, ok := item1["extra"]; ok {
+			t.Error("should strip null in array items")
+		}
+	})
+
+	t.Run("no-op when compact is false", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		// Compact is false by default
+		v.SetOutput(buf)
+
+		data := map[string]any{
+			"self":        "https://example.atlassian.net/rest/api/3/issue/1",
+			"description": nil,
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := result["self"]; !ok {
+			t.Error("non-compact should preserve self links")
+		}
+		// Note: encoding/json does include null values from map[string]any
+		// but nil in the original map becomes json null
+	})
+}
+
 func TestView_RenderText(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}

--- a/shared/view/view_test.go
+++ b/shared/view/view_test.go
@@ -766,6 +766,72 @@ func TestView_JSON_Compact(t *testing.T) {
 		}
 	})
 
+	t.Run("strips empty maps after pruning", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		data := map[string]any{
+			"key": "MON-1",
+			"assignee": map[string]any{
+				"avatarUrls": map[string]any{"48x48": "https://example.com"},
+				"self":       "https://example.atlassian.net/rest/api/3/user/1",
+			},
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := result["assignee"]; ok {
+			t.Error("compact should strip maps left empty after pruning")
+		}
+	})
+
+	t.Run("works with top-level array", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		data := []any{
+			map[string]any{
+				"id":   "1",
+				"self": "https://example.atlassian.net/rest/api/3/issue/1",
+				"name": nil,
+			},
+			map[string]any{
+				"id": "2",
+			},
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result []map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected 2 items, got %d", len(result))
+		}
+		if _, ok := result[0]["self"]; ok {
+			t.Error("should strip self in array items")
+		}
+		if _, ok := result[0]["name"]; ok {
+			t.Error("should strip null in array items")
+		}
+		if result[0]["id"] != "1" {
+			t.Error("should preserve non-null fields in array items")
+		}
+	})
+
 	t.Run("no-op when compact is false", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}

--- a/shared/view/view_test.go
+++ b/shared/view/view_test.go
@@ -656,7 +656,32 @@ func TestView_JSON_Compact(t *testing.T) {
 		}
 	})
 
-	t.Run("preserves self when not API URL", func(t *testing.T) {
+	t.Run("strips self for any HTTP URL", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		// Confluence v2 uses /wiki/api/v2/ paths, not /rest/
+		data := map[string]any{
+			"id":   "123",
+			"self": "https://example.atlassian.net/wiki/api/v2/pages/123",
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := result["self"]; ok {
+			t.Error("compact should strip self for Confluence v2 URLs")
+		}
+	})
+
+	t.Run("preserves self when not a URL", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
 		v := New(FormatJSON, false)
@@ -676,6 +701,35 @@ func TestView_JSON_Compact(t *testing.T) {
 		}
 		if _, ok := result["self"]; !ok {
 			t.Error("compact should preserve non-URL 'self' values")
+		}
+	})
+
+	t.Run("preserves originally-empty arrays and maps", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		data := map[string]any{
+			"key":        "MON-1",
+			"labels":     []any{},
+			"components": []any{},
+			"subtasks":   []any{},
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if _, ok := result["labels"]; !ok {
+			t.Error("compact should preserve originally-empty 'labels' array")
+		}
+		if _, ok := result["components"]; !ok {
+			t.Error("compact should preserve originally-empty 'components' array")
 		}
 	})
 
@@ -829,6 +883,77 @@ func TestView_JSON_Compact(t *testing.T) {
 		}
 		if result[0]["id"] != "1" {
 			t.Error("should preserve non-null fields in array items")
+		}
+	})
+
+	t.Run("drops empty array items after pruning", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatJSON, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		data := []any{
+			map[string]any{
+				"id":         "1",
+				"avatarUrls": map[string]any{"48x48": "https://example.com"},
+			},
+			map[string]any{
+				// This item has only stripped fields — should be dropped entirely
+				"avatarUrls": map[string]any{"48x48": "https://example.com"},
+				"self":       "https://example.atlassian.net/rest/api/3/user/1",
+			},
+			map[string]any{
+				"id": "3",
+			},
+		}
+		if err := v.JSON(data); err != nil {
+			t.Fatalf("JSON() error = %v", err)
+		}
+
+		var result []map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected 2 items after pruning empty, got %d", len(result))
+		}
+		if result[0]["id"] != "1" || result[1]["id"] != "3" {
+			t.Error("surviving items should be id=1 and id=3")
+		}
+	})
+
+	t.Run("compact is no-op for table format", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatTable, true)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		headers := []string{"KEY", "STATUS"}
+		rows := [][]string{{"MON-1", "Open"}}
+		if err := v.Table(headers, rows); err != nil {
+			t.Fatalf("Table() error = %v", err)
+		}
+		output := buf.String()
+		if !strings.Contains(output, "MON-1") {
+			t.Error("table output should still contain row data when compact is set")
+		}
+	})
+
+	t.Run("compact is no-op for plain format", func(t *testing.T) {
+		t.Parallel()
+		buf := &bytes.Buffer{}
+		v := New(FormatPlain, false)
+		v.Compact = true
+		v.SetOutput(buf)
+
+		rows := [][]string{{"a", "b"}}
+		if err := v.Plain(rows); err != nil {
+			t.Fatalf("Plain() error = %v", err)
+		}
+		if !strings.Contains(buf.String(), "a\tb") {
+			t.Error("plain output should be unchanged when compact is set")
 		}
 	})
 

--- a/tools/cfl/internal/cmd/root/root.go
+++ b/tools/cfl/internal/cmd/root/root.go
@@ -20,6 +20,7 @@ import (
 type Options struct {
 	Output  string
 	NoColor bool
+	Compact bool
 	Stdin   io.Reader
 	Stdout  io.Writer
 	Stderr  io.Writer
@@ -34,6 +35,7 @@ type Options struct {
 // View returns a configured View instance
 func (o *Options) View() *view.View {
 	v := view.NewWithFormat(o.Output, o.NoColor)
+	v.Compact = o.Compact
 	v.Out = o.Stdout
 	v.Err = o.Stderr
 	return v
@@ -113,6 +115,7 @@ Get started by running: cfl init`,
 	cmd.PersistentFlags().StringP("config", "c", "", "config file (default: ~/.config/cfl/config.yml)")
 	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "table", "output format: table, json, plain")
 	cmd.PersistentFlags().BoolVar(&opts.NoColor, "no-color", false, "disable colored output")
+	cmd.PersistentFlags().BoolVar(&opts.Compact, "compact", false, "strip null fields and metadata from JSON output (reduces size for agent consumers)")
 
 	// Set version template
 	cmd.SetVersionTemplate("cfl version {{.Version}} (commit: " + version.Commit + ", built: " + version.BuildDate + ")\n")

--- a/tools/jtk/internal/cmd/root/root.go
+++ b/tools/jtk/internal/cmd/root/root.go
@@ -18,6 +18,7 @@ import (
 type Options struct {
 	Output  string
 	NoColor bool
+	Compact bool
 	Verbose bool
 	Stdin   io.Reader
 	Stdout  io.Writer
@@ -33,6 +34,7 @@ type Options struct {
 // View returns a configured View instance
 func (o *Options) View() *view.View {
 	v := view.NewWithFormat(o.Output, o.NoColor)
+	v.Compact = o.Compact
 	v.Out = o.Stdout
 	v.Err = o.Stderr
 	return v
@@ -91,6 +93,7 @@ func NewCmd() (*cobra.Command, *Options) {
 	// Global flags - bound to opts struct
 	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "table", "Output format: table, json, plain")
 	cmd.PersistentFlags().BoolVar(&opts.NoColor, "no-color", false, "Disable colored output")
+	cmd.PersistentFlags().BoolVar(&opts.Compact, "compact", false, "Strip null fields and metadata from JSON output (reduces size for agent consumers)")
 	cmd.PersistentFlags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Enable verbose output")
 
 	return cmd, opts
@@ -107,11 +110,13 @@ func RegisterCommands(root *cobra.Command, opts *Options, registrars ...func(*co
 func GetOptions(cmd *cobra.Command) *Options {
 	output, _ := cmd.Root().PersistentFlags().GetString("output")
 	noColor, _ := cmd.Root().PersistentFlags().GetBool("no-color")
+	compact, _ := cmd.Root().PersistentFlags().GetBool("compact")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
 	return &Options{
 		Output:  output,
 		NoColor: noColor,
+		Compact: compact,
 		Verbose: verbose,
 		Stdin:   os.Stdin,
 		Stdout:  os.Stdout,


### PR DESCRIPTION
## Summary

- Adds `--compact` global flag to both `jtk` and `cfl` that strips verbose metadata from JSON output
- Targets LLM/agent consumers where every token has a cost — reduces context window usage without losing any meaningful content
- Implemented in the shared `view` package so both tools get it automatically

### What `--compact` strips

| Category | Example | Savings |
|----------|---------|---------|
| Null fields | `"customfield_10088": null` (20-30 per Jira issue) | ~500 chars/issue |
| Avatar URLs | `"avatarUrls": {"16x16": "...", "24x24": "...", ...}` per user | ~200 chars/user |
| API self-links | `"self": "https://...atlassian.net/rest/api/3/..."` on every nested object | ~100 chars/object |
| Confluence metadata | `"_links"`, `"_expandable"` objects | Variable |

### What it preserves

Everything meaningful: summaries, descriptions, status, assignee names, comments, page content, etc. Only API plumbing metadata is removed.

### Usage

```bash
# Before: 392,263 chars
jtk issues search --jql "project = MON" --max 10 --output json

# After: 342,159 chars (12% smaller)
jtk issues search --jql "project = MON" --max 10 --output json --compact

# Single issue: 42,908 → 38,691 chars (10% smaller)
jtk issues get an internal ticket --output json --compact

# Works with cfl too
cfl page view 12345 --output json --full --compact
```

The flag has no effect on `table` or `plain` output formats.

### Motivation

We run an AI assistant (Opus orchestrator + MCP tool servers) that calls `jtk` and `cfl` ~200-400 times/day. Cache-write tokens (from tool output entering the LLM context) account for 73% of our API cost. The top offenders by output volume:

| Tool | Avg Output | Calls/30d |
|------|-----------|-----------|
| `jtk issues get` | 18,462 chars | 73 |
| `cfl page view` | 12,568 chars | 248 |
| `jtk issues search` | 12,134 chars | 134 |

A 10-12% reduction across these calls meaningfully reduces token costs without any risk to answer quality.

## Test plan

- [x] 7 new compact tests covering: null stripping, avatarUrls, self-links, _links/_expandable, nested recursion, array items, no-op when disabled
- [x] All existing tests pass (`make test`)
- [x] Both tools build (`make build`)
- [x] End-to-end verified: `jtk issues get/search` with real Jira data shows 10-12% size reduction
