### PR TITLE
feat(cfl): migrate core commands to artifact projection

### DIFF
--- a/tools/cfl/internal/artifact/page.go
+++ b/tools/cfl/internal/artifact/page.go
@@ -1,0 +1,86 @@
+// Package artifact provides artifact types for projecting API responses to
+// structured output for CLI commands.
+package artifact
+
+import (
+	"github.com/open-cli-collective/atlassian-go/artifact"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+)
+
+// PageArtifact represents a content-bearing page artifact for page view.
+type PageArtifact struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	SpaceID   string `json:"spaceId"`
+	SpaceKey  string `json:"spaceKey,omitempty"`
+	ParentID  string `json:"parentId,omitempty"`
+	Content   string `json:"content"`
+	Version   int    `json:"version,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+	AuthorID  string `json:"authorId,omitempty"`
+}
+
+// ProjectPage projects an api.Page to a PageArtifact.
+// The spaceKey is passed separately since api.Page only has SpaceID.
+// Content should be pre-transformed (XHTML or markdown) by the caller.
+func ProjectPage(p *api.Page, spaceKey string, content string, mode artifact.Type) *PageArtifact {
+	art := &PageArtifact{
+		ID:       p.ID,
+		Title:    p.Title,
+		SpaceID:  p.SpaceID,
+		SpaceKey: spaceKey,
+		ParentID: p.ParentID,
+		Content:  content,
+	}
+
+	if mode == artifact.Full {
+		if p.Version != nil {
+			art.Version = p.Version.Number
+			if !p.Version.CreatedAt.IsZero() {
+				art.CreatedAt = p.Version.CreatedAt.Format("2006-01-02T15:04:05Z")
+			}
+			art.AuthorID = p.Version.AuthorID
+		}
+	}
+
+	return art
+}
+
+// PageListArtifact represents a metadata-only page artifact for page list.
+type PageListArtifact struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	SpaceID  string `json:"spaceId"`
+	Status   string `json:"status"`
+	Version  int    `json:"version,omitempty"`
+	ParentID string `json:"parentId,omitempty"`
+}
+
+// ProjectPageListItem projects an api.Page to a PageListArtifact.
+func ProjectPageListItem(p *api.Page, mode artifact.Type) *PageListArtifact {
+	art := &PageListArtifact{
+		ID:      p.ID,
+		Title:   p.Title,
+		SpaceID: p.SpaceID,
+		Status:  p.Status,
+	}
+
+	if mode == artifact.Full {
+		if p.Version != nil {
+			art.Version = p.Version.Number
+		}
+		art.ParentID = p.ParentID
+	}
+
+	return art
+}
+
+// ProjectPageListItems projects a slice of api.Page to PageListArtifacts.
+func ProjectPageListItems(pages []api.Page, mode artifact.Type) []*PageListArtifact {
+	arts := make([]*PageListArtifact, len(pages))
+	for i := range pages {
+		arts[i] = ProjectPageListItem(&pages[i], mode)
+	}
+	return arts
+}

--- a/tools/cfl/internal/artifact/page.go
+++ b/tools/cfl/internal/artifact/page.go
@@ -38,7 +38,7 @@ func ProjectPage(p *api.Page, spaceKey string, content string, mode artifact.Typ
 		if p.Version != nil {
 			art.Version = p.Version.Number
 			if !p.Version.CreatedAt.IsZero() {
-				art.CreatedAt = p.Version.CreatedAt.Format("2006-01-02T15:04:05Z")
+				art.CreatedAt = p.Version.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
 			}
 			art.AuthorID = p.Version.AuthorID
 		}

--- a/tools/cfl/internal/artifact/page_test.go
+++ b/tools/cfl/internal/artifact/page_test.go
@@ -46,7 +46,7 @@ func TestProjectPage(t *testing.T) {
 		testutil.Equal(t, "12345", art.ID)
 		testutil.Equal(t, "Test Page", art.Title)
 		testutil.Equal(t, 5, art.Version)
-		testutil.Equal(t, "2024-01-15T10:30:00Z", art.CreatedAt)
+		testutil.Equal(t, "2024-01-15T10:30:00Z", art.CreatedAt) // UTC with Z offset
 		testutil.Equal(t, "user123", art.AuthorID)
 	})
 

--- a/tools/cfl/internal/artifact/page_test.go
+++ b/tools/cfl/internal/artifact/page_test.go
@@ -1,0 +1,116 @@
+package artifact
+
+import (
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+)
+
+func TestProjectPage(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	page := &api.Page{
+		ID:       "12345",
+		Title:    "Test Page",
+		SpaceID:  "SPACE123",
+		ParentID: "PARENT456",
+		Version: &api.Version{
+			Number:    5,
+			AuthorID:  "user123",
+			CreatedAt: api.Time{Time: createdAt},
+		},
+	}
+
+	t.Run("agent mode includes core fields only", func(t *testing.T) {
+		art := ProjectPage(page, "DEV", "<p>content</p>", artifact.Agent)
+
+		testutil.Equal(t, "12345", art.ID)
+		testutil.Equal(t, "Test Page", art.Title)
+		testutil.Equal(t, "SPACE123", art.SpaceID)
+		testutil.Equal(t, "DEV", art.SpaceKey)
+		testutil.Equal(t, "PARENT456", art.ParentID)
+		testutil.Equal(t, "<p>content</p>", art.Content)
+		testutil.Equal(t, 0, art.Version) // not set in agent mode
+		testutil.Equal(t, "", art.CreatedAt)
+		testutil.Equal(t, "", art.AuthorID)
+	})
+
+	t.Run("full mode includes version and dates", func(t *testing.T) {
+		art := ProjectPage(page, "DEV", "<p>content</p>", artifact.Full)
+
+		testutil.Equal(t, "12345", art.ID)
+		testutil.Equal(t, "Test Page", art.Title)
+		testutil.Equal(t, 5, art.Version)
+		testutil.Equal(t, "2024-01-15T10:30:00Z", art.CreatedAt)
+		testutil.Equal(t, "user123", art.AuthorID)
+	})
+
+	t.Run("handles nil version", func(t *testing.T) {
+		pageNoVersion := &api.Page{
+			ID:      "12345",
+			Title:   "Test Page",
+			SpaceID: "SPACE123",
+		}
+
+		art := ProjectPage(pageNoVersion, "DEV", "<p>content</p>", artifact.Full)
+		testutil.Equal(t, 0, art.Version)
+		testutil.Equal(t, "", art.CreatedAt)
+	})
+}
+
+func TestProjectPageListItem(t *testing.T) {
+	t.Parallel()
+
+	page := &api.Page{
+		ID:       "12345",
+		Title:    "Test Page",
+		SpaceID:  "SPACE123",
+		Status:   "current",
+		ParentID: "PARENT456",
+		Version: &api.Version{
+			Number: 3,
+		},
+	}
+
+	t.Run("agent mode includes core metadata", func(t *testing.T) {
+		art := ProjectPageListItem(page, artifact.Agent)
+
+		testutil.Equal(t, "12345", art.ID)
+		testutil.Equal(t, "Test Page", art.Title)
+		testutil.Equal(t, "SPACE123", art.SpaceID)
+		testutil.Equal(t, "current", art.Status)
+		testutil.Equal(t, 0, art.Version)   // not set in agent mode
+		testutil.Equal(t, "", art.ParentID) // not set in agent mode
+	})
+
+	t.Run("full mode includes version and parent", func(t *testing.T) {
+		art := ProjectPageListItem(page, artifact.Full)
+
+		testutil.Equal(t, "12345", art.ID)
+		testutil.Equal(t, "Test Page", art.Title)
+		testutil.Equal(t, 3, art.Version)
+		testutil.Equal(t, "PARENT456", art.ParentID)
+	})
+}
+
+func TestProjectPageListItems(t *testing.T) {
+	t.Parallel()
+
+	pages := []api.Page{
+		{ID: "1", Title: "Page 1", SpaceID: "S1", Status: "current"},
+		{ID: "2", Title: "Page 2", SpaceID: "S1", Status: "archived"},
+	}
+
+	arts := ProjectPageListItems(pages, artifact.Agent)
+
+	testutil.Equal(t, 2, len(arts))
+	testutil.Equal(t, "1", arts[0].ID)
+	testutil.Equal(t, "Page 1", arts[0].Title)
+	testutil.Equal(t, "2", arts[1].ID)
+	testutil.Equal(t, "archived", arts[1].Status)
+}

--- a/tools/cfl/internal/artifact/search.go
+++ b/tools/cfl/internal/artifact/search.go
@@ -1,0 +1,57 @@
+package artifact
+
+import (
+	"github.com/open-cli-collective/atlassian-go/artifact"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+)
+
+// SearchResultArtifact represents a search result artifact.
+type SearchResultArtifact struct {
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	Type       string `json:"type"`
+	SpaceName  string `json:"spaceName"`
+	Excerpt    string `json:"excerpt,omitempty"`
+	URL        string `json:"url,omitempty"`
+	ModifiedAt string `json:"modifiedAt,omitempty"`
+}
+
+// maxExcerptRunes is the maximum number of runes for excerpt in agent mode.
+const maxExcerptRunes = 200
+
+// ProjectSearchResult projects an api.SearchResult to a SearchResultArtifact.
+func ProjectSearchResult(r *api.SearchResult, mode artifact.Type) *SearchResultArtifact {
+	art := &SearchResultArtifact{
+		ID:        r.Content.ID,
+		Title:     r.Title,
+		Type:      r.Content.Type,
+		SpaceName: r.ResultGlobalContainer.Title,
+	}
+
+	// Truncate excerpt in agent mode
+	excerpt := r.Excerpt
+	if mode == artifact.Agent && len([]rune(excerpt)) > maxExcerptRunes {
+		runes := []rune(excerpt)
+		excerpt = string(runes[:maxExcerptRunes]) + "..."
+	}
+	if excerpt != "" {
+		art.Excerpt = excerpt
+	}
+
+	if mode == artifact.Full {
+		art.URL = r.URL
+		art.ModifiedAt = r.LastModified
+	}
+
+	return art
+}
+
+// ProjectSearchResults projects a slice of api.SearchResult to SearchResultArtifacts.
+func ProjectSearchResults(results []api.SearchResult, mode artifact.Type) []*SearchResultArtifact {
+	arts := make([]*SearchResultArtifact, len(results))
+	for i := range results {
+		arts[i] = ProjectSearchResult(&results[i], mode)
+	}
+	return arts
+}

--- a/tools/cfl/internal/artifact/search.go
+++ b/tools/cfl/internal/artifact/search.go
@@ -31,9 +31,11 @@ func ProjectSearchResult(r *api.SearchResult, mode artifact.Type) *SearchResultA
 
 	// Truncate excerpt in agent mode
 	excerpt := r.Excerpt
-	if mode == artifact.Agent && len([]rune(excerpt)) > maxExcerptRunes {
+	if mode == artifact.Agent {
 		runes := []rune(excerpt)
-		excerpt = string(runes[:maxExcerptRunes]) + "..."
+		if len(runes) > maxExcerptRunes {
+			excerpt = string(runes[:maxExcerptRunes]) + "..."
+		}
 	}
 	if excerpt != "" {
 		art.Excerpt = excerpt

--- a/tools/cfl/internal/artifact/search_test.go
+++ b/tools/cfl/internal/artifact/search_test.go
@@ -1,0 +1,134 @@
+package artifact
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+)
+
+func TestProjectSearchResult(t *testing.T) {
+	t.Parallel()
+
+	result := &api.SearchResult{
+		Content: api.SearchContent{
+			ID:   "12345",
+			Type: "page",
+		},
+		Title:   "Test Search Result",
+		Excerpt: "This is a short excerpt",
+		URL:     "/wiki/spaces/DEV/pages/12345",
+		ResultGlobalContainer: api.SearchContainer{
+			Title: "Development Space",
+		},
+		LastModified: "2024-01-15T10:30:00Z",
+	}
+
+	t.Run("agent mode includes core fields", func(t *testing.T) {
+		art := ProjectSearchResult(result, artifact.Agent)
+
+		testutil.Equal(t, "12345", art.ID)
+		testutil.Equal(t, "Test Search Result", art.Title)
+		testutil.Equal(t, "page", art.Type)
+		testutil.Equal(t, "Development Space", art.SpaceName)
+		testutil.Equal(t, "This is a short excerpt", art.Excerpt)
+		testutil.Equal(t, "", art.URL)        // not set in agent mode
+		testutil.Equal(t, "", art.ModifiedAt) // not set in agent mode
+	})
+
+	t.Run("full mode includes URL and modified date", func(t *testing.T) {
+		art := ProjectSearchResult(result, artifact.Full)
+
+		testutil.Equal(t, "12345", art.ID)
+		testutil.Equal(t, "/wiki/spaces/DEV/pages/12345", art.URL)
+		testutil.Equal(t, "2024-01-15T10:30:00Z", art.ModifiedAt)
+	})
+
+	t.Run("truncates long excerpt in agent mode", func(t *testing.T) {
+		longExcerpt := strings.Repeat("a", 250)
+		resultLong := &api.SearchResult{
+			Content:               api.SearchContent{ID: "1", Type: "page"},
+			Title:                 "Test",
+			Excerpt:               longExcerpt,
+			ResultGlobalContainer: api.SearchContainer{Title: "Space"},
+		}
+
+		art := ProjectSearchResult(resultLong, artifact.Agent)
+
+		// Should be truncated to 200 runes + "..."
+		testutil.Equal(t, 203, len(art.Excerpt))
+		testutil.True(t, strings.HasSuffix(art.Excerpt, "..."))
+	})
+
+	t.Run("does not truncate excerpt in full mode", func(t *testing.T) {
+		longExcerpt := strings.Repeat("a", 250)
+		resultLong := &api.SearchResult{
+			Content:               api.SearchContent{ID: "1", Type: "page"},
+			Title:                 "Test",
+			Excerpt:               longExcerpt,
+			ResultGlobalContainer: api.SearchContainer{Title: "Space"},
+		}
+
+		art := ProjectSearchResult(resultLong, artifact.Full)
+
+		testutil.Equal(t, 250, len(art.Excerpt))
+	})
+
+	t.Run("handles multi-byte UTF-8 in excerpt truncation", func(t *testing.T) {
+		// 200 runes of multi-byte characters
+		multiByteExcerpt := strings.Repeat("日", 250)
+		resultMultiByte := &api.SearchResult{
+			Content:               api.SearchContent{ID: "1", Type: "page"},
+			Title:                 "Test",
+			Excerpt:               multiByteExcerpt,
+			ResultGlobalContainer: api.SearchContainer{Title: "Space"},
+		}
+
+		art := ProjectSearchResult(resultMultiByte, artifact.Agent)
+
+		runes := []rune(art.Excerpt)
+		// 200 runes + 3 for "..."
+		testutil.Equal(t, 203, len(runes))
+		testutil.True(t, strings.HasSuffix(art.Excerpt, "..."))
+	})
+
+	t.Run("empty excerpt is omitted", func(t *testing.T) {
+		resultNoExcerpt := &api.SearchResult{
+			Content:               api.SearchContent{ID: "1", Type: "page"},
+			Title:                 "Test",
+			Excerpt:               "",
+			ResultGlobalContainer: api.SearchContainer{Title: "Space"},
+		}
+
+		art := ProjectSearchResult(resultNoExcerpt, artifact.Agent)
+		testutil.Equal(t, "", art.Excerpt)
+	})
+}
+
+func TestProjectSearchResults(t *testing.T) {
+	t.Parallel()
+
+	results := []api.SearchResult{
+		{
+			Content:               api.SearchContent{ID: "1", Type: "page"},
+			Title:                 "Page 1",
+			ResultGlobalContainer: api.SearchContainer{Title: "Space A"},
+		},
+		{
+			Content:               api.SearchContent{ID: "2", Type: "blogpost"},
+			Title:                 "Blog Post 1",
+			ResultGlobalContainer: api.SearchContainer{Title: "Space B"},
+		},
+	}
+
+	arts := ProjectSearchResults(results, artifact.Agent)
+
+	testutil.Equal(t, 2, len(arts))
+	testutil.Equal(t, "1", arts[0].ID)
+	testutil.Equal(t, "page", arts[0].Type)
+	testutil.Equal(t, "2", arts[1].ID)
+	testutil.Equal(t, "blogpost", arts[1].Type)
+}

--- a/tools/cfl/internal/artifact/space.go
+++ b/tools/cfl/internal/artifact/space.go
@@ -1,0 +1,45 @@
+package artifact
+
+import (
+	"github.com/open-cli-collective/atlassian-go/artifact"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+)
+
+// SpaceArtifact represents a space artifact.
+type SpaceArtifact struct {
+	ID          string `json:"id"`
+	Key         string `json:"key"`
+	Name        string `json:"name"`
+	Type        string `json:"type,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// ProjectSpace projects an api.Space to a SpaceArtifact.
+func ProjectSpace(s *api.Space, mode artifact.Type) *SpaceArtifact {
+	art := &SpaceArtifact{
+		ID:   s.ID,
+		Key:  s.Key,
+		Name: s.Name,
+	}
+
+	if mode == artifact.Full {
+		art.Type = s.Type
+		art.Status = s.Status
+		if s.Description != nil && s.Description.Plain != nil {
+			art.Description = s.Description.Plain.Value
+		}
+	}
+
+	return art
+}
+
+// ProjectSpaces projects a slice of api.Space to SpaceArtifacts.
+func ProjectSpaces(spaces []api.Space, mode artifact.Type) []*SpaceArtifact {
+	arts := make([]*SpaceArtifact, len(spaces))
+	for i := range spaces {
+		arts[i] = ProjectSpace(&spaces[i], mode)
+	}
+	return arts
+}

