### PR TITLE
feat(jtk): resolve --full flag collisions for artifact migration

### DIFF
--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -258,7 +258,7 @@ jtk issues list --project MYPROJECT --fields summary,status,customfield_10005 -o
 | `--sprint` | `-s` | | Filter by sprint: sprint ID or `current` |
 | `--max` | `-m` | `25` | Maximum number of results to return |
 | `--fields` | | `*all` | Comma-separated list of fields to include in JSON output |
-| `--full` | | `false` | Include all fields (e.g. description) |
+| `--all-fields` | | `false` | Include all fields (e.g. description) |
 | `--next-page-token` | | | Token for next page of results |
 
 ---
@@ -269,13 +269,13 @@ Get details of a specific issue.
 
 ```bash
 jtk issues get PROJ-123
-jtk issues get PROJ-123 --full
+jtk issues get PROJ-123 --no-truncate
 jtk issues get PROJ-123 -o json
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--full` | `false` | Show full description without truncation |
+| `--no-truncate` | `false` | Show full description without truncation |
 
 **Arguments:**
 - `<issue-key>` - The issue key (e.g., `PROJ-123`) (**required**)
@@ -354,7 +354,7 @@ jtk issues search --jql "project = MYPROJECT" --fields summary,status -o json
 | `--jql` | | | JQL query string (**required**) |
 | `--max` | `-m` | `25` | Maximum number of results to return |
 | `--fields` | | `*all` | Comma-separated list of fields to include in JSON output |
-| `--full` | | `false` | Include all fields (e.g. description) |
+| `--all-fields` | | `false` | Include all fields (e.g. description) |
 | `--next-page-token` | | | Token for next page of results |
 
 ---
@@ -761,14 +761,14 @@ List comments on an issue.
 
 ```bash
 jtk comments list PROJ-123
-jtk comments list PROJ-123 --full
+jtk comments list PROJ-123 --no-truncate
 jtk comments list PROJ-123 -o json
 ```
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--max` | `-m` | `50` | Maximum number of comments |
-| `--full` | | `false` | Show full comment bodies without truncation |
+| `--no-truncate` | | `false` | Show full comment bodies without truncation |
 
 **Arguments:**
 - `<issue-key>` - The issue key (**required**)
@@ -1139,12 +1139,12 @@ Get details of an automation rule.
 
 ```bash
 jtk automation get 123
-jtk automation get 123 --full
+jtk automation get 123 --show-components
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--full` | `false` | Show component type details |
+| `--show-components` | `false` | Show component type details |
 
 **Arguments:**
 - `<rule-id>` - The rule ID (**required**)

--- a/tools/jtk/automation-integration-tests.md
+++ b/tools/jtk/automation-integration-tests.md
@@ -211,7 +211,7 @@ Creates a rule using the pattern from real backups: extract a custom field to a 
    ```
    Capture UUID → `$COMP_UUID`
    ```bash
-   jtk auto get $COMP_UUID --full
+   jtk auto get $COMP_UUID --show-components
    jtk auto export $COMP_UUID > /tmp/auto-comparator-export.json
    ```
 
@@ -333,7 +333,7 @@ Creates a rule with if/else branching — the most complex structure.
    ```
    Capture UUID → `$IFELSE_UUID`
    ```bash
-   jtk auto get $IFELSE_UUID --full
+   jtk auto get $IFELSE_UUID --show-components
    jtk auto export $IFELSE_UUID > /tmp/auto-ifelse-export.json
    ```
 
@@ -424,7 +424,7 @@ Creates a rule with multiple conditions: platform = Q2 AND product includes Chec
    ```
    Capture UUID → `$MULTI_UUID`
    ```bash
-   jtk auto get $MULTI_UUID --full
+   jtk auto get $MULTI_UUID --show-components
    jtk auto export $MULTI_UUID > /tmp/auto-multi-export.json
    ```
 
@@ -546,7 +546,7 @@ Creates a rule with a `jira.issue.edit` action that sets a custom field.
    ```
    Capture UUID → `$EDIT_UUID`
    ```bash
