### PR TITLE
feat(jtk): add --name filter to fields list

### DIFF
--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -441,17 +441,19 @@ Manage custom fields, their contexts, and options.
 
 #### `jtk fields list`
 
-List all fields (system and custom).
+List all fields (system and custom). Supports filtering by name with case-insensitive substring matching.
 
 ```bash
 jtk fields list
 jtk fields list --custom
+jtk fields list --name "story point"
 jtk fields list -o json
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--custom` | `false` | Show only custom fields |
+| `--name` | | Filter fields by name (case-insensitive substring match) |
 
 #### `jtk fields create`
 

--- a/tools/jtk/integration-tests.md
+++ b/tools/jtk/integration-tests.md
@@ -350,6 +350,10 @@ jtk fields list --custom
 | 1 | `jtk fields list` | Table with columns: ID, NAME, TYPE, CUSTOM |
 | 2 | `jtk fields list --custom` | Same table but only rows where CUSTOM = yes |
 | 3 | `jtk fields list -o json` | Valid JSON array |
+| 4 | `jtk fields list --name "story"` | Table showing only fields with "story" in the name |
+| 5 | `jtk fields list --name "story" -o json` | Valid JSON array, filtered to matching fields |
+| 6 | `jtk fields list --name "nonexistent"` | `No fields found` |
+| 7 | `jtk fields list --name "story" --custom` | Only custom fields matching "story" |
 
 ### fields contexts list
 
@@ -830,6 +834,11 @@ Run these steps in order. Each step depends on the previous.
    Capture the field ID → `$TEST_FIELD`
 
 2. **Verify creation:**
+   ```bash
+   jtk fields list --name "[Test] Integration Select"
+   ```
+   Expected: Table showing the newly created field
+
    ```bash
    jtk fields list --custom -o json | jq '.[] | select(.name == "[Test] Integration Select")'
    ```

--- a/tools/jtk/internal/cmd/fields/fields.go
+++ b/tools/jtk/internal/cmd/fields/fields.go
@@ -3,6 +3,7 @@ package fields
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -33,30 +34,35 @@ func Register(parent *cobra.Command, opts *root.Options) {
 
 func newListCmd(opts *root.Options) *cobra.Command {
 	var customOnly bool
+	var nameFilter string
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List field definitions",
-		Long:  "List all fields or only custom fields. Shows field ID, name, type, and whether it is custom.",
+		Long:  "List all fields or only custom fields. Supports filtering by name with case-insensitive substring matching.",
 		Example: `  # List all fields
   jtk fields list
 
   # List only custom fields
   jtk fields list --custom
 
+  # Search for fields by name
+  jtk fields list --name "story point"
+
   # List fields as JSON
   jtk fields list -o json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runList(cmd.Context(), opts, customOnly)
+			return runList(cmd.Context(), opts, customOnly, nameFilter)
 		},
 	}
 
 	cmd.Flags().BoolVar(&customOnly, "custom", false, "Show only custom fields")
+	cmd.Flags().StringVar(&nameFilter, "name", "", "Filter fields by name (case-insensitive substring match)")
 
 	return cmd
 }
 
-func runList(ctx context.Context, opts *root.Options, customOnly bool) error {
+func runList(ctx context.Context, opts *root.Options, customOnly bool, nameFilter string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -72,6 +78,17 @@ func runList(ctx context.Context, opts *root.Options, customOnly bool) error {
 	}
 	if err != nil {
 		return err
+	}
+
+	if nameFilter != "" {
+		nameLower := strings.ToLower(nameFilter)
+		var filtered []api.Field
+		for _, f := range fields {
+			if strings.Contains(strings.ToLower(f.Name), nameLower) {
+				filtered = append(filtered, f)
+			}
+		}
+		fields = filtered
 	}
 
 	if len(fields) == 0 {

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -36,6 +36,10 @@ func TestNewListCmd(t *testing.T) {
 	customFlag := cmd.Flags().Lookup("custom")
 	testutil.NotNil(t, customFlag)
 	testutil.Equal(t, customFlag.DefValue, "false")
+
+	nameFlag := cmd.Flags().Lookup("name")
+	testutil.NotNil(t, nameFlag)
+	testutil.Equal(t, nameFlag.DefValue, "")
 }
 
 func TestRunList_Table(t *testing.T) {
@@ -55,7 +59,7 @@ func TestRunList_Table(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, false)
+	err = runList(context.Background(), opts, false, "")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "summary")
 	testutil.Contains(t, stdout.String(), "customfield_10100")
@@ -78,7 +82,7 @@ func TestRunList_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, false)
+	err = runList(context.Background(), opts, false, "")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), `"id"`)
 	testutil.Contains(t, stdout.String(), "customfield_10100")
@@ -98,9 +102,125 @@ func TestRunList_Empty(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, false)
+	err = runList(context.Background(), opts, false, "")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "No fields found")
+}
+
+func TestRunList_NameFilter(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.Field{
+			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+			{ID: "customfield_10016", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+			{ID: "customfield_10020", Name: "Story Status", Custom: true, Schema: api.FieldSchema{Type: "option"}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, false, "story")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Story Points")
+	testutil.Contains(t, stdout.String(), "Story Status")
+	testutil.NotContains(t, stdout.String(), "Summary")
+}
+
+func TestRunList_NameFilter_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.Field{
+			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+			{ID: "customfield_10016", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, false, "STORY")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Story Points")
+	testutil.NotContains(t, stdout.String(), "Summary")
+}
+
+func TestRunList_NameFilter_NoMatch(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.Field{
+			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, false, "nonexistent")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "No fields found")
+}
+
+func TestRunList_NameFilter_JSON(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.Field{
+			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+			{ID: "customfield_10016", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, false, "story")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Story Points")
+	testutil.NotContains(t, stdout.String(), "Summary")
+}
+
+func TestRunList_NameFilter_WithCustom(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// GetCustomFields returns only custom fields
+		_ = json.NewEncoder(w).Encode([]api.Field{
+			{ID: "customfield_10016", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+			{ID: "customfield_10020", Name: "Sprint", Custom: true, Schema: api.FieldSchema{Type: "array"}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, true, "story")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Story Points")
+	testutil.NotContains(t, stdout.String(), "Sprint")
 }
 
 func TestNewCreateCmd(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `--name` flag to `jtk fields list` for case-insensitive substring filtering on field names
- AI agents frequently pass `--project` (which doesn't exist), causing Cobra errors — `--name` gives a direct way to find fields like `jtk fields list --name "story point"`
- Client-side filtering of the global field list, composes with `--custom`
- Updated README command docs and integration test cases

Closes #194

## Test plan

- [x] 5 new unit tests: name filter, case insensitivity, no match, JSON output, composition with `--custom`
- [x] Updated 3 existing `runList` test calls for new parameter
- [x] `make build` passes
- [x] `make test` passes
- [x] Integration test cases added to `integration-tests.md`