### PR TITLE
feat(jtk): migrate sprints, boards, users, me to artifact projection

### DIFF
--- a/tools/jtk/internal/artifact/board.go
+++ b/tools/jtk/internal/artifact/board.go
@@ -1,0 +1,42 @@
+package artifact
+
+import (
+	"github.com/open-cli-collective/atlassian-go/artifact"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// BoardArtifact is the projected output for an agile board.
+type BoardArtifact struct {
+	// Agent fields - essential for board selection
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+
+	// Full-only fields
+	ProjectKey  string `json:"projectKey,omitempty"`
+	ProjectName string `json:"projectName,omitempty"`
+}
+
+// ProjectBoard projects an api.Board to a BoardArtifact.
+func ProjectBoard(b *api.Board, mode artifact.Type) *BoardArtifact {
+	a := &BoardArtifact{
+		ID:   b.ID,
+		Name: b.Name,
+		Type: b.Type,
+	}
+	if mode.IsFull() {
+		a.ProjectKey = b.Location.ProjectKey
+		a.ProjectName = b.Location.ProjectName
+	}
+	return a
+}
+
+// ProjectBoards projects a slice of api.Board to BoardArtifacts.
+func ProjectBoards(boards []api.Board, mode artifact.Type) []*BoardArtifact {
+	result := make([]*BoardArtifact, len(boards))
+	for i := range boards {
+		result[i] = ProjectBoard(&boards[i], mode)
+	}
+	return result
+}

--- a/tools/jtk/internal/artifact/board_test.go
+++ b/tools/jtk/internal/artifact/board_test.go
@@ -1,0 +1,89 @@
+package artifact
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestProjectBoard_AgentMode(t *testing.T) {
+	t.Parallel()
+
+	board := &api.Board{
+		ID:   123,
+		Name: "My Board",
+		Type: "scrum",
+		Location: api.BoardLocation{
+			ProjectID:   456,
+			ProjectKey:  "PROJ",
+			ProjectName: "My Project",
+		},
+	}
+
+	art := ProjectBoard(board, artifact.Agent)
+
+	// Agent fields populated
+	testutil.Equal(t, art.ID, 123)
+	testutil.Equal(t, art.Name, "My Board")
+	testutil.Equal(t, art.Type, "scrum")
+
+	// Full-only fields empty
+	testutil.Equal(t, art.ProjectKey, "")
+	testutil.Equal(t, art.ProjectName, "")
+}
+
+func TestProjectBoard_FullMode(t *testing.T) {
+	t.Parallel()
+
+	board := &api.Board{
+		ID:   123,
+		Name: "My Board",
+		Type: "kanban",
+		Location: api.BoardLocation{
+			ProjectID:   456,
+			ProjectKey:  "PROJ",
+			ProjectName: "My Project",
+		},
+	}
+
+	art := ProjectBoard(board, artifact.Full)
+
+	// Agent fields populated
+	testutil.Equal(t, art.ID, 123)
+	testutil.Equal(t, art.Name, "My Board")
+	testutil.Equal(t, art.Type, "kanban")
+
+	// Full-only fields populated
+	testutil.Equal(t, art.ProjectKey, "PROJ")
+	testutil.Equal(t, art.ProjectName, "My Project")
+}
+
+func TestProjectBoards(t *testing.T) {
+	t.Parallel()
+
+	boards := []api.Board{
+		{ID: 1, Name: "Board 1", Type: "scrum"},
+		{ID: 2, Name: "Board 2", Type: "kanban"},
+	}
+
+	arts := ProjectBoards(boards, artifact.Agent)
+
+	testutil.Equal(t, len(arts), 2)
+	testutil.Equal(t, arts[0].ID, 1)
+	testutil.Equal(t, arts[0].Name, "Board 1")
+	testutil.Equal(t, arts[1].ID, 2)
+	testutil.Equal(t, arts[1].Name, "Board 2")
+}
+
+func TestProjectBoards_Empty(t *testing.T) {
+	t.Parallel()
+
+	var boards []api.Board
+	arts := ProjectBoards(boards, artifact.Agent)
+
+	testutil.Equal(t, len(arts), 0)
+	testutil.NotNil(t, arts)
+}

--- a/tools/jtk/internal/artifact/doc.go
+++ b/tools/jtk/internal/artifact/doc.go
@@ -1,0 +1,12 @@
+// Package artifact provides output artifact types and projection functions
+// for jtk commands. Artifacts are intentionally-shaped output structures
+// that support agent (action-oriented) and full (inspection-oriented) modes.
+//
+// Each resource type has:
+//   - An artifact struct with agent fields and full-only fields (omitempty)
+//   - A Project<Type> function: (domain, mode) -> artifact
+//   - A Project<Type>s helper for slices
+//
+// Commands check v.Format == view.FormatJSON before calling projection,
+// then use v.RenderArtifact() or v.RenderArtifactList() for output.
+package artifact

--- a/tools/jtk/internal/artifact/issue.go
+++ b/tools/jtk/internal/artifact/issue.go
@@ -1,0 +1,59 @@
+package artifact
+
+import (
+	"github.com/open-cli-collective/atlassian-go/artifact"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// IssueArtifact is the projected output for an issue.
+// This is a minimal artifact for list contexts (e.g., sprints issues).
+// Full issue artifact with more fields will be added when issues commands
+// are migrated after the --full flag collision is resolved.
+type IssueArtifact struct {
+	// Agent fields - essential for triage
+	Key      string `json:"key"`
+	Summary  string `json:"summary"`
+	Status   string `json:"status"`
+	Type     string `json:"type,omitempty"`
+	Assignee string `json:"assignee,omitempty"`
+
+	// Full-only fields
+	Priority string `json:"priority,omitempty"`
+	Project  string `json:"project,omitempty"`
+}
+
+// ProjectIssue projects an api.Issue to an IssueArtifact.
+func ProjectIssue(issue *api.Issue, mode artifact.Type) *IssueArtifact {
+	a := &IssueArtifact{
+		Key:     issue.Key,
+		Summary: issue.Fields.Summary,
+	}
+	if issue.Fields.Status != nil {
+		a.Status = issue.Fields.Status.Name
+	}
+	if issue.Fields.IssueType != nil {
+		a.Type = issue.Fields.IssueType.Name
+	}
+	if issue.Fields.Assignee != nil {
+		a.Assignee = issue.Fields.Assignee.DisplayName
+	}
+	if mode.IsFull() {
+		if issue.Fields.Priority != nil {
+			a.Priority = issue.Fields.Priority.Name
+		}
+		if issue.Fields.Project != nil {
+			a.Project = issue.Fields.Project.Key
+		}
+	}
+	return a
+}
+
+// ProjectIssues projects a slice of api.Issue to IssueArtifacts.
+func ProjectIssues(issues []api.Issue, mode artifact.Type) []*IssueArtifact {
+	result := make([]*IssueArtifact, len(issues))
+	for i := range issues {
+		result[i] = ProjectIssue(&issues[i], mode)
+	}
+	return result
+}

--- a/tools/jtk/internal/artifact/issue_test.go
+++ b/tools/jtk/internal/artifact/issue_test.go
@@ -1,0 +1,117 @@
+package artifact
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestProjectIssue_AgentMode(t *testing.T) {
+	t.Parallel()
+
+	issue := &api.Issue{
+		Key: "PROJ-123",
+		Fields: api.IssueFields{
+			Summary:   "Fix the bug",
+			Status:    &api.Status{Name: "In Progress"},
+			IssueType: &api.IssueType{Name: "Bug"},
+			Assignee:  &api.User{DisplayName: "John Doe"},
+			Priority:  &api.Priority{Name: "High"},
+			Project:   &api.Project{Key: "PROJ"},
+		},
+	}
+
+	art := ProjectIssue(issue, artifact.Agent)
+
+	// Agent fields populated
+	testutil.Equal(t, art.Key, "PROJ-123")
+	testutil.Equal(t, art.Summary, "Fix the bug")
+	testutil.Equal(t, art.Status, "In Progress")
+	testutil.Equal(t, art.Type, "Bug")
+	testutil.Equal(t, art.Assignee, "John Doe")
+
+	// Full-only fields empty
+	testutil.Equal(t, art.Priority, "")
+	testutil.Equal(t, art.Project, "")
+}
+
+func TestProjectIssue_FullMode(t *testing.T) {
+	t.Parallel()
+
+	issue := &api.Issue{
+		Key: "PROJ-123",
+		Fields: api.IssueFields{
+			Summary:   "Fix the bug",
+			Status:    &api.Status{Name: "Done"},
+			IssueType: &api.IssueType{Name: "Task"},
+			Assignee:  &api.User{DisplayName: "Jane Doe"},
+			Priority:  &api.Priority{Name: "Critical"},
+			Project:   &api.Project{Key: "PROJ"},
+		},
+	}
+
+	art := ProjectIssue(issue, artifact.Full)
+
+	// Agent fields populated
+	testutil.Equal(t, art.Key, "PROJ-123")
+	testutil.Equal(t, art.Summary, "Fix the bug")
+	testutil.Equal(t, art.Status, "Done")
+	testutil.Equal(t, art.Type, "Task")
+	testutil.Equal(t, art.Assignee, "Jane Doe")
+
+	// Full-only fields populated
+	testutil.Equal(t, art.Priority, "Critical")
+	testutil.Equal(t, art.Project, "PROJ")
+}
+
+func TestProjectIssue_NilFields(t *testing.T) {
+	t.Parallel()
+
+	issue := &api.Issue{
+		Key: "PROJ-456",
+		Fields: api.IssueFields{
+			Summary: "Minimal issue",
+			// All pointer fields nil
+		},
+	}
+
+	art := ProjectIssue(issue, artifact.Full)
+
+	testutil.Equal(t, art.Key, "PROJ-456")
+	testutil.Equal(t, art.Summary, "Minimal issue")
+	testutil.Equal(t, art.Status, "")
+	testutil.Equal(t, art.Type, "")
+	testutil.Equal(t, art.Assignee, "")
+	testutil.Equal(t, art.Priority, "")
+	testutil.Equal(t, art.Project, "")
+}
+
+func TestProjectIssues(t *testing.T) {
+	t.Parallel()
+
+	issues := []api.Issue{
+		{Key: "PROJ-1", Fields: api.IssueFields{Summary: "Issue 1"}},
+		{Key: "PROJ-2", Fields: api.IssueFields{Summary: "Issue 2"}},
+		{Key: "PROJ-3", Fields: api.IssueFields{Summary: "Issue 3"}},
+	}
+
+	arts := ProjectIssues(issues, artifact.Agent)
+
+	testutil.Equal(t, len(arts), 3)
+	testutil.Equal(t, arts[0].Key, "PROJ-1")
+	testutil.Equal(t, arts[1].Key, "PROJ-2")
+	testutil.Equal(t, arts[2].Key, "PROJ-3")
+}
+
+func TestProjectIssues_Empty(t *testing.T) {
+	t.Parallel()
+
+	var issues []api.Issue
+	arts := ProjectIssues(issues, artifact.Agent)
+
+	testutil.Equal(t, len(arts), 0)
+	testutil.NotNil(t, arts)
+}

--- a/tools/jtk/internal/artifact/sprint.go
+++ b/tools/jtk/internal/artifact/sprint.go
@@ -20,7 +20,7 @@ type SprintArtifact struct {
 	EndDate      string `json:"endDate,omitempty"`
 	CompleteDate string `json:"completeDate,omitempty"`
 	Goal         string `json:"goal,omitempty"`
-	BoardID      int    `json:"boardId,omitempty"`
+	BoardID      *int   `json:"boardId,omitempty"` // Pointer so 0 is explicit in full mode
 }
 
 // ProjectSprint projects an api.Sprint to a SprintArtifact.
@@ -41,7 +41,7 @@ func ProjectSprint(s *api.Sprint, mode artifact.Type) *SprintArtifact {
 			a.CompleteDate = s.CompleteDate.Format(time.RFC3339)
 		}
 		a.Goal = s.Goal
-		a.BoardID = s.OriginBoardID
+		a.BoardID = &s.OriginBoardID
 	}
 	return a
 }