-   jtk auto get $EDIT_UUID --full
+   jtk auto get $EDIT_UUID --show-components
    jtk auto export $EDIT_UUID > /tmp/auto-edit-export.json
    jq '.rule.components[0].value.operations' /tmp/auto-edit-export.json
    ```

--- a/tools/jtk/integration-tests.md
+++ b/tools/jtk/integration-tests.md
@@ -334,7 +334,7 @@ jtk fields list --custom
 | 3 | `jtk auto list --state DISABLED` | Only DISABLED rules |
 | 4 | `jtk auto list -o json` | Valid JSON array |
 | 5 | `jtk auto get $AUTO_UUID` | Shows Name, UUID, State, Description, Components summary |
-| 6 | `jtk auto get $AUTO_UUID --full` | Adds component details: `[1] CONDITION: type`, `[2] ACTION: type`, etc. |
+| 6 | `jtk auto get $AUTO_UUID --show-components` | Adds component details: `[1] CONDITION: type`, `[2] ACTION: type`, etc. |
 | 7 | `jtk auto get $AUTO_UUID -o json` | Valid JSON |
 | 8 | `jtk auto export $AUTO_UUID \| jq .` | Pretty-printed valid JSON (top-level keys: `rule`, `connections`) |
 | 9 | `jtk auto export $AUTO_UUID --compact` | Single-line JSON |
@@ -420,7 +420,7 @@ Run these steps in order. Each step depends on the previous.
 
 6b. **Verify escape sequences rendered:**
    ```bash
-   jtk comments list $TEST_ISSUE --full
+   jtk comments list $TEST_ISSUE --no-truncate
    ```
    Expected: Comment body shows actual newlines and tab, not literal `\n` or `\t`
 
@@ -1078,7 +1078,7 @@ Verify each alias produces the same output as the full command:
 
 #### Automation Read-Only (Section 8)
 - [ ] `auto list` (all, filtered, JSON)
-- [ ] `auto get` (summary, --full, JSON)
+- [ ] `auto get` (summary, --show-components, JSON)
 - [ ] `auto export` (pretty, compact)
 
 #### Fields Read-Only (Section 9)

--- a/tools/jtk/internal/artifact/issue.go
+++ b/tools/jtk/internal/artifact/issue.go
@@ -9,7 +9,7 @@ import (
 // IssueArtifact is the projected output for an issue.
 // This is a minimal artifact for list contexts (e.g., sprints issues).
 // Full issue artifact with more fields will be added when issues commands
-// are migrated after the --full flag collision is resolved.
+// are migrated to artifact projection (see #205 for flag collision resolution).
 type IssueArtifact struct {
 	// Agent fields - essential for triage
 	Key      string `json:"key"`

--- a/tools/jtk/internal/cmd/automation/get.go
+++ b/tools/jtk/internal/cmd/automation/get.go
@@ -12,32 +12,32 @@ import (
 )
 
 func newGetCmd(opts *root.Options) *cobra.Command {
-	var full bool
+	var showComponents bool
 
 	cmd := &cobra.Command{
 		Use:   "get <rule-id>",
 		Short: "Get automation rule details",
 		Long: `Retrieve and display details for a specific automation rule.
 
-Shows rule metadata and a summary of components. Use --full to see
+Shows rule metadata and a summary of components. Use --show-components to see
 component type details. Use -o json for the full rule object.
 
 For the exact JSON needed for editing, use 'jtk auto export' instead.`,
 		Example: `  jtk automation get 12345
-  jtk auto get 12345 --full
+  jtk auto get 12345 --show-components
   jtk auto get 12345 -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGet(cmd.Context(), opts, args[0], full)
+			return runGet(cmd.Context(), opts, args[0], showComponents)
 		},
 	}
 
-	cmd.Flags().BoolVar(&full, "full", false, "Show component type details")
+	cmd.Flags().BoolVar(&showComponents, "show-components", false, "Show component type details")
 
 	return cmd
 }
 
