### PR TITLE
ci: remove pull_request trigger from packaging test workflows

### DIFF
--- a/.github/workflows/test-chocolatey.yml
+++ b/.github/workflows/test-chocolatey.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
     paths:
       - 'tools/*/packaging/chocolatey/**'
-  pull_request:
-    paths:
-      - 'tools/*/packaging/chocolatey/**'
 
 jobs:
   test-cfl:

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
     paths:
       - 'tools/*/packaging/winget/**'
-  pull_request:
-    paths:
-      - 'tools/*/packaging/winget/**'
 
 jobs:
   test-cfl:


### PR DESCRIPTION
## Summary

- `test-chocolatey.yml` and `test-winget.yml` both had `pull_request` triggers that fired whenever packaging files were modified in a PR
- These workflows run `windows-latest` runners for validation/dry-run only — no publishing — but they still cost CI time on every PR
- The triggers have been there since day one (Jan 29) and were never intentional

## Fix

Removed the `pull_request` block from both workflows. Validation now runs only on push to `main`.

## Test plan

- [ ] Open a PR touching `tools/*/packaging/chocolatey/**` or `tools/*/packaging/winget/**` — confirm neither test workflow appears in PR checks
- [ ] Merge such a PR — confirm both workflows run on the resulting push to `main`

Closes #223