--- a/tools/cfl/internal/artifact/space_test.go
+++ b/tools/cfl/internal/artifact/space_test.go
@@ -1,0 +1,89 @@
+package artifact
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+)
+
+func TestProjectSpace(t *testing.T) {
+	t.Parallel()
+
+	space := &api.Space{
+		ID:     "SPACE123",
+		Key:    "DEV",
+		Name:   "Development",
+		Type:   "global",
+		Status: "current",
+		Description: &api.SpaceDescription{
+			Plain: &api.DescriptionValue{
+				Value: "Development space for testing",
+			},
+		},
+	}
+
+	t.Run("agent mode includes core fields only", func(t *testing.T) {
+		art := ProjectSpace(space, artifact.Agent)
+
+		testutil.Equal(t, "SPACE123", art.ID)
+		testutil.Equal(t, "DEV", art.Key)
+		testutil.Equal(t, "Development", art.Name)
+		testutil.Equal(t, "", art.Type)        // not set in agent mode
+		testutil.Equal(t, "", art.Status)      // not set in agent mode
+		testutil.Equal(t, "", art.Description) // not set in agent mode
+	})
+
+	t.Run("full mode includes type, status, description", func(t *testing.T) {
+		art := ProjectSpace(space, artifact.Full)
+
+		testutil.Equal(t, "SPACE123", art.ID)
+		testutil.Equal(t, "DEV", art.Key)
+		testutil.Equal(t, "Development", art.Name)
+		testutil.Equal(t, "global", art.Type)
+		testutil.Equal(t, "current", art.Status)
+		testutil.Equal(t, "Development space for testing", art.Description)
+	})
+
+	t.Run("handles nil description", func(t *testing.T) {
+		spaceNoDesc := &api.Space{
+			ID:   "SPACE123",
+			Key:  "DEV",
+			Name: "Development",
+		}
+
+		art := ProjectSpace(spaceNoDesc, artifact.Full)
+		testutil.Equal(t, "", art.Description)
+	})
+
+	t.Run("handles description with nil plain", func(t *testing.T) {
+		spaceNilPlain := &api.Space{
+			ID:          "SPACE123",
+			Key:         "DEV",
+			Name:        "Development",
+			Description: &api.SpaceDescription{},
+		}
+
+		art := ProjectSpace(spaceNilPlain, artifact.Full)
+		testutil.Equal(t, "", art.Description)
+	})
+}
+
+func TestProjectSpaces(t *testing.T) {
+	t.Parallel()
+
+	spaces := []api.Space{
+		{ID: "1", Key: "DEV", Name: "Development"},
+		{ID: "2", Key: "PROD", Name: "Production"},
+	}
+
+	arts := ProjectSpaces(spaces, artifact.Agent)
+
+	testutil.Equal(t, 2, len(arts))
+	testutil.Equal(t, "1", arts[0].ID)
+	testutil.Equal(t, "DEV", arts[0].Key)
+	testutil.Equal(t, "2", arts[1].ID)
+	testutil.Equal(t, "PROD", arts[1].Key)
+}