-func runGet(ctx context.Context, opts *root.Options, ruleID string, full bool) error {
+func runGet(ctx context.Context, opts *root.Options, ruleID string, showComponents bool) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -85,7 +85,7 @@ func runGet(ctx context.Context, opts *root.Options, ruleID string, full bool) e
 
 	v.Println("Components:  %s", summarizeComponents(rule.Components))
 
-	if full && len(rule.Components) > 0 {
+	if showComponents && len(rule.Components) > 0 {
 		v.Println("")
 		v.Println("Component Details:")
 		for i, c := range rule.Components {

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -28,27 +28,27 @@ func Register(parent *cobra.Command, opts *root.Options) {
 
 func newListCmd(opts *root.Options) *cobra.Command {
 	var maxResults int
-	var full bool
+	var noTruncate bool
 
 	cmd := &cobra.Command{
 		Use:   "list <issue-key>",
 		Short: "List comments on an issue",
 		Long:  "List all comments on a specific issue.",
 		Example: `  jtk comments list PROJ-123
-  jtk comments list PROJ-123 --full`,
+  jtk comments list PROJ-123 --no-truncate`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), opts, args[0], maxResults, full)
+			return runList(cmd.Context(), opts, args[0], maxResults, noTruncate)
 		},
 	}
 
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of comments")
-	cmd.Flags().BoolVar(&full, "full", false, "Show full comment bodies without truncation")
+	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full comment bodies without truncation")
 
 	return cmd
 }
 
-func runList(ctx context.Context, opts *root.Options, issueKey string, maxResults int, full bool) error {
+func runList(ctx context.Context, opts *root.Options, issueKey string, maxResults int, noTruncate bool) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -70,8 +70,8 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 		return v.JSON(result.Comments)
 	}
 
-	// Full mode: display each comment with complete body text
-	if full {
+	// No-truncate mode: display each comment with complete body text
+	if noTruncate {
 		for i, c := range result.Comments {
 			if i > 0 {
 				v.Println("---")
@@ -96,7 +96,7 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 		if c.Body != nil {
 			body = c.Body.ToPlainText()
 			if len(body) > 100 {
-				body = body[:100] + "... [truncated, use --full for complete text]"
+				body = body[:100] + "... [truncated, use --no-truncate for complete text]"
 			}
 		}
 

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -22,10 +22,10 @@ func TestNewListCmd(t *testing.T) {
 
 	testutil.Equal(t, cmd.Use, "list <issue-key>")
 
-	// Check that full flag exists
-	fullFlag := cmd.Flags().Lookup("full")
-	testutil.NotNil(t, fullFlag)
-	testutil.Equal(t, fullFlag.DefValue, "false")
+	// Check that no-truncate flag exists
+	noTruncateFlag := cmd.Flags().Lookup("no-truncate")
+	testutil.NotNil(t, noTruncateFlag)
+	testutil.Equal(t, noTruncateFlag.DefValue, "false")
 
 	// Check that max flag exists
 	maxFlag := cmd.Flags().Lookup("max")
@@ -92,7 +92,7 @@ func TestRunList_TruncatesCommentBody(t *testing.T) {
 
 	output := stdout.String()
 	testutil.Contains(t, output, "Alice")
-	testutil.Contains(t, output, "[truncated, use --full for complete text]")
+	testutil.Contains(t, output, "[truncated, use --no-truncate for complete text]")
 	testutil.NotContains(t, output, longText)
 }
 

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -12,27 +12,27 @@ import (
 )
 
 func newGetCmd(opts *root.Options) *cobra.Command {
-	var full bool
+	var noTruncate bool
 
 	cmd := &cobra.Command{
 		Use:   "get <issue-key>",
 		Short: "Get issue details",
 		Long:  "Retrieve and display details for a specific issue.",
 		Example: `  jtk issues get PROJ-123
-  jtk issues get PROJ-123 --full
+  jtk issues get PROJ-123 --no-truncate
   jtk issues get PROJ-123 -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGet(cmd.Context(), opts, args[0], full)
+			return runGet(cmd.Context(), opts, args[0], noTruncate)
 		},
 	}
 
-	cmd.Flags().BoolVar(&full, "full", false, "Show full description without truncation")
+	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full description without truncation")
 
 	return cmd
 }
 
-func runGet(ctx context.Context, opts *root.Options, issueKey string, full bool) error {
+func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate bool) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -79,8 +79,8 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, full bool)
 	description := ""
 	if issue.Fields.Description != nil {
 		description = issue.Fields.Description.ToPlainText()
-		if !full && len(description) > 200 {
-			description = description[:200] + "... [truncated, use --full for complete text]"
+		if !noTruncate && len(description) > 200 {
+			description = description[:200] + "... [truncated, use --no-truncate for complete text]"
 		}
 	}
 

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -23,10 +23,10 @@ func TestNewGetCmd(t *testing.T) {
 	testutil.Equal(t, cmd.Use, "get <issue-key>")
 	testutil.Equal(t, cmd.Short, "Get issue details")
 
-	// Check that full flag exists
-	fullFlag := cmd.Flags().Lookup("full")
-	testutil.NotNil(t, fullFlag)
-	testutil.Equal(t, fullFlag.DefValue, "false")
+	// Check that no-truncate flag exists
+	noTruncateFlag := cmd.Flags().Lookup("no-truncate")
+	testutil.NotNil(t, noTruncateFlag)
+	testutil.Equal(t, noTruncateFlag.DefValue, "false")
 }
 
 func newTestIssueServer(_ *testing.T, issue api.Issue) *httptest.Server {
@@ -72,7 +72,7 @@ func TestRunGet_TruncatesDescription(t *testing.T) {
 
 	output := stdout.String()
 	testutil.Contains(t, output, "TEST-1")
-	testutil.Contains(t, output, "[truncated, use --full for complete text]")
+	testutil.Contains(t, output, "[truncated, use --no-truncate for complete text]")
 	testutil.NotContains(t, output, longText)
 }
 

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -15,7 +15,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
 	var sprint string
 	var maxResults int
 	var nextPageToken string
-	var full bool
+	var allFields bool
 	var fieldsFlag string
 
 	cmd := &cobra.Command{
@@ -34,13 +34,13 @@ func newListCmd(opts *root.Options) *cobra.Command {
   # Resume from a previous page token
   jtk issues list --project MYPROJECT --next-page-token <token>
 
-  # List with full details (includes description)
-  jtk issues list --project MYPROJECT --full
+  # List with all fields (includes description)
+  jtk issues list --project MYPROJECT --all-fields
 
   # List with specific fields (e.g. custom fields)
   jtk issues list --project MYPROJECT --fields summary,status,customfield_10005 -o json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runList(cmd.Context(), opts, project, sprint, maxResults, nextPageToken, full, fieldsFlag)
+			return runList(cmd.Context(), opts, project, sprint, maxResults, nextPageToken, allFields, fieldsFlag)
 		},
 	}
 
@@ -48,13 +48,13 @@ func newListCmd(opts *root.Options) *cobra.Command {
 	cmd.Flags().StringVarP(&sprint, "sprint", "s", "", "Filter by sprint (use 'current' for active sprint)")
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 25, "Maximum number of results to return")
 	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Token for next page of results")
-	cmd.Flags().BoolVar(&full, "full", false, "Include all fields (e.g. description)")
+	cmd.Flags().BoolVar(&allFields, "all-fields", false, "Include all fields (e.g. description)")
 	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated list of fields to return (e.g. summary,customfield_10005)")
 
 	return cmd
 }
 
-func runList(ctx context.Context, opts *root.Options, project, sprint string, maxResults int, nextPageToken string, full bool, fieldsFlag string) error {
+func runList(ctx context.Context, opts *root.Options, project, sprint string, maxResults int, nextPageToken string, allFields bool, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -89,7 +89,7 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 		jql += " ORDER BY updated DESC"
 	}
 
-	fields := resolveFields(fieldsFlag, opts.Output, full)
+	fields := resolveFields(fieldsFlag, opts.Output, allFields)
 
 	result, err := client.SearchPage(ctx, api.SearchPageOptions{
 		JQL:           jql,

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -13,7 +13,7 @@ func newSearchCmd(opts *root.Options) *cobra.Command {
 	var jql string
 	var maxResults int
 	var nextPageToken string
-	var full bool
+	var allFields bool
 	var fieldsFlag string
 
 	cmd := &cobra.Command{
@@ -32,27 +32,27 @@ func newSearchCmd(opts *root.Options) *cobra.Command {
   # Resume from a previous page token
   jtk issues search --jql "project = MYPROJECT" --next-page-token <token>
 
-  # Search with full details (includes description)
-  jtk issues search --jql "project = MYPROJECT" --full
+  # Search with all fields (includes description)
+  jtk issues search --jql "project = MYPROJECT" --all-fields
 
   # Search with specific fields (e.g. custom fields)
   jtk issues search --jql "project = MYPROJECT" --fields summary,status,customfield_10005 -o json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runSearch(cmd.Context(), opts, jql, maxResults, nextPageToken, full, fieldsFlag)
+			return runSearch(cmd.Context(), opts, jql, maxResults, nextPageToken, allFields, fieldsFlag)
 		},
 	}
 
 	cmd.Flags().StringVar(&jql, "jql", "", "JQL query string (required)")
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 25, "Maximum number of results to return")
 	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Token for next page of results")
-	cmd.Flags().BoolVar(&full, "full", false, "Include all fields (e.g. description)")
+	cmd.Flags().BoolVar(&allFields, "all-fields", false, "Include all fields (e.g. description)")
 	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated list of fields to return (e.g. summary,customfield_10005)")
 	_ = cmd.MarkFlagRequired("jql")
 
 	return cmd
 }
 
-func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults int, nextPageToken string, full bool, fieldsFlag string) error {
+func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults int, nextPageToken string, allFields bool, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -60,7 +60,7 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 		return err
 	}
 
-	fields := resolveFields(fieldsFlag, opts.Output, full)
+	fields := resolveFields(fieldsFlag, opts.Output, allFields)
 
 	result, err := client.SearchPage(ctx, api.SearchPageOptions{
 		JQL:           jql,

--- a/tools/jtk/internal/cmd/issues/search_fields.go
+++ b/tools/jtk/internal/cmd/issues/search_fields.go
@@ -7,8 +7,8 @@ import (
 )
 
 // resolveFields determines which fields to request from the Jira API based on
-// the --fields flag, output format, and --full flag.
-func resolveFields(fieldsFlag, outputFormat string, full bool) []string {
+// the --fields flag, output format, and --all-fields flag.
+func resolveFields(fieldsFlag, outputFormat string, allFields bool) []string {
 	if fieldsFlag != "" {
 		parts := strings.Split(fieldsFlag, ",")
 		fields := make([]string, 0, len(parts))
@@ -25,7 +25,7 @@ func resolveFields(fieldsFlag, outputFormat string, full bool) []string {
 	if outputFormat == "json" {
 		return []string{"*all"}
 	}
-	if full {
+	if allFields {
 		return append([]string(nil), api.DefaultSearchFields...)
 	}
 	return append([]string(nil), api.ListSearchFields...)


### PR DESCRIPTION
## Summary

- Rename local `--full` flags to command-specific names so global `--full` controls artifact projection mode uniformly
- **BREAKING CHANGE**: Users of local `--full` on affected commands must use new flag names

| Command | Old Flag | New Flag |
|---------|----------|----------|
| `issues get` | `--full` | `--no-truncate` |
| `issues list` | `--full` | `--all-fields` |
| `issues search` | `--full` | `--all-fields` |
| `comments list` | `--full` | `--no-truncate` |
| `automation get` | `--full` | `--show-components` |

## Test plan

- [x] `make build` succeeds
- [x] `make test` passes
- [x] No stale `--full` references in internal code
- [ ] `jtk issues get PROJ-123 --no-truncate` works
- [ ] `jtk issues list -p PROJ --all-fields` works
- [ ] `jtk comments list PROJ-123 --no-truncate` works
- [ ] `jtk auto get <UUID> --show-components` works
- [ ] Global `--full` now works on these commands for artifact mode

Closes #205