### PR TITLE
docs: define output artifact contract for agent, full, and raw representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Unified CLI tools for Atlassian Cloud products.
   - [Configuration](#configuration)
   - [Authentication](#authentication)
   - [Shared Credentials](#shared-credentials)
+  - [Output Representations](#output-representations)
 - [jtk - Jira CLI](#jtk---jira-cli)
 - [cfl - Confluence CLI](#cfl---confluence-cli)
 - [Shell Completion](#shell-completion)
@@ -228,6 +229,33 @@ export ATLASSIAN_API_TOKEN="your-api-token"
 jtk issues list --project PROJ
 cfl page list --space DEV
 ```
+
+### Output Representations
+
+Both tools support three output representations:
+
+| Flag | Representation | Description |
+|------|----------------|-------------|
+| (default) | `agent` | Action-oriented output with essential fields. Optimized for LLM/agent consumption. |
+| `--full` | `full` | Inspection-oriented output with additional fields (dates, authors, versions). |
+| `--raw` | `raw` | Source-faithful content (e.g., XHTML instead of markdown). Command-specific. |
+
+**Examples:**
+
+```bash
+# Default agent output (curated, action-ready)
+jtk issues get PROJ-123
+cfl page view 123456
+
+# Full output for debugging
+jtk issues get PROJ-123 --full
+cfl page view 123456 --full
+
+# Raw content (cfl only, where content transformation occurs)
+cfl page view 123456 --raw
+```
+
+Output format (`-o table|json|plain`) is independent of representation. See [docs/ARTIFACT_CONTRACT.md](docs/ARTIFACT_CONTRACT.md) for the full contract specification.
 
 ## jtk - Jira CLI
 

--- a/docs/ARTIFACT_CONTRACT.md
+++ b/docs/ARTIFACT_CONTRACT.md
@@ -56,6 +56,8 @@ Some commands expose a `--raw` mode for source-faithful content where transforma
 --full --raw → error: mutually exclusive
 ```
 
+> **Implementation note:** The mutual exclusivity constraint (`--full --raw → error`) and command-specific `--raw` validation are forward-looking requirements. They will be enforced as commands are migrated in #199 and #200.
+
 ## Output Format Interaction
 
 Artifact type and output format (`-o table|json|plain`) are independent concerns:
@@ -68,7 +70,7 @@ Artifact type and output format (`-o table|json|plain`) are independent concerns
 **Table output:**
 - `agent` = focused columns for action (defined per-command)
 - `full` = additional columns for inspection (defined per-command, still curated)
-- `raw` = not applicable (raw is about content fidelity, not list views)
+- `raw` = error (raw is about content fidelity, not list views; commands should reject `--raw -o table`)
 
 ## Design Principles
 

--- a/docs/ARTIFACT_CONTRACT.md
+++ b/docs/ARTIFACT_CONTRACT.md
@@ -1,0 +1,91 @@
+# Output Artifact Contract
+
+This document defines the output representation model for `jtk` and `cfl`. It establishes the vocabulary and semantics that all commands must follow.
+
+## Artifact Types
+
+Two general artifact types apply across all commands:
+
+| Type | Purpose | Default? | Flag |
+|------|---------|----------|------|
+| `agent` | Action-oriented output for LLM/agent consumption. Contains what's needed to decide the next step. | Yes | (none - default) |
+| `full` | Inspection-oriented output for human debugging. Richer curated fields beyond agent. | No | `--full` |
+
+### agent (default)
+
+The agent artifact is intentionally curated output containing what you need to decide the next step.
+
+- Each command defines its agent artifact: which fields are action-relevant
+- Content is transformed for readability (e.g., markdown instead of XHTML)
+- Strips transport metadata (self URLs, `_links`, `_expandable`)
+- Strips visual-only fields (`avatarUrls`)
+
+**Examples:**
+- `jtk issues get` → key, summary, status, assignee (enough to triage)
+- `cfl page view` → id, title, space, ancestors, content as markdown (enough to navigate and act)
+
+### full
+
+The full artifact provides richer inspection-oriented output for debugging and deeper understanding.
+
+- Each command defines additional fields beyond agent (dates, authors, versions, relationships)
+- Still curated by the CLI, not a pass-through of API payloads
+- Content transformation same as agent (readable format)
+
+**Examples:**
+- `jtk issues get --full` → agent fields + created, updated, reporter, components, labels
+- `cfl page view --full` → agent fields + version, created, modified, author
+
+## Raw Mode (Command-Specific)
+
+Some commands expose a `--raw` mode for source-faithful content where transformation would lose fidelity. This is **not** a general artifact type—it applies only to commands that transform content.
+
+- Shows original storage format (XHTML, ADF JSON) instead of transformed content
+- Errors on commands where raw has no meaning (e.g., list commands)
+- Mutually exclusive with `--full`
+
+**Example:**
+- `cfl page view --raw` → XHTML storage format instead of markdown
+
+## Flag Behavior
+
+```
+(none)       → agent artifact (curated, transformed content)
+--full       → full artifact (richer curation, transformed content)
+--raw        → raw mode (source-faithful content, command-specific)
+--full --raw → error: mutually exclusive
+```
+
+## Output Format Interaction
+
+Artifact type and output format (`-o table|json|plain`) are independent concerns:
+
+**JSON output:**
+- `agent` = curated JSON with action-relevant fields (defined per-command)
+- `full` = richer JSON with inspection fields (defined per-command)
+- `raw` = source format as JSON-escaped string or native structure (command-specific)
+
+**Table output:**
+- `agent` = focused columns for action (defined per-command)
+- `full` = additional columns for inspection (defined per-command, still curated)
+- `raw` = not applicable (raw is about content fidelity, not list views)
+
+## Design Principles
+
+1. **Intentional artifacts, not field stripping.** Commands project domain objects into purpose-built artifacts. They don't start with everything and strip fields away.
+
+2. **Agent is the default.** LLM/agent consumption is the primary use case. Human inspection is opt-in via `--full`.
+
+3. **Raw is command-specific.** Not every command needs `--raw`. It's only for commands where content transformation occurs.
+
+4. **Curated, not pass-through.** Even `--full` is curated by the CLI. Raw API payloads are not exposed directly.
+
+## Migration from --compact
+
+The `--compact` flag is deprecated. Its behavior is replaced by agent-default semantics:
+
+| Old | New |
+|-----|-----|
+| Default output | Now produces agent artifact (was full-ish) |
+| `--compact` | Deprecated (agent is now default) |
+| Explicit full output | Use `--full` |

--- a/tools/cfl/CLAUDE.md
+++ b/tools/cfl/CLAUDE.md
@@ -157,6 +157,17 @@ Two auth methods are supported:
 
 Bearer auth routes requests through `https://api.atlassian.com/ex/confluence/{cloudId}/wiki/...` and requires a Cloud ID. The `api/client.go` file has a separate `NewBearerClient()` constructor, selected in `root.go` based on config auth method.
 
+## Output Artifact Contract
+
+Commands produce intentional artifacts, not raw API payloads. See [docs/ARTIFACT_CONTRACT.md](../../docs/ARTIFACT_CONTRACT.md) for the full specification.
+
+**Representations:**
+- `agent` (default): Action-oriented output with essential fields for LLM/agent consumption
+- `full` (`--full`): Inspection-oriented output with additional fields (dates, authors, versions)
+- `raw` (`--raw`): Source-faithful content (XHTML instead of markdown). Command-specific.
+
+For cfl, the `agent` artifact for page view includes: id, title, space, ancestors, content as markdown.
+
 ## Undocumented Constants
 
 | Constant | Value | Location |

--- a/tools/jtk/CLAUDE.md
+++ b/tools/jtk/CLAUDE.md
@@ -207,6 +207,17 @@ Bearer auth routes requests through `https://api.atlassian.com/ex/jira/{cloudId}
 
 > **Scope limitations:** Scoped tokens lack Agile (boards/sprints), Automation, and Dashboard scopes. These commands are unavailable with bearer auth — this is an Atlassian platform limitation.
 
+## Output Artifact Contract
+
+Commands produce intentional artifacts, not raw API payloads. See [docs/ARTIFACT_CONTRACT.md](../../docs/ARTIFACT_CONTRACT.md) for the full specification.
+
+**Representations:**
+- `agent` (default): Action-oriented output with essential fields for LLM/agent consumption
+- `full` (`--full`): Inspection-oriented output with additional fields (dates, authors, versions)
+- `raw` (`--raw`): Source-faithful content. Command-specific (not all commands support this).
+
+For jtk, the `agent` artifact for issues includes: key, summary, status, assignee (enough to triage).
+
 ## Dependencies
 
 Key dependencies:


### PR DESCRIPTION
## Summary

- Adds `docs/ARTIFACT_CONTRACT.md` defining the output representation model
- Updates README with Output Representations section and examples
- Updates cfl and jtk CLAUDE.md files to reference the contract

This establishes the vocabulary that #198, #199, and #200 must use. It also enables #201 (--compact removal) once commands are migrated.

## Key Definitions

| Representation | Purpose | Flag |
|----------------|---------|------|
| `agent` | Action-oriented output for LLM/agent consumption | (default) |
| `full` | Inspection-oriented output with additional fields | `--full` |
| `raw` | Source-faithful content (command-specific) | `--raw` |

## Test plan

- [x] Build passes (`make build`)
- [x] Tests pass (`make test`)
- [x] Lint issues are pre-existing (docs-only change)
- [ ] Review contract document for clarity and consistency

Closes #197