--- a/tools/cfl/internal/cmd/page/list.go
+++ b/tools/cfl/internal/cmd/page/list.go
@@ -79,7 +79,8 @@ func runList(ctx context.Context, opts *listOptions) error {
 
 	if opts.limit == 0 {
 		if opts.Output == "json" {
-			return v.JSON([]any{})
+			arts := cflartifact.ProjectPageListItems(nil, opts.ArtifactMode())
+			return v.RenderArtifactList(artifact.NewListResult(arts, false))
 		}
 		v.RenderText("No pages found.")
 		return nil

--- a/tools/cfl/internal/cmd/page/list.go
+++ b/tools/cfl/internal/cmd/page/list.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/artifact"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/confluence-cli/api"
+	cflartifact "github.com/open-cli-collective/confluence-cli/internal/artifact"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
@@ -118,10 +120,21 @@ func runList(ctx context.Context, opts *listOptions) error {
 	}
 
 	if len(result.Results) == 0 {
+		if opts.Output == "json" {
+			arts := cflartifact.ProjectPageListItems(nil, opts.ArtifactMode())
+			return v.RenderArtifactList(artifact.NewListResult(arts, false))
+		}
 		v.RenderText(fmt.Sprintf("No pages found in space %s.", spaceKey))
 		return nil
 	}
 
+	// JSON output uses artifact projection
+	if opts.Output == "json" {
+		arts := cflartifact.ProjectPageListItems(result.Results, opts.ArtifactMode())
+		return v.RenderArtifactList(artifact.NewListResult(arts, result.HasMore()))
+	}
+
+	// Table output
 	headers := []string{"ID", "TITLE", "STATUS", "VERSION"}
 	rows := make([][]string, 0, len(result.Results))
 
@@ -138,9 +151,11 @@ func runList(ctx context.Context, opts *listOptions) error {
 		})
 	}
 
