### PR TITLE
feat(jtk): migrate deferred commands to artifact projection

### DIFF
--- a/tools/jtk/internal/artifact/automation.go
+++ b/tools/jtk/internal/artifact/automation.go
@@ -1,0 +1,79 @@
+package artifact
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// AutomationRuleArtifact is the projected output for an automation rule.
+type AutomationRuleArtifact struct {
+	// Agent fields - essential for triage
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	State            string `json:"state"`
+	ComponentSummary string `json:"componentSummary"`
+
+	// Full-only fields
+	Description string   `json:"description,omitempty"`
+	Labels      []string `json:"labels,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+// ProjectAutomationRule projects an api.AutomationRule to an AutomationRuleArtifact.
+func ProjectAutomationRule(rule *api.AutomationRule, mode artifact.Type) *AutomationRuleArtifact {
+	a := &AutomationRuleArtifact{
+		ID:               rule.Identifier(),
+		Name:             rule.Name,
+		State:            rule.State,
+		ComponentSummary: summarizeComponents(rule.Components),
+	}
+
+	if mode.IsFull() {
+		a.Description = rule.Description
+		if len(rule.Labels) > 0 {
+			a.Labels = rule.Labels
+		}
+		if len(rule.Tags) > 0 {
+			a.Tags = rule.Tags
+		}
+	}
+
+	return a
+}
+
+// summarizeComponents creates a compact summary of rule components.
+// Format: "3 total — 1 trigger(s), 2 action(s)"
+func summarizeComponents(components []api.RuleComponent) string {
+	if len(components) == 0 {
+		return "none"
+	}
+
+	triggers, conditions, actions := 0, 0, 0
+	for _, c := range components {
+		switch c.Component {
+		case "TRIGGER":
+			triggers++
+		case "CONDITION":
+			conditions++
+		case "ACTION":
+			actions++
+		}
+	}
+
+	parts := make([]string, 0, 3)
+	if triggers > 0 {
+		parts = append(parts, fmt.Sprintf("%d trigger(s)", triggers))
+	}
+	if conditions > 0 {
+		parts = append(parts, fmt.Sprintf("%d condition(s)", conditions))
+	}
+	if actions > 0 {
+		parts = append(parts, fmt.Sprintf("%d action(s)", actions))
+	}
+
+	return fmt.Sprintf("%d total — %s", len(components), strings.Join(parts, ", "))
+}

--- a/tools/jtk/internal/artifact/automation.go
+++ b/tools/jtk/internal/artifact/automation.go
@@ -52,7 +52,7 @@ func summarizeComponents(components []api.RuleComponent) string {
 		return "none"
 	}
 
-	triggers, conditions, actions := 0, 0, 0
+	triggers, conditions, actions, other := 0, 0, 0, 0
 	for _, c := range components {
 		switch c.Component {
 		case "TRIGGER":
@@ -61,10 +61,12 @@ func summarizeComponents(components []api.RuleComponent) string {
 			conditions++
 		case "ACTION":
 			actions++
+		default:
+			other++
 		}
 	}
 
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 4)
 	if triggers > 0 {
 		parts = append(parts, fmt.Sprintf("%d trigger(s)", triggers))
 	}
@@ -73,6 +75,9 @@ func summarizeComponents(components []api.RuleComponent) string {
 	}
 	if actions > 0 {
 		parts = append(parts, fmt.Sprintf("%d action(s)", actions))
+	}
+	if other > 0 {
+		parts = append(parts, fmt.Sprintf("%d other", other))
 	}
 
 	return fmt.Sprintf("%d total — %s", len(components), strings.Join(parts, ", "))

--- a/tools/jtk/internal/artifact/automation_test.go
+++ b/tools/jtk/internal/artifact/automation_test.go
@@ -1,0 +1,238 @@
+package artifact
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestProjectAutomationRule_AgentMode(t *testing.T) {
+	t.Parallel()
+
+	rule := &api.AutomationRule{
+		UUID:        "abc-123-def",
+		Name:        "Close stale issues",
+		State:       "ENABLED",
+		Description: "Closes issues after 30 days of inactivity",
+		Labels:      []string{"cleanup", "maintenance"},
+		Tags:        []string{"automated"},
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "scheduled"},
+			{Component: "CONDITION", Type: "jql"},
+			{Component: "ACTION", Type: "transition"},
+		},
+	}
+
+	art := ProjectAutomationRule(rule, artifact.Agent)
+
+	// Agent fields populated
+	testutil.Equal(t, art.ID, "abc-123-def")
+	testutil.Equal(t, art.Name, "Close stale issues")
+	testutil.Equal(t, art.State, "ENABLED")
+	testutil.Equal(t, art.ComponentSummary, "3 total — 1 trigger(s), 1 condition(s), 1 action(s)")
+
+	// Full-only fields empty
+	testutil.Equal(t, art.Description, "")
+	testutil.Nil(t, art.Labels)
+	testutil.Nil(t, art.Tags)
+}
+
+func TestProjectAutomationRule_FullMode(t *testing.T) {
+	t.Parallel()
+
+	rule := &api.AutomationRule{
+		UUID:        "abc-123-def",
+		Name:        "Close stale issues",
+		State:       "ENABLED",
+		Description: "Closes issues after 30 days of inactivity",
+		Labels:      []string{"cleanup", "maintenance"},
+		Tags:        []string{"automated"},
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "scheduled"},
+			{Component: "ACTION", Type: "transition"},
+		},
+	}
+
+	art := ProjectAutomationRule(rule, artifact.Full)
+
+	// Agent fields populated
+	testutil.Equal(t, art.ID, "abc-123-def")
+	testutil.Equal(t, art.Name, "Close stale issues")
+	testutil.Equal(t, art.State, "ENABLED")
+	testutil.Equal(t, art.ComponentSummary, "2 total — 1 trigger(s), 1 action(s)")
+
+	// Full-only fields populated
+	testutil.Equal(t, art.Description, "Closes issues after 30 days of inactivity")
+	testutil.Equal(t, len(art.Labels), 2)
+	testutil.Equal(t, art.Labels[0], "cleanup")
+	testutil.Equal(t, len(art.Tags), 1)
+	testutil.Equal(t, art.Tags[0], "automated")
+}
+
+func TestProjectAutomationRule_EmptyOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	rule := &api.AutomationRule{
+		UUID:  "xyz-789",
+		Name:  "Simple rule",
+		State: "DISABLED",
+		// No description, labels, tags, or components
+	}
+
+	art := ProjectAutomationRule(rule, artifact.Full)
+
+	testutil.Equal(t, art.ID, "xyz-789")
+	testutil.Equal(t, art.Name, "Simple rule")
+	testutil.Equal(t, art.State, "DISABLED")
+	testutil.Equal(t, art.ComponentSummary, "none")
+	testutil.Equal(t, art.Description, "")
+	testutil.Nil(t, art.Labels)
+	testutil.Nil(t, art.Tags)
+}
+
+func TestProjectAutomationRule_IdentifierFallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses UUID when available", func(t *testing.T) {
+		t.Parallel()
+		rule := &api.AutomationRule{
+			UUID:    "uuid-value",
+			RuleKey: "rulekey-value",
+			ID:      "123",
+			Name:    "Test",
+			State:   "ENABLED",
+		}
+		art := ProjectAutomationRule(rule, artifact.Agent)
+		testutil.Equal(t, art.ID, "uuid-value")
+	})
+
+	t.Run("falls back to RuleKey", func(t *testing.T) {
+		t.Parallel()
+		rule := &api.AutomationRule{
+			RuleKey: "rulekey-value",
+			ID:      "123",
+			Name:    "Test",
+			State:   "ENABLED",
+		}
+		art := ProjectAutomationRule(rule, artifact.Agent)
+		testutil.Equal(t, art.ID, "rulekey-value")
+	})
+
+	t.Run("falls back to numeric ID", func(t *testing.T) {
+		t.Parallel()
+		rule := &api.AutomationRule{
+			ID:    "456",
+			Name:  "Test",
+			State: "ENABLED",
+		}
+		art := ProjectAutomationRule(rule, artifact.Agent)
+		testutil.Equal(t, art.ID, "456")
+	})
+}
+
+func TestProjectAutomationRule_JSONSerialization(t *testing.T) {
+	t.Parallel()
+
+	t.Run("agent mode omits full-only fields", func(t *testing.T) {
+		t.Parallel()
+		rule := &api.AutomationRule{
+			UUID:        "abc",
+			Name:        "Test",
+			State:       "ENABLED",
+			Description: "A description",
+			Labels:      []string{"label1"},
+			Tags:        []string{"tag1"},
+		}
+		art := ProjectAutomationRule(rule, artifact.Agent)
+
+		data, err := json.Marshal(art)
+		testutil.RequireNoError(t, err)
+
+		var parsed map[string]any
+		err = json.Unmarshal(data, &parsed)
+		testutil.RequireNoError(t, err)
+
+		_, exists := parsed["description"]
+		testutil.False(t, exists)
+		_, exists = parsed["labels"]
+		testutil.False(t, exists)
+		_, exists = parsed["tags"]
+		testutil.False(t, exists)
+	})
+
+	t.Run("full mode includes all fields", func(t *testing.T) {
+		t.Parallel()
+		rule := &api.AutomationRule{
+			UUID:        "abc",
+			Name:        "Test",
+			State:       "ENABLED",
+			Description: "A description",
+			Labels:      []string{"label1"},
+			Tags:        []string{"tag1"},
+		}
+		art := ProjectAutomationRule(rule, artifact.Full)
+
+		data, err := json.Marshal(art)
+		testutil.RequireNoError(t, err)
+
+		var parsed map[string]any
+		err = json.Unmarshal(data, &parsed)
+		testutil.RequireNoError(t, err)
+
+		testutil.Equal(t, parsed["description"], "A description")
+		labels, ok := parsed["labels"].([]any)
+		testutil.True(t, ok)
+		testutil.Equal(t, len(labels), 1)
+	})
+}
+
+func TestSummarizeComponents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		components []api.RuleComponent
+		expected   string
+	}{
+		{
+			name:       "empty",
+			components: nil,
+			expected:   "none",
+		},
+		{
+			name: "triggers only",
+			components: []api.RuleComponent{
+				{Component: "TRIGGER", Type: "scheduled"},
+				{Component: "TRIGGER", Type: "manual"},
+			},
+			expected: "2 total — 2 trigger(s)",
+		},
+		{
+			name: "actions only",
+			components: []api.RuleComponent{
+				{Component: "ACTION", Type: "transition"},
+			},
+			expected: "1 total — 1 action(s)",
+		},
+		{
+			name: "mixed",
+			components: []api.RuleComponent{
+				{Component: "TRIGGER", Type: "scheduled"},
+				{Component: "CONDITION", Type: "jql"},
+				{Component: "CONDITION", Type: "field"},
+				{Component: "ACTION", Type: "transition"},
+				{Component: "ACTION", Type: "comment"},
+			},
+			expected: "5 total — 1 trigger(s), 2 condition(s), 2 action(s)",
+		},
+	}
+
+	for _, tt := range tests {
+		result := summarizeComponents(tt.components)
+		testutil.Equal(t, result, tt.expected)
+	}
+}

--- a/tools/jtk/internal/artifact/automation_test.go
+++ b/tools/jtk/internal/artifact/automation_test.go
@@ -229,10 +229,22 @@ func TestSummarizeComponents(t *testing.T) {
 			},
 			expected: "5 total — 1 trigger(s), 2 condition(s), 2 action(s)",
 		},
+		{
+			name: "with unknown component types",
+			components: []api.RuleComponent{
+				{Component: "TRIGGER", Type: "scheduled"},
+				{Component: "BRANCH", Type: "parallel"},
+				{Component: "ACTION", Type: "transition"},
+			},
+			expected: "3 total — 1 trigger(s), 1 action(s), 1 other",
+		},
 	}
 
 	for _, tt := range tests {
-		result := summarizeComponents(tt.components)
-		testutil.Equal(t, result, tt.expected)
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := summarizeComponents(tt.components)
+			testutil.Equal(t, result, tt.expected)
+		})
 	}
 }

--- a/tools/jtk/internal/artifact/comment.go
+++ b/tools/jtk/internal/artifact/comment.go
@@ -1,0 +1,65 @@
+package artifact
+
+import (
+	"strings"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// CommentArtifact is the projected output for a comment.
+// Body is included in agent mode (truncated) because it's the primary semantic content.
+type CommentArtifact struct {
+	// Agent fields - body is primary content, truncated for triage
+	ID      string `json:"id"`
+	Author  string `json:"author"`
+	Created string `json:"created"`
+	Body    string `json:"body"` // Truncated in agent mode, full in full mode
+
+	// Full-only fields
+	Updated string `json:"updated,omitempty"`
+}
+
+// ProjectComment projects an api.Comment to a CommentArtifact.
+func ProjectComment(c *api.Comment, mode artifact.Type) *CommentArtifact {
+	body := ""
+	if c.Body != nil {
+		body = strings.TrimSpace(c.Body.ToPlainText())
+	}
+
+	// In agent mode, truncate body for triage readability
+	if !mode.IsFull() && len(body) > 200 {
+		body = body[:200] + "..."
+	}
+
+	a := &CommentArtifact{
+		ID:      c.ID,
+		Author:  c.Author.DisplayName,
+		Created: formatDate(c.Created),
+		Body:    body,
+	}
+
+	if mode.IsFull() {
+		a.Updated = formatDate(c.Updated)
+	}
+
+	return a
+}
+
+// ProjectComments projects a slice of api.Comment to CommentArtifacts.
+func ProjectComments(comments []api.Comment, mode artifact.Type) []*CommentArtifact {
+	result := make([]*CommentArtifact, len(comments))
+	for i := range comments {
+		result[i] = ProjectComment(&comments[i], mode)
+	}
+	return result
+}
+
+// formatDate extracts just the date portion from an ISO timestamp.
+func formatDate(timestamp string) string {
+	if len(timestamp) >= 10 {
+		return timestamp[:10]
+	}
+	return timestamp
+}

--- a/tools/jtk/internal/artifact/comment.go
+++ b/tools/jtk/internal/artifact/comment.go
@@ -28,9 +28,13 @@ func ProjectComment(c *api.Comment, mode artifact.Type) *CommentArtifact {
 		body = strings.TrimSpace(c.Body.ToPlainText())
 	}
 
-	// In agent mode, truncate body for triage readability
-	if !mode.IsFull() && len(body) > 200 {
-		body = body[:200] + "..."
+	// In agent mode, truncate body for triage readability.
+	// Use rune-based truncation to avoid cutting multi-byte UTF-8 characters.
+	if !mode.IsFull() {
+		runes := []rune(body)
+		if len(runes) > 200 {
+			body = string(runes[:200]) + "..."
+		}
 	}
 
 	a := &CommentArtifact{

--- a/tools/jtk/internal/artifact/comment_test.go
+++ b/tools/jtk/internal/artifact/comment_test.go
@@ -1,0 +1,187 @@
+package artifact
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestProjectComment_AgentMode(t *testing.T) {
+	t.Parallel()
+
+	comment := &api.Comment{
+		ID:      "12345",
+		Author:  api.User{DisplayName: "John Doe"},
+		Body:    api.NewADFDocument("Short comment body"),
+		Created: "2024-01-15T10:00:00.000Z",
+		Updated: "2024-01-16T11:00:00.000Z",
+	}
+
+	art := ProjectComment(comment, artifact.Agent)
+
+	// Agent fields populated
+	testutil.Equal(t, art.ID, "12345")
+	testutil.Equal(t, art.Author, "John Doe")
+	testutil.Equal(t, art.Created, "2024-01-15")
+	testutil.Equal(t, art.Body, "Short comment body")
+
+	// Full-only fields empty
+	testutil.Equal(t, art.Updated, "")
+}
+
+func TestProjectComment_AgentMode_TruncatesLongBody(t *testing.T) {
+	t.Parallel()
+
+	longBody := strings.Repeat("A", 300)
+	comment := &api.Comment{
+		ID:      "12345",
+		Author:  api.User{DisplayName: "John Doe"},
+		Body:    api.NewADFDocument(longBody),
+		Created: "2024-01-15T10:00:00.000Z",
+	}
+
+	art := ProjectComment(comment, artifact.Agent)
+
+	// Body should be truncated to 200 chars + "..."
+	testutil.Equal(t, len(art.Body), 203)
+	testutil.True(t, strings.HasSuffix(art.Body, "..."))
+}
+
+func TestProjectComment_FullMode(t *testing.T) {
+	t.Parallel()
+
+	longBody := strings.Repeat("A", 300)
+	comment := &api.Comment{
+		ID:      "12345",
+		Author:  api.User{DisplayName: "John Doe"},
+		Body:    api.NewADFDocument(longBody),
+		Created: "2024-01-15T10:00:00.000Z",
+		Updated: "2024-01-16T11:00:00.000Z",
+	}
+
+	art := ProjectComment(comment, artifact.Full)
+
+	// Agent fields populated
+	testutil.Equal(t, art.ID, "12345")
+	testutil.Equal(t, art.Author, "John Doe")
+	testutil.Equal(t, art.Created, "2024-01-15")
+
+	// Full mode: body not truncated
+	testutil.Equal(t, len(art.Body), 300)
+	testutil.Equal(t, art.Body, longBody)
+
+	// Full-only fields populated
+	testutil.Equal(t, art.Updated, "2024-01-16")
+}
+
+func TestProjectComment_NilBody(t *testing.T) {
+	t.Parallel()
+
+	comment := &api.Comment{
+		ID:      "12345",
+		Author:  api.User{DisplayName: "John Doe"},
+		Body:    nil,
+		Created: "2024-01-15T10:00:00.000Z",
+	}
+
+	art := ProjectComment(comment, artifact.Agent)
+
+	testutil.Equal(t, art.Body, "")
+}
+
+func TestProjectComment_JSONSerialization(t *testing.T) {
+	t.Parallel()
+
+	t.Run("agent mode omits updated", func(t *testing.T) {
+		t.Parallel()
+		comment := &api.Comment{
+			ID:      "123",
+			Author:  api.User{DisplayName: "Test"},
+			Body:    api.NewADFDocument("test"),
+			Created: "2024-01-15T10:00:00.000Z",
+			Updated: "2024-01-16T10:00:00.000Z",
+		}
+		art := ProjectComment(comment, artifact.Agent)
+
+		data, err := json.Marshal(art)
+		testutil.RequireNoError(t, err)
+
+		var parsed map[string]any
+		err = json.Unmarshal(data, &parsed)
+		testutil.RequireNoError(t, err)
+
+		_, exists := parsed["updated"]
+		testutil.False(t, exists) // Should not be present in agent mode
+	})
+
+	t.Run("full mode includes updated", func(t *testing.T) {
+		t.Parallel()
+		comment := &api.Comment{
+			ID:      "123",
+			Author:  api.User{DisplayName: "Test"},
+			Body:    api.NewADFDocument("test"),
+			Created: "2024-01-15T10:00:00.000Z",
+			Updated: "2024-01-16T10:00:00.000Z",
+		}
+		art := ProjectComment(comment, artifact.Full)
+
+		data, err := json.Marshal(art)
+		testutil.RequireNoError(t, err)
+
+		var parsed map[string]any
+		err = json.Unmarshal(data, &parsed)
+		testutil.RequireNoError(t, err)
+
+		_, exists := parsed["updated"]
+		testutil.True(t, exists)
+	})
+}
+
+func TestProjectComments(t *testing.T) {
+	t.Parallel()
+
+	comments := []api.Comment{
+		{ID: "1", Author: api.User{DisplayName: "User 1"}, Body: api.NewADFDocument("Comment 1"), Created: "2024-01-15T10:00:00.000Z"},
+		{ID: "2", Author: api.User{DisplayName: "User 2"}, Body: api.NewADFDocument("Comment 2"), Created: "2024-01-16T10:00:00.000Z"},
+	}
+
+	arts := ProjectComments(comments, artifact.Agent)
+
+	testutil.Equal(t, len(arts), 2)
+	testutil.Equal(t, arts[0].ID, "1")
+	testutil.Equal(t, arts[1].ID, "2")
+}
+
+func TestProjectComments_Empty(t *testing.T) {
+	t.Parallel()
+
+	var comments []api.Comment
+	arts := ProjectComments(comments, artifact.Agent)
+
+	testutil.Equal(t, len(arts), 0)
+	testutil.NotNil(t, arts)
+}
+
+func TestFormatDate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"2024-01-15T10:00:00.000Z", "2024-01-15"},
+		{"2024-01-15", "2024-01-15"},
+		{"short", "short"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		result := formatDate(tt.input)
+		testutil.Equal(t, result, tt.expected)
+	}
+}

--- a/tools/jtk/internal/artifact/comment_test.go
+++ b/tools/jtk/internal/artifact/comment_test.go
@@ -52,6 +52,33 @@ func TestProjectComment_AgentMode_TruncatesLongBody(t *testing.T) {
 	testutil.True(t, strings.HasSuffix(art.Body, "..."))
 }
 
+func TestProjectComment_AgentMode_TruncatesMultiByteChars(t *testing.T) {
+	t.Parallel()
+
+	// Use multi-byte characters (emoji and CJK) to verify rune-based truncation
+	// Each emoji is 4 bytes, each CJK character is 3 bytes
+	longBody := strings.Repeat("日本語", 100) // 300 runes, 900 bytes
+	comment := &api.Comment{
+		ID:      "12345",
+		Author:  api.User{DisplayName: "John Doe"},
+		Body:    api.NewADFDocument(longBody),
+		Created: "2024-01-15T10:00:00.000Z",
+	}
+
+	art := ProjectComment(comment, artifact.Agent)
+
+	// Body should be truncated to 200 runes + "..."
+	runes := []rune(art.Body)
+	testutil.Equal(t, len(runes), 203) // 200 runes + "..."
+	testutil.True(t, strings.HasSuffix(art.Body, "..."))
+
+	// Verify the truncated body is valid UTF-8 (no partial runes)
+	truncatedPart := art.Body[:len(art.Body)-3] // Remove "..."
+	for _, r := range truncatedPart {
+		testutil.True(t, r != '\uFFFD') // No replacement characters
+	}
+}
+
 func TestProjectComment_FullMode(t *testing.T) {
 	t.Parallel()
 

--- a/tools/jtk/internal/artifact/issue.go
+++ b/tools/jtk/internal/artifact/issue.go
@@ -16,12 +16,13 @@ type IssueArtifact struct {
 	Assignee string `json:"assignee,omitempty"`
 
 	// Full-only fields
-	Priority string   `json:"priority,omitempty"`
-	Project  string   `json:"project,omitempty"`
-	Created  string   `json:"created,omitempty"`
-	Updated  string   `json:"updated,omitempty"`
-	Reporter string   `json:"reporter,omitempty"`
-	Labels   []string `json:"labels,omitempty"`
+	Priority    string   `json:"priority,omitempty"`
+	Project     string   `json:"project,omitempty"`
+	Created     string   `json:"created,omitempty"`
+	Updated     string   `json:"updated,omitempty"`
+	Reporter    string   `json:"reporter,omitempty"`
+	Labels      []string `json:"labels,omitempty"`
+	Description string   `json:"description,omitempty"`
 }
 
 // ProjectIssue projects an api.Issue to an IssueArtifact.
@@ -53,6 +54,9 @@ func ProjectIssue(issue *api.Issue, mode artifact.Type) *IssueArtifact {
 		}
 		if len(issue.Fields.Labels) > 0 {
 			a.Labels = issue.Fields.Labels
+		}
+		if issue.Fields.Description != nil {
+			a.Description = issue.Fields.Description.ToPlainText()
 		}
 	}
 	return a

--- a/tools/jtk/internal/artifact/issue.go
+++ b/tools/jtk/internal/artifact/issue.go
@@ -7,9 +7,6 @@ import (
 )
 
 // IssueArtifact is the projected output for an issue.
-// This is a minimal artifact for list contexts (e.g., sprints issues).
-// Full issue artifact with more fields will be added when issues commands
-// are migrated to artifact projection (see #205 for flag collision resolution).
 type IssueArtifact struct {
 	// Agent fields - essential for triage
 	Key      string `json:"key"`
@@ -19,8 +16,12 @@ type IssueArtifact struct {
 	Assignee string `json:"assignee,omitempty"`
 
 	// Full-only fields
-	Priority string `json:"priority,omitempty"`
-	Project  string `json:"project,omitempty"`
+	Priority string   `json:"priority,omitempty"`
+	Project  string   `json:"project,omitempty"`
+	Created  string   `json:"created,omitempty"`
+	Updated  string   `json:"updated,omitempty"`
+	Reporter string   `json:"reporter,omitempty"`
+	Labels   []string `json:"labels,omitempty"`
 }
 
 // ProjectIssue projects an api.Issue to an IssueArtifact.
@@ -44,6 +45,14 @@ func ProjectIssue(issue *api.Issue, mode artifact.Type) *IssueArtifact {
 		}
 		if issue.Fields.Project != nil {
 			a.Project = issue.Fields.Project.Key
+		}
+		a.Created = formatDate(issue.Fields.Created)
+		a.Updated = formatDate(issue.Fields.Updated)
+		if issue.Fields.Reporter != nil {
+			a.Reporter = issue.Fields.Reporter.DisplayName
+		}
+		if len(issue.Fields.Labels) > 0 {
+			a.Labels = issue.Fields.Labels
 		}
 	}
 	return a

--- a/tools/jtk/internal/artifact/issue_test.go
+++ b/tools/jtk/internal/artifact/issue_test.go
@@ -15,16 +15,17 @@ func TestProjectIssue_AgentMode(t *testing.T) {
 	issue := &api.Issue{
 		Key: "PROJ-123",
 		Fields: api.IssueFields{
-			Summary:   "Fix the bug",
-			Status:    &api.Status{Name: "In Progress"},
-			IssueType: &api.IssueType{Name: "Bug"},
-			Assignee:  &api.User{DisplayName: "John Doe"},
-			Priority:  &api.Priority{Name: "High"},
-			Project:   &api.Project{Key: "PROJ"},
-			Created:   "2024-01-15T10:00:00.000Z",
-			Updated:   "2024-01-16T11:00:00.000Z",
-			Reporter:  &api.User{DisplayName: "Jane Doe"},
-			Labels:    []string{"bug", "urgent"},
+			Summary:     "Fix the bug",
+			Description: &api.Description{Text: "This is a bug description"},
+			Status:      &api.Status{Name: "In Progress"},
+			IssueType:   &api.IssueType{Name: "Bug"},
+			Assignee:    &api.User{DisplayName: "John Doe"},
+			Priority:    &api.Priority{Name: "High"},
+			Project:     &api.Project{Key: "PROJ"},
+			Created:     "2024-01-15T10:00:00.000Z",
+			Updated:     "2024-01-16T11:00:00.000Z",
+			Reporter:    &api.User{DisplayName: "Jane Doe"},
+			Labels:      []string{"bug", "urgent"},
 		},
 	}
 
@@ -44,6 +45,7 @@ func TestProjectIssue_AgentMode(t *testing.T) {
 	testutil.Equal(t, art.Updated, "")
 	testutil.Equal(t, art.Reporter, "")
 	testutil.Nil(t, art.Labels)
+	testutil.Equal(t, art.Description, "")
 }
 
 func TestProjectIssue_FullMode(t *testing.T) {
@@ -52,16 +54,17 @@ func TestProjectIssue_FullMode(t *testing.T) {
 	issue := &api.Issue{
 		Key: "PROJ-123",
 		Fields: api.IssueFields{
-			Summary:   "Fix the bug",
-			Status:    &api.Status{Name: "Done"},
-			IssueType: &api.IssueType{Name: "Task"},
-			Assignee:  &api.User{DisplayName: "Jane Doe"},
-			Priority:  &api.Priority{Name: "Critical"},
-			Project:   &api.Project{Key: "PROJ"},
-			Created:   "2024-01-15T10:00:00.000Z",
-			Updated:   "2024-01-16T11:00:00.000Z",
-			Reporter:  &api.User{DisplayName: "John Doe"},
-			Labels:    []string{"bug", "urgent"},
+			Summary:     "Fix the bug",
+			Description: &api.Description{Text: "This is a detailed description"},
+			Status:      &api.Status{Name: "Done"},
+			IssueType:   &api.IssueType{Name: "Task"},
+			Assignee:    &api.User{DisplayName: "Jane Doe"},
+			Priority:    &api.Priority{Name: "Critical"},
+			Project:     &api.Project{Key: "PROJ"},
+			Created:     "2024-01-15T10:00:00.000Z",
+			Updated:     "2024-01-16T11:00:00.000Z",
+			Reporter:    &api.User{DisplayName: "John Doe"},
+			Labels:      []string{"bug", "urgent"},
 		},
 	}
 
@@ -82,6 +85,7 @@ func TestProjectIssue_FullMode(t *testing.T) {
 	testutil.Equal(t, art.Reporter, "John Doe")
 	testutil.Equal(t, len(art.Labels), 2)
 	testutil.Equal(t, art.Labels[0], "bug")
+	testutil.Equal(t, art.Description, "This is a detailed description")
 }
 
 func TestProjectIssue_NilFields(t *testing.T) {
@@ -108,6 +112,7 @@ func TestProjectIssue_NilFields(t *testing.T) {
 	testutil.Equal(t, art.Updated, "")
 	testutil.Equal(t, art.Reporter, "")
 	testutil.Nil(t, art.Labels)
+	testutil.Equal(t, art.Description, "")
 }
 
 func TestProjectIssues(t *testing.T) {

--- a/tools/jtk/internal/artifact/issue_test.go
+++ b/tools/jtk/internal/artifact/issue_test.go
@@ -21,6 +21,10 @@ func TestProjectIssue_AgentMode(t *testing.T) {
 			Assignee:  &api.User{DisplayName: "John Doe"},
 			Priority:  &api.Priority{Name: "High"},
 			Project:   &api.Project{Key: "PROJ"},
+			Created:   "2024-01-15T10:00:00.000Z",
+			Updated:   "2024-01-16T11:00:00.000Z",
+			Reporter:  &api.User{DisplayName: "Jane Doe"},
+			Labels:    []string{"bug", "urgent"},
 		},
 	}
 
@@ -36,6 +40,10 @@ func TestProjectIssue_AgentMode(t *testing.T) {
 	// Full-only fields empty
 	testutil.Equal(t, art.Priority, "")
 	testutil.Equal(t, art.Project, "")
+	testutil.Equal(t, art.Created, "")
+	testutil.Equal(t, art.Updated, "")
+	testutil.Equal(t, art.Reporter, "")
+	testutil.Nil(t, art.Labels)
 }
 
 func TestProjectIssue_FullMode(t *testing.T) {
@@ -50,6 +58,10 @@ func TestProjectIssue_FullMode(t *testing.T) {
 			Assignee:  &api.User{DisplayName: "Jane Doe"},
 			Priority:  &api.Priority{Name: "Critical"},
 			Project:   &api.Project{Key: "PROJ"},
+			Created:   "2024-01-15T10:00:00.000Z",
+			Updated:   "2024-01-16T11:00:00.000Z",
+			Reporter:  &api.User{DisplayName: "John Doe"},
+			Labels:    []string{"bug", "urgent"},
 		},
 	}
 
@@ -65,6 +77,11 @@ func TestProjectIssue_FullMode(t *testing.T) {
 	// Full-only fields populated
 	testutil.Equal(t, art.Priority, "Critical")
 	testutil.Equal(t, art.Project, "PROJ")
+	testutil.Equal(t, art.Created, "2024-01-15")
+	testutil.Equal(t, art.Updated, "2024-01-16")
+	testutil.Equal(t, art.Reporter, "John Doe")
+	testutil.Equal(t, len(art.Labels), 2)
+	testutil.Equal(t, art.Labels[0], "bug")
 }
 
 func TestProjectIssue_NilFields(t *testing.T) {
@@ -74,7 +91,7 @@ func TestProjectIssue_NilFields(t *testing.T) {
 		Key: "PROJ-456",
 		Fields: api.IssueFields{
 			Summary: "Minimal issue",
-			// All pointer fields nil
+			// All pointer fields nil, no dates/labels
 		},
 	}
 
@@ -87,6 +104,10 @@ func TestProjectIssue_NilFields(t *testing.T) {
 	testutil.Equal(t, art.Assignee, "")
 	testutil.Equal(t, art.Priority, "")
 	testutil.Equal(t, art.Project, "")
+	testutil.Equal(t, art.Created, "")
+	testutil.Equal(t, art.Updated, "")
+	testutil.Equal(t, art.Reporter, "")
+	testutil.Nil(t, art.Labels)
 }
 
 func TestProjectIssues(t *testing.T) {

--- a/tools/jtk/internal/cmd/automation/get.go
+++ b/tools/jtk/internal/cmd/automation/get.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -50,8 +53,8 @@ func runGet(ctx context.Context, opts *root.Options, ruleID string, showComponen
 		return err
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(rule)
+	if v.Format == view.FormatJSON {
+		return v.RenderArtifact(jtkartifact.ProjectAutomationRule(rule, opts.ArtifactMode()))
 	}
 
 	v.Println("Name:        %s", rule.Name)

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -72,8 +72,16 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectComments(result.Comments, opts.ArtifactMode())
-		// Use authoritative pagination metadata from API response
-		hasMore := result.StartAt+len(result.Comments) < result.Total
+		// Use authoritative pagination metadata from API response.
+		// Guard against Total==0 edge case in Jira Cloud by also checking
+		// if we received a full page of results.
+		hasMore := false
+		if result.Total > 0 {
+			hasMore = result.StartAt+len(result.Comments) < result.Total
+		} else if len(result.Comments) == maxResults {
+			// Total is 0 but we got a full page - likely more results exist
+			hasMore = true
+		}
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -6,6 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/text"
 )
@@ -66,8 +70,11 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 		return nil
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(result.Comments)
+	if v.Format == view.FormatJSON {
+		arts := jtkartifact.ProjectComments(result.Comments, opts.ArtifactMode())
+		// Use authoritative pagination metadata from API response
+		hasMore := result.StartAt+len(result.Comments) < result.Total
+		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
 	// No-truncate mode: display each comment with complete body text

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -45,9 +46,9 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		return err
 	}
 
-	// For JSON output, return the full issue
-	if opts.Output == "json" {
-		return v.JSON(issue)
+	// For JSON output, return the projected artifact
+	if v.Format == view.FormatJSON {
+		return v.RenderArtifact(jtkartifact.ProjectIssue(issue, opts.ArtifactMode()))
 	}
 
 	// For table/plain output, display key details

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -6,7 +6,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -106,9 +110,11 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 		return nil
 	}
 
-	// For JSON output, return the paginated wrapper
-	if opts.Output == "json" {
-		return v.JSON(result)
+	// For JSON output, return the projected artifacts
+	if v.Format == view.FormatJSON {
+		arts := jtkartifact.ProjectIssues(result.Issues, opts.ArtifactMode())
+		hasMore := !result.Pagination.IsLast
+		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
 	headers := []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"}

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -5,7 +5,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -77,8 +81,10 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 		return nil
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(result)
+	if v.Format == view.FormatJSON {
+		arts := jtkartifact.ProjectIssues(result.Issues, opts.ArtifactMode())
+		hasMore := !result.Pagination.IsLast
+		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
 	headers := []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"}

--- a/tools/jtk/internal/cmd/issues/search_fields_test.go
+++ b/tools/jtk/internal/cmd/issues/search_fields_test.go
@@ -416,4 +416,6 @@ func TestRunList_AutoPaginationJSON(t *testing.T) {
 	testutil.Equal(t, 120, len(result.Results))
 	testutil.Equal(t, 120, result.Meta.Count)
 	testutil.False(t, result.Meta.HasMore) // All results fetched
+	testutil.Equal(t, "TEST-1", result.Results[0].Key)
+	testutil.Equal(t, "TEST-120", result.Results[119].Key)
 }

--- a/tools/jtk/internal/cmd/issues/search_fields_test.go
+++ b/tools/jtk/internal/cmd/issues/search_fields_test.go
@@ -14,8 +14,18 @@ import (
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
+
+// artifactListResult is a helper struct for parsing artifact list output in tests.
+type artifactListResult struct {
+	Results []*jtkartifact.IssueArtifact `json:"results"`
+	Meta    struct {
+		Count   int  `json:"count"`
+		HasMore bool `json:"hasMore"`
+	} `json:"_meta"`
+}
 
 func TestResolveFields(t *testing.T) {
 	t.Parallel()
@@ -366,14 +376,14 @@ func TestRunSearch_AutoPaginationJSON(t *testing.T) {
 	err = runSearch(context.Background(), opts, "project = TEST", 150, "", false, "")
 	testutil.RequireNoError(t, err)
 
-	var result api.PaginatedIssues
+	var result artifactListResult
 	err = json.Unmarshal(stdout.Bytes(), &result)
 	testutil.RequireNoError(t, err)
-	testutil.Equal(t, 150, len(result.Issues))
-	testutil.Equal(t, 150, result.Pagination.Total)
-	testutil.True(t, result.Pagination.IsLast)
-	testutil.Equal(t, "TEST-1", result.Issues[0].Key)
-	testutil.Equal(t, "TEST-150", result.Issues[149].Key)
+	testutil.Equal(t, 150, len(result.Results))
+	testutil.Equal(t, 150, result.Meta.Count)
+	testutil.False(t, result.Meta.HasMore) // All results fetched
+	testutil.Equal(t, "TEST-1", result.Results[0].Key)
+	testutil.Equal(t, "TEST-150", result.Results[149].Key)
 }
 
 func TestRunList_AutoPaginationJSON(t *testing.T) {
@@ -400,10 +410,10 @@ func TestRunList_AutoPaginationJSON(t *testing.T) {
 	err = runList(context.Background(), opts, "TEST", "", 120, "", false, "")
 	testutil.RequireNoError(t, err)
 
-	var result api.PaginatedIssues
+	var result artifactListResult
 	err = json.Unmarshal(stdout.Bytes(), &result)
 	testutil.RequireNoError(t, err)
-	testutil.Equal(t, 120, len(result.Issues))
-	testutil.Equal(t, 120, result.Pagination.Total)
-	testutil.True(t, result.Pagination.IsLast)
+	testutil.Equal(t, 120, len(result.Results))
+	testutil.Equal(t, 120, result.Meta.Count)
+	testutil.False(t, result.Meta.HasMore) // All results fetched
 }


### PR DESCRIPTION
## Summary

Closes #206

- Migrate `issues get/list/search`, `comments list`, and `automation get` to artifact projection
- Add `CommentArtifact` with truncated body in agent mode (~200 chars) for comment triage
- Add `AutomationRuleArtifact` with component summary ("3 total - 1 trigger(s), 2 action(s)")
- Expand `IssueArtifact` full-mode fields: created, updated, reporter, labels
- JSON output now uses standard artifact format: `{"results": [...], "_meta": {"count": N, "hasMore": bool}}`

This completes the jtk artifact migration started in #199 and unblocked by #205.

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes for jtk
- [ ] Manual: `jtk issues get PROJ-123 -o json` returns IssueArtifact
- [ ] Manual: `jtk issues get PROJ-123 -o json --full` includes created/updated/reporter/labels
- [ ] Manual: `jtk issues list -p PROJ -o json` returns artifact list format
- [ ] Manual: `jtk comments list PROJ-123 -o json` returns CommentArtifact list
- [ ] Manual: `jtk auto get <UUID> -o json` returns AutomationRuleArtifact