--- a/tools/jtk/internal/artifact/sprint.go
+++ b/tools/jtk/internal/artifact/sprint.go
@@ -1,0 +1,56 @@
+package artifact
+
+import (
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// SprintArtifact is the projected output for a sprint.
+type SprintArtifact struct {
+	// Agent fields - essential for sprint selection
+	ID    int    `json:"id"`
+	Name  string `json:"name"`
+	State string `json:"state"`
+
+	// Full-only fields
+	StartDate    string `json:"startDate,omitempty"`
+	EndDate      string `json:"endDate,omitempty"`
+	CompleteDate string `json:"completeDate,omitempty"`
+	Goal         string `json:"goal,omitempty"`
+	BoardID      int    `json:"boardId,omitempty"`
+}
+
+// ProjectSprint projects an api.Sprint to a SprintArtifact.
+func ProjectSprint(s *api.Sprint, mode artifact.Type) *SprintArtifact {
+	a := &SprintArtifact{
+		ID:    s.ID,
+		Name:  s.Name,
+		State: s.State,
+	}
+	if mode.IsFull() {
+		if s.StartDate != nil {
+			a.StartDate = s.StartDate.Format(time.RFC3339)
+		}
+		if s.EndDate != nil {
+			a.EndDate = s.EndDate.Format(time.RFC3339)
+		}
+		if s.CompleteDate != nil {
+			a.CompleteDate = s.CompleteDate.Format(time.RFC3339)
+		}
+		a.Goal = s.Goal
+		a.BoardID = s.OriginBoardID
+	}
+	return a
+}
+
+// ProjectSprints projects a slice of api.Sprint to SprintArtifacts.
+func ProjectSprints(sprints []api.Sprint, mode artifact.Type) []*SprintArtifact {
+	result := make([]*SprintArtifact, len(sprints))
+	for i := range sprints {
+		result[i] = ProjectSprint(&sprints[i], mode)
+	}
+	return result
+}

--- a/tools/jtk/internal/artifact/sprint_test.go
+++ b/tools/jtk/internal/artifact/sprint_test.go
@@ -1,0 +1,119 @@
+package artifact
+
+import (
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestProjectSprint_AgentMode(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 14, 0, 0, 0, 0, time.UTC)
+
+	sprint := &api.Sprint{
+		ID:            123,
+		Name:          "Sprint 1",
+		State:         "active",
+		StartDate:     &start,
+		EndDate:       &end,
+		Goal:          "Complete feature X",
+		OriginBoardID: 456,
+	}
+
+	art := ProjectSprint(sprint, artifact.Agent)
+
+	// Agent fields populated
+	testutil.Equal(t, art.ID, 123)
+	testutil.Equal(t, art.Name, "Sprint 1")
+	testutil.Equal(t, art.State, "active")
+
+	// Full-only fields empty
+	testutil.Equal(t, art.StartDate, "")
+	testutil.Equal(t, art.EndDate, "")
+	testutil.Equal(t, art.CompleteDate, "")
+	testutil.Equal(t, art.Goal, "")
+	testutil.Equal(t, art.BoardID, 0)
+}
+
+func TestProjectSprint_FullMode(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 14, 0, 0, 0, 0, time.UTC)
+	complete := time.Date(2024, 1, 13, 0, 0, 0, 0, time.UTC)
+
+	sprint := &api.Sprint{
+		ID:            123,
+		Name:          "Sprint 1",
+		State:         "closed",
+		StartDate:     &start,
+		EndDate:       &end,
+		CompleteDate:  &complete,
+		Goal:          "Complete feature X",
+		OriginBoardID: 456,
+	}
+
+	art := ProjectSprint(sprint, artifact.Full)
+
+	// Agent fields populated
+	testutil.Equal(t, art.ID, 123)
+	testutil.Equal(t, art.Name, "Sprint 1")
+	testutil.Equal(t, art.State, "closed")
+
+	// Full-only fields populated
+	testutil.Equal(t, art.StartDate, "2024-01-01T00:00:00Z")
+	testutil.Equal(t, art.EndDate, "2024-01-14T00:00:00Z")
+	testutil.Equal(t, art.CompleteDate, "2024-01-13T00:00:00Z")
+	testutil.Equal(t, art.Goal, "Complete feature X")
+	testutil.Equal(t, art.BoardID, 456)
+}
+
+func TestProjectSprint_NilDates(t *testing.T) {
+	t.Parallel()
+
+	sprint := &api.Sprint{
+		ID:    123,
+		Name:  "Sprint 1",
+		State: "future",
+	}
+
+	art := ProjectSprint(sprint, artifact.Full)
+
+	// Nil dates should result in empty strings
+	testutil.Equal(t, art.StartDate, "")
+	testutil.Equal(t, art.EndDate, "")
+	testutil.Equal(t, art.CompleteDate, "")
+}
+
+func TestProjectSprints(t *testing.T) {
+	t.Parallel()
+
+	sprints := []api.Sprint{
+		{ID: 1, Name: "Sprint 1", State: "closed"},
+		{ID: 2, Name: "Sprint 2", State: "active"},
+		{ID: 3, Name: "Sprint 3", State: "future"},
+	}
+
+	arts := ProjectSprints(sprints, artifact.Agent)
+
+	testutil.Equal(t, len(arts), 3)
+	testutil.Equal(t, arts[0].ID, 1)
+	testutil.Equal(t, arts[1].ID, 2)
+	testutil.Equal(t, arts[2].ID, 3)
+}
+
+func TestProjectSprints_Empty(t *testing.T) {
+	t.Parallel()
+
+	var sprints []api.Sprint
+	arts := ProjectSprints(sprints, artifact.Agent)
+
+	testutil.Equal(t, len(arts), 0)
+	testutil.NotNil(t, arts) // Should be empty slice, not nil
+}