-	_ = v.RenderList(headers, rows, result.HasMore())
+	if err := v.Table(headers, rows); err != nil {
+		return err
+	}
 
-	if result.HasMore() && opts.Output != "json" {
+	if result.HasMore() {
 		fmt.Fprintf(os.Stderr, "\n(showing first %d results, use --limit to see more)\n", len(result.Results))
 	}
 

--- a/tools/cfl/internal/cmd/page/view.go
+++ b/tools/cfl/internal/cmd/page/view.go
@@ -24,7 +24,7 @@ type viewOptions struct {
 	*root.Options
 	raw         bool
 	web         bool
-	full        bool
+	noTruncate  bool
 	showMacros  bool
 	contentOnly bool
 }
@@ -41,14 +41,14 @@ The page body is fetched in storage format (XHTML) and converted to
 markdown for display. Use --raw to see the original storage format.
 
 By default, output is truncated to 5000 characters for concise display.
-Use --full to show the complete page content without truncation.
-The --content-only flag implies --full since it is intended for piping.
+Use --no-truncate to show the complete page content without truncation.
+The --content-only flag implies --no-truncate since it is intended for piping.
 JSON output (--output json) always includes the full body.`,
 		Example: `  # View a page (markdown, truncated if large)
   cfl page view 12345
 
   # View full content without truncation
-  cfl page view 12345 --full
+  cfl page view 12345 --no-truncate
 
   # View raw storage format (XHTML)
   cfl page view 12345 --raw
@@ -69,9 +69,9 @@ JSON output (--output json) always includes the full body.`,
 
 	cmd.Flags().BoolVar(&opts.raw, "raw", false, "Show raw Confluence storage format (XHTML) instead of markdown")
 	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser instead of displaying")
-	cmd.Flags().BoolVar(&opts.full, "full", false, "Show full content without truncation")
+	cmd.Flags().BoolVar(&opts.noTruncate, "no-truncate", false, "Show full content without truncation")
 	cmd.Flags().BoolVar(&opts.showMacros, "show-macros", false, "Show Confluence macro placeholders (e.g., [TOC]) instead of stripping them")
-	cmd.Flags().BoolVar(&opts.contentOnly, "content-only", false, "Output only page content (no metadata headers); implies --full")
+	cmd.Flags().BoolVar(&opts.contentOnly, "content-only", false, "Output only page content (no metadata headers); implies --no-truncate")
 
 	return cmd
 }
@@ -194,14 +194,14 @@ func runView(ctx context.Context, pageID string, opts *viewOptions) error {
 
 // truncateContent truncates content if it exceeds the character limit.
 // Uses rune count to avoid splitting multi-byte UTF-8 characters.
-// --content-only implies --full since it is intended for piping.
+// --content-only implies --no-truncate since it is intended for piping.
 func truncateContent(content string, opts *viewOptions) string {
-	if opts.full || opts.contentOnly {
+	if opts.noTruncate || opts.contentOnly {
 		return content
 	}
 	runes := []rune(content)
 	if len(runes) > maxViewChars {
-		return string(runes[:maxViewChars]) + fmt.Sprintf("\n\n... [truncated at %d chars, use --full for complete text]", maxViewChars)
+		return string(runes[:maxViewChars]) + fmt.Sprintf("\n\n... [truncated at %d chars, use --no-truncate for complete text]", maxViewChars)
 	}
 	return content
 }

--- a/tools/cfl/internal/cmd/page/view.go
+++ b/tools/cfl/internal/cmd/page/view.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/view"
 
-	"github.com/open-cli-collective/confluence-cli/api"
+	cflartifact "github.com/open-cli-collective/confluence-cli/internal/artifact"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	"github.com/open-cli-collective/confluence-cli/pkg/md"
 )
@@ -128,9 +128,16 @@ func runView(ctx context.Context, pageID string, opts *viewOptions) error {
 	}
 
 	if opts.Output == "json" {
-		// Enrich JSON output with spaceKey
-		enriched := enrichPageWithSpaceKey(page, spaceKey)
-		return v.JSON(enriched)
+		// Extract content (XHTML storage format by default, until #196 validates markdown)
+		content := ""
+		if hasStorageContent(page) {
+			content = page.Body.Storage.Value
+		} else if hasADFContent(page) {
+			content = page.Body.AtlasDocFormat.Value
+		}
+
+		art := cflartifact.ProjectPage(page, spaceKey, content, opts.ArtifactMode())
+		return v.RenderArtifact(art)
 	}
 
 	if !opts.contentOnly {
@@ -214,18 +221,4 @@ func openBrowser(url string) error {
 	}
 
 	return cmd.Start()
-}
-
-// enrichedPage wraps api.Page with an additional spaceKey field for JSON output.
-type enrichedPage struct {
-	*api.Page
-	SpaceKey string `json:"spaceKey,omitempty"`
-}
-
-// enrichPageWithSpaceKey creates an enriched page with the space key for JSON output.
-func enrichPageWithSpaceKey(page *api.Page, spaceKey string) *enrichedPage {
-	return &enrichedPage{
-		Page:     page,
-		SpaceKey: spaceKey,
-	}
 }

--- a/tools/cfl/internal/cmd/page/view_test.go
+++ b/tools/cfl/internal/cmd/page/view_test.go
@@ -441,12 +441,12 @@ func TestTruncateContent(t *testing.T) {
 		long := strings.Repeat("x", maxViewChars+100)
 		result := truncateContent(long, opts)
 		testutil.Len(t, strings.SplitN(result, "\n\n... [truncated", 2)[0], maxViewChars)
-		testutil.Contains(t, result, fmt.Sprintf("... [truncated at %d chars, use --full for complete text]", maxViewChars))
+		testutil.Contains(t, result, fmt.Sprintf("... [truncated at %d chars, use --no-truncate for complete text]", maxViewChars))
 	})
 
 	t.Run("--full bypasses truncation", func(t *testing.T) {
 		t.Parallel()
-		opts := &viewOptions{full: true}
+		opts := &viewOptions{noTruncate: true}
 		long := strings.Repeat("x", maxViewChars+100)
 		result := truncateContent(long, opts)
 		testutil.Equal(t, long, result)

--- a/tools/cfl/internal/cmd/page/view_test.go
+++ b/tools/cfl/internal/cmd/page/view_test.go
@@ -426,21 +426,6 @@ func TestRunView_SpaceLookupFails_Graceful(t *testing.T) {
 	testutil.RequireNoError(t, err)
 }
 
-func TestEnrichPageWithSpaceKey(t *testing.T) {
-	t.Parallel()
-	page := &api.Page{
-		ID:      "12345",
-		Title:   "Test Page",
-		SpaceID: "98765",
-	}
-
-	enriched := enrichPageWithSpaceKey(page, "DEV")
-
-	testutil.Equal(t, "12345", enriched.ID)
-	testutil.Equal(t, "Test Page", enriched.Title)
-	testutil.Equal(t, "DEV", enriched.SpaceKey)
-}
-
 func TestTruncateContent(t *testing.T) {
 	t.Parallel()
 	t.Run("short content is not truncated", func(t *testing.T) {

--- a/tools/cfl/internal/cmd/search/search.go
+++ b/tools/cfl/internal/cmd/search/search.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/artifact"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/confluence-cli/api"
+	cflartifact "github.com/open-cli-collective/confluence-cli/internal/artifact"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
@@ -126,7 +128,8 @@ func runSearch(ctx context.Context, opts *searchOptions) error {
 	// Handle limit 0 - return empty
 	if opts.limit == 0 {
 		if opts.Output == "json" {
-			return v.JSON([]any{})
+			arts := cflartifact.ProjectSearchResults(nil, opts.ArtifactMode())
+			return v.RenderArtifactList(artifact.NewListResult(arts, false))
 		}
 		v.RenderText("No results.")
 		return nil
@@ -166,11 +169,21 @@ func runSearch(ctx context.Context, opts *searchOptions) error {
 	}
 
 	if len(result.Results) == 0 {
+		if opts.Output == "json" {
+			arts := cflartifact.ProjectSearchResults(nil, opts.ArtifactMode())
+			return v.RenderArtifactList(artifact.NewListResult(arts, false))
+		}
 		v.RenderText("No results found.")
 		return nil
 	}
 
-	// Render results
+	// JSON output uses artifact projection
+	if opts.Output == "json" {
+		arts := cflartifact.ProjectSearchResults(result.Results, opts.ArtifactMode())
+		return v.RenderArtifactList(artifact.NewListResult(arts, result.HasMore()))
+	}
+
+	// Table output
 	headers := []string{"ID", "TYPE", "SPACE KEY", "TITLE"}
 	rows := make([][]string, 0, len(result.Results))
 
@@ -184,9 +197,11 @@ func runSearch(ctx context.Context, opts *searchOptions) error {
 		})
 	}
 
-	_ = v.RenderList(headers, rows, result.HasMore())
+	if err := v.Table(headers, rows); err != nil {
+		return err
+	}
 
-	if result.HasMore() && opts.Output != "json" {
+	if result.HasMore() {
 		_, _ = fmt.Fprintf(opts.Stderr, "\n(showing %d of %d results, use --limit to see more)\n",
 			len(result.Results), result.TotalSize)
 	}

--- a/tools/cfl/internal/cmd/space/list.go
+++ b/tools/cfl/internal/cmd/space/list.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/artifact"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/confluence-cli/api"
+	cflartifact "github.com/open-cli-collective/confluence-cli/internal/artifact"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
@@ -64,7 +66,8 @@ func runList(ctx context.Context, opts *listOptions) error {
 
 	if opts.limit == 0 {
 		if opts.Output == "json" {
-			return v.JSON([]any{})
+			arts := cflartifact.ProjectSpaces(nil, opts.ArtifactMode())
+			return v.RenderArtifactList(artifact.NewListResult(arts, false))
 		}
 		v.RenderText("No spaces found.")
 		return nil
@@ -87,10 +90,21 @@ func runList(ctx context.Context, opts *listOptions) error {
 	}
 
 	if len(result.Results) == 0 {
+		if opts.Output == "json" {
+			arts := cflartifact.ProjectSpaces(nil, opts.ArtifactMode())
+			return v.RenderArtifactList(artifact.NewListResult(arts, false))
+		}
 		v.RenderText("No spaces found.")
 		return nil
 	}
 
+	// JSON output uses artifact projection
+	if opts.Output == "json" {
+		arts := cflartifact.ProjectSpaces(result.Results, opts.ArtifactMode())
+		return v.RenderArtifactList(artifact.NewListResult(arts, result.HasMore()))
+	}
+
+	// Table output
 	headers := []string{"KEY", "NAME", "TYPE", "DESCRIPTION"}
 	rows := make([][]string, 0, len(result.Results))
 
@@ -107,9 +121,11 @@ func runList(ctx context.Context, opts *listOptions) error {
 		})
 	}
 
-	_ = v.RenderList(headers, rows, result.HasMore())
+	if err := v.Table(headers, rows); err != nil {
+		return err
+	}
 
-	if result.HasMore() && opts.Output != "json" {
+	if result.HasMore() {
 		nextCursor := extractCursor(result.Links.Next)
 		if nextCursor != "" {
 			_, _ = fmt.Fprintf(opts.Stderr, "\nNext page: cfl space list --cursor %q\n", nextCursor)

--- a/tools/cfl/internal/cmd/space/view.go
+++ b/tools/cfl/internal/cmd/space/view.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	cflartifact "github.com/open-cli-collective/confluence-cli/internal/artifact"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
@@ -55,7 +56,8 @@ func runView(ctx context.Context, spaceKey string, opts *viewOptions) error {
 	v := opts.View()
 
 	if opts.Output == "json" {
-		return v.JSON(space)
+		art := cflartifact.ProjectSpace(space, opts.ArtifactMode())
+		return v.RenderArtifact(art)
 	}
 
 	v.RenderKeyValue("Key", space.Key)


### PR DESCRIPTION
## Summary

- Migrate `page view`, `page list`, `space view`, `space list`, and `search` to artifact projection
- Create `tools/cfl/internal/artifact/` package with PageArtifact, PageListArtifact, SpaceArtifact, SearchResultArtifact
- JSON output now returns intentional artifacts instead of raw API payloads
- Content is XHTML by default until #196 validates markdown conversion

### Artifacts

| Artifact | Fields (agent) | Additional (full) |
|----------|----------------|-------------------|
| PageArtifact | id, title, spaceId, spaceKey, parentId, content | version, createdAt, authorId |
| PageListArtifact | id, title, spaceId, status | version, parentId |
| SpaceArtifact | id, key, name | type, status, description |
| SearchResultArtifact | id, title, type, spaceName, excerpt | url, modifiedAt |

### Deferred to follow-up issues

- `page create`, `page edit`, `page copy` (return minimal responses)
- Ancestors support (requires API enhancement)
- Attachment artifacts

## Test plan

- [x] `make build` passes
- [x] `make test` passes (940 tests in 13 cfl packages)
- [x] `make lint` passes (pre-existing gosec warnings only)
- [ ] Manual: `cfl page view <id> -o json` returns PageArtifact
- [ ] Manual: `cfl page list <space> -o json` returns list format with `_meta`
- [ ] Manual: `cfl space list -o json` returns SpaceArtifact list

Closes #200