--- a/tools/jtk/internal/artifact/sprint_test.go
+++ b/tools/jtk/internal/artifact/sprint_test.go
@@ -33,12 +33,12 @@ func TestProjectSprint_AgentMode(t *testing.T) {
 	testutil.Equal(t, art.Name, "Sprint 1")
 	testutil.Equal(t, art.State, "active")
 
-	// Full-only fields empty
+	// Full-only fields empty/nil
 	testutil.Equal(t, art.StartDate, "")
 	testutil.Equal(t, art.EndDate, "")
 	testutil.Equal(t, art.CompleteDate, "")
 	testutil.Equal(t, art.Goal, "")
-	testutil.Equal(t, art.BoardID, 0)
+	testutil.Nil(t, art.BoardID)
 }
 
 func TestProjectSprint_FullMode(t *testing.T) {
@@ -71,7 +71,8 @@ func TestProjectSprint_FullMode(t *testing.T) {
 	testutil.Equal(t, art.EndDate, "2024-01-14T00:00:00Z")
 	testutil.Equal(t, art.CompleteDate, "2024-01-13T00:00:00Z")
 	testutil.Equal(t, art.Goal, "Complete feature X")
-	testutil.Equal(t, art.BoardID, 456)
+	testutil.NotNil(t, art.BoardID)
+	testutil.Equal(t, *art.BoardID, 456)
 }
 
 func TestProjectSprint_NilDates(t *testing.T) {

--- a/tools/jtk/internal/artifact/user.go
+++ b/tools/jtk/internal/artifact/user.go
@@ -1,0 +1,40 @@
+package artifact
+
+import (
+	"github.com/open-cli-collective/atlassian-go/artifact"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// UserArtifact is the projected output for a user.
+type UserArtifact struct {
+	// Agent fields - essential for user identification
+	AccountID   string `json:"accountId"`
+	DisplayName string `json:"displayName"`
+
+	// Full-only fields
+	Email  string `json:"email,omitempty"`
+	Active *bool  `json:"active,omitempty"` // Pointer so inactive users show "active": false
+}
+
+// ProjectUser projects an api.User to a UserArtifact.
+func ProjectUser(u *api.User, mode artifact.Type) *UserArtifact {
+	a := &UserArtifact{
+		AccountID:   u.AccountID,
+		DisplayName: u.DisplayName,
+	}
+	if mode.IsFull() {
+		a.Email = u.EmailAddress
+		a.Active = &u.Active // Explicit true/false, never omitted in full mode
+	}
+	return a
+}
+
+// ProjectUsers projects a slice of api.User to UserArtifacts.
+func ProjectUsers(users []api.User, mode artifact.Type) []*UserArtifact {
+	result := make([]*UserArtifact, len(users))
+	for i := range users {
+		result[i] = ProjectUser(&users[i], mode)
+	}
+	return result
+}

--- a/tools/jtk/internal/artifact/user_test.go
+++ b/tools/jtk/internal/artifact/user_test.go
@@ -1,0 +1,133 @@
+package artifact
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestProjectUser_AgentMode(t *testing.T) {
+	t.Parallel()
+
+	user := &api.User{
+		AccountID:    "abc123",
+		DisplayName:  "John Doe",
+		EmailAddress: "john@example.com",
+		Active:       true,
+	}
+
+	art := ProjectUser(user, artifact.Agent)
+
+	// Agent fields populated
+	testutil.Equal(t, art.AccountID, "abc123")
+	testutil.Equal(t, art.DisplayName, "John Doe")
+
+	// Full-only fields empty/nil
+	testutil.Equal(t, art.Email, "")
+	testutil.Nil(t, art.Active)
+}
+
+func TestProjectUser_FullMode_ActiveUser(t *testing.T) {
+	t.Parallel()
+
+	user := &api.User{
+		AccountID:    "abc123",
+		DisplayName:  "John Doe",
+		EmailAddress: "john@example.com",
+		Active:       true,
+	}
+
+	art := ProjectUser(user, artifact.Full)
+
+	// Agent fields populated
+	testutil.Equal(t, art.AccountID, "abc123")
+	testutil.Equal(t, art.DisplayName, "John Doe")
+
+	// Full-only fields populated
+	testutil.Equal(t, art.Email, "john@example.com")
+	testutil.NotNil(t, art.Active)
+	testutil.True(t, *art.Active)
+}
+
+func TestProjectUser_FullMode_InactiveUser(t *testing.T) {
+	t.Parallel()
+
+	user := &api.User{
+		AccountID:    "abc123",
+		DisplayName:  "Jane Doe",
+		EmailAddress: "jane@example.com",
+		Active:       false,
+	}
+
+	art := ProjectUser(user, artifact.Full)
+
+	// Full-only Active should be explicitly false, not omitted
+	testutil.NotNil(t, art.Active)
+	testutil.False(t, *art.Active)
+}
+
+func TestProjectUser_JSONSerialization(t *testing.T) {
+	t.Parallel()
+
+	t.Run("agent mode omits active", func(t *testing.T) {
+		t.Parallel()
+		user := &api.User{AccountID: "abc", DisplayName: "Test", Active: true}
+		art := ProjectUser(user, artifact.Agent)
+
+		data, err := json.Marshal(art)
+		testutil.RequireNoError(t, err)
+
+		var parsed map[string]any
+		err = json.Unmarshal(data, &parsed)
+		testutil.RequireNoError(t, err)
+
+		_, exists := parsed["active"]
+		testutil.False(t, exists) // Should not be present in agent mode
+	})
+
+	t.Run("full mode includes active false", func(t *testing.T) {
+		t.Parallel()
+		user := &api.User{AccountID: "abc", DisplayName: "Test", Active: false}
+		art := ProjectUser(user, artifact.Full)
+
+		data, err := json.Marshal(art)
+		testutil.RequireNoError(t, err)
+
+		var parsed map[string]any
+		err = json.Unmarshal(data, &parsed)
+		testutil.RequireNoError(t, err)
+
+		active, exists := parsed["active"]
+		testutil.True(t, exists)                // Should be present
+		testutil.Equal(t, active.(bool), false) // Should be false, not omitted
+	})
+}
+
+func TestProjectUsers(t *testing.T) {
+	t.Parallel()
+
+	users := []api.User{
+		{AccountID: "1", DisplayName: "User 1"},
+		{AccountID: "2", DisplayName: "User 2"},
+	}
+
+	arts := ProjectUsers(users, artifact.Agent)
+
+	testutil.Equal(t, len(arts), 2)
+	testutil.Equal(t, arts[0].AccountID, "1")
+	testutil.Equal(t, arts[1].AccountID, "2")
+}
+
+func TestProjectUsers_Empty(t *testing.T) {
+	t.Parallel()
+
+	var users []api.User
+	arts := ProjectUsers(users, artifact.Agent)
+
+	testutil.Equal(t, len(arts), 0)
+	testutil.NotNil(t, arts)
+}

--- a/tools/jtk/internal/cmd/boards/boards.go
+++ b/tools/jtk/internal/cmd/boards/boards.go
@@ -7,7 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -80,8 +84,10 @@ func runList(ctx context.Context, opts *root.Options, project string, maxResults
 		return nil
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(result.Values)
+	if v.Format == view.FormatJSON {
+		arts := jtkartifact.ProjectBoards(result.Values, opts.ArtifactMode())
+		hasMore := !result.IsLast
+		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
 	headers := []string{"ID", "NAME", "TYPE", "PROJECT"}
@@ -129,8 +135,8 @@ func runGet(ctx context.Context, opts *root.Options, boardID int) error {
 		return err
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(board)
+	if v.Format == view.FormatJSON {
+		return v.RenderArtifact(jtkartifact.ProjectBoard(board, opts.ArtifactMode()))
 	}
 
 	v.Println("ID:      %d", board.ID)

--- a/tools/jtk/internal/cmd/me/me.go
+++ b/tools/jtk/internal/cmd/me/me.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -41,11 +44,11 @@ func run(ctx context.Context, opts *root.Options) error {
 		return err
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(user)
+	if v.Format == view.FormatJSON {
+		return v.RenderArtifact(jtkartifact.ProjectUser(user, opts.ArtifactMode()))
 	}
 
-	if opts.Output == "plain" {
+	if v.Format == view.FormatPlain {
 		v.Println("%s", user.AccountID)
 		return nil
 	}

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -7,7 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -87,8 +91,10 @@ func runList(ctx context.Context, opts *root.Options, boardID int, state string,
 		return nil
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(result.Values)
+	if v.Format == view.FormatJSON {
+		arts := jtkartifact.ProjectSprints(result.Values, opts.ArtifactMode())
+		hasMore := !result.IsLast
+		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
 	headers := []string{"ID", "NAME", "STATE", "START", "END"}
@@ -150,8 +156,8 @@ func runCurrent(ctx context.Context, opts *root.Options, boardID int) error {
 		return err
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(sprint)
+	if v.Format == view.FormatJSON {
+		return v.RenderArtifact(jtkartifact.ProjectSprint(sprint, opts.ArtifactMode()))
 	}
 
 	v.Println("ID:    %d", sprint.ID)
@@ -211,8 +217,10 @@ func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults
 		return nil
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(result.Issues)
+	if v.Format == view.FormatJSON {
+		arts := jtkartifact.ProjectIssues(result.Issues, opts.ArtifactMode())
+		hasMore := result.StartAt+len(result.Issues) < result.Total
+		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
 	headers := []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"}

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -219,7 +219,14 @@ func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults
 
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectIssues(result.Issues, opts.ArtifactMode())
-		hasMore := result.StartAt+len(result.Issues) < result.Total
+		// Guard against Total < 0 (Jira returns -1 when count is unknown).
+		// When Total is unknown, assume more results if we got a full page.
+		var hasMore bool
+		if result.Total < 0 {
+			hasMore = len(result.Issues) == maxResults
+		} else {
+			hasMore = result.StartAt+len(result.Issues) < result.Total
+		}
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 

--- a/tools/jtk/internal/cmd/users/users.go
+++ b/tools/jtk/internal/cmd/users/users.go
@@ -6,6 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -54,8 +58,8 @@ func runGet(ctx context.Context, opts *root.Options, accountID string) error {
 		return err
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(user)
+	if v.Format == view.FormatJSON {
+		return v.RenderArtifact(jtkartifact.ProjectUser(user, opts.ArtifactMode()))
 	}
 
 	active := "yes"
@@ -120,8 +124,9 @@ func runSearch(ctx context.Context, opts *root.Options, query string, maxResults
 		return nil
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(users)
+	if v.Format == view.FormatJSON {
+		arts := jtkartifact.ProjectUsers(users, opts.ArtifactMode())
+		return v.RenderArtifactList(artifact.NewListResult(arts, false))
 	}
 
 	headers := []string{"ACCOUNT_ID", "NAME", "EMAIL", "ACTIVE"}

--- a/tools/jtk/internal/cmd/users/users.go
+++ b/tools/jtk/internal/cmd/users/users.go
@@ -126,7 +126,10 @@ func runSearch(ctx context.Context, opts *root.Options, query string, maxResults
 
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectUsers(users, opts.ArtifactMode())
-		return v.RenderArtifactList(artifact.NewListResult(arts, false))
+		// API returns bare []User with no pagination metadata.
+		// Infer hasMore when result count equals requested max.
+		hasMore := maxResults > 0 && len(users) == maxResults
+		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
 	headers := []string{"ACCOUNT_ID", "NAME", "EMAIL", "ACTIVE"}


### PR DESCRIPTION
## Summary

Migrates the first slice of jtk commands to use the artifact projection framework from #198. Commands now produce intentional artifacts with agent (default) and full (`--full`) modes.

**Migrated commands:**
- `sprints list`, `sprints current`, `sprints issues`
- `boards list`, `boards get`
- `users get`, `users search`
- `me`

**New internal/artifact package:**
- `SprintArtifact`, `BoardArtifact`, `UserArtifact`, `IssueArtifact`
- `Project<Type>` and `Project<Type>s` functions
- 22 unit tests

**Key implementation details:**
- Pagination metadata preserved where API provides it (`IsLast`, `Total/StartAt`)
- `UserArtifact.Active` uses `*bool` so inactive users explicitly show `"active": false` in full mode
- Commands with local `--full` flag conflicts (issues, comments, automation) deferred to follow-up issue

## Test plan

- [x] `make build` succeeds
- [x] `make test` passes (22 new artifact tests + all existing)
- [x] `make lint` passes for jtk (cfl has pre-existing gosec warnings)
- [ ] Manual: `jtk sprints list -b <id> -o json` returns `{results: [...], _meta: {count, hasMore}}`
- [ ] Manual: `jtk me -o json --full` includes email and active fields

Closes #199