### PR TITLE
feat(jtk): complete presenter boundary architecture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,345 @@
+# Rendering Architecture
+
+This document defines the output architecture for this repository.
+
+It exists to prevent a recurring anti-pattern across the Go CLIs in this repo:
+
+- commands fetch Atlassian data
+- commands assemble ad hoc display strings
+- shared view helpers rewrite or reshape those strings
+
+That approach is easy to start and hard to scale. It creates weak boundaries, stringly-typed rendering code, and brittle tests.
+
+The target architecture is a clean, testable pipeline:
+
+```text
+Atlassian/API domain data -> presenter/formatter -> presentation model -> renderer -> CLI output
+```
+
+## Goals
+
+- Keep domain concerns separate from presentation concerns
+- Make each stage of the output pipeline pure and easy to unit test
+- Make new formatters and renderers easy to add
+- Prevent `shared/view` from becoming a string-massaging utility
+- Support multiple output styles without embedding formatting rules in commands
+
+## Layers
+
+### 1. Domain layer
+
+This layer contains:
+
+- Atlassian API response types
+- internal domain projections
+- artifact projections where already established
+
+It should not contain display layout concerns.
+
+Examples:
+
+- `tools/jtk/api/...`
+- `tools/cfl/api/...`
+- `internal/artifact/...`
+
+### 2. Presenter / formatter layer
+
+This layer maps domain values into a presentation model.
+
+It is responsible for deciding:
+
+- which fields are shown
+- field labels
+- field ordering
+- section ordering
+- truncation
+- normalization
+- empty-state wording
+- whether a value is represented as detail, table, message, or nested sections
+
+This layer should be pure:
+
+- input: domain value
+- output: presentation model
+- no IO
+- no CLI side effects
+
+### 3. Renderer layer
+
+This layer turns a presentation model into a concrete output style.
+
+Examples:
+
+- agent renderer
+- human renderer
+- table-oriented renderer
+- plain text renderer
+
+This layer is responsible for layout and style only. It should not:
+
+- inspect raw API types
+- decide which domain fields are important
+- normalize arbitrary content strings after the fact
+- escape or repair display content that should have been handled by the presenter
+
+It should be pure:
+
+- input: presentation model
+- output: rendered string or bytes
+- no IO
+
+### 4. CLI command layer
+
+Commands should orchestrate, not format.
+
+The command layer should:
+
+- fetch domain data
+- choose the right presenter
+- choose the right renderer or output mode
+- write final output
+
+The command layer should not:
+
+- manually build user-facing tables
+- manually assemble `Key: Value` strings
+- perform inline truncation/escaping/label selection except as transitional code during migration
+
+## Required separation
+
+The key boundary in this repo is:
+
+```text
+domain model != presentation model != rendered string
+```
+
+If a function accepts or returns `[][]string`, `[]string`, or preformatted display text as its primary contract, that is usually too low-level for new architecture work.
+
+Prefer explicit presentation types.
+
+## Presentation model
+
+The presentation model should be small and boring. It does not need to be generic-heavy or framework-like.
+
+A minimal shape is enough:
+
+```go
+type OutputModel struct {
+    Sections []Section
+}
+
+type Section interface {
+    isSection()
+}
+
+type DetailSection struct {
+    Fields []DetailField
+}
+
+type TableSection struct {
+    Columns []Column
+    Rows    []TableRow
+}
+
+type MessageSection struct {
+    Kind    MessageKind
+    Message string
+}
+
+type DetailField struct {
+    Label string
+    Value string
+}
+
+type Column struct {
+    Key   string
+    Label string
+}
+
+type TableRow struct {
+    Cells []Cell
+}
+
+type Cell struct {
+    Value string
+}
+```
+
+This is illustrative, not mandatory. The important point is that presenters return structured display intent, and renderers turn that into final text.
+
+## Preferred interfaces
+
+For most cases, prefer a structured presenter plus renderer split:
+
+```go
+type Presenter[T any] interface {
+    Present(T) OutputModel
+}
+
+type Renderer interface {
+    Render(OutputModel) string
+}
+```
+
+This keeps the renderer dumb and reusable.
+
+Avoid collapsing everything into a single formatter that directly returns strings unless the scope is extremely small and unlikely to grow.
+
+## Output styles in this repo
+
+This repository already distinguishes between:
+
+- artifact shape
+- output format
+- command intent
+
+See [docs/ARTIFACT_CONTRACT.md](docs/ARTIFACT_CONTRACT.md).
+
+That contract still applies. This document adds the architecture for how those outputs should be constructed.
+
+In practice:
+
+- artifact selection decides what information is relevant
+- presenter shapes that information into a presentation model
+- renderer decides how that presentation model is displayed
+
+## JSON and artifact outputs
+
+JSON and artifact paths are first-class output pathways. They are not fallback representations and should not be incidental byproducts of text rendering.
+
+Rules:
+
+- preserve existing JSON/artifact contracts unless intentionally changing them
+- do not route JSON through text-focused helpers
+- do not use text-oriented helpers as the canonical output model for JSON
+
+The same domain value may support:
+
+- artifact projection for `-o json`
+- presentation modeling for text output
+
+These are related, but not identical, responsibilities.
+
+## Hard rules
+
+For new rendering work in this repo:
+
+1. Do not build user-facing strings in commands except for trivial dispatch or temporary migration glue.
+2. Do not make `shared/view` responsible for rewriting arbitrary content strings.
+3. Do not normalize, truncate, or escape display content in the renderer if that decision belongs to presentation logic.
+4. Do not pass raw Atlassian API DTOs directly into low-level rendering helpers.
+5. Do not encode presentation intent as `[][]string` in new code when a structured presentation model would make the boundary clearer.
+6. Do not add output policy by sprinkling ad hoc conditionals through commands.
+
+## TDD expectations
+
+New work in this area should be test-first.
+
+### Presenter tests
+
+Given a domain value, assert the exact presentation model produced.
+
+These should be:
+
+- pure unit tests
+- no Cobra
+- no stdout/stderr
+- no network mocks unless the presenter itself requires a domain object assembled by a higher layer
+
+### Renderer tests
+
+Given a presentation model, assert the exact rendered output.
+
+These should be:
+
+- pure unit tests
+- exact-string assertions where the contract matters
+- separated by render style
+
+### Command wiring tests
+
+Commands should have lighter tests that prove:
+
+- the correct presenter/renderer path is used
+- the correct mode is chosen
+- JSON/artifact behavior is preserved
+
+The deeper contract tests belong in presenter and renderer tests, not only in Cobra command tests.
+
+## Refactor strategy
+
+When refactoring existing output code:
+
+1. Identify one command/output shape.
+2. Introduce a presenter for that domain object.
+3. Introduce or adapt a renderer for the desired output style.
+4. Lock the behavior with presenter and renderer tests.
+5. Replace command-local string building with presenter/renderer wiring.
+6. Repeat by output shape, not by scattered one-off string fixes.
+
+Preferred rollout order:
+
+1. representative detail view
+2. representative table view
+3. representative mutation/message output
+4. composite/nested output
+5. broader migration
+
+## Repo-specific implications
+
+### `shared/view`
+
+`shared/view` should evolve toward rendering presentation models, not performing string surgery on arbitrary display text.
+
+Its role should be:
+
+- accept a structured presentation model
+- render it according to policy/style
+- remain pure where feasible
+
+It should not be the place where content semantics are repaired after commands have already flattened domain data into strings.
+
+### `jtk` and `cfl`
+
+The same architectural rules apply to both tools.
+
+It is acceptable for one tool to adopt a renderer/policy earlier than the other, but the shared abstractions should be designed so both can use them without reintroducing command-local formatting logic.
+
+### Artifact contract
+
+The artifact contract remains the source of truth for intentional output content. This architecture defines how that content should move through the system cleanly.
+
+## Review smells
+
+Treat these as warning signs in PR review:
+
+- command code builds `[]string` rows directly from API response fields
+- command code uses `fmt.Sprintf` only to create display values
+- renderer escapes delimiters or rewrites content strings to recover structure
+- output helpers require callers to pre-flatten structured data into strings
+- tests only check `strings.Contains` for new output contracts
+- adding a new output style requires editing many unrelated commands
+
+## Acceptance criteria
+
+The architecture is in a good state when:
+
+- commands mostly orchestrate
+- presenters own content decisions
+- renderers own display style only
+- new presenters are easy to add
+- new renderers are easy to add
+- most output behavior is testable without Cobra or stdout
+
+## Non-goals
+
+This document does not require:
+
+- a large inheritance hierarchy
+- a complicated registry system
+- reflection-heavy rendering
+- a framework-style abstraction layer
+
+Prefer simple explicit types and composition.
+
+The standard for success is not “abstract.” It is “cleanly separated, easy to test, easy to extend.”

--- a/shared/present/model.go
+++ b/shared/present/model.go
@@ -1,0 +1,113 @@
+// Package present provides presentation models and pure rendering for CLI output.
+package present
+
+// RenderMode is the authoritative rendering configuration.
+// Both legacy view.Policy and new present.Style derive from this.
+//
+// RenderMode exists at the CLI root/options level as the single source of truth.
+// Tool-specific options (e.g., root.Options.RenderMode()) return this type.
+type RenderMode int
+
+// RenderMode constants.
+const (
+	RenderModeHuman RenderMode = iota // Padded tables, decorators
+	RenderModeAgent                   // Pipe-delimited, plain text, token-efficient
+)
+
+// Style controls rendering format for the pure Render() function.
+//
+// Style is derived from RenderMode via StyleFromMode(). While currently 1:1
+// with RenderMode, Style is a separate type to allow the renderer API to
+// evolve independently of CLI configuration. For example, the renderer could
+// add finer-grained styles (e.g., StyleCompact) without changing the CLI mode.
+//
+// During migration from view.View to present.Render, both view.RenderPolicy
+// and present.Style coexist. They derive from the same RenderMode, ensuring
+// a single knob controls both legacy and new paths. See root.Options.RenderMode().
+type Style int
+
+// Style constants.
+const (
+	StyleHuman Style = iota // Padded tables, decorators (checkmark, warning)
+	StyleAgent              // Pipe-delimited, plain text, token-efficient
+)
+
+// StyleFromMode converts RenderMode to Style.
+// Currently a 1:1 mapping; may diverge as rendering needs evolve.
+func StyleFromMode(m RenderMode) Style {
+	if m == RenderModeAgent {
+		return StyleAgent
+	}
+	return StyleHuman
+}
+
+// RenderedOutput contains the rendered text for each output stream.
+type RenderedOutput struct {
+	Stdout string // Primary result/artifact
+	Stderr string // Warnings, diagnostics, errors
+}
+
+// OutputModel is the complete presentation output for a command.
+type OutputModel struct {
+	Sections []Section
+}
+
+// Section is a polymorphic output section.
+type Section interface {
+	sectionMarker()
+}
+
+// DetailSection displays key-value pairs (single record detail view).
+type DetailSection struct {
+	Fields []Field
+}
+
+func (*DetailSection) sectionMarker() {}
+
+// Field is a labeled value.
+type Field struct {
+	Label string
+	Value string
+}
+
+// TableSection displays tabular data (list views).
+type TableSection struct {
+	Headers []string
+	Rows    []Row
+}
+
+func (*TableSection) sectionMarker() {}
+
+// Row is a table row.
+type Row struct {
+	Cells []string
+}
+
+// Stream indicates which output stream a section targets.
+type Stream int
+
+// Stream constants.
+const (
+	StreamStdout Stream = iota // Primary result/artifact
+	StreamStderr               // Diagnostics, advisory, progress, commentary
+)
+
+// MessageSection displays a status message (mutations, confirmations).
+type MessageSection struct {
+	Kind    MessageKind
+	Message string
+	Stream  Stream // Explicit stream routing (zero value = StreamStdout)
+}
+
+func (*MessageSection) sectionMarker() {}
+
+// MessageKind indicates the type of status message.
+type MessageKind int
+
+// MessageKind constants for status message types.
+const (
+	MessageInfo MessageKind = iota
+	MessageSuccess
+	MessageWarning
+	MessageError
+)

--- a/shared/present/render.go
+++ b/shared/present/render.go
@@ -1,0 +1,125 @@
+package present
+
+import (
+	"bytes"
+	"strings"
+	"text/tabwriter"
+)
+
+// Render converts an OutputModel to RenderedOutput with proper stream routing.
+// This is a pure function with no side effects.
+func Render(model *OutputModel, style Style) RenderedOutput {
+	if model == nil {
+		return RenderedOutput{}
+	}
+	var stdout, stderr bytes.Buffer
+	for _, section := range model.Sections {
+		text := renderSection(section, style)
+		if isStderrSection(section) {
+			stderr.WriteString(text)
+		} else {
+			stdout.WriteString(text)
+		}
+	}
+	return RenderedOutput{Stdout: stdout.String(), Stderr: stderr.String()}
+}
+
+// isStderrSection returns true if this section should go to stderr.
+func isStderrSection(s Section) bool {
+	if msg, ok := s.(*MessageSection); ok {
+		return msg.Stream == StreamStderr // Explicit stream routing
+	}
+	return false // DetailSection, TableSection -> stdout
+}
+
+func renderSection(s Section, style Style) string {
+	switch sec := s.(type) {
+	case *DetailSection:
+		return renderDetail(sec)
+	case *TableSection:
+		return renderTable(sec, style)
+	case *MessageSection:
+		return renderMessage(sec, style)
+	}
+	return ""
+}
+
+func renderDetail(sec *DetailSection) string {
+	var buf bytes.Buffer
+	for _, f := range sec.Fields {
+		// Both styles use "Label: Value\n" for key-value pairs
+		buf.WriteString(f.Label)
+		buf.WriteString(": ")
+		buf.WriteString(f.Value)
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}
+
+func renderTable(sec *TableSection, style Style) string {
+	if style == StyleAgent {
+		return renderAgentTable(sec)
+	}
+	return renderHumanTable(sec)
+}
+
+func renderAgentTable(sec *TableSection) string {
+	var buf bytes.Buffer
+	// Headers - escape pipes defensively
+	escapedHeaders := make([]string, len(sec.Headers))
+	for i, h := range sec.Headers {
+		escapedHeaders[i] = escapeAgentCell(h)
+	}
+	buf.WriteString(strings.Join(escapedHeaders, " | "))
+	buf.WriteByte('\n')
+	// Rows - escape pipes and normalize newlines defensively
+	for _, row := range sec.Rows {
+		escapedCells := make([]string, len(row.Cells))
+		for i, cell := range row.Cells {
+			escapedCells[i] = escapeAgentCell(cell)
+		}
+		buf.WriteString(strings.Join(escapedCells, " | "))
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}
+
+// escapeAgentCell escapes pipe characters and normalizes newlines in cell content.
+// This prevents cell content from being structurally indistinguishable from delimiters.
+func escapeAgentCell(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return s
+}
+
+func renderHumanTable(sec *TableSection) string {
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+	// Headers
+	_, _ = w.Write([]byte(strings.Join(sec.Headers, "\t") + "\n"))
+	// Rows
+	for _, row := range sec.Rows {
+		_, _ = w.Write([]byte(strings.Join(row.Cells, "\t") + "\n"))
+	}
+	_ = w.Flush()
+	return buf.String()
+}
+
+func renderMessage(sec *MessageSection, style Style) string {
+	if style == StyleAgent {
+		// Plain text, no decorators
+		return sec.Message + "\n"
+	}
+	// Human style with decorators
+	switch sec.Kind {
+	case MessageSuccess:
+		return "✓ " + sec.Message + "\n"
+	case MessageWarning:
+		return "⚠ " + sec.Message + "\n"
+	case MessageError:
+		return "✗ " + sec.Message + "\n"
+	case MessageInfo:
+		return sec.Message + "\n"
+	}
+	return sec.Message + "\n"
+}

--- a/shared/present/render_test.go
+++ b/shared/present/render_test.go
@@ -1,0 +1,408 @@
+package present
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRender_DetailSection_Agent(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&DetailSection{
+				Fields: []Field{
+					{Label: "Name", Value: "Alice"},
+					{Label: "ID", Value: "123"},
+				},
+			},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	want := "Name: Alice\nID: 123\n"
+	if out.Stdout != want {
+		t.Errorf("detail agent stdout:\ngot:\n%s\nwant:\n%s", out.Stdout, want)
+	}
+	if out.Stderr != "" {
+		t.Errorf("detail agent stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
+func TestRender_DetailSection_Human(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&DetailSection{
+				Fields: []Field{
+					{Label: "Name", Value: "Alice"},
+					{Label: "ID", Value: "123"},
+				},
+			},
+		},
+	}
+
+	out := Render(model, StyleHuman)
+	want := "Name: Alice\nID: 123\n"
+	if out.Stdout != want {
+		t.Errorf("detail human stdout:\ngot:\n%s\nwant:\n%s", out.Stdout, want)
+	}
+	if out.Stderr != "" {
+		t.Errorf("detail human stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
+func TestRender_TableSection_Agent(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&TableSection{
+				Headers: []string{"KEY", "SUMMARY"},
+				Rows: []Row{
+					{Cells: []string{"PROJ-1", "First issue"}},
+					{Cells: []string{"PROJ-2", "Second issue"}},
+				},
+			},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	want := "KEY | SUMMARY\nPROJ-1 | First issue\nPROJ-2 | Second issue\n"
+	if out.Stdout != want {
+		t.Errorf("table agent stdout:\ngot:\n%s\nwant:\n%s", out.Stdout, want)
+	}
+	if out.Stderr != "" {
+		t.Errorf("table agent stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
+func TestRender_TableSection_Human(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&TableSection{
+				Headers: []string{"KEY", "SUMMARY"},
+				Rows: []Row{
+					{Cells: []string{"PROJ-1", "First"}},
+					{Cells: []string{"PROJ-2", "Second"}},
+				},
+			},
+		},
+	}
+
+	out := Render(model, StyleHuman)
+	// Human style uses tabwriter - verify structure, not exact spacing
+	if !strings.Contains(out.Stdout, "KEY") || !strings.Contains(out.Stdout, "SUMMARY") {
+		t.Errorf("missing headers in stdout: %s", out.Stdout)
+	}
+	if !strings.Contains(out.Stdout, "PROJ-1") || !strings.Contains(out.Stdout, "First") {
+		t.Errorf("missing row 1 in stdout: %s", out.Stdout)
+	}
+	if !strings.Contains(out.Stdout, "PROJ-2") || !strings.Contains(out.Stdout, "Second") {
+		t.Errorf("missing row 2 in stdout: %s", out.Stdout)
+	}
+	if out.Stderr != "" {
+		t.Errorf("table human stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
+func TestRender_MessageSection_Success_Agent(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&MessageSection{Kind: MessageSuccess, Message: "Issue updated"},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	want := "Issue updated\n"
+	if out.Stdout != want {
+		t.Errorf("message success agent stdout:\ngot: %q\nwant: %q", out.Stdout, want)
+	}
+	if out.Stderr != "" {
+		t.Errorf("message success agent stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
+func TestRender_MessageSection_Success_Human(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&MessageSection{Kind: MessageSuccess, Message: "Issue updated"},
+		},
+	}
+
+	out := Render(model, StyleHuman)
+	want := "✓ Issue updated\n"
+	if out.Stdout != want {
+		t.Errorf("message success human stdout:\ngot: %q\nwant: %q", out.Stdout, want)
+	}
+	if out.Stderr != "" {
+		t.Errorf("message success human stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
+func TestRender_MessageSection_Warning_GoesToStderr(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&MessageSection{Kind: MessageWarning, Message: "Deprecated API", Stream: StreamStderr},
+		},
+	}
+
+	// Agent style - warning goes to stderr
+	outAgent := Render(model, StyleAgent)
+	if outAgent.Stdout != "" {
+		t.Errorf("warning agent stdout should be empty, got: %q", outAgent.Stdout)
+	}
+	if outAgent.Stderr != "Deprecated API\n" {
+		t.Errorf("warning agent stderr:\ngot: %q\nwant: %q", outAgent.Stderr, "Deprecated API\n")
+	}
+
+	// Human style - warning goes to stderr with decorator
+	outHuman := Render(model, StyleHuman)
+	if outHuman.Stdout != "" {
+		t.Errorf("warning human stdout should be empty, got: %q", outHuman.Stdout)
+	}
+	if outHuman.Stderr != "⚠ Deprecated API\n" {
+		t.Errorf("warning human stderr:\ngot: %q\nwant: %q", outHuman.Stderr, "⚠ Deprecated API\n")
+	}
+}
+
+func TestRender_MessageSection_Info_Human(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&MessageSection{Kind: MessageInfo, Message: "Processing..."},
+		},
+	}
+
+	out := Render(model, StyleHuman)
+	want := "Processing...\n"
+	if out.Stdout != want {
+		t.Errorf("message info human stdout:\ngot: %q\nwant: %q", out.Stdout, want)
+	}
+	if out.Stderr != "" {
+		t.Errorf("message info human stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
+func TestRender_MixedSections_WithWarning(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&DetailSection{
+				Fields: []Field{{Label: "ID", Value: "123"}},
+			},
+			&MessageSection{Kind: MessageWarning, Message: "Field deprecated", Stream: StreamStderr},
+			&TableSection{
+				Headers: []string{"NAME", "VALUE"},
+				Rows:    []Row{{Cells: []string{"foo", "bar"}}},
+			},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	wantStdout := "ID: 123\nNAME | VALUE\nfoo | bar\n"
+	wantStderr := "Field deprecated\n"
+	if out.Stdout != wantStdout {
+		t.Errorf("mixed stdout:\ngot:\n%s\nwant:\n%s", out.Stdout, wantStdout)
+	}
+	if out.Stderr != wantStderr {
+		t.Errorf("mixed stderr:\ngot:\n%s\nwant:\n%s", out.Stderr, wantStderr)
+	}
+}
+
+func TestRender_EmptyModel(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{Sections: []Section{}}
+	out := Render(model, StyleAgent)
+	if out.Stdout != "" {
+		t.Errorf("empty model stdout should be empty, got: %q", out.Stdout)
+	}
+	if out.Stderr != "" {
+		t.Errorf("empty model stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
+func TestRender_NilModel(t *testing.T) {
+	t.Parallel()
+	out := Render(nil, StyleAgent)
+	if out.Stdout != "" {
+		t.Errorf("nil model stdout should be empty, got: %q", out.Stdout)
+	}
+	if out.Stderr != "" {
+		t.Errorf("nil model stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
+func TestRender_EmptyTable(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&TableSection{
+				Headers: []string{"KEY", "SUMMARY"},
+				Rows:    []Row{},
+			},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	want := "KEY | SUMMARY\n"
+	if out.Stdout != want {
+		t.Errorf("empty table stdout:\ngot: %q\nwant: %q", out.Stdout, want)
+	}
+	if out.Stderr != "" {
+		t.Errorf("empty table stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
+func TestRender_MessageSection_UnknownKind(t *testing.T) {
+	t.Parallel()
+	// Test that unknown MessageKind values fall through gracefully
+	model := &OutputModel{
+		Sections: []Section{
+			&MessageSection{Kind: MessageKind(99), Message: "Unknown kind"},
+		},
+	}
+
+	// Unknown kinds go to stdout (not stderr)
+	outAgent := Render(model, StyleAgent)
+	if outAgent.Stdout != "Unknown kind\n" {
+		t.Errorf("unknown kind agent stdout:\ngot: %q\nwant: %q", outAgent.Stdout, "Unknown kind\n")
+	}
+	if outAgent.Stderr != "" {
+		t.Errorf("unknown kind agent stderr should be empty, got: %q", outAgent.Stderr)
+	}
+
+	outHuman := Render(model, StyleHuman)
+	if outHuman.Stdout != "Unknown kind\n" {
+		t.Errorf("unknown kind human stdout:\ngot: %q\nwant: %q", outHuman.Stdout, "Unknown kind\n")
+	}
+	if outHuman.Stderr != "" {
+		t.Errorf("unknown kind human stderr should be empty, got: %q", outHuman.Stderr)
+	}
+}
+
+func TestStyleFromMode(t *testing.T) {
+	t.Parallel()
+	if got := StyleFromMode(RenderModeAgent); got != StyleAgent {
+		t.Errorf("StyleFromMode(RenderModeAgent) = %v, want %v", got, StyleAgent)
+	}
+	if got := StyleFromMode(RenderModeHuman); got != StyleHuman {
+		t.Errorf("StyleFromMode(RenderModeHuman) = %v, want %v", got, StyleHuman)
+	}
+}
+
+func TestRender_TableSection_Agent_EscapesPipes(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&TableSection{
+				Headers: []string{"KEY", "SUMMARY"},
+				Rows: []Row{
+					{Cells: []string{"PROJ-1", "Fix A | B pipeline"}},
+				},
+			},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	// Pipes in cell content should be escaped to avoid delimiter confusion
+	want := "KEY | SUMMARY\nPROJ-1 | Fix A \\| B pipeline\n"
+	if out.Stdout != want {
+		t.Errorf("pipe escaping:\ngot:\n%s\nwant:\n%s", out.Stdout, want)
+	}
+}
+
+func TestRender_TableSection_Agent_NormalizesNewlines(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&TableSection{
+				Headers: []string{"KEY", "DESC"},
+				Rows: []Row{
+					{Cells: []string{"PROJ-1", "Line one\nLine two"}},
+				},
+			},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	// Newlines in cell content should be normalized to spaces
+	want := "KEY | DESC\nPROJ-1 | Line one Line two\n"
+	if out.Stdout != want {
+		t.Errorf("newline normalization:\ngot:\n%s\nwant:\n%s", out.Stdout, want)
+	}
+}
+
+func TestRender_TableSection_Human_NoEscaping(t *testing.T) {
+	t.Parallel()
+	// Human mode should NOT escape pipes - verifies style-agnostic presenters
+	model := &OutputModel{
+		Sections: []Section{
+			&TableSection{
+				Headers: []string{"KEY", "DESC"},
+				Rows: []Row{
+					{Cells: []string{"PROJ-1", "A | B"}},
+				},
+			},
+		},
+	}
+
+	out := Render(model, StyleHuman)
+	// Human mode passes through raw content (tabwriter handles alignment)
+	if strings.Contains(out.Stdout, "\\|") {
+		t.Errorf("human mode should not escape pipes, got: %s", out.Stdout)
+	}
+	if !strings.Contains(out.Stdout, "A | B") {
+		t.Errorf("human mode should preserve raw pipe character, got: %s", out.Stdout)
+	}
+}
+
+func TestRender_MessageSection_Error(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&MessageSection{Kind: MessageError, Message: "Connection failed", Stream: StreamStderr},
+		},
+	}
+
+	// Agent style - error goes to stderr, no decorator
+	outAgent := Render(model, StyleAgent)
+	if outAgent.Stdout != "" {
+		t.Errorf("error agent stdout should be empty, got: %q", outAgent.Stdout)
+	}
+	if outAgent.Stderr != "Connection failed\n" {
+		t.Errorf("error agent stderr:\ngot: %q\nwant: %q", outAgent.Stderr, "Connection failed\n")
+	}
+
+	// Human style - error goes to stderr with ✗ decorator
+	outHuman := Render(model, StyleHuman)
+	if outHuman.Stdout != "" {
+		t.Errorf("error human stdout should be empty, got: %q", outHuman.Stdout)
+	}
+	if outHuman.Stderr != "✗ Connection failed\n" {
+		t.Errorf("error human stderr:\ngot: %q\nwant: %q", outHuman.Stderr, "✗ Connection failed\n")
+	}
+}
+
+func TestRender_Stream_ExplicitRouting(t *testing.T) {
+	t.Parallel()
+	// Test that Stream field controls routing, not Kind
+	model := &OutputModel{
+		Sections: []Section{
+			// Info message explicitly routed to stderr (advisory)
+			&MessageSection{Kind: MessageInfo, Message: "More results available", Stream: StreamStderr},
+			// Success message to stdout (default)
+			&MessageSection{Kind: MessageSuccess, Message: "Operation completed", Stream: StreamStdout},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	if out.Stdout != "Operation completed\n" {
+		t.Errorf("explicit stdout routing:\ngot: %q\nwant: %q", out.Stdout, "Operation completed\n")
+	}
+	if out.Stderr != "More results available\n" {
+		t.Errorf("explicit stderr routing:\ngot: %q\nwant: %q", out.Stderr, "More results available\n")
+	}
+}

--- a/shared/view/view.go
+++ b/shared/view/view.go
@@ -24,6 +24,15 @@ const (
 	FormatPlain Format = "plain"
 )
 
+// RenderPolicy controls output formatting style.
+type RenderPolicy int
+
+// Rendering policy constants.
+const (
+	PolicyDefault RenderPolicy = iota // Human-oriented (padded tables, ✓ decorators)
+	PolicyAgent                       // Token-efficient (pipe-delimited, plain text)
+)
+
 // ValidFormats returns the list of valid output formats.
 func ValidFormats() []string {
 	return []string{string(FormatTable), string(FormatJSON), string(FormatPlain)}
@@ -44,6 +53,7 @@ func ValidateFormat(format string) error {
 type View struct {
 	Format  Format
 	NoColor bool
+	Policy  RenderPolicy // Zero value is PolicyDefault
 	Out     io.Writer
 	Err     io.Writer
 }
@@ -75,6 +85,11 @@ func (v *View) SetError(w io.Writer) {
 	v.Err = w
 }
 
+// SetPolicy sets the rendering policy.
+func (v *View) SetPolicy(p RenderPolicy) {
+	v.Policy = p
+}
+
 // Table renders data as a formatted table with aligned columns.
 // For JSON format, use the JSON method instead.
 func (v *View) Table(headers []string, rows [][]string) error {
@@ -86,6 +101,31 @@ func (v *View) Table(headers []string, rows [][]string) error {
 		return v.Plain(rows)
 	}
 
+	if v.Policy == PolicyAgent {
+		return v.agentTable(headers, rows)
+	}
+	return v.humanTable(headers, rows)
+}
+
+// agentTable renders a pipe-delimited table for token-efficient agent output.
+// Escapes pipes in cell content to avoid delimiter confusion.
+func (v *View) agentTable(headers []string, rows [][]string) error {
+	_, _ = fmt.Fprintln(v.Out, strings.Join(headers, " | "))
+	for _, row := range rows {
+		normalized := make([]string, len(row))
+		for i, cell := range row {
+			// Normalize newlines to spaces, escape pipes to avoid delimiter confusion
+			cell = strings.ReplaceAll(cell, "\n", " ")
+			cell = strings.ReplaceAll(cell, "|", "\\|")
+			normalized[i] = cell
+		}
+		_, _ = fmt.Fprintln(v.Out, strings.Join(normalized, " | "))
+	}
+	return nil
+}
+
+// humanTable renders a padded table using tabwriter for human-readable output.
+func (v *View) humanTable(headers []string, rows [][]string) error {
 	w := tabwriter.NewWriter(v.Out, 0, 0, 2, ' ', 0)
 
 	// Print headers with bold formatting
@@ -168,8 +208,13 @@ func (v *View) Render(headers []string, rows [][]string, jsonData any) error {
 }
 
 // Success prints a success message with a green checkmark.
+// With PolicyAgent, prints plain text without the checkmark.
 func (v *View) Success(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
+	if v.Policy == PolicyAgent {
+		_, _ = fmt.Fprintln(v.Out, msg)
+		return
+	}
 	if v.NoColor {
 		_, _ = fmt.Fprintln(v.Out, "✓ "+msg)
 	} else {
@@ -190,6 +235,10 @@ func (v *View) Error(format string, args ...any) {
 // Warning prints a warning message with a yellow warning sign.
 func (v *View) Warning(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
+	if v.Policy == PolicyAgent {
+		_, _ = fmt.Fprintln(v.Err, msg)
+		return
+	}
 	if v.NoColor {
 		_, _ = fmt.Fprintln(v.Err, "⚠ "+msg)
 	} else {
@@ -272,6 +321,22 @@ func (v *View) RenderKeyValue(key, value string) {
 		bold := color.New(color.Bold)
 		_, _ = bold.Fprintf(v.Out, "%s: ", key)
 		_, _ = fmt.Fprintln(v.Out, value)
+	}
+}
+
+// KeyValue represents a single key-value pair for rendering.
+type KeyValue struct {
+	Key   string
+	Value string
+}
+
+// RenderKeyValues renders multiple key-value pairs for default/table/plain text output.
+// Delegates to RenderKeyValue() for each pair to maintain single source of truth.
+// Note: This helper is NOT for JSON output. Commands should handle JSON at the command
+// level (branching on v.Format == FormatJSON before calling this).
+func (v *View) RenderKeyValues(pairs []KeyValue) {
+	for _, kv := range pairs {
+		v.RenderKeyValue(kv.Key, kv.Value)
 	}
 }
 

--- a/shared/view/view_test.go
+++ b/shared/view/view_test.go
@@ -642,6 +642,173 @@ func TestView_RenderArtifact(t *testing.T) {
 	})
 }
 
+// --- Phase 1 TDD: RenderPolicy tests ---
+
+func TestRenderPolicy_DefaultIsZeroValue(t *testing.T) {
+	t.Parallel()
+	var p RenderPolicy
+	if p != PolicyDefault {
+		t.Errorf("zero value of RenderPolicy should be PolicyDefault, got %v", p)
+	}
+}
+
+func TestView_Table_AgentPolicy(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	v := New(FormatTable, true)
+	v.SetPolicy(PolicyAgent)
+	v.SetOutput(buf)
+
+	headers := []string{"ID", "NAME", "STATUS"}
+	rows := [][]string{
+		{"1", "First", "Active"},
+		{"2", "Second", "Done"},
+	}
+	_ = v.Table(headers, rows)
+
+	want := "ID | NAME | STATUS\n1 | First | Active\n2 | Second | Done\n"
+	if buf.String() != want {
+		t.Errorf("agent table:\ngot:\n%s\nwant:\n%s", buf.String(), want)
+	}
+}
+
+func TestView_Table_AgentPolicy_NormalizesNewlines(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	v := New(FormatTable, true)
+	v.SetPolicy(PolicyAgent)
+	v.SetOutput(buf)
+
+	headers := []string{"KEY", "SUMMARY"}
+	rows := [][]string{
+		{"A", "Line one\nLine two"},
+	}
+	_ = v.Table(headers, rows)
+
+	want := "KEY | SUMMARY\nA | Line one Line two\n"
+	if buf.String() != want {
+		t.Errorf("newline normalization:\ngot:\n%s\nwant:\n%s", buf.String(), want)
+	}
+}
+
+func TestView_Table_AgentPolicy_EscapesPipes(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	v := New(FormatTable, true)
+	v.SetPolicy(PolicyAgent)
+	v.SetOutput(buf)
+
+	headers := []string{"KEY", "SUMMARY"}
+	rows := [][]string{
+		{"A", "Fix A | B pipeline"},
+	}
+	_ = v.Table(headers, rows)
+
+	// Pipe in content should be escaped to avoid delimiter confusion
+	want := "KEY | SUMMARY\nA | Fix A \\| B pipeline\n"
+	if buf.String() != want {
+		t.Errorf("pipe escaping:\ngot:\n%s\nwant:\n%s", buf.String(), want)
+	}
+}
+
+func TestView_Table_DefaultPolicy_UsesTabwriter(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	v := New(FormatTable, true)
+	// No SetPolicy — uses PolicyDefault
+	v.SetOutput(buf)
+
+	headers := []string{"ID", "NAME"}
+	rows := [][]string{{"1", "First"}}
+	_ = v.Table(headers, rows)
+
+	// Tabwriter pads with spaces, not pipes
+	output := buf.String()
+	if strings.Contains(output, "|") {
+		t.Error("default policy should not contain pipes")
+	}
+	if !strings.Contains(output, "ID") || !strings.Contains(output, "NAME") {
+		t.Error("default policy should contain headers")
+	}
+}
+
+func TestView_Success_AgentPolicy(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	v := New(FormatTable, true)
+	v.SetPolicy(PolicyAgent)
+	v.SetOutput(buf)
+
+	v.Success("Issue %s updated", "MON-123")
+
+	want := "Issue MON-123 updated\n"
+	if buf.String() != want {
+		t.Errorf("agent success:\ngot: %q\nwant: %q", buf.String(), want)
+	}
+}
+
+func TestView_Success_DefaultPolicy_HasCheckmark(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	v := New(FormatTable, true)
+	// No SetPolicy — uses PolicyDefault
+	v.SetOutput(buf)
+
+	v.Success("Done")
+
+	if !strings.Contains(buf.String(), "✓") {
+		t.Error("default policy success should contain checkmark")
+	}
+}
+
+func TestView_Warning_AgentPolicy(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	v := New(FormatTable, true)
+	v.SetPolicy(PolicyAgent)
+	v.SetError(buf)
+
+	v.Warning("Field %s is deprecated", "foo")
+
+	want := "Field foo is deprecated\n"
+	if buf.String() != want {
+		t.Errorf("agent warning:\ngot: %q\nwant: %q", buf.String(), want)
+	}
+}
+
+func TestView_Warning_DefaultPolicy_HasWarningSign(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	v := New(FormatTable, true)
+	// No SetPolicy — uses PolicyDefault
+	v.SetError(buf)
+
+	v.Warning("Deprecated")
+
+	if !strings.Contains(buf.String(), "⚠") {
+		t.Error("default policy warning should contain warning sign")
+	}
+}
+
+func TestView_RenderKeyValues(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	v := New(FormatTable, true)
+	v.SetOutput(buf)
+
+	pairs := []KeyValue{
+		{Key: "Account ID", Value: "abc123"},
+		{Key: "Name", Value: "Alice"},
+		{Key: "Email", Value: "alice@example.com"},
+	}
+	v.RenderKeyValues(pairs)
+
+	want := "Account ID: abc123\nName: Alice\nEmail: alice@example.com\n"
+	if buf.String() != want {
+		t.Errorf("batch key/value:\ngot:\n%s\nwant:\n%s", buf.String(), want)
+	}
+}
+
 func TestView_RenderArtifactList(t *testing.T) {
 	t.Parallel()
 

--- a/tools/cfl/internal/cmd/root/root_test.go
+++ b/tools/cfl/internal/cmd/root/root_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
 	"github.com/open-cli-collective/atlassian-go/testutil"
+	"github.com/open-cli-collective/atlassian-go/view"
 	"github.com/spf13/cobra"
 )
 
@@ -111,4 +112,19 @@ func TestRegisterCommands(t *testing.T) {
 
 	RegisterCommands(cmd, opts, registrar)
 	testutil.True(t, called)
+}
+
+func TestOptions_View_UsesDefaultPolicy(t *testing.T) {
+	t.Parallel()
+	opts := &Options{
+		Output: "table",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	v := opts.View()
+
+	// cfl should NOT use PolicyAgent - it keeps human-oriented output
+	if v.Policy != view.PolicyDefault {
+		t.Errorf("cfl View should use PolicyDefault, got %v", v.Policy)
+	}
 }

--- a/tools/jtk/api/issues.go
+++ b/tools/jtk/api/issues.go
@@ -137,3 +137,55 @@ func BuildCreateRequest(projectKey, issueType, summary, description string, extr
 func BuildUpdateRequest(fields map[string]any) *UpdateIssueRequest {
 	return &UpdateIssueRequest{Fields: fields}
 }
+
+// EditFieldMeta represents field metadata from issue edit metadata API.
+type EditFieldMeta struct {
+	ID       string
+	Name     string
+	Type     string // from schema.type
+	Required bool
+}
+
+// ParseEditMeta extracts field metadata from raw edit metadata response.
+// The input is the "fields" map from the edit metadata API response.
+func ParseEditMeta(fieldsData map[string]any) []EditFieldMeta {
+	result := make([]EditFieldMeta, 0, len(fieldsData))
+
+	for id, data := range fieldsData {
+		fieldData, ok := data.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name := safeString(fieldData["name"])
+		required := false
+		if req, ok := fieldData["required"].(bool); ok && req {
+			required = true
+		}
+
+		fieldType := ""
+		if schema, ok := fieldData["schema"].(map[string]any); ok {
+			fieldType = safeString(schema["type"])
+		}
+
+		result = append(result, EditFieldMeta{
+			ID:       id,
+			Name:     name,
+			Type:     fieldType,
+			Required: required,
+		})
+	}
+
+	return result
+}
+
+// safeString extracts a string from an interface value.
+func safeString(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/tools/jtk/api/issues_test.go
+++ b/tools/jtk/api/issues_test.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestParseEditMeta_BasicFields(t *testing.T) {
+	t.Parallel()
+
+	fieldsData := map[string]any{
+		"summary": map[string]any{
+			"name":     "Summary",
+			"required": true,
+			"schema": map[string]any{
+				"type": "string",
+			},
+		},
+		"description": map[string]any{
+			"name":     "Description",
+			"required": false,
+			"schema": map[string]any{
+				"type": "string",
+			},
+		},
+	}
+
+	result := ParseEditMeta(fieldsData)
+
+	testutil.Equal(t, len(result), 2)
+
+	// Find fields by ID (map iteration order is random)
+	fieldMap := make(map[string]EditFieldMeta)
+	for _, f := range result {
+		fieldMap[f.ID] = f
+	}
+
+	summary := fieldMap["summary"]
+	testutil.Equal(t, summary.Name, "Summary")
+	testutil.Equal(t, summary.Type, "string")
+	testutil.True(t, summary.Required)
+
+	desc := fieldMap["description"]
+	testutil.Equal(t, desc.Name, "Description")
+	testutil.Equal(t, desc.Type, "string")
+	testutil.False(t, desc.Required)
+}
+
+func TestParseEditMeta_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	result := ParseEditMeta(nil)
+	testutil.Equal(t, len(result), 0)
+
+	result = ParseEditMeta(map[string]any{})
+	testutil.Equal(t, len(result), 0)
+}
+
+func TestParseEditMeta_SkipsInvalidFieldData(t *testing.T) {
+	t.Parallel()
+
+	fieldsData := map[string]any{
+		"valid": map[string]any{
+			"name": "Valid Field",
+		},
+		"invalid_string": "not a map",
+		"invalid_nil":    nil,
+		"invalid_number": 42,
+	}
+
+	result := ParseEditMeta(fieldsData)
+
+	// Should only parse the valid field
+	testutil.Equal(t, len(result), 1)
+	testutil.Equal(t, result[0].ID, "valid")
+	testutil.Equal(t, result[0].Name, "Valid Field")
+}
+
+func TestParseEditMeta_MissingSchema(t *testing.T) {
+	t.Parallel()
+
+	fieldsData := map[string]any{
+		"no_schema": map[string]any{
+			"name":     "No Schema",
+			"required": true,
+		},
+	}
+
+	result := ParseEditMeta(fieldsData)
+
+	testutil.Equal(t, len(result), 1)
+	testutil.Equal(t, result[0].ID, "no_schema")
+	testutil.Equal(t, result[0].Name, "No Schema")
+	testutil.Equal(t, result[0].Type, "") // Empty when no schema
+	testutil.True(t, result[0].Required)
+}
+
+func TestParseEditMeta_InvalidSchema(t *testing.T) {
+	t.Parallel()
+
+	fieldsData := map[string]any{
+		"bad_schema": map[string]any{
+			"name":   "Bad Schema",
+			"schema": "not a map",
+		},
+	}
+
+	result := ParseEditMeta(fieldsData)
+
+	testutil.Equal(t, len(result), 1)
+	testutil.Equal(t, result[0].Type, "") // Empty when schema isn't a map
+}
+
+func TestParseEditMeta_RequiredFalseExplicitly(t *testing.T) {
+	t.Parallel()
+
+	fieldsData := map[string]any{
+		"optional": map[string]any{
+			"name":     "Optional",
+			"required": false,
+		},
+	}
+
+	result := ParseEditMeta(fieldsData)
+
+	testutil.Equal(t, len(result), 1)
+	testutil.False(t, result[0].Required)
+}
+
+func TestParseEditMeta_RequiredMissing(t *testing.T) {
+	t.Parallel()
+
+	fieldsData := map[string]any{
+		"no_required": map[string]any{
+			"name": "No Required Field",
+		},
+	}
+
+	result := ParseEditMeta(fieldsData)
+
+	testutil.Equal(t, len(result), 1)
+	testutil.False(t, result[0].Required) // Defaults to false
+}
+
+func TestParseEditMeta_RequiredInvalidType(t *testing.T) {
+	t.Parallel()
+
+	fieldsData := map[string]any{
+		"bad_required": map[string]any{
+			"name":     "Bad Required",
+			"required": "yes", // String instead of bool
+		},
+	}
+
+	result := ParseEditMeta(fieldsData)
+
+	testutil.Equal(t, len(result), 1)
+	testutil.False(t, result[0].Required) // Falls back to false when not bool
+}
+
+func TestSafeString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{"nil", nil, ""},
+		{"string", "hello", "hello"},
+		{"empty_string", "", ""},
+		{"int", 42, "42"},
+		{"float", 3.14, "3.14"},
+		{"bool", true, "true"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			testutil.Equal(t, safeString(tt.input), tt.want)
+		})
+	}
+}

--- a/tools/jtk/internal/cmd/attachments/attachments.go
+++ b/tools/jtk/internal/cmd/attachments/attachments.go
@@ -9,8 +9,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // Register registers the attachments commands
@@ -64,37 +68,35 @@ func runList(ctx context.Context, opts *root.Options, issueKey string) error {
 	}
 
 	if len(attachments) == 0 {
-		v.Info("No attachments found on %s", issueKey)
+		model := jtkpresent.AttachmentPresenter{}.PresentEmpty(issueKey)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
-	headers := []string{"ID", "FILENAME", "SIZE", "CREATED", "AUTHOR"}
-	rows := make([][]string, 0, len(attachments))
+	if v.Format == view.FormatJSON {
+		data := make([]map[string]any, 0, len(attachments))
+		for _, att := range attachments {
+			data = append(data, map[string]any{
+				"id":       att.ID.String(),
+				"filename": att.Filename,
+				"size":     att.Size,
+				"mimeType": att.MimeType,
+				"created":  att.Created,
+				"author":   att.Author.DisplayName,
+				"content":  att.Content,
+			})
+		}
 
-	for _, att := range attachments {
-		rows = append(rows, []string{
-			att.ID.String(),
-			att.Filename,
-			api.FormatFileSize(att.Size),
-			att.Created[:10], // Date only
-			att.Author.DisplayName,
-		})
+		return v.JSON(data)
 	}
 
-	data := make([]map[string]any, 0, len(attachments))
-	for _, att := range attachments {
-		data = append(data, map[string]any{
-			"id":       att.ID.String(),
-			"filename": att.Filename,
-			"size":     att.Size,
-			"mimeType": att.MimeType,
-			"created":  att.Created,
-			"author":   att.Author.DisplayName,
-			"content":  att.Content,
-		})
-	}
-
-	return v.Render(headers, rows, data)
+	// Text path: presenter → render → write
+	model := jtkpresent.AttachmentPresenter{}.PresentList(attachments)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newAddCmd(opts *root.Options) *cobra.Command {
@@ -122,8 +124,6 @@ func newAddCmd(opts *root.Options) *cobra.Command {
 }
 
 func runAdd(ctx context.Context, opts *root.Options, issueKey string, files []string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -147,7 +147,9 @@ func runAdd(ctx context.Context, opts *root.Options, issueKey string, files []st
 		}
 
 		for _, att := range attachments {
-			v.Success("Uploaded %s (ID: %s, Size: %s)", att.Filename, att.ID.String(), api.FormatFileSize(att.Size))
+			model := jtkpresent.AttachmentPresenter{}.PresentUploaded(att.Filename, att.ID.String(), api.FormatFileSize(att.Size))
+			out := present.Render(model, opts.RenderStyle())
+			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		}
 	}
 
@@ -182,8 +184,6 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 }
 
 func runGet(ctx context.Context, opts *root.Options, attachmentID, outputPath string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -206,7 +206,9 @@ func runGet(ctx context.Context, opts *root.Options, attachmentID, outputPath st
 		actualPath = filepath.Join(outputPath, attachment.Filename)
 	}
 
-	v.Success("Downloaded %s (%s)", actualPath, api.FormatFileSize(attachment.Size))
+	model := jtkpresent.AttachmentPresenter{}.PresentDownloaded(actualPath, api.FormatFileSize(attachment.Size))
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }
 
@@ -228,8 +230,6 @@ func newDeleteCmd(opts *root.Options) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, opts *root.Options, attachmentID string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -239,6 +239,8 @@ func runDelete(ctx context.Context, opts *root.Options, attachmentID string) err
 		return fmt.Errorf("deleting attachment: %w", err)
 	}
 
-	v.Success("Deleted attachment %s", attachmentID)
+	model := jtkpresent.AttachmentPresenter{}.PresentDeleted(attachmentID)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }

--- a/tools/jtk/internal/cmd/automation/create.go
+++ b/tools/jtk/internal/cmd/automation/create.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newCreateCmd(opts *root.Options) *cobra.Command {
@@ -44,7 +47,6 @@ New rules are created in DISABLED state by default.`,
 }
 
 func runCreate(ctx context.Context, opts *root.Options, filePath string) error {
-	v := opts.View()
 
 	// Read and validate file before creating the API client so we fail
 	// fast on bad input without needing network access.
@@ -93,7 +95,9 @@ func runCreate(ctx context.Context, opts *root.Options, filePath string) error {
 	}
 	if err := json.Unmarshal(respBody, &created); err != nil {
 		// Even if we can't parse the response, the rule was created.
-		v.Success("Created automation rule (could not parse response for details)")
+		model := jtkpresent.AutomationPresenter{}.PresentCreatedUnparsed()
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
@@ -108,11 +112,14 @@ func runCreate(ctx context.Context, opts *root.Options, filePath string) error {
 		identifier = created.ID.String()
 	}
 
+	var model *present.OutputModel
 	if created.Name != "" {
-		v.Success("Created automation rule: %s (UUID: %s)", created.Name, identifier)
+		model = jtkpresent.AutomationPresenter{}.PresentCreated(created.Name, identifier)
 	} else {
-		v.Success("Created automation rule (UUID: %s)", identifier)
+		model = jtkpresent.AutomationPresenter{}.PresentCreatedMinimal(identifier)
 	}
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
 
 	return nil
 }

--- a/tools/jtk/internal/cmd/automation/delete.go
+++ b/tools/jtk/internal/cmd/automation/delete.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/prompt"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {
@@ -38,8 +40,6 @@ This action cannot be undone.`,
 }
 
 func runDelete(ctx context.Context, opts *root.Options, ruleID string, force bool) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -59,7 +59,9 @@ func runDelete(ctx context.Context, opts *root.Options, ruleID string, force boo
 			return fmt.Errorf("reading confirmation: %w", err)
 		}
 		if !confirmed {
-			v.Info("Deletion cancelled.")
+			model := jtkpresent.AutomationPresenter{}.PresentDeleteCancelled()
+			out := present.Render(model, opts.RenderStyle())
+			fmt.Fprint(opts.Stdout, out.Stdout)
 			return nil
 		}
 	}
@@ -80,9 +82,12 @@ func runDelete(ctx context.Context, opts *root.Options, ruleID string, force boo
 	}
 
 	if opts.Output == "json" {
+		v := opts.View()
 		return v.JSON(map[string]string{"status": "deleted", "ruleId": ruleID, "name": current.Name})
 	}
 
-	v.Success("Deleted automation rule %q (%s)", current.Name, ruleID)
+	model := jtkpresent.AutomationPresenter{}.PresentDeleted(current.Name, ruleID)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }

--- a/tools/jtk/internal/cmd/automation/enable.go
+++ b/tools/jtk/internal/cmd/automation/enable.go
@@ -2,10 +2,14 @@ package automation
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newEnableCmd(opts *root.Options) *cobra.Command {
@@ -25,8 +29,6 @@ func newEnableCmd(opts *root.Options) *cobra.Command {
 }
 
 func runSetState(ctx context.Context, opts *root.Options, ruleID string, enabled bool) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -44,7 +46,10 @@ func runSetState(ctx context.Context, opts *root.Options, ruleID string, enabled
 	}
 
 	if current.State == newState {
-		v.Info("Rule %q is already %s", current.Name, newState)
+		model := jtkpresent.AutomationPresenter{}.PresentNoChange(current.Name, newState)
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		fmt.Fprint(opts.Stderr, out.Stderr)
 		return nil
 	}
 
@@ -52,6 +57,9 @@ func runSetState(ctx context.Context, opts *root.Options, ruleID string, enabled
 		return err
 	}
 
-	v.Success("Rule %q: %s → %s", current.Name, current.State, newState)
+	model := jtkpresent.AutomationPresenter{}.PresentStateChanged(current.Name, current.State, newState)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/automation/enable_test.go
+++ b/tools/jtk/internal/cmd/automation/enable_test.go
@@ -56,7 +56,8 @@ func TestRunSetState_AlreadyEnabled(t *testing.T) {
 
 	err = runSetState(context.Background(), opts, "42", true)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "already ENABLED")
+	// No-change messages route to stderr (no mutation occurred)
+	testutil.Contains(t, stderr.String(), "already ENABLED")
 }
 
 func TestRunSetState_AlreadyDisabled(t *testing.T) {
@@ -87,7 +88,8 @@ func TestRunSetState_AlreadyDisabled(t *testing.T) {
 
 	err = runSetState(context.Background(), opts, "42", false)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "already DISABLED")
+	// No-change messages route to stderr (no mutation occurred)
+	testutil.Contains(t, stderr.String(), "already DISABLED")
 }
 
 func TestRunSetState_EnableDisabledRule(t *testing.T) {

--- a/tools/jtk/internal/cmd/automation/get.go
+++ b/tools/jtk/internal/cmd/automation/get.go
@@ -3,15 +3,15 @@ package automation
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
-	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newGetCmd(opts *root.Options) *cobra.Command {
@@ -58,75 +58,9 @@ func runGet(ctx context.Context, opts *root.Options, ruleID string, showComponen
 		return v.RenderArtifact(jtkartifact.ProjectAutomationRule(rule, opts.ArtifactMode()))
 	}
 
-	v.Println("Name:        %s", rule.Name)
-	v.Println("UUID:        %s", rule.Identifier())
-	v.Println("State:       %s", rule.State)
-
-	if rule.Description != "" {
-		v.Println("Description: %s", rule.Description)
-	}
-
-	if len(rule.Labels) > 0 {
-		v.Println("Labels:      %s", strings.Join(rule.Labels, ", "))
-	}
-	if len(rule.Tags) > 0 {
-		v.Println("Tags:        %s", strings.Join(rule.Tags, ", "))
-	}
-
-	if len(rule.Projects) > 0 {
-		projects := make([]string, 0, len(rule.Projects))
-		for _, p := range rule.Projects {
-			if p.ProjectKey != "" {
-				projects = append(projects, p.ProjectKey)
-			} else if p.ProjectName != "" {
-				projects = append(projects, p.ProjectName)
-			}
-		}
-		if len(projects) > 0 {
-			v.Println("Projects:    %s", strings.Join(projects, ", "))
-		}
-	}
-
-	v.Println("Components:  %s", summarizeComponents(rule.Components))
-
-	if showComponents && len(rule.Components) > 0 {
-		v.Println("")
-		v.Println("Component Details:")
-		for i, c := range rule.Components {
-			v.Println("  [%d] %s: %s", i+1, c.Component, c.Type)
-		}
-	}
-
+	model := jtkpresent.AutomationPresenter{}.PresentDetail(rule, showComponents)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
-}
-
-func summarizeComponents(components []api.RuleComponent) string {
-	if len(components) == 0 {
-		return "none"
-	}
-
-	triggers, conditions, actions := 0, 0, 0
-	for _, c := range components {
-		switch c.Component {
-		case "TRIGGER":
-			triggers++
-		case "CONDITION":
-			conditions++
-		case "ACTION":
-			actions++
-		}
-	}
-
-	parts := make([]string, 0, 3)
-	if triggers > 0 {
-		parts = append(parts, fmt.Sprintf("%d trigger(s)", triggers))
-	}
-	if conditions > 0 {
-		parts = append(parts, fmt.Sprintf("%d condition(s)", conditions))
-	}
-	if actions > 0 {
-		parts = append(parts, fmt.Sprintf("%d action(s)", actions))
-	}
-
-	return fmt.Sprintf("%d total — %s", len(components), strings.Join(parts, ", "))
 }

--- a/tools/jtk/internal/cmd/automation/get_test.go
+++ b/tools/jtk/internal/cmd/automation/get_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func TestSummarizeComponents(t *testing.T) {
@@ -59,7 +60,7 @@ func TestSummarizeComponents(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := summarizeComponents(tt.components)
+			got := jtkpresent.SummarizeComponents(tt.components)
 			testutil.Equal(t, got, tt.want)
 		})
 	}

--- a/tools/jtk/internal/cmd/automation/list.go
+++ b/tools/jtk/internal/cmd/automation/list.go
@@ -2,13 +2,15 @@ package automation
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/view"
+	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newListCmd(opts *root.Options) *cobra.Command {
@@ -32,8 +34,6 @@ func newListCmd(opts *root.Options) *cobra.Command {
 }
 
 func runList(ctx context.Context, opts *root.Options, state string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -45,32 +45,21 @@ func runList(ctx context.Context, opts *root.Options, state string) error {
 	}
 
 	if len(rules) == 0 {
-		v.Info("No automation rules found")
+		model := jtkpresent.AutomationPresenter{}.PresentEmpty()
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
-	headers := []string{"UUID", "NAME", "STATE", "LABELS"}
-	rows := make([][]string, 0, len(rules))
-	for _, r := range rules {
-		labels := "-"
-		if len(r.Labels) > 0 {
-			labels = strings.Join(r.Labels, ", ")
-		}
-		if len(r.Tags) > 0 && labels == "-" {
-			labels = strings.Join(r.Tags, ", ")
-		}
-
-		rows = append(rows, []string{
-			r.Identifier(),
-			view.Truncate(r.Name, 60),
-			r.State,
-			labels,
-		})
-	}
-
 	if opts.Output == "json" {
+		v := opts.View()
 		return v.JSON(rules)
 	}
 
-	return v.Table(headers, rows)
+	model := jtkpresent.AutomationPresenter{}.PresentList(rules)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
+
+	return nil
 }

--- a/tools/jtk/internal/cmd/automation/update.go
+++ b/tools/jtk/internal/cmd/automation/update.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newUpdateCmd(opts *root.Options) *cobra.Command {
@@ -48,8 +51,6 @@ field mappings and workflow configuration.`,
 }
 
 func runUpdate(ctx context.Context, opts *root.Options, ruleID, filePath string) error {
-	v := opts.View()
-
 	// Read and validate file before creating the API client so we fail
 	// fast on bad input without needing network access.
 	data, err := os.ReadFile(filePath) //nolint:gosec // CLI tool reads user-provided file paths
@@ -72,12 +73,13 @@ func runUpdate(ctx context.Context, opts *root.Options, ruleID, filePath string)
 		return fmt.Errorf("fetching current rule: %w", err)
 	}
 
-	v.Info("Updating rule: %s (UUID: %s, State: %s)", current.Name, current.Identifier(), current.State)
-
 	if err := client.UpdateAutomationRule(ctx, ruleID, json.RawMessage(data)); err != nil {
 		return err
 	}
 
-	v.Success("Updated automation rule %s", ruleID)
+	model := jtkpresent.AutomationPresenter{}.PresentUpdateComplete(current.Name, current.Identifier(), current.State, ruleID)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/boards/boards.go
+++ b/tools/jtk/internal/cmd/boards/boards.go
@@ -8,11 +8,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // Register registers the boards commands
@@ -80,7 +82,9 @@ func runList(ctx context.Context, opts *root.Options, project string, maxResults
 	}
 
 	if len(result.Values) == 0 {
-		v.Info("No boards found")
+		model := jtkpresent.BoardPresenter{}.PresentEmpty()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
@@ -90,19 +94,12 @@ func runList(ctx context.Context, opts *root.Options, project string, maxResults
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	headers := []string{"ID", "NAME", "TYPE", "PROJECT"}
-	rows := make([][]string, 0, len(result.Values))
-
-	for _, b := range result.Values {
-		rows = append(rows, []string{
-			fmt.Sprintf("%d", b.ID),
-			b.Name,
-			b.Type,
-			b.Location.ProjectKey,
-		})
-	}
-
-	return v.Table(headers, rows)
+	// Text path: presenter → render → write
+	model := jtkpresent.BoardPresenter{}.PresentList(result.Values)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newGetCmd(opts *root.Options) *cobra.Command {
@@ -139,10 +136,10 @@ func runGet(ctx context.Context, opts *root.Options, boardID int) error {
 		return v.RenderArtifact(jtkartifact.ProjectBoard(board, opts.ArtifactMode()))
 	}
 
-	v.Println("ID:      %d", board.ID)
-	v.Println("Name:    %s", board.Name)
-	v.Println("Type:    %s", board.Type)
-	v.Println("Project: %s", board.Location.ProjectKey)
-
+	// Text path: presenter → render → write
+	model := jtkpresent.BoardPresenter{}.PresentDetail(board)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -3,14 +3,17 @@ package comments
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/text"
 )
 
@@ -66,7 +69,10 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 	}
 
 	if len(result.Comments) == 0 {
-		v.Info("No comments on %s", issueKey)
+		model := jtkpresent.CommentPresenter{}.PresentEmpty(issueKey)
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		fmt.Fprint(opts.Stderr, out.Stderr)
 		return nil
 	}
 
@@ -85,45 +91,16 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	// No-truncate mode: display each comment with complete body text
+	var model *present.OutputModel
 	if noTruncate {
-		for i, c := range result.Comments {
-			if i > 0 {
-				v.Println("---")
-			}
-			body := ""
-			if c.Body != nil {
-				body = c.Body.ToPlainText()
-			}
-			v.Println("ID:      %s", c.ID)
-			v.Println("Author:  %s", c.Author.DisplayName)
-			v.Println("Created: %s", formatTime(c.Created))
-			v.Println("Body:    %s", body)
-		}
-		return nil
+		model = jtkpresent.CommentPresenter{}.PresentListFull(result.Comments)
+	} else {
+		model = jtkpresent.CommentPresenter{}.PresentList(result.Comments)
 	}
-
-	headers := []string{"ID", "AUTHOR", "CREATED", "BODY"}
-	rows := make([][]string, 0, len(result.Comments))
-
-	for _, c := range result.Comments {
-		body := ""
-		if c.Body != nil {
-			body = c.Body.ToPlainText()
-			if len(body) > 100 {
-				body = body[:100] + "... [truncated, use --no-truncate for complete text]"
-			}
-		}
-
-		rows = append(rows, []string{
-			c.ID,
-			c.Author.DisplayName,
-			formatTime(c.Created),
-			body,
-		})
-	}
-
-	return v.Table(headers, rows)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newAddCmd(opts *root.Options) *cobra.Command {
@@ -163,7 +140,10 @@ func runAdd(ctx context.Context, opts *root.Options, issueKey, body string) erro
 		return v.JSON(comment)
 	}
 
-	v.Success("Added comment %s to %s", comment.ID, issueKey)
+	model := jtkpresent.CommentPresenter{}.PresentAdded(comment.ID, issueKey)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }
 
@@ -198,14 +178,9 @@ func runDelete(ctx context.Context, opts *root.Options, issueKey, commentID stri
 		return v.JSON(map[string]string{"status": "deleted", "commentId": commentID})
 	}
 
-	v.Success("Deleted comment %s from %s", commentID, issueKey)
+	model := jtkpresent.CommentPresenter{}.PresentDeleted(commentID, issueKey)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
-}
-
-func formatTime(t string) string {
-	// Jira returns ISO 8601 format, just show date
-	if len(t) >= 10 {
-		return t[:10]
-	}
-	return t
 }

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -277,5 +277,5 @@ func TestRunList_MultipleCommentsFullMode(t *testing.T) {
 	output := stdout.String()
 	testutil.Contains(t, output, "First comment")
 	testutil.Contains(t, output, "Second comment")
-	testutil.Contains(t, output, "---") // separator between comments
+	// Comments are now rendered as DetailSections with blank line separators (renderer-owned)
 }

--- a/tools/jtk/internal/cmd/configcmd/configcmd.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd.go
@@ -10,8 +10,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // Register registers the config commands
@@ -45,8 +48,6 @@ func newShowCmd(opts *root.Options) *cobra.Command {
 		Short: "Show current configuration",
 		Long:  "Display the current configuration values (token is masked).",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			v := opts.View()
-
 			url := config.GetURL()
 			email := config.GetEmail()
 			token := config.GetAPIToken()
@@ -56,36 +57,37 @@ func newShowCmd(opts *root.Options) *cobra.Command {
 
 			maskedToken := maskToken(token)
 
+			// JSON output
+			if opts.Output == "json" {
+				data := map[string]string{
+					"url":             url,
+					"email":           email,
+					"api_token":       maskedToken,
+					"default_project": defaultProject,
+					"auth_method":     authMethod,
+					"cloud_id":        cloudID,
+					"path":            config.Path(),
+				}
+				return opts.View().JSON(data)
+			}
+
+			// Text output
 			_, authMethodSource := config.GetAuthMethodWithSource()
 			_, cloudIDSource := config.GetCloudIDWithSource()
 
-			headers := []string{"KEY", "VALUE", "SOURCE"}
-			rows := [][]string{
-				{"url", url, getURLSource()},
-				{"email", email, getEmailSource()},
-				{"api_token", maskedToken, getAPITokenSource()},
-				{"default_project", defaultProject, getDefaultProjectSource()},
-				{"auth_method", authMethod, authMethodSource},
-				{"cloud_id", cloudID, cloudIDSource},
+			entries := []jtkpresent.ConfigEntry{
+				{Key: "url", Value: url, Source: getURLSource()},
+				{Key: "email", Value: email, Source: getEmailSource()},
+				{Key: "api_token", Value: maskedToken, Source: getAPITokenSource()},
+				{Key: "default_project", Value: defaultProject, Source: getDefaultProjectSource()},
+				{Key: "auth_method", Value: authMethod, Source: authMethodSource},
+				{Key: "cloud_id", Value: cloudID, Source: cloudIDSource},
 			}
 
-			data := map[string]string{
-				"url":             url,
-				"email":           email,
-				"api_token":       maskedToken,
-				"default_project": defaultProject,
-				"auth_method":     authMethod,
-				"cloud_id":        cloudID,
-				"path":            config.Path(),
-			}
-
-			if err := v.Render(headers, rows, data); err != nil {
-				return err
-			}
-
-			if opts.Output != "json" {
-				v.Info("\nConfig file: %s", config.Path())
-			}
+			model := jtkpresent.ConfigPresenter{}.PresentConfigWithPath(entries, config.Path())
+			out := present.Render(model, opts.RenderStyle())
+			fmt.Fprint(opts.Stdout, out.Stdout)
+			fmt.Fprint(opts.Stderr, out.Stderr)
 			return nil
 		},
 	}
@@ -126,12 +128,14 @@ Note: Environment variables (JIRA_*, ATLASSIAN_*) will still be used if set.`,
 
 func runClear(ctx context.Context, opts *clearOptions) error {
 	_ = ctx
-	v := opts.View()
 	configPath := config.Path()
 
 	// Check if config file exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		v.Info("No configuration file found at %s", configPath)
+		model := jtkpresent.ConfigPresenter{}.PresentNoConfig(configPath)
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		fmt.Fprint(opts.Stderr, out.Stderr)
 		return nil
 	}
 
@@ -148,7 +152,10 @@ func runClear(ctx context.Context, opts *clearOptions) error {
 
 		response = strings.TrimSpace(strings.ToLower(response))
 		if response != "y" && response != "yes" {
-			v.Info("Cancelled.")
+			cancelModel := jtkpresent.ConfigPresenter{}.PresentClearCancelled()
+			cancelOut := present.Render(cancelModel, opts.RenderStyle())
+			fmt.Fprint(opts.Stdout, cancelOut.Stdout)
+			fmt.Fprint(opts.Stderr, cancelOut.Stderr)
 			return nil
 		}
 	}
@@ -157,10 +164,8 @@ func runClear(ctx context.Context, opts *clearOptions) error {
 		return err
 	}
 
-	v.Success("Configuration file removed: %s", configPath)
-
 	// Check for active environment variables
-	envVars := []string{}
+	var envVars []string
 	if os.Getenv("JIRA_URL") != "" || os.Getenv("ATLASSIAN_URL") != "" {
 		envVars = append(envVars, "URL")
 	}
@@ -171,12 +176,10 @@ func runClear(ctx context.Context, opts *clearOptions) error {
 		envVars = append(envVars, "API Token")
 	}
 
-	if len(envVars) > 0 {
-		fmt.Fprintln(opts.Stderr)
-		fmt.Fprintf(opts.Stderr, "Note: The following are still configured via environment variables: %s\n",
-			strings.Join(envVars, ", "))
-		fmt.Fprintln(opts.Stderr, "These will continue to be used. Unset them if you want to fully clear configuration.")
-	}
+	model := jtkpresent.ConfigPresenter{}.PresentClearedWithEnvVars(configPath, envVars)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
 
 	return nil
 }
@@ -264,44 +267,26 @@ pass/fail status and troubleshooting suggestions on failure.`,
 		Example: `  # Test connection
   jtk config test`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			v := opts.View()
+			result := jtkpresent.TestResult{URL: config.GetURL()}
 
-			url := config.GetURL()
-			if url == "" {
-				v.Error("No Jira URL configured")
-				v.Println("")
-				v.Info("Configure with: jtk init")
-				v.Info("Or set environment variable: JIRA_URL")
-				return nil
+			if result.URL != "" {
+				client, err := opts.APIClient()
+				if err != nil {
+					result.ClientError = err
+				} else {
+					user, err := client.GetCurrentUser(cmd.Context())
+					if err != nil {
+						result.AuthError = err
+					} else {
+						result.User = user
+					}
+				}
 			}
 
-			v.Println("Testing connection to %s...", url)
-			v.Println("")
-
-			client, err := opts.APIClient()
-			if err != nil {
-				v.Error("Failed to create client: %v", err)
-				v.Println("")
-				v.Info("Check your configuration with: jtk config show")
-				v.Info("Reconfigure with: jtk init")
-				return nil
-			}
-
-			user, err := client.GetCurrentUser(cmd.Context())
-			if err != nil {
-				v.Error("Authentication failed: %v", err)
-				v.Println("")
-				v.Info("Check your credentials with: jtk config show")
-				v.Info("Reconfigure with: jtk init")
-				return nil
-			}
-
-			v.Success("Authentication successful")
-			v.Success("API access verified")
-			v.Println("")
-			v.Println("Authenticated as: %s (%s)", user.DisplayName, user.EmailAddress)
-			v.Println("Account ID: %s", user.AccountID)
-
+			model := jtkpresent.ConfigPresenter{}.PresentTestResult(result)
+			out := present.Render(model, opts.RenderStyle())
+			fmt.Fprint(opts.Stdout, out.Stdout)
+			fmt.Fprint(opts.Stderr, out.Stderr)
 			return nil
 		},
 	}

--- a/tools/jtk/internal/cmd/configcmd/configcmd.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/present"
 
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
@@ -48,43 +49,33 @@ func newShowCmd(opts *root.Options) *cobra.Command {
 		Short: "Show current configuration",
 		Long:  "Display the current configuration values (token is masked).",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			url := config.GetURL()
-			email := config.GetEmail()
-			token := config.GetAPIToken()
-			defaultProject := config.GetDefaultProject()
-			authMethod := config.GetAuthMethod()
-			cloudID := config.GetCloudID()
-
-			maskedToken := maskToken(token)
+			cfg := config.GetValuesWithSources()
+			maskedToken := maskToken(cfg.APIToken)
 
 			// JSON output
 			if opts.Output == "json" {
 				data := map[string]string{
-					"url":             url,
-					"email":           email,
+					"url":             cfg.URL,
+					"email":           cfg.Email,
 					"api_token":       maskedToken,
-					"default_project": defaultProject,
-					"auth_method":     authMethod,
-					"cloud_id":        cloudID,
-					"path":            config.Path(),
+					"default_project": cfg.DefaultProject,
+					"auth_method":     cfg.AuthMethod,
+					"cloud_id":        cfg.CloudID,
+					"path":            cfg.Path,
 				}
 				return opts.View().JSON(data)
 			}
 
 			// Text output
-			_, authMethodSource := config.GetAuthMethodWithSource()
-			_, cloudIDSource := config.GetCloudIDWithSource()
-
-			entries := []jtkpresent.ConfigEntry{
-				{Key: "url", Value: url, Source: getURLSource()},
-				{Key: "email", Value: email, Source: getEmailSource()},
-				{Key: "api_token", Value: maskedToken, Source: getAPITokenSource()},
-				{Key: "default_project", Value: defaultProject, Source: getDefaultProjectSource()},
-				{Key: "auth_method", Value: authMethod, Source: authMethodSource},
-				{Key: "cloud_id", Value: cloudID, Source: cloudIDSource},
-			}
-
-			model := jtkpresent.ConfigPresenter{}.PresentConfigWithPath(entries, config.Path())
+			model := jtkpresent.ConfigPresenter{}.PresentConfigShow(
+				cfg.URL, cfg.URLSource,
+				cfg.Email, cfg.EmailSource,
+				maskedToken, cfg.TokenSource,
+				cfg.DefaultProject, cfg.ProjectSource,
+				cfg.AuthMethod, cfg.AuthMethodSrc,
+				cfg.CloudID, cfg.CloudIDSrc,
+				cfg.Path,
+			)
 			out := present.Render(model, opts.RenderStyle())
 			fmt.Fprint(opts.Stdout, out.Stdout)
 			fmt.Fprint(opts.Stderr, out.Stderr)
@@ -184,78 +175,6 @@ func runClear(ctx context.Context, opts *clearOptions) error {
 	return nil
 }
 
-func getURLSource() string {
-	if os.Getenv("JIRA_URL") != "" {
-		return "env (JIRA_URL)"
-	}
-	if os.Getenv("ATLASSIAN_URL") != "" {
-		return "env (ATLASSIAN_URL)"
-	}
-	cfg, err := config.Load()
-	if err != nil {
-		return "-"
-	}
-	if cfg.URL != "" {
-		return "config"
-	}
-	// Check legacy domain sources
-	if os.Getenv("JIRA_DOMAIN") != "" {
-		return "env (JIRA_DOMAIN, deprecated)"
-	}
-	if cfg.Domain != "" {
-		return "config (domain, deprecated)"
-	}
-	return "-"
-}
-
-func getEmailSource() string {
-	if os.Getenv("JIRA_EMAIL") != "" {
-		return "env (JIRA_EMAIL)"
-	}
-	if os.Getenv("ATLASSIAN_EMAIL") != "" {
-		return "env (ATLASSIAN_EMAIL)"
-	}
-	cfg, err := config.Load()
-	if err != nil {
-		return "-"
-	}
-	if cfg.Email != "" {
-		return "config"
-	}
-	return "-"
-}
-
-func getAPITokenSource() string {
-	if os.Getenv("JIRA_API_TOKEN") != "" {
-		return "env (JIRA_API_TOKEN)"
-	}
-	if os.Getenv("ATLASSIAN_API_TOKEN") != "" {
-		return "env (ATLASSIAN_API_TOKEN)"
-	}
-	cfg, err := config.Load()
-	if err != nil {
-		return "-"
-	}
-	if cfg.APIToken != "" {
-		return "config"
-	}
-	return "-"
-}
-
-func getDefaultProjectSource() string {
-	if os.Getenv("JIRA_DEFAULT_PROJECT") != "" {
-		return "env (JIRA_DEFAULT_PROJECT)"
-	}
-	cfg, err := config.Load()
-	if err != nil {
-		return "-"
-	}
-	if cfg.DefaultProject != "" {
-		return "config"
-	}
-	return "-"
-}
-
 func newTestCmd(opts *root.Options) *cobra.Command {
 	return &cobra.Command{
 		Use:   "test",
@@ -267,23 +186,20 @@ pass/fail status and troubleshooting suggestions on failure.`,
 		Example: `  # Test connection
   jtk config test`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			result := jtkpresent.TestResult{URL: config.GetURL()}
+			url := config.GetURL()
+			var user *api.User
+			var clientErr, authErr error
 
-			if result.URL != "" {
+			if url != "" {
 				client, err := opts.APIClient()
 				if err != nil {
-					result.ClientError = err
+					clientErr = err
 				} else {
-					user, err := client.GetCurrentUser(cmd.Context())
-					if err != nil {
-						result.AuthError = err
-					} else {
-						result.User = user
-					}
+					user, authErr = client.GetCurrentUser(cmd.Context())
 				}
 			}
 
-			model := jtkpresent.ConfigPresenter{}.PresentTestResult(result)
+			model := jtkpresent.ConfigPresenter{}.PresentTestResult(url, user, clientErr, authErr)
 			out := present.Render(model, opts.RenderStyle())
 			fmt.Fprint(opts.Stdout, out.Stdout)
 			fmt.Fprint(opts.Stderr, out.Stderr)

--- a/tools/jtk/internal/cmd/configcmd/configcmd_test.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd_test.go
@@ -289,7 +289,7 @@ func TestRunClear_Force(t *testing.T) {
 	testutil.True(t, os.IsNotExist(err))
 }
 
-func TestGetDefaultProjectSource(t *testing.T) {
+func TestGetDefaultProjectWithSource(t *testing.T) {
 	// Clear env vars
 	t.Setenv("JIRA_DEFAULT_PROJECT", "")
 
@@ -299,11 +299,13 @@ func TestGetDefaultProjectSource(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tempDir)
 
 	// No config, no env
-	testutil.Equal(t, getDefaultProjectSource(), "-")
+	_, source := config.GetDefaultProjectWithSource()
+	testutil.Equal(t, source, "-")
 
 	// With env var
 	t.Setenv("JIRA_DEFAULT_PROJECT", "PROJ")
-	testutil.Equal(t, getDefaultProjectSource(), "env (JIRA_DEFAULT_PROJECT)")
+	_, source = config.GetDefaultProjectWithSource()
+	testutil.Equal(t, source, "env (JIRA_DEFAULT_PROJECT)")
 }
 
 func TestShowCmd_BearerAuth_JSONOutput(t *testing.T) {

--- a/tools/jtk/internal/cmd/dashboards/dashboards.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards.go
@@ -2,13 +2,18 @@
 package dashboards
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // Register registers the dashboards commands
@@ -52,8 +57,8 @@ func newListCmd(opts *root.Options) *cobra.Command {
 		Example: `  jtk dashboards list
   jtk dashboards list --search "Sprint"
   jtk dashboards list --max 10`,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return runList(opts, search, maxResults)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runList(cmd.Context(), opts, search, maxResults)
 		},
 	}
 
@@ -63,7 +68,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
 	return cmd
 }
 
-func runList(opts *root.Options, search string, maxResults int) error {
+func runList(_ context.Context, opts *root.Options, search string, maxResults int) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -71,39 +76,39 @@ func runList(opts *root.Options, search string, maxResults int) error {
 		return err
 	}
 
+	var dashboards []api.Dashboard
+
 	if search != "" {
 		result, err := client.SearchDashboards(search, maxResults)
 		if err != nil {
 			return err
 		}
-
-		if len(result.Values) == 0 {
-			v.Info("No dashboards found matching %q", search)
-			return nil
+		dashboards = result.Values
+	} else {
+		result, err := client.GetDashboards(0, maxResults)
+		if err != nil {
+			return err
 		}
-
-		if opts.Output == "json" {
-			return v.JSON(result.Values)
-		}
-
-		return renderDashboardTable(v, result.Values)
+		dashboards = result.Dashboards
 	}
 
-	result, err := client.GetDashboards(0, maxResults)
-	if err != nil {
-		return err
-	}
-
-	if len(result.Dashboards) == 0 {
-		v.Info("No dashboards found")
+	if len(dashboards) == 0 {
+		model := jtkpresent.DashboardPresenter{}.PresentEmpty()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(result.Dashboards)
+	if v.Format == view.FormatJSON {
+		return v.JSON(dashboards)
 	}
 
-	return renderDashboardTable(v, result.Dashboards)
+	// Text path: presenter → render → write
+	model := jtkpresent.DashboardPresenter{}.PresentList(dashboards)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newGetCmd(opts *root.Options) *cobra.Command {
@@ -114,15 +119,15 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Example: `  jtk dashboards get 10001
   jtk dashboards get 10001 -o json`,
 		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			return runGet(opts, args[0])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGet(cmd.Context(), opts, args[0])
 		},
 	}
 
 	return cmd
 }
 
-func runGet(opts *root.Options, dashboardID string) error {
+func runGet(_ context.Context, opts *root.Options, dashboardID string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -136,50 +141,23 @@ func runGet(opts *root.Options, dashboardID string) error {
 	}
 
 	// Also get gadgets
-	gadgets, err := client.GetDashboardGadgets(dashboardID)
+	gadgetsResp, err := client.GetDashboardGadgets(dashboardID)
 	if err != nil {
 		return fmt.Errorf("failed to get gadgets: %w", err)
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(map[string]interface{}{
 			"dashboard": dash,
-			"gadgets":   gadgets.Gadgets,
+			"gadgets":   gadgetsResp.Gadgets,
 		})
 	}
 
-	v.Println("ID:          %s", dash.ID)
-	v.Println("Name:        %s", dash.Name)
-	if dash.Description != "" {
-		v.Println("Description: %s", dash.Description)
-	}
-	if dash.Owner != nil {
-		v.Println("Owner:       %s", dash.Owner.DisplayName)
-	}
-	if dash.View != "" {
-		v.Println("URL:         %s", dash.View)
-	}
-
-	if len(gadgets.Gadgets) > 0 {
-		v.Println("")
-		v.Println("Gadgets (%d):", len(gadgets.Gadgets))
-
-		headers := []string{"ID", "TITLE", "MODULE", "POSITION"}
-		var rows [][]string
-
-		for _, g := range gadgets.Gadgets {
-			pos := fmt.Sprintf("row=%d col=%d", g.Position.Row, g.Position.Column)
-			rows = append(rows, []string{
-				strconv.Itoa(g.ID),
-				g.Title,
-				g.ModuleID,
-				pos,
-			})
-		}
-		return v.Table(headers, rows)
-	}
-
-	v.Info("\nNo gadgets on this dashboard")
+	// Text path: presenter → render → write
+	model := jtkpresent.DashboardPresenter{}.PresentDetail(dash, gadgetsResp.Gadgets)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }
 
@@ -225,14 +203,18 @@ func runCreate(opts *root.Options, name, description string) error {
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(dash)
 	}
 
-	v.Success("Created dashboard %s (%s)", dash.Name, dash.ID)
+	var model *present.OutputModel
 	if dash.View != "" {
-		v.Info("URL: %s", dash.View)
+		model = jtkpresent.DashboardPresenter{}.PresentCreatedWithURL(dash.Name, dash.ID, dash.View)
+	} else {
+		model = jtkpresent.DashboardPresenter{}.PresentCreated(dash.Name, dash.ID)
 	}
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 
 	return nil
 }
@@ -264,11 +246,13 @@ func runDelete(opts *root.Options, dashboardID string) error {
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(map[string]string{"status": "deleted", "dashboardId": dashboardID})
 	}
 
-	v.Success("Deleted dashboard %s", dashboardID)
+	model := jtkpresent.DashboardPresenter{}.PresentDeleted(dashboardID)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }
 
@@ -293,15 +277,15 @@ func newGadgetsListCmd(opts *root.Options) *cobra.Command {
 		Example: `  jtk dashboards gadgets list 10001
   jtk dashboards gadgets list 10001 -o json`,
 		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			return runGadgetsList(opts, args[0])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGadgetsList(cmd.Context(), opts, args[0])
 		},
 	}
 
 	return cmd
 }
 
-func runGadgetsList(opts *root.Options, dashboardID string) error {
+func runGadgetsList(_ context.Context, opts *root.Options, dashboardID string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -315,28 +299,22 @@ func runGadgetsList(opts *root.Options, dashboardID string) error {
 	}
 
 	if len(result.Gadgets) == 0 {
-		v.Info("No gadgets on dashboard %s", dashboardID)
+		model := jtkpresent.DashboardPresenter{}.PresentNoGadgets(dashboardID)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(result.Gadgets)
 	}
 
-	headers := []string{"ID", "TITLE", "MODULE", "POSITION"}
-	var rows [][]string
-
-	for _, g := range result.Gadgets {
-		pos := fmt.Sprintf("row=%d col=%d", g.Position.Row, g.Position.Column)
-		rows = append(rows, []string{
-			strconv.Itoa(g.ID),
-			g.Title,
-			g.ModuleID,
-			pos,
-		})
-	}
-
-	return v.Table(headers, rows)
+	// Text path: presenter → render → write
+	model := jtkpresent.DashboardPresenter{}.PresentGadgets(result.Gadgets)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newGadgetsRemoveCmd(opts *root.Options) *cobra.Command {
@@ -370,7 +348,7 @@ func runGadgetsRemove(opts *root.Options, dashboardID string, gadgetID int) erro
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(map[string]interface{}{
 			"status":      "removed",
 			"dashboardId": dashboardID,
@@ -378,29 +356,8 @@ func runGadgetsRemove(opts *root.Options, dashboardID string, gadgetID int) erro
 		})
 	}
 
-	v.Success("Removed gadget %d from dashboard %s", gadgetID, dashboardID)
+	model := jtkpresent.DashboardPresenter{}.PresentGadgetRemoved(gadgetID, dashboardID)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
-}
-
-type viewWriter interface {
-	Table(headers []string, rows [][]string) error
-}
-
-func renderDashboardTable(v viewWriter, dashboards []api.Dashboard) error {
-	headers := []string{"ID", "NAME", "OWNER", "FAVOURITE"}
-	var rows [][]string
-
-	for _, d := range dashboards {
-		owner := ""
-		if d.Owner != nil {
-			owner = d.Owner.DisplayName
-		}
-		fav := ""
-		if d.IsFavourite {
-			fav = "yes"
-		}
-		rows = append(rows, []string{d.ID, d.Name, owner, fav})
-	}
-
-	return v.Table(headers, rows)
 }

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -2,6 +2,7 @@ package dashboards
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -32,7 +33,7 @@ func TestRunList(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(opts, "", 50)
+	err = runList(context.Background(), opts, "", 50)
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Sprint Board")
 }
@@ -56,7 +57,7 @@ func TestRunList_Search(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(opts, "Sprint", 50)
+	err = runList(context.Background(), opts, "Sprint", 50)
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Sprint Board")
 }
@@ -88,7 +89,7 @@ func TestRunGet(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGet(opts, "10001")
+	err = runGet(context.Background(), opts, "10001")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "My Dashboard")
 	testutil.Contains(t, stdout.String(), "Filter Results")
@@ -158,7 +159,7 @@ func TestRunGadgetsList(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGadgetsList(opts, "10001")
+	err = runGadgetsList(context.Background(), opts, "10001")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Filter Results")
 	testutil.Contains(t, stdout.String(), "Pie Chart")

--- a/tools/jtk/internal/cmd/fields/contexts.go
+++ b/tools/jtk/internal/cmd/fields/contexts.go
@@ -7,10 +7,13 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/prompt"
+	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newContextsCmd(opts *root.Options) *cobra.Command {
@@ -55,30 +58,32 @@ func runContextsList(ctx context.Context, opts *root.Options, fieldID string) er
 	}
 
 	if len(result.Values) == 0 {
-		v.Info("No contexts found for field %s", fieldID)
+		model := jtkpresent.FieldPresenter{}.PresentNoContexts(fieldID)
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		fmt.Fprint(opts.Stderr, out.Stderr)
 		return nil
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(result.Values)
 	}
 
-	headers := []string{"ID", "NAME", "GLOBAL", "ANY_ISSUE_TYPE"}
-	var rows [][]string
-
-	for _, ctx := range result.Values {
-		global := "no"
-		if ctx.IsGlobalContext {
-			global = "yes"
+	contexts := make([]jtkpresent.FieldContext, len(result.Values))
+	for i, ctx := range result.Values {
+		contexts[i] = jtkpresent.FieldContext{
+			ID:              ctx.ID,
+			Name:            ctx.Name,
+			IsGlobalContext: ctx.IsGlobalContext,
+			IsAnyIssueType:  ctx.IsAnyIssueType,
 		}
-		anyIssueType := "no"
-		if ctx.IsAnyIssueType {
-			anyIssueType = "yes"
-		}
-		rows = append(rows, []string{ctx.ID, ctx.Name, global, anyIssueType})
 	}
 
-	return v.Table(headers, rows)
+	model := jtkpresent.FieldPresenter{}.PresentContexts(contexts)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newContextsCreateCmd(opts *root.Options) *cobra.Command {
@@ -126,11 +131,13 @@ func runContextsCreate(ctx context.Context, opts *root.Options, fieldID, name, p
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(fc)
 	}
 
-	v.Success("Created context %s (%s)", fc.ID, fc.Name)
+	model := jtkpresent.FieldPresenter{}.PresentContextCreated(fc.ID, fc.Name)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }
 
@@ -157,8 +164,6 @@ func newContextsDeleteCmd(opts *root.Options) *cobra.Command {
 }
 
 func runContextsDelete(ctx context.Context, opts *root.Options, fieldID, contextID string, force bool) error {
-	v := opts.View()
-
 	if !force {
 		fmt.Fprintf(opts.Stderr, "This will delete context %s from field %s.\n", contextID, fieldID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
@@ -168,7 +173,10 @@ func runContextsDelete(ctx context.Context, opts *root.Options, fieldID, context
 			return fmt.Errorf("reading confirmation: %w", err)
 		}
 		if !confirmed {
-			v.Info("Deletion cancelled.")
+			model := jtkpresent.FieldPresenter{}.PresentDeleteCancelled()
+			out := present.Render(model, opts.RenderStyle())
+			fmt.Fprint(opts.Stdout, out.Stdout)
+			fmt.Fprint(opts.Stderr, out.Stderr)
 			return nil
 		}
 	}
@@ -182,6 +190,8 @@ func runContextsDelete(ctx context.Context, opts *root.Options, fieldID, context
 		return err
 	}
 
-	v.Success("Deleted context %s from field %s", contextID, fieldID)
+	model := jtkpresent.FieldPresenter{}.PresentContextDeleted(contextID, fieldID)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }

--- a/tools/jtk/internal/cmd/fields/contexts.go
+++ b/tools/jtk/internal/cmd/fields/contexts.go
@@ -69,17 +69,7 @@ func runContextsList(ctx context.Context, opts *root.Options, fieldID string) er
 		return v.JSON(result.Values)
 	}
 
-	contexts := make([]jtkpresent.FieldContext, len(result.Values))
-	for i, ctx := range result.Values {
-		contexts[i] = jtkpresent.FieldContext{
-			ID:              ctx.ID,
-			Name:            ctx.Name,
-			IsGlobalContext: ctx.IsGlobalContext,
-			IsAnyIssueType:  ctx.IsAnyIssueType,
-		}
-	}
-
-	model := jtkpresent.FieldPresenter{}.PresentContexts(contexts)
+	model := jtkpresent.FieldPresenter{}.PresentContexts(result.Values)
 	out := present.Render(model, opts.RenderStyle())
 	fmt.Fprint(opts.Stdout, out.Stdout)
 	fmt.Fprint(opts.Stderr, out.Stderr)

--- a/tools/jtk/internal/cmd/fields/fields.go
+++ b/tools/jtk/internal/cmd/fields/fields.go
@@ -7,10 +7,13 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/prompt"
+	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // Register registers the fields commands
@@ -92,26 +95,22 @@ func runList(ctx context.Context, opts *root.Options, customOnly bool, nameFilte
 	}
 
 	if len(fields) == 0 {
-		v.Info("No fields found")
+		model := jtkpresent.FieldPresenter{}.PresentEmpty()
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		fmt.Fprint(opts.Stderr, out.Stderr)
 		return nil
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(fields)
 	}
 
-	headers := []string{"ID", "NAME", "TYPE", "CUSTOM"}
-	var rows [][]string
-
-	for _, f := range fields {
-		custom := "no"
-		if f.Custom {
-			custom = "yes"
-		}
-		rows = append(rows, []string{f.ID, f.Name, f.Schema.Type, custom})
-	}
-
-	return v.Table(headers, rows)
+	model := jtkpresent.FieldPresenter{}.PresentList(fields)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newCreateCmd(opts *root.Options) *cobra.Command {
@@ -165,11 +164,13 @@ func runCreate(ctx context.Context, opts *root.Options, name, fieldType, descrip
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(field)
 	}
 
-	v.Success("Created field %s (%s)", field.ID, field.Name)
+	model := jtkpresent.FieldPresenter{}.PresentCreated(field.ID, field.Name)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }
 
@@ -200,8 +201,6 @@ Trashed fields are permanently deleted after 60 days.`,
 }
 
 func runDelete(ctx context.Context, opts *root.Options, fieldID string, force bool) error {
-	v := opts.View()
-
 	if !force {
 		fmt.Fprintf(opts.Stderr, "This will trash field %s. It can be restored later.\n", fieldID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
@@ -211,7 +210,10 @@ func runDelete(ctx context.Context, opts *root.Options, fieldID string, force bo
 			return fmt.Errorf("reading confirmation: %w", err)
 		}
 		if !confirmed {
-			v.Info("Deletion cancelled.")
+			model := jtkpresent.FieldPresenter{}.PresentDeleteCancelled()
+			out := present.Render(model, opts.RenderStyle())
+			fmt.Fprint(opts.Stdout, out.Stdout)
+			fmt.Fprint(opts.Stderr, out.Stderr)
 			return nil
 		}
 	}
@@ -225,7 +227,9 @@ func runDelete(ctx context.Context, opts *root.Options, fieldID string, force bo
 		return err
 	}
 
-	v.Success("Trashed field %s", fieldID)
+	model := jtkpresent.FieldPresenter{}.PresentTrashed(fieldID)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }
 
@@ -244,8 +248,6 @@ func newRestoreCmd(opts *root.Options) *cobra.Command {
 }
 
 func runRestore(ctx context.Context, opts *root.Options, fieldID string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -255,6 +257,8 @@ func runRestore(ctx context.Context, opts *root.Options, fieldID string) error {
 		return err
 	}
 
-	v.Success("Restored field %s", fieldID)
+	model := jtkpresent.FieldPresenter{}.PresentRestored(fieldID)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }

--- a/tools/jtk/internal/cmd/fields/options.go
+++ b/tools/jtk/internal/cmd/fields/options.go
@@ -6,10 +6,13 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/prompt"
+	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newOptionsCmd(opts *root.Options) *cobra.Command {
@@ -84,26 +87,31 @@ func runOptionsList(ctx context.Context, opts *root.Options, fieldID, contextFla
 	}
 
 	if len(result.Values) == 0 {
-		v.Info("No options found for field %s", fieldID)
+		model := jtkpresent.FieldPresenter{}.PresentNoOptions(fieldID)
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		fmt.Fprint(opts.Stderr, out.Stderr)
 		return nil
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(result.Values)
 	}
 
-	headers := []string{"ID", "VALUE", "DISABLED"}
-	var rows [][]string
-
-	for _, opt := range result.Values {
-		disabled := "no"
-		if opt.Disabled {
-			disabled = "yes"
+	options := make([]jtkpresent.FieldContextOption, len(result.Values))
+	for i, opt := range result.Values {
+		options[i] = jtkpresent.FieldContextOption{
+			ID:       opt.ID,
+			Value:    opt.Value,
+			Disabled: opt.Disabled,
 		}
-		rows = append(rows, []string{opt.ID, opt.Value, disabled})
 	}
 
-	return v.Table(headers, rows)
+	model := jtkpresent.FieldPresenter{}.PresentContextOptions(options)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newOptionsAddCmd(opts *root.Options) *cobra.Command {
@@ -154,15 +162,19 @@ func runOptionsAdd(ctx context.Context, opts *root.Options, fieldID, value, cont
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(options)
 	}
 
+	optionID := ""
+	optionValue := value
 	if len(options) > 0 {
-		v.Success("Added option %s (%s)", options[0].ID, options[0].Value)
-	} else {
-		v.Success("Added option %s", value)
+		optionID = options[0].ID
+		optionValue = options[0].Value
 	}
+	model := jtkpresent.FieldPresenter{}.PresentOptionAdded(optionID, optionValue)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }
 
@@ -213,11 +225,13 @@ func runOptionsUpdate(ctx context.Context, opts *root.Options, fieldID, optionID
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(options)
 	}
 
-	v.Success("Updated option %s", optionID)
+	model := jtkpresent.FieldPresenter{}.PresentOptionUpdated(optionID)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }
 
@@ -250,8 +264,6 @@ func newOptionsDeleteCmd(opts *root.Options) *cobra.Command {
 }
 
 func runOptionsDelete(ctx context.Context, opts *root.Options, fieldID, optionID, contextFlag string, force bool) error {
-	v := opts.View()
-
 	if !force {
 		fmt.Fprintf(opts.Stderr, "This will delete option %s from field %s.\n", optionID, fieldID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
@@ -261,7 +273,10 @@ func runOptionsDelete(ctx context.Context, opts *root.Options, fieldID, optionID
 			return fmt.Errorf("reading confirmation: %w", err)
 		}
 		if !confirmed {
-			v.Info("Deletion cancelled.")
+			model := jtkpresent.FieldPresenter{}.PresentDeleteCancelled()
+			out := present.Render(model, opts.RenderStyle())
+			fmt.Fprint(opts.Stdout, out.Stdout)
+			fmt.Fprint(opts.Stderr, out.Stderr)
 			return nil
 		}
 	}
@@ -280,6 +295,8 @@ func runOptionsDelete(ctx context.Context, opts *root.Options, fieldID, optionID
 		return err
 	}
 
-	v.Success("Deleted option %s from field %s", optionID, fieldID)
+	model := jtkpresent.FieldPresenter{}.PresentOptionDeleted(optionID, fieldID)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }

--- a/tools/jtk/internal/cmd/fields/options.go
+++ b/tools/jtk/internal/cmd/fields/options.go
@@ -98,16 +98,7 @@ func runOptionsList(ctx context.Context, opts *root.Options, fieldID, contextFla
 		return v.JSON(result.Values)
 	}
 
-	options := make([]jtkpresent.FieldContextOption, len(result.Values))
-	for i, opt := range result.Values {
-		options[i] = jtkpresent.FieldContextOption{
-			ID:       opt.ID,
-			Value:    opt.Value,
-			Disabled: opt.Disabled,
-		}
-	}
-
-	model := jtkpresent.FieldPresenter{}.PresentContextOptions(options)
+	model := jtkpresent.FieldPresenter{}.PresentContextOptions(result.Values)
 	out := present.Render(model, opts.RenderStyle())
 	fmt.Fprint(opts.Stdout, out.Stdout)
 	fmt.Fprint(opts.Stderr, out.Stderr)

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -1,4 +1,10 @@
 // Package initcmd provides the interactive setup wizard for the jtk CLI.
+//
+// This package intentionally uses direct view output (v.Println, v.Success, etc.)
+// rather than the presenter pattern used elsewhere. The presenter model is designed
+// for structured results (tables, detail views, messages) that get rendered once.
+// Interactive wizards have a different flow: prompts, stdin reads, progressive
+// feedback, and conversational back-and-forth that doesn't fit that model cleanly.
 package initcmd
 
 import (

--- a/tools/jtk/internal/cmd/issues/assign.go
+++ b/tools/jtk/internal/cmd/issues/assign.go
@@ -3,10 +3,14 @@ package issues
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newAssignCmd(opts *root.Options) *cobra.Command {
@@ -37,8 +41,6 @@ func newAssignCmd(opts *root.Options) *cobra.Command {
 }
 
 func runAssign(ctx context.Context, opts *root.Options, issueKey, accountID string, unassign bool) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -52,16 +54,18 @@ func runAssign(ctx context.Context, opts *root.Options, issueKey, accountID stri
 		return err
 	}
 
-	if unassign || accountID == "" {
-		v.Success("Unassigned issue %s", issueKey)
-	} else {
-		// Try to get the user's display name for a friendlier message
-		displayName := accountID
+	// Resolve display name for a friendlier message
+	displayName := ""
+	if !unassign && accountID != "" {
+		displayName = accountID
 		if user, err := client.GetUser(ctx, accountID); err == nil && user.DisplayName != "" {
 			displayName = user.DisplayName
 		}
-		v.Success("Assigned issue %s to %s", issueKey, displayName)
 	}
 
+	model := jtkpresent.IssuePresenter{}.PresentAssigned(issueKey, displayName)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/issues/create.go
+++ b/tools/jtk/internal/cmd/issues/create.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/text"
 )
 
@@ -132,8 +135,10 @@ func runCreate(ctx context.Context, opts *root.Options, project, issueType, summ
 		return v.JSON(issue)
 	}
 
-	v.Success("Created issue %s", issue.Key)
-	v.Info("URL: %s", client.IssueURL(issue.Key))
-
+	// Success message includes the URL for convenience
+	model := jtkpresent.IssuePresenter{}.PresentCreated(issue.Key, client.IssueURL(issue.Key))
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/issues/delete.go
+++ b/tools/jtk/internal/cmd/issues/delete.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/prompt"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {
@@ -35,9 +37,8 @@ func newDeleteCmd(opts *root.Options) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, opts *root.Options, issueKey string, force bool) error {
-	v := opts.View()
-
 	if !force {
+		// Interactive prompt goes directly to stderr
 		fmt.Fprintf(opts.Stderr, "This will permanently delete issue %s. This action cannot be undone.\n", issueKey)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
 
@@ -46,7 +47,9 @@ func runDelete(ctx context.Context, opts *root.Options, issueKey string, force b
 			return fmt.Errorf("reading confirmation: %w", err)
 		}
 		if !confirmed {
-			v.Info("Deletion cancelled.")
+			model := jtkpresent.IssuePresenter{}.PresentDeleteCancelled()
+			out := present.Render(model, opts.RenderStyle())
+			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 			return nil
 		}
 	}
@@ -60,6 +63,9 @@ func runDelete(ctx context.Context, opts *root.Options, issueKey string, force b
 		return err
 	}
 
-	v.Success("Deleted issue %s", issueKey)
+	model := jtkpresent.IssuePresenter{}.PresentDeleted(issueKey)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/issues/field_options.go
+++ b/tools/jtk/internal/cmd/issues/field_options.go
@@ -6,8 +6,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newFieldOptionsCmd(opts *root.Options) *cobra.Command {
@@ -38,6 +41,7 @@ Without --issue, attempts to show all possible values for the field.`,
 
 func runFieldOptions(ctx context.Context, opts *root.Options, fieldNameOrID, issueKey string) error {
 	v := opts.View()
+	fp := jtkpresent.FieldPresenter{}
 
 	client, err := opts.APIClient()
 	if err != nil {
@@ -76,13 +80,17 @@ func runFieldOptions(ctx context.Context, opts *root.Options, fieldNameOrID, iss
 		// Try to get options without issue context
 		options, err = client.GetFieldOptions(ctx, fieldID)
 		if err != nil {
-			v.Warning("Could not get field options without issue context. Use --issue flag for better results.")
+			warnModel := fp.PresentOptionsNoContext()
+			warnOut := present.Render(warnModel, opts.RenderStyle())
+			_, _ = fmt.Fprint(opts.Stderr, warnOut.Stderr)
 			return fmt.Errorf("getting options for field %s: %w", fieldName, err)
 		}
 	}
 
 	if len(options) == 0 {
-		v.Info("No options found for field '%s'", fieldName)
+		model := fp.PresentNoOptions(fieldID)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
@@ -90,23 +98,25 @@ func runFieldOptions(ctx context.Context, opts *root.Options, fieldNameOrID, iss
 		return v.JSON(options)
 	}
 
-	// Display options table
-	v.Info("Allowed values for field '%s':", fieldName)
-
-	headers := []string{"VALUE", "ID"}
-	var rows [][]string
-
-	for _, opt := range options {
+	// Build field options list
+	fieldOpts := make([]jtkpresent.FieldOption, len(options))
+	for i, opt := range options {
 		value := opt.Value
 		if value == "" {
 			value = opt.Name
 		}
-		id := opt.ID
 		if opt.Disabled {
 			value = value + " (disabled)"
 		}
-		rows = append(rows, []string{value, id})
+		fieldOpts[i] = jtkpresent.FieldOption{
+			ID:    opt.ID,
+			Value: value,
+		}
 	}
 
-	return v.Table(headers, rows)
+	model := fp.PresentFieldOptionsWithHeader(fieldName, fieldOpts)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }

--- a/tools/jtk/internal/cmd/issues/field_options.go
+++ b/tools/jtk/internal/cmd/issues/field_options.go
@@ -98,23 +98,7 @@ func runFieldOptions(ctx context.Context, opts *root.Options, fieldNameOrID, iss
 		return v.JSON(options)
 	}
 
-	// Build field options list
-	fieldOpts := make([]jtkpresent.FieldOption, len(options))
-	for i, opt := range options {
-		value := opt.Value
-		if value == "" {
-			value = opt.Name
-		}
-		if opt.Disabled {
-			value = value + " (disabled)"
-		}
-		fieldOpts[i] = jtkpresent.FieldOption{
-			ID:    opt.ID,
-			Value: value,
-		}
-	}
-
-	model := fp.PresentFieldOptionsWithHeader(fieldName, fieldOpts)
+	model := fp.PresentFieldOptionsWithHeader(fieldName, options)
 	out := present.Render(model, opts.RenderStyle())
 	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)

--- a/tools/jtk/internal/cmd/issues/fields.go
+++ b/tools/jtk/internal/cmd/issues/fields.go
@@ -2,11 +2,15 @@ package issues
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newFieldsCmd(opts *root.Options) *cobra.Command {
@@ -61,12 +65,14 @@ func runFields(ctx context.Context, opts *root.Options, issueKey string, customO
 		// Extract field information from metadata
 		fieldsData, ok := meta["fields"].(map[string]any)
 		if !ok {
-			v.Info("No editable fields found for %s", issueKey)
+			model := jtkpresent.IssuePresenter{}.PresentNoEditableFields(issueKey)
+			out := present.Render(model, opts.RenderStyle())
+			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 			return nil
 		}
 
-		headers := []string{"ID", "NAME", "TYPE", "REQUIRED"}
-		rows := make([][]string, 0, len(fieldsData))
+		// Build editable fields list
+		editableFields := make([]jtkpresent.EditableField, 0, len(fieldsData))
 
 		for id, data := range fieldsData {
 			fieldData, ok := data.(map[string]any)
@@ -75,9 +81,9 @@ func runFields(ctx context.Context, opts *root.Options, issueKey string, customO
 			}
 
 			name := safeString(fieldData["name"])
-			required := "no"
+			required := false
 			if req, ok := fieldData["required"].(bool); ok && req {
-				required = "yes"
+				required = true
 			}
 
 			// Get schema type
@@ -86,10 +92,19 @@ func runFields(ctx context.Context, opts *root.Options, issueKey string, customO
 				fieldType = safeString(schema["type"])
 			}
 
-			rows = append(rows, []string{id, name, fieldType, required})
+			editableFields = append(editableFields, jtkpresent.EditableField{
+				ID:       id,
+				Name:     name,
+				Type:     fieldType,
+				Required: required,
+			})
 		}
 
-		return v.Table(headers, rows)
+		model := jtkpresent.FieldPresenter{}.PresentEditableFields(editableFields)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+		return nil
 	}
 
 	// List all fields
@@ -108,16 +123,9 @@ func runFields(ctx context.Context, opts *root.Options, issueKey string, customO
 		return v.JSON(fields)
 	}
 
-	headers := []string{"ID", "NAME", "TYPE", "CUSTOM"}
-	rows := make([][]string, 0, len(fields))
-
-	for _, f := range fields {
-		custom := "no"
-		if f.Custom {
-			custom = "yes"
-		}
-		rows = append(rows, []string{f.ID, f.Name, f.Schema.Type, custom})
-	}
-
-	return v.Table(headers, rows)
+	model := jtkpresent.FieldPresenter{}.PresentList(fields)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }

--- a/tools/jtk/internal/cmd/issues/fields.go
+++ b/tools/jtk/internal/cmd/issues/fields.go
@@ -71,35 +71,7 @@ func runFields(ctx context.Context, opts *root.Options, issueKey string, customO
 			return nil
 		}
 
-		// Build editable fields list
-		editableFields := make([]jtkpresent.EditableField, 0, len(fieldsData))
-
-		for id, data := range fieldsData {
-			fieldData, ok := data.(map[string]any)
-			if !ok {
-				continue
-			}
-
-			name := safeString(fieldData["name"])
-			required := false
-			if req, ok := fieldData["required"].(bool); ok && req {
-				required = true
-			}
-
-			// Get schema type
-			fieldType := ""
-			if schema, ok := fieldData["schema"].(map[string]any); ok {
-				fieldType = safeString(schema["type"])
-			}
-
-			editableFields = append(editableFields, jtkpresent.EditableField{
-				ID:       id,
-				Name:     name,
-				Type:     fieldType,
-				Required: required,
-			})
-		}
-
+		editableFields := api.ParseEditMeta(fieldsData)
 		model := jtkpresent.FieldPresenter{}.PresentEditableFields(editableFields)
 		out := present.Render(model, opts.RenderStyle())
 		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newGetCmd(opts *root.Options) *cobra.Command {
@@ -51,77 +53,12 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		return v.RenderArtifact(jtkartifact.ProjectIssue(issue, opts.ArtifactMode()))
 	}
 
-	// For table/plain output, display key details
-	status := ""
-	if issue.Fields.Status != nil {
-		status = issue.Fields.Status.Name
-	}
-
-	issueType := ""
-	if issue.Fields.IssueType != nil {
-		issueType = issue.Fields.IssueType.Name
-	}
-
-	assignee := "Unassigned"
-	if issue.Fields.Assignee != nil {
-		assignee = issue.Fields.Assignee.DisplayName
-	}
-
-	priority := ""
-	if issue.Fields.Priority != nil {
-		priority = issue.Fields.Priority.Name
-	}
-
-	project := ""
-	if issue.Fields.Project != nil {
-		project = issue.Fields.Project.Key
-	}
-
-	description := ""
-	if issue.Fields.Description != nil {
-		description = issue.Fields.Description.ToPlainText()
-		if !noTruncate && len(description) > 200 {
-			description = description[:200] + "... [truncated, use --no-truncate for complete text]"
-		}
-	}
-
-	v.Println("Key:         %s", issue.Key)
-	v.Println("Summary:     %s", issue.Fields.Summary)
-	v.Println("Status:      %s", status)
-	v.Println("Type:        %s", issueType)
-	v.Println("Priority:    %s", priority)
-	v.Println("Assignee:    %s", assignee)
-	v.Println("Project:     %s", project)
-	if description != "" {
-		v.Println("Description: %s", description)
-	}
-	v.Println("URL:         %s", client.IssueURL(issue.Key))
-
+	// Text path: presenter → render → write
+	model := jtkpresent.IssuePresenter{}.PresentDetail(issue, client.IssueURL(issue.Key), noTruncate)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
-}
-
-func orDash(s string) string {
-	if s == "" {
-		return "-"
-	}
-	return s
-}
-
-func formatAssignee(name string) string {
-	if name == "" {
-		return "Unassigned"
-	}
-	return name
-}
-
-func formatIssueRow(key, summary, status, assignee, issueType string) []string {
-	return []string{
-		key,
-		view.Truncate(summary, 50),
-		orDash(status),
-		formatAssignee(assignee),
-		orDash(issueType),
-	}
 }
 
 // safeString extracts string from an interface value

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -60,14 +60,3 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }
-
-// safeString extracts string from an interface value
-func safeString(v any) string {
-	if v == nil {
-		return ""
-	}
-	if s, ok := v.(string); ok {
-		return s
-	}
-	return fmt.Sprintf("%v", v)
-}

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -7,11 +7,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newListCmd(opts *root.Options) *cobra.Command {
@@ -106,7 +108,9 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 	}
 
 	if len(result.Issues) == 0 {
-		v.Info("No issues found")
+		model := jtkpresent.IssuePresenter{}.PresentEmpty()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
@@ -117,36 +121,12 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	headers := []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"}
-	rows := make([][]string, 0, len(result.Issues))
-
-	for _, issue := range result.Issues {
-		status := ""
-		if issue.Fields.Status != nil {
-			status = issue.Fields.Status.Name
-		}
-
-		assignee := ""
-		if issue.Fields.Assignee != nil {
-			assignee = issue.Fields.Assignee.DisplayName
-		}
-
-		issueType := ""
-		if issue.Fields.IssueType != nil {
-			issueType = issue.Fields.IssueType.Name
-		}
-
-		rows = append(rows, formatIssueRow(issue.Key, issue.Fields.Summary, status, assignee, issueType))
-	}
-
-	if err := v.Table(headers, rows); err != nil {
-		return err
-	}
-
-	// Print pagination footer on stderr when there are more results
-	if !result.Pagination.IsLast {
-		v.Info("More results available (use --next-page-token to fetch next page)")
-	}
+	// Text path: presenter → render → write
+	hasMore := !result.Pagination.IsLast
+	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, hasMore)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 
 	return nil
 }

--- a/tools/jtk/internal/cmd/issues/move.go
+++ b/tools/jtk/internal/cmd/issues/move.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newMoveCmd(opts *root.Options) *cobra.Command {
@@ -64,7 +67,7 @@ Limitations:
 }
 
 func runMove(ctx context.Context, opts *root.Options, issueKeys []string, targetProject, targetType string, notify, wait bool) error {
-	v := opts.View()
+	ip := jtkpresent.IssuePresenter{}
 
 	if len(issueKeys) > 1000 {
 		return fmt.Errorf("cannot move more than 1000 issues at once (got %d)", len(issueKeys))
@@ -122,17 +125,23 @@ func runMove(ctx context.Context, opts *root.Options, issueKeys []string, target
 	}
 
 	if targetIssueType == nil {
-		v.Error("Issue type not found in target project")
-		v.Info("Available types in %s:", targetProject)
+		var availableTypes []string
 		for _, t := range issueTypes {
 			if !t.Subtask {
-				v.Info("  - %s", t.Name)
+				availableTypes = append(availableTypes, t.Name)
 			}
 		}
+		model := ip.PresentTypeNotFound(targetType, targetProject, availableTypes)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 		return fmt.Errorf("issue type not found: %s", targetType)
 	}
 
-	v.Info("Moving %d issue(s) to %s (%s)...", len(issueKeys), targetProject, targetIssueType.Name)
+	// Progress message to stderr
+	progressModel := ip.PresentMoveProgress(len(issueKeys), targetProject, targetIssueType.Name)
+	progressOut := present.Render(progressModel, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stderr, progressOut.Stderr)
 
 	// Build and execute the move request
 	req := api.BuildMoveRequest(issueKeys, targetProject, targetIssueType.ID, notify)
@@ -147,13 +156,17 @@ func runMove(ctx context.Context, opts *root.Options, issueKeys []string, target
 	}
 
 	if !wait {
-		v.Success("Move initiated (Task ID: %s)", resp.TaskID)
-		v.Info("Check status with: jtk issues move-status %s", resp.TaskID)
+		model := ip.PresentMoveInitiated(resp.TaskID)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 		return nil
 	}
 
-	// Wait for completion
-	v.Info("Waiting for move to complete...")
+	// Wait for completion - progress to stderr
+	waitModel := ip.PresentMoveWaiting()
+	waitOut := present.Render(waitModel, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stderr, waitOut.Stderr)
 
 	for {
 		status, err := client.GetMoveTaskStatus(ctx, resp.TaskID)
@@ -164,16 +177,19 @@ func runMove(ctx context.Context, opts *root.Options, issueKeys []string, target
 		switch status.Status {
 		case "COMPLETE":
 			if status.Result != nil && len(status.Result.Failed) > 0 {
-				v.Warning("Move completed with errors")
-				for _, failed := range status.Result.Failed {
-					v.Error("  %s: %s", failed.IssueKey, strings.Join(failed.Errors, ", "))
+				failed := make([]jtkpresent.MoveFailedIssue, len(status.Result.Failed))
+				for i, f := range status.Result.Failed {
+					failed[i] = jtkpresent.MoveFailedIssue{Key: f.IssueKey, Errors: f.Errors}
 				}
-				if len(status.Result.Successful) > 0 {
-					v.Success("Successfully moved: %s", strings.Join(status.Result.Successful, ", "))
-				}
+				model := ip.PresentMovePartialFailure(status.Result.Successful, failed)
+				out := present.Render(model, opts.RenderStyle())
+				_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+				_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 				return fmt.Errorf("some issues failed to move")
 			}
-			v.Success("Moved %d issue(s) to %s", len(issueKeys), targetProject)
+			model := ip.PresentMoved(len(issueKeys), targetProject)
+			out := present.Render(model, opts.RenderStyle())
+			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 			return nil
 
 		case "FAILED":
@@ -225,30 +241,9 @@ func runMoveStatus(ctx context.Context, opts *root.Options, taskID string) error
 		return v.JSON(status)
 	}
 
-	v.Println("Task ID:     %s", status.TaskID)
-	v.Println("Status:      %s", status.Status)
-	v.Println("Progress:    %d%%", status.Progress)
-	v.Println("Submitted:   %s", status.SubmittedAt)
-
-	if status.StartedAt != "" {
-		v.Println("Started:     %s", status.StartedAt)
-	}
-	if status.FinishedAt != "" {
-		v.Println("Finished:    %s", status.FinishedAt)
-	}
-
-	if status.Result != nil {
-		v.Println("")
-		if len(status.Result.Successful) > 0 {
-			v.Success("Successful: %s", strings.Join(status.Result.Successful, ", "))
-		}
-		if len(status.Result.Failed) > 0 {
-			v.Error("Failed:")
-			for _, failed := range status.Result.Failed {
-				v.Error("  %s: %s", failed.IssueKey, strings.Join(failed.Errors, ", "))
-			}
-		}
-	}
-
+	model := jtkpresent.IssuePresenter{}.PresentMoveStatus(status)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/issues/move.go
+++ b/tools/jtk/internal/cmd/issues/move.go
@@ -177,11 +177,7 @@ func runMove(ctx context.Context, opts *root.Options, issueKeys []string, target
 		switch status.Status {
 		case "COMPLETE":
 			if status.Result != nil && len(status.Result.Failed) > 0 {
-				failed := make([]jtkpresent.MoveFailedIssue, len(status.Result.Failed))
-				for i, f := range status.Result.Failed {
-					failed[i] = jtkpresent.MoveFailedIssue{Key: f.IssueKey, Errors: f.Errors}
-				}
-				model := ip.PresentMovePartialFailure(status.Result.Successful, failed)
+				model := ip.PresentMovePartialFailure(status.Result.Successful, status.Result.Failed)
 				out := present.Render(model, opts.RenderStyle())
 				_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 				_, _ = fmt.Fprint(opts.Stderr, out.Stderr)

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -2,15 +2,18 @@ package issues
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newSearchCmd(opts *root.Options) *cobra.Command {
@@ -77,7 +80,9 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 	}
 
 	if len(result.Issues) == 0 {
-		v.Info("No issues found")
+		model := jtkpresent.IssuePresenter{}.PresentEmpty()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
@@ -87,35 +92,12 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	headers := []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"}
-	rows := make([][]string, 0, len(result.Issues))
-
-	for _, issue := range result.Issues {
-		status := ""
-		if issue.Fields.Status != nil {
-			status = issue.Fields.Status.Name
-		}
-
-		assignee := ""
-		if issue.Fields.Assignee != nil {
-			assignee = issue.Fields.Assignee.DisplayName
-		}
-
-		issueType := ""
-		if issue.Fields.IssueType != nil {
-			issueType = issue.Fields.IssueType.Name
-		}
-
-		rows = append(rows, formatIssueRow(issue.Key, issue.Fields.Summary, status, assignee, issueType))
-	}
-
-	if err := v.Table(headers, rows); err != nil {
-		return err
-	}
-
-	if !result.Pagination.IsLast {
-		v.Info("More results available (use --next-page-token to fetch next page)")
-	}
+	// Text path: presenter → render → write
+	hasMore := !result.Pagination.IsLast
+	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, hasMore)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 
 	return nil
 }

--- a/tools/jtk/internal/cmd/issues/types.go
+++ b/tools/jtk/internal/cmd/issues/types.go
@@ -2,12 +2,14 @@ package issues
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/view"
+	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newTypesCmd(opts *root.Options) *cobra.Command {
@@ -51,20 +53,16 @@ func runTypes(ctx context.Context, opts *root.Options, project string) error {
 	}
 
 	if len(projectDetail.IssueTypes) == 0 {
-		v.Info("No issue types found for project %s", project)
+		model := jtkpresent.IssuePresenter{}.PresentNoTypes(project)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
-	headers := []string{"ID", "NAME", "SUBTASK", "DESCRIPTION"}
-	var rows [][]string
-
-	for _, t := range projectDetail.IssueTypes {
-		subtask := "no"
-		if t.Subtask {
-			subtask = "yes"
-		}
-		rows = append(rows, []string{t.ID, t.Name, subtask, view.Truncate(t.Description, 60)})
-	}
-
-	return v.Table(headers, rows)
+	// Text path: presenter → render → write
+	model := jtkpresent.IssuePresenter{}.PresentTypes(projectDetail.IssueTypes)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/text"
 )
 
@@ -65,8 +68,6 @@ transparently (since the standard update API does not support type changes).`,
 }
 
 func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, description, parent, assignee, issueType string, fieldArgs []string) error {
-	v := opts.View()
-
 	// Validate that at least one field is being updated before making API calls
 	if summary == "" && description == "" && parent == "" && assignee == "" && issueType == "" && len(fieldArgs) == 0 {
 		return fmt.Errorf("no fields specified to update")
@@ -79,7 +80,7 @@ func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, descr
 
 	// Handle type change via the move API
 	if issueType != "" {
-		if err := changeIssueType(ctx, client, v, issueKey, issueType); err != nil {
+		if err := changeIssueType(ctx, client, opts, issueKey, issueType); err != nil {
 			return err
 		}
 	}
@@ -160,14 +161,14 @@ func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, descr
 		return err
 	}
 
-	v.Success("Updated issue %s", issueKey)
+	model := jtkpresent.IssuePresenter{}.PresentUpdated(issueKey)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }
 
-func changeIssueType(ctx context.Context, client *api.Client, v interface {
-	Info(string, ...any)
-	Success(string, ...any)
-}, issueKey, targetTypeName string) error {
+func changeIssueType(ctx context.Context, client *api.Client, opts *root.Options, issueKey, targetTypeName string) error {
 	// Get the issue to find its project
 	issue, err := client.GetIssue(ctx, issueKey)
 	if err != nil {
@@ -181,7 +182,10 @@ func changeIssueType(ctx context.Context, client *api.Client, v interface {
 
 	// Check if the type is already correct
 	if issue.Fields.IssueType != nil && strings.EqualFold(issue.Fields.IssueType.Name, targetTypeName) {
-		v.Info("Issue %s is already type %s", issueKey, targetTypeName)
+		model := jtkpresent.IssuePresenter{}.PresentTypeAlreadyCurrent(issueKey, targetTypeName)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 		return nil
 	}
 
@@ -209,7 +213,10 @@ func changeIssueType(ctx context.Context, client *api.Client, v interface {
 		return fmt.Errorf("issue type %q not found in project %s (available: %s)", targetTypeName, projectKey, strings.Join(available, ", "))
 	}
 
-	v.Info("Changing %s type to %s...", issueKey, targetIssueType.Name)
+	// Progress message to stderr (advisory)
+	advisory := jtkpresent.IssuePresenter{}.PresentTypeChangeProgress(issueKey, targetIssueType.Name)
+	advOut := present.Render(advisory, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stderr, advOut.Stderr)
 
 	// Use the move API to change the type within the same project
 	req := api.BuildMoveRequest([]string{issueKey}, projectKey, targetIssueType.ID, false)
@@ -236,7 +243,9 @@ func changeIssueType(ctx context.Context, client *api.Client, v interface {
 					return fmt.Errorf("type change failed for %s: %s", failed.IssueKey, strings.Join(failed.Errors, ", "))
 				}
 			}
-			v.Success("Changed %s type to %s", issueKey, targetIssueType.Name)
+			model := jtkpresent.IssuePresenter{}.PresentTypeChanged(issueKey, targetIssueType.Name)
+			out := present.Render(model, opts.RenderStyle())
+			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 			return nil
 
 		case "FAILED":

--- a/tools/jtk/internal/cmd/links/links.go
+++ b/tools/jtk/internal/cmd/links/links.go
@@ -7,8 +7,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // Register registers the links commands
@@ -58,42 +62,22 @@ func runList(opts *root.Options, issueKey string) error {
 	}
 
 	if len(links) == 0 {
-		v.Info("No links on %s", issueKey)
+		model := jtkpresent.LinkPresenter{}.PresentEmpty(issueKey)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(links)
 	}
 
-	headers := []string{"ID", "TYPE", "DIRECTION", "ISSUE", "SUMMARY"}
-	var rows [][]string
-
-	for _, link := range links {
-		var direction, key, summary string
-
-		if link.OutwardIssue != nil {
-			// OutwardIssue is set → current issue is the inward side
-			direction = link.Type.Inward
-			key = link.OutwardIssue.Key
-			summary = link.OutwardIssue.Fields.Summary
-		} else if link.InwardIssue != nil {
-			// InwardIssue is set → current issue is the outward side
-			direction = link.Type.Outward
-			key = link.InwardIssue.Key
-			summary = link.InwardIssue.Fields.Summary
-		}
-
-		rows = append(rows, []string{
-			link.ID,
-			link.Type.Name,
-			direction,
-			key,
-			summary,
-		})
-	}
-
-	return v.Table(headers, rows)
+	// Text path: presenter → render → write
+	model := jtkpresent.LinkPresenter{}.PresentList(links)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newCreateCmd(opts *root.Options) *cobra.Command {
@@ -161,7 +145,7 @@ func runCreate(opts *root.Options, outwardKey, inwardKey, linkType string) error
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(map[string]string{
 			"status":       "created",
 			"outwardIssue": outwardKey,
@@ -170,7 +154,9 @@ func runCreate(opts *root.Options, outwardKey, inwardKey, linkType string) error
 		})
 	}
 
-	v.Success("Created %s link: %s → %s", linkType, outwardKey, inwardKey)
+	model := jtkpresent.LinkPresenter{}.PresentCreated(linkType, outwardKey, inwardKey)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }
 
@@ -202,11 +188,13 @@ func runDelete(opts *root.Options, linkID string) error {
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(map[string]string{"status": "deleted", "linkId": linkID})
 	}
 
-	v.Success("Deleted link %s", linkID)
+	model := jtkpresent.LinkPresenter{}.PresentDeleted(linkID)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }
 
@@ -239,27 +227,22 @@ func runTypes(opts *root.Options) error {
 	}
 
 	if len(linkTypes) == 0 {
-		v.Info("No link types available")
+		model := jtkpresent.LinkPresenter{}.PresentNoTypes()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(linkTypes)
 	}
 
-	headers := []string{"ID", "NAME", "OUTWARD", "INWARD"}
-	var rows [][]string
-
-	for _, lt := range linkTypes {
-		rows = append(rows, []string{
-			lt.ID,
-			lt.Name,
-			lt.Outward,
-			lt.Inward,
-		})
-	}
-
-	return v.Table(headers, rows)
+	// Text path: presenter → render → write
+	model := jtkpresent.LinkPresenter{}.PresentTypes(linkTypes)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 // GetIssueLinkTypes returns all link types (exported for use by other commands)

--- a/tools/jtk/internal/cmd/me/me.go
+++ b/tools/jtk/internal/cmd/me/me.go
@@ -3,13 +3,16 @@ package me
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // Register registers the me command
@@ -44,21 +47,21 @@ func run(ctx context.Context, opts *root.Options) error {
 		return err
 	}
 
+	// JSON path: use existing artifact layer (unchanged)
 	if v.Format == view.FormatJSON {
 		return v.RenderArtifact(jtkartifact.ProjectUser(user, opts.ArtifactMode()))
 	}
 
+	// Plain path: just the account ID
 	if v.Format == view.FormatPlain {
-		v.Println("%s", user.AccountID)
+		_, _ = fmt.Fprintln(opts.Stdout, user.AccountID)
 		return nil
 	}
 
-	v.Println("Account ID:   %s", user.AccountID)
-	v.Println("Display Name: %s", user.DisplayName)
-	if user.EmailAddress != "" {
-		v.Println("Email:        %s", user.EmailAddress)
-	}
-	v.Println("Active:       %t", user.Active)
-
+	// Text path: presenter → model → pure render → write to both streams
+	model := jtkpresent.UserPresenter{}.Present(user)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/me/me_test.go
+++ b/tools/jtk/internal/cmd/me/me_test.go
@@ -60,7 +60,7 @@ func TestRun_Table(t *testing.T) {
 	testutil.Contains(t, output, "abc123")
 	testutil.Contains(t, output, "John Doe")
 	testutil.Contains(t, output, "john@example.com")
-	testutil.Contains(t, output, "true")
+	testutil.Contains(t, output, "yes")
 }
 
 func TestRun_JSON(t *testing.T) {
@@ -185,4 +185,33 @@ func TestRun_AuthFailure(t *testing.T) {
 
 	err = run(context.Background(), opts)
 	testutil.NotNil(t, err)
+}
+
+func TestRun_UnpaddedKeyValueOutput(t *testing.T) {
+	t.Parallel()
+	// Verifies the migration from manual padding to RenderKeyValues produces unpadded output
+	user := &api.User{
+		AccountID:    "abc123",
+		DisplayName:  "Alice",
+		EmailAddress: "alice@example.com",
+		Active:       true,
+	}
+
+	server := newTestUserServer(t, http.StatusOK, user)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = run(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+
+	want := "Account ID: abc123\nDisplay Name: Alice\nEmail: alice@example.com\nActive: yes\n"
+	if stdout.String() != want {
+		t.Errorf("me output:\ngot:\n%s\nwant:\n%s", stdout.String(), want)
+	}
 }

--- a/tools/jtk/internal/cmd/projects/create.go
+++ b/tools/jtk/internal/cmd/projects/create.go
@@ -3,11 +3,16 @@ package projects
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newCreateCmd(opts *root.Options) *cobra.Command {
@@ -71,11 +76,12 @@ func runCreate(ctx context.Context, opts *root.Options, key, name, projectType, 
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(project)
 	}
 
-	v.Success("Created project %s (%s)", project.Key, name)
-
+	model := jtkpresent.ProjectPresenter{}.PresentCreated(project.Key, name)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }

--- a/tools/jtk/internal/cmd/projects/delete.go
+++ b/tools/jtk/internal/cmd/projects/delete.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/prompt"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {
@@ -37,8 +39,6 @@ The project can be restored from trash using 'jtk projects restore'.`,
 }
 
 func runDelete(ctx context.Context, opts *root.Options, keyOrID string, force bool) error {
-	v := opts.View()
-
 	if !force {
 		fmt.Fprintf(opts.Stderr, "This will delete project %s (moves to trash). It can be restored later.\n", keyOrID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
@@ -48,7 +48,9 @@ func runDelete(ctx context.Context, opts *root.Options, keyOrID string, force bo
 			return fmt.Errorf("reading confirmation: %w", err)
 		}
 		if !confirmed {
-			v.Info("Deletion cancelled.")
+			model := jtkpresent.ProjectPresenter{}.PresentDeleteCancelled()
+			out := present.Render(model, opts.RenderStyle())
+			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 			return nil
 		}
 	}
@@ -62,6 +64,8 @@ func runDelete(ctx context.Context, opts *root.Options, keyOrID string, force bo
 		return err
 	}
 
-	v.Success("Deleted project %s (moved to trash)", keyOrID)
+	model := jtkpresent.ProjectPresenter{}.PresentDeleted(keyOrID)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }

--- a/tools/jtk/internal/cmd/projects/get.go
+++ b/tools/jtk/internal/cmd/projects/get.go
@@ -2,11 +2,15 @@ package projects
 
 import (
 	"context"
-	"strings"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newGetCmd(opts *root.Options) *cobra.Command {
@@ -36,34 +40,13 @@ func runGet(ctx context.Context, opts *root.Options, keyOrID string) error {
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(project)
 	}
 
-	v.Println("Key:         %s", project.Key)
-	v.Println("Name:        %s", project.Name)
-	v.Println("ID:          %s", project.ID.String())
-	v.Println("Type:        %s", project.ProjectTypeKey)
-
-	if project.Lead != nil {
-		v.Println("Lead:        %s", project.Lead.DisplayName)
-	}
-
-	if project.Description != "" {
-		v.Println("Description: %s", project.Description)
-	}
-
-	if len(project.IssueTypes) > 0 {
-		var names []string
-		for _, it := range project.IssueTypes {
-			names = append(names, it.Name)
-		}
-		v.Println("Issue Types: %s", strings.Join(names, ", "))
-	}
-
-	if project.URL != "" {
-		v.Println("URL:         %s", project.URL)
-	}
-
+	model := jtkpresent.ProjectPresenter{}.Present(project)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/projects/list.go
+++ b/tools/jtk/internal/cmd/projects/list.go
@@ -2,10 +2,15 @@ package projects
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newListCmd(opts *root.Options) *cobra.Command {
@@ -49,29 +54,19 @@ func runList(ctx context.Context, opts *root.Options, query string, maxResults i
 	}
 
 	if len(result.Values) == 0 {
-		v.Info("No projects found")
+		model := jtkpresent.ProjectPresenter{}.PresentEmpty()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(result.Values)
 	}
 
-	headers := []string{"KEY", "NAME", "TYPE", "LEAD"}
-	rows := make([][]string, 0, len(result.Values))
-
-	for _, p := range result.Values {
-		lead := ""
-		if p.Lead != nil {
-			lead = p.Lead.DisplayName
-		}
-		rows = append(rows, []string{
-			p.Key,
-			p.Name,
-			p.ProjectTypeKey,
-			lead,
-		})
-	}
-
-	return v.Table(headers, rows)
+	model := jtkpresent.ProjectPresenter{}.PresentList(result.Values)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }

--- a/tools/jtk/internal/cmd/projects/restore.go
+++ b/tools/jtk/internal/cmd/projects/restore.go
@@ -2,10 +2,15 @@ package projects
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newRestoreCmd(opts *root.Options) *cobra.Command {
@@ -34,11 +39,12 @@ func runRestore(ctx context.Context, opts *root.Options, keyOrID string) error {
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(project)
 	}
 
-	v.Success("Restored project %s (%s)", project.Key, project.Name)
-
+	model := jtkpresent.ProjectPresenter{}.PresentRestored(project.Key, project.Name)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }

--- a/tools/jtk/internal/cmd/projects/types.go
+++ b/tools/jtk/internal/cmd/projects/types.go
@@ -2,10 +2,15 @@ package projects
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newTypesCmd(opts *root.Options) *cobra.Command {
@@ -34,23 +39,19 @@ func runTypes(ctx context.Context, opts *root.Options) error {
 	}
 
 	if len(types) == 0 {
-		v.Info("No project types found")
+		model := jtkpresent.ProjectPresenter{}.PresentNoTypes()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(types)
 	}
 
-	headers := []string{"KEY", "FORMATTED"}
-	var rows [][]string
-
-	for _, t := range types {
-		rows = append(rows, []string{
-			t.Key,
-			t.FormattedKey,
-		})
-	}
-
-	return v.Table(headers, rows)
+	model := jtkpresent.ProjectPresenter{}.PresentTypes(types)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }

--- a/tools/jtk/internal/cmd/projects/update.go
+++ b/tools/jtk/internal/cmd/projects/update.go
@@ -2,11 +2,16 @@ package projects
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 func newUpdateCmd(opts *root.Options) *cobra.Command {
@@ -58,11 +63,12 @@ func runUpdate(ctx context.Context, opts *root.Options, keyOrID, name, descripti
 		return err
 	}
 
-	if opts.Output == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(project)
 	}
 
-	v.Success("Updated project %s", project.Key)
-
+	model := jtkpresent.ProjectPresenter{}.PresentUpdated(project.Key)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil
 }

--- a/tools/jtk/internal/cmd/root/root.go
+++ b/tools/jtk/internal/cmd/root/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/version"
 	"github.com/open-cli-collective/atlassian-go/view"
 
@@ -32,9 +33,13 @@ type Options struct {
 	cachedClient *api.Client
 }
 
-// View returns a configured View instance
+// View returns a configured View instance, deriving policy from RenderMode.
 func (o *Options) View() *view.View {
 	v := view.NewWithFormat(o.Output, o.NoColor)
+	// Derive legacy policy from RenderMode - single source of truth
+	if o.RenderMode() == present.RenderModeAgent {
+		v.SetPolicy(view.PolicyAgent)
+	}
 	v.Out = o.Stdout
 	v.Err = o.Stderr
 	return v
@@ -43,6 +48,18 @@ func (o *Options) View() *view.View {
 // ArtifactMode returns the artifact type based on the --full flag.
 func (o *Options) ArtifactMode() artifact.Type {
 	return artifact.Mode(o.Full)
+}
+
+// RenderMode returns the authoritative rendering mode.
+// This is the single source of truth that both legacy View() and new render paths use.
+// jtk always uses agent mode for token efficiency.
+func (o *Options) RenderMode() present.RenderMode {
+	return present.RenderModeAgent
+}
+
+// RenderStyle returns the presentation rendering style, derived from RenderMode.
+func (o *Options) RenderStyle() present.Style {
+	return present.StyleFromMode(o.RenderMode())
 }
 
 // APIClient returns the API client, creating it on first call.
@@ -94,6 +111,7 @@ func NewCmd() (*cobra.Command, *Options) {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+	cmd.SetVersionTemplate("{{.Version}}\n") // Bare version output for token efficiency
 
 	// Global flags - bound to opts struct
 	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "table", "Output format: table, json, plain")

--- a/tools/jtk/internal/cmd/root/root_test.go
+++ b/tools/jtk/internal/cmd/root/root_test.go
@@ -2,10 +2,14 @@ package root
 
 import (
 	"bytes"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/testutil"
+	"github.com/open-cli-collective/atlassian-go/view"
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -132,4 +136,55 @@ func TestOptions_ArtifactMode(t *testing.T) {
 		opts := &Options{Full: true}
 		testutil.Equal(t, opts.ArtifactMode(), artifact.Full)
 	})
+}
+
+func TestOptions_View_UsesAgentPolicy(t *testing.T) {
+	t.Parallel()
+	opts := &Options{
+		Output: "table",
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+	v := opts.View()
+
+	if v.Policy != view.PolicyAgent {
+		t.Errorf("jtk View should use PolicyAgent, got %v", v.Policy)
+	}
+}
+
+func TestOptions_RenderMode(t *testing.T) {
+	t.Parallel()
+	opts := &Options{}
+	// jtk always uses agent mode for token efficiency
+	if got := opts.RenderMode(); got != present.RenderModeAgent {
+		t.Errorf("RenderMode() = %v, want RenderModeAgent", got)
+	}
+}
+
+func TestOptions_RenderStyle(t *testing.T) {
+	t.Parallel()
+	opts := &Options{}
+	// RenderStyle derives from RenderMode via StyleFromMode
+	if got := opts.RenderStyle(); got != present.StyleAgent {
+		t.Errorf("RenderStyle() = %v, want StyleAgent", got)
+	}
+}
+
+func TestVersion_BareOutput(t *testing.T) {
+	t.Parallel()
+	cmd, _ := NewCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"--version"})
+	_ = cmd.Execute()
+
+	got := strings.TrimSpace(buf.String())
+	// Should be just the version number, no "jtk version" prefix
+	if strings.HasPrefix(got, "jtk") {
+		t.Errorf("version output should be bare, got %q", got)
+	}
+	// Should match semver pattern or "dev"
+	if got != "dev" && !regexp.MustCompile(`^\d+\.\d+\.\d+`).MatchString(got) {
+		t.Errorf("version output should be semver or 'dev', got %q", got)
+	}
 }

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -8,11 +8,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // Register registers the sprints commands
@@ -87,7 +89,9 @@ func runList(ctx context.Context, opts *root.Options, boardID int, state string,
 	}
 
 	if len(result.Values) == 0 {
-		v.Info("No sprints found")
+		model := jtkpresent.SprintPresenter{}.PresentEmpty()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
@@ -97,29 +101,12 @@ func runList(ctx context.Context, opts *root.Options, boardID int, state string,
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	headers := []string{"ID", "NAME", "STATE", "START", "END"}
-	rows := make([][]string, 0, len(result.Values))
-
-	for _, s := range result.Values {
-		startDate := ""
-		if s.StartDate != nil {
-			startDate = s.StartDate.Format("2006-01-02")
-		}
-		endDate := ""
-		if s.EndDate != nil {
-			endDate = s.EndDate.Format("2006-01-02")
-		}
-
-		rows = append(rows, []string{
-			fmt.Sprintf("%d", s.ID),
-			s.Name,
-			s.State,
-			startDate,
-			endDate,
-		})
-	}
-
-	return v.Table(headers, rows)
+	// Text path: presenter → render → write
+	model := jtkpresent.SprintPresenter{}.PresentList(result.Values)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newCurrentCmd(opts *root.Options) *cobra.Command {
@@ -160,19 +147,11 @@ func runCurrent(ctx context.Context, opts *root.Options, boardID int) error {
 		return v.RenderArtifact(jtkartifact.ProjectSprint(sprint, opts.ArtifactMode()))
 	}
 
-	v.Println("ID:    %d", sprint.ID)
-	v.Println("Name:  %s", sprint.Name)
-	v.Println("State: %s", sprint.State)
-	if sprint.StartDate != nil {
-		v.Println("Start: %s", sprint.StartDate.Format("2006-01-02"))
-	}
-	if sprint.EndDate != nil {
-		v.Println("End:   %s", sprint.EndDate.Format("2006-01-02"))
-	}
-	if sprint.Goal != "" {
-		v.Println("Goal:  %s", sprint.Goal)
-	}
-
+	// Text path: presenter → render → write
+	model := jtkpresent.SprintPresenter{}.PresentDetail(sprint)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }
 
@@ -213,7 +192,9 @@ func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults
 	}
 
 	if len(result.Issues) == 0 {
-		v.Info("No issues in sprint")
+		model := jtkpresent.SprintPresenter{}.PresentNoIssues()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
@@ -230,40 +211,12 @@ func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	headers := []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"}
-	rows := make([][]string, 0, len(result.Issues))
-
-	for _, issue := range result.Issues {
-		status := ""
-		if issue.Fields.Status != nil {
-			status = issue.Fields.Status.Name
-		}
-
-		assignee := ""
-		if issue.Fields.Assignee != nil {
-			assignee = issue.Fields.Assignee.DisplayName
-		}
-
-		issueType := ""
-		if issue.Fields.IssueType != nil {
-			issueType = issue.Fields.IssueType.Name
-		}
-
-		summary := issue.Fields.Summary
-		if len(summary) > 50 {
-			summary = summary[:50] + "..."
-		}
-
-		rows = append(rows, []string{
-			issue.Key,
-			summary,
-			status,
-			assignee,
-			issueType,
-		})
-	}
-
-	return v.Table(headers, rows)
+	// Text path: presenter → render → write
+	model := jtkpresent.IssuePresenter{}.PresentList(result.Issues)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 func newAddCmd(opts *root.Options) *cobra.Command {
@@ -290,8 +243,6 @@ func newAddCmd(opts *root.Options) *cobra.Command {
 }
 
 func runAdd(ctx context.Context, opts *root.Options, sprintID int, issueKeys []string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -301,11 +252,9 @@ func runAdd(ctx context.Context, opts *root.Options, sprintID int, issueKeys []s
 		return err
 	}
 
-	if len(issueKeys) == 1 {
-		v.Success("Moved %s to sprint %d", issueKeys[0], sprintID)
-	} else {
-		v.Success("Moved %d issues to sprint %d", len(issueKeys), sprintID)
-	}
-
+	model := jtkpresent.SprintPresenter{}.PresentMoved(issueKeys, sprintID)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -430,4 +431,32 @@ func TestRunAdd_SingleIssue(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	testutil.Contains(t, stdout.String(), "Moved PROJ-101 to sprint 123")
+}
+
+func TestRunAdd_AgentOutput(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, NoColor: true}
+	opts.SetAPIClient(client)
+
+	err = runAdd(context.Background(), opts, 456, []string{"MON-123"})
+	testutil.RequireNoError(t, err)
+
+	// Agent policy: plain text, no checkmark
+	want := "Moved MON-123 to sprint 456\n"
+	if stdout.String() != want {
+		t.Errorf("mutation output:\ngot: %q\nwant: %q", stdout.String(), want)
+	}
+	// Verify no checkmark
+	if strings.Contains(stdout.String(), "✓") {
+		t.Error("agent policy should not have checkmark")
+	}
 }

--- a/tools/jtk/internal/cmd/transitions/transitions.go
+++ b/tools/jtk/internal/cmd/transitions/transitions.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // Register registers the transitions commands
@@ -64,7 +67,10 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, showField
 	}
 
 	if len(transitions) == 0 {
-		v.Info("No transitions available for %s", issueKey)
+		model := jtkpresent.TransitionPresenter{}.PresentEmpty(issueKey)
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		fmt.Fprint(opts.Stderr, out.Stderr)
 		return nil
 	}
 
@@ -72,40 +78,22 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, showField
 		return v.JSON(transitions)
 	}
 
+	var model *present.OutputModel
 	if showFields {
-		headers := []string{"ID", "NAME", "TO STATUS", "REQUIRED FIELDS"}
-		rows := make([][]string, 0, len(transitions))
-
-		for _, t := range transitions {
-			required := getRequiredFields(t)
-			rows = append(rows, []string{t.ID, t.Name, t.To.Name, required})
-		}
-
-		return v.Table(headers, rows)
+		model = jtkpresent.TransitionPresenter{}.PresentListWithFields(transitions)
+	} else {
+		model = jtkpresent.TransitionPresenter{}.PresentList(transitions)
 	}
-
-	headers := []string{"ID", "NAME", "TO STATUS"}
-	rows := make([][]string, 0, len(transitions))
-
-	for _, t := range transitions {
-		rows = append(rows, []string{t.ID, t.Name, t.To.Name})
-	}
-
-	return v.Table(headers, rows)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }
 
 // getRequiredFields returns a comma-separated list of required field names
+// This is exported for testing and delegates to the presenter implementation
 func getRequiredFields(t api.Transition) string {
-	var required []string
-	for _, field := range t.Fields {
-		if field.Required {
-			required = append(required, field.Name)
-		}
-	}
-	if len(required) == 0 {
-		return "-"
-	}
-	return strings.Join(required, ", ")
+	return jtkpresent.GetRequiredFieldsForTransition(t)
 }
 
 func newDoCmd(opts *root.Options) *cobra.Command {
@@ -138,8 +126,6 @@ Some transitions require additional fields to be set. Use --field to provide the
 }
 
 func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID string, fieldArgs []string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -170,11 +156,10 @@ func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID
 	}
 
 	if transitionID == "" {
-		v.Error("Transition '%s' not found", transitionNameOrID)
-		v.Info("Available transitions:")
-		for _, t := range transitions {
-			v.Info("  %s: %s -> %s", t.ID, t.Name, t.To.Name)
-		}
+		model := jtkpresent.TransitionPresenter{}.PresentNotFound(transitionNameOrID, transitions)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 		return fmt.Errorf("transition not found: %s", transitionNameOrID)
 	}
 
@@ -219,6 +204,9 @@ func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID
 		return err
 	}
 
-	v.Success("Transitioned %s", issueKey)
+	model := jtkpresent.TransitionPresenter{}.PresentTransitioned(issueKey)
+	out := present.Render(model, opts.RenderStyle())
+	fmt.Fprint(opts.Stdout, out.Stdout)
+	fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }

--- a/tools/jtk/internal/cmd/users/users.go
+++ b/tools/jtk/internal/cmd/users/users.go
@@ -3,14 +3,17 @@ package users
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // Register registers the users commands
@@ -62,18 +65,11 @@ func runGet(ctx context.Context, opts *root.Options, accountID string) error {
 		return v.RenderArtifact(jtkartifact.ProjectUser(user, opts.ArtifactMode()))
 	}
 
-	active := "yes"
-	if !user.Active {
-		active = "no"
-	}
-
-	v.Println("Account ID:  %s", user.AccountID)
-	v.Println("Name:        %s", user.DisplayName)
-	if user.EmailAddress != "" {
-		v.Println("Email:       %s", user.EmailAddress)
-	}
-	v.Println("Active:      %s", active)
-
+	// Text path: presenter → render → write
+	model := jtkpresent.UserPresenter{}.Present(user)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }
 
@@ -120,7 +116,9 @@ func runSearch(ctx context.Context, opts *root.Options, query string, maxResults
 	}
 
 	if len(users) == 0 {
-		v.Info("No users found matching '%s'", query)
+		model := jtkpresent.UserPresenter{}.PresentEmpty(query)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 		return nil
 	}
 
@@ -132,16 +130,10 @@ func runSearch(ctx context.Context, opts *root.Options, query string, maxResults
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	headers := []string{"ACCOUNT_ID", "NAME", "EMAIL", "ACTIVE"}
-	rows := make([][]string, 0, len(users))
-
-	for _, u := range users {
-		active := "yes"
-		if !u.Active {
-			active = "no"
-		}
-		rows = append(rows, []string{u.AccountID, u.DisplayName, u.EmailAddress, active})
-	}
-
-	return v.Table(headers, rows)
+	// Text path: presenter → render → write
+	model := jtkpresent.UserPresenter{}.PresentList(users)
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
 }

--- a/tools/jtk/internal/config/source.go
+++ b/tools/jtk/internal/config/source.go
@@ -1,0 +1,128 @@
+package config
+
+import "os"
+
+// ValuesWithSources holds all config values with their source information.
+// This is a projection helper that inspects env vars and config file to determine
+// where each value came from. Used by commands to pass resolved values to presenters.
+type ValuesWithSources struct {
+	URL            string
+	URLSource      string
+	Email          string
+	EmailSource    string
+	APIToken       string // Unmasked - caller should mask before passing to presenter
+	TokenSource    string
+	DefaultProject string
+	ProjectSource  string
+	AuthMethod     string
+	AuthMethodSrc  string
+	CloudID        string
+	CloudIDSrc     string
+	Path           string
+}
+
+// GetValuesWithSources returns all config values with their source information.
+func GetValuesWithSources() ValuesWithSources {
+	url, urlSrc := GetURLWithSource()
+	email, emailSrc := GetEmailWithSource()
+	token, tokenSrc := GetAPITokenWithSource()
+	project, projectSrc := GetDefaultProjectWithSource()
+	authMethod, authMethodSrc := GetAuthMethodWithSource()
+	cloudID, cloudIDSrc := GetCloudIDWithSource()
+
+	return ValuesWithSources{
+		URL:            url,
+		URLSource:      urlSrc,
+		Email:          email,
+		EmailSource:    emailSrc,
+		APIToken:       token,
+		TokenSource:    tokenSrc,
+		DefaultProject: project,
+		ProjectSource:  projectSrc,
+		AuthMethod:     authMethod,
+		AuthMethodSrc:  authMethodSrc,
+		CloudID:        cloudID,
+		CloudIDSrc:     cloudIDSrc,
+		Path:           Path(),
+	}
+}
+
+// GetURLWithSource returns the URL and its source.
+// Precedence: JIRA_URL → ATLASSIAN_URL → config url → JIRA_DOMAIN (legacy) → config domain (legacy)
+func GetURLWithSource() (value, source string) {
+	if os.Getenv("JIRA_URL") != "" {
+		return GetURL(), "env (JIRA_URL)"
+	}
+	if os.Getenv("ATLASSIAN_URL") != "" {
+		return GetURL(), "env (ATLASSIAN_URL)"
+	}
+	cfg, err := Load()
+	if err != nil {
+		return "", "-"
+	}
+	if cfg.URL != "" {
+		return GetURL(), "config"
+	}
+	// Check legacy domain sources
+	if os.Getenv("JIRA_DOMAIN") != "" {
+		return GetURL(), "env (JIRA_DOMAIN, deprecated)"
+	}
+	if cfg.Domain != "" {
+		return GetURL(), "config (domain, deprecated)"
+	}
+	return "", "-"
+}
+
+// GetEmailWithSource returns the email and its source.
+// Precedence: JIRA_EMAIL → ATLASSIAN_EMAIL → config email
+func GetEmailWithSource() (value, source string) {
+	if os.Getenv("JIRA_EMAIL") != "" {
+		return GetEmail(), "env (JIRA_EMAIL)"
+	}
+	if os.Getenv("ATLASSIAN_EMAIL") != "" {
+		return GetEmail(), "env (ATLASSIAN_EMAIL)"
+	}
+	cfg, err := Load()
+	if err != nil {
+		return "", "-"
+	}
+	if cfg.Email != "" {
+		return cfg.Email, "config"
+	}
+	return "", "-"
+}
+
+// GetAPITokenWithSource returns the API token and its source.
+// Precedence: JIRA_API_TOKEN → ATLASSIAN_API_TOKEN → config api_token
+func GetAPITokenWithSource() (value, source string) {
+	if os.Getenv("JIRA_API_TOKEN") != "" {
+		return GetAPIToken(), "env (JIRA_API_TOKEN)"
+	}
+	if os.Getenv("ATLASSIAN_API_TOKEN") != "" {
+		return GetAPIToken(), "env (ATLASSIAN_API_TOKEN)"
+	}
+	cfg, err := Load()
+	if err != nil {
+		return "", "-"
+	}
+	if cfg.APIToken != "" {
+		return cfg.APIToken, "config"
+	}
+	return "", "-"
+}
+
+// GetDefaultProjectWithSource returns the default project and its source.
+// Precedence: JIRA_DEFAULT_PROJECT → config default_project
+func GetDefaultProjectWithSource() (value, source string) {
+	if os.Getenv("JIRA_DEFAULT_PROJECT") != "" {
+		return GetDefaultProject(), "env (JIRA_DEFAULT_PROJECT)"
+	}
+	cfg, err := Load()
+	if err != nil {
+		return "", "-"
+	}
+	if cfg.DefaultProject != "" {
+		return cfg.DefaultProject, "config"
+	}
+	return "", "-"
+}

--- a/tools/jtk/internal/config/source_test.go
+++ b/tools/jtk/internal/config/source_test.go
@@ -1,0 +1,215 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestGetURLWithSource_EnvPrecedence(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// No config, no env
+	value, source := GetURLWithSource()
+	testutil.Equal(t, value, "")
+	testutil.Equal(t, source, "-")
+
+	// Config file
+	cfg := &Config{URL: "https://config.atlassian.net"}
+	err := Save(cfg)
+	testutil.RequireNoError(t, err)
+
+	value, source = GetURLWithSource()
+	testutil.Equal(t, value, "https://config.atlassian.net")
+	testutil.Equal(t, source, "config")
+
+	// ATLASSIAN_URL takes precedence over config
+	t.Setenv("ATLASSIAN_URL", "https://atlassian.atlassian.net")
+	value, source = GetURLWithSource()
+	testutil.Equal(t, value, "https://atlassian.atlassian.net")
+	testutil.Equal(t, source, "env (ATLASSIAN_URL)")
+
+	// JIRA_URL takes precedence over ATLASSIAN_URL
+	t.Setenv("JIRA_URL", "https://jira.atlassian.net")
+	value, source = GetURLWithSource()
+	testutil.Equal(t, value, "https://jira.atlassian.net")
+	testutil.Equal(t, source, "env (JIRA_URL)")
+}
+
+func TestGetURLWithSource_LegacyDomain(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Config with legacy domain
+	cfg := &Config{Domain: "legacy"}
+	err := Save(cfg)
+	testutil.RequireNoError(t, err)
+
+	value, source := GetURLWithSource()
+	testutil.Equal(t, value, "https://legacy.atlassian.net")
+	testutil.Equal(t, source, "config (domain, deprecated)")
+
+	// JIRA_DOMAIN env var
+	err = Clear()
+	testutil.RequireNoError(t, err)
+	t.Setenv("JIRA_DOMAIN", "env-legacy")
+
+	value, source = GetURLWithSource()
+	testutil.Equal(t, value, "https://env-legacy.atlassian.net")
+	testutil.Equal(t, source, "env (JIRA_DOMAIN, deprecated)")
+}
+
+func TestGetEmailWithSource_EnvPrecedence(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// No config, no env
+	value, source := GetEmailWithSource()
+	testutil.Equal(t, value, "")
+	testutil.Equal(t, source, "-")
+
+	// Config file
+	cfg := &Config{Email: "config@example.com"}
+	err := Save(cfg)
+	testutil.RequireNoError(t, err)
+
+	value, source = GetEmailWithSource()
+	testutil.Equal(t, value, "config@example.com")
+	testutil.Equal(t, source, "config")
+
+	// ATLASSIAN_EMAIL takes precedence over config
+	t.Setenv("ATLASSIAN_EMAIL", "atlassian@example.com")
+	value, source = GetEmailWithSource()
+	testutil.Equal(t, value, "atlassian@example.com")
+	testutil.Equal(t, source, "env (ATLASSIAN_EMAIL)")
+
+	// JIRA_EMAIL takes precedence over ATLASSIAN_EMAIL
+	t.Setenv("JIRA_EMAIL", "jira@example.com")
+	value, source = GetEmailWithSource()
+	testutil.Equal(t, value, "jira@example.com")
+	testutil.Equal(t, source, "env (JIRA_EMAIL)")
+}
+
+func TestGetAPITokenWithSource_EnvPrecedence(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// No config, no env
+	value, source := GetAPITokenWithSource()
+	testutil.Equal(t, value, "")
+	testutil.Equal(t, source, "-")
+
+	// Config file
+	cfg := &Config{APIToken: "config-token"}
+	err := Save(cfg)
+	testutil.RequireNoError(t, err)
+
+	value, source = GetAPITokenWithSource()
+	testutil.Equal(t, value, "config-token")
+	testutil.Equal(t, source, "config")
+
+	// ATLASSIAN_API_TOKEN takes precedence over config
+	t.Setenv("ATLASSIAN_API_TOKEN", "atlassian-token")
+	value, source = GetAPITokenWithSource()
+	testutil.Equal(t, value, "atlassian-token")
+	testutil.Equal(t, source, "env (ATLASSIAN_API_TOKEN)")
+
+	// JIRA_API_TOKEN takes precedence over ATLASSIAN_API_TOKEN
+	t.Setenv("JIRA_API_TOKEN", "jira-token")
+	value, source = GetAPITokenWithSource()
+	testutil.Equal(t, value, "jira-token")
+	testutil.Equal(t, source, "env (JIRA_API_TOKEN)")
+}
+
+func TestGetDefaultProjectWithSource_EnvPrecedence(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// No config, no env
+	value, source := GetDefaultProjectWithSource()
+	testutil.Equal(t, value, "")
+	testutil.Equal(t, source, "-")
+
+	// Config file
+	cfg := &Config{DefaultProject: "PROJ"}
+	err := Save(cfg)
+	testutil.RequireNoError(t, err)
+
+	value, source = GetDefaultProjectWithSource()
+	testutil.Equal(t, value, "PROJ")
+	testutil.Equal(t, source, "config")
+
+	// JIRA_DEFAULT_PROJECT takes precedence over config
+	t.Setenv("JIRA_DEFAULT_PROJECT", "ENV-PROJ")
+	value, source = GetDefaultProjectWithSource()
+	testutil.Equal(t, value, "ENV-PROJ")
+	testutil.Equal(t, source, "env (JIRA_DEFAULT_PROJECT)")
+}
+
+func TestGetValuesWithSources_AllFields(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Set up mixed sources
+	cfg := &Config{
+		URL:            "https://config.atlassian.net",
+		Email:          "config@example.com",
+		DefaultProject: "PROJ",
+	}
+	err := Save(cfg)
+	testutil.RequireNoError(t, err)
+
+	t.Setenv("JIRA_API_TOKEN", "env-token")
+	t.Setenv("JIRA_AUTH_METHOD", "bearer")
+	t.Setenv("JIRA_CLOUD_ID", "cloud-123")
+
+	result := GetValuesWithSources()
+
+	// Verify all fields are populated
+	testutil.Equal(t, result.URL, "https://config.atlassian.net")
+	testutil.Equal(t, result.URLSource, "config")
+
+	testutil.Equal(t, result.Email, "config@example.com")
+	testutil.Equal(t, result.EmailSource, "config")
+
+	testutil.Equal(t, result.APIToken, "env-token")
+	testutil.Equal(t, result.TokenSource, "env (JIRA_API_TOKEN)")
+
+	testutil.Equal(t, result.DefaultProject, "PROJ")
+	testutil.Equal(t, result.ProjectSource, "config")
+
+	testutil.Equal(t, result.AuthMethod, "bearer")
+	testutil.Equal(t, result.AuthMethodSrc, "env (JIRA_AUTH_METHOD)")
+
+	testutil.Equal(t, result.CloudID, "cloud-123")
+	testutil.Equal(t, result.CloudIDSrc, "env (JIRA_CLOUD_ID)")
+
+	testutil.NotEmpty(t, result.Path)
+}
+
+func TestGetValuesWithSources_AllEmpty(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	result := GetValuesWithSources()
+
+	testutil.Equal(t, result.URL, "")
+	testutil.Equal(t, result.URLSource, "-")
+
+	testutil.Equal(t, result.Email, "")
+	testutil.Equal(t, result.EmailSource, "-")
+
+	testutil.Equal(t, result.APIToken, "")
+	testutil.Equal(t, result.TokenSource, "-")
+
+	testutil.Equal(t, result.DefaultProject, "")
+	testutil.Equal(t, result.ProjectSource, "-")
+
+	// AuthMethod defaults to "basic"
+	testutil.Equal(t, result.AuthMethod, "basic")
+	testutil.Equal(t, result.AuthMethodSrc, "default")
+
+	testutil.Equal(t, result.CloudID, "")
+	testutil.Equal(t, result.CloudIDSrc, "-")
+}

--- a/tools/jtk/internal/present/attachment.go
+++ b/tools/jtk/internal/present/attachment.go
@@ -1,0 +1,83 @@
+// Package present provides presenters that map domain types to presentation models.
+package present
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// AttachmentPresenter creates presentation models for issue attachments.
+type AttachmentPresenter struct{}
+
+// PresentList creates a table presentation of attachments.
+func (AttachmentPresenter) PresentList(attachments []api.Attachment) *present.OutputModel {
+	rows := make([]present.Row, len(attachments))
+	for i, a := range attachments {
+		rows[i] = present.Row{
+			Cells: []string{a.ID.String(), a.Filename, FormatSize(a.Size), FormatTime(a.Created), a.Author.DisplayName},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "FILENAME", "SIZE", "CREATED", "AUTHOR"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentUploaded creates a success message for attachment upload.
+func (AttachmentPresenter) PresentUploaded(filename, id, size string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Uploaded %s (ID: %s, Size: %s)", filename, id, size),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDownloaded creates a success message for attachment download.
+func (AttachmentPresenter) PresentDownloaded(filename, size string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Downloaded %s (%s)", filename, size),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDeleted creates a success message for attachment deletion.
+func (AttachmentPresenter) PresentDeleted(attachmentID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Deleted attachment %s", attachmentID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message when no attachments are found.
+func (AttachmentPresenter) PresentEmpty(issueKey string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No attachments found on %s", issueKey),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/automation.go
+++ b/tools/jtk/internal/present/automation.go
@@ -1,0 +1,271 @@
+// Package present provides presenters that map domain types to presentation models.
+package present
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// AutomationPresenter creates presentation models for automation rules.
+type AutomationPresenter struct{}
+
+// PresentDetail creates a detailed view of a single automation rule.
+// When showComponents is true, a table of component details is appended.
+func (AutomationPresenter) PresentDetail(rule *api.AutomationRule, showComponents bool) *present.OutputModel {
+	fields := []present.Field{
+		{Label: "Name", Value: rule.Name},
+		{Label: "UUID", Value: rule.Identifier()},
+		{Label: "State", Value: rule.State},
+	}
+
+	if rule.Description != "" {
+		fields = append(fields, present.Field{Label: "Description", Value: rule.Description})
+	}
+
+	if len(rule.Labels) > 0 {
+		fields = append(fields, present.Field{Label: "Labels", Value: strings.Join(rule.Labels, ", ")})
+	}
+
+	if len(rule.Tags) > 0 {
+		fields = append(fields, present.Field{Label: "Tags", Value: strings.Join(rule.Tags, ", ")})
+	}
+
+	if len(rule.Projects) > 0 {
+		projects := make([]string, 0, len(rule.Projects))
+		for _, p := range rule.Projects {
+			if p.ProjectKey != "" {
+				projects = append(projects, p.ProjectKey)
+			} else if p.ProjectName != "" {
+				projects = append(projects, p.ProjectName)
+			}
+		}
+		if len(projects) > 0 {
+			fields = append(fields, present.Field{Label: "Projects", Value: strings.Join(projects, ", ")})
+		}
+	}
+
+	fields = append(fields, present.Field{Label: "Components", Value: SummarizeComponents(rule.Components)})
+
+	sections := []present.Section{&present.DetailSection{Fields: fields}}
+
+	// Append component details table when requested
+	if showComponents && len(rule.Components) > 0 {
+		rows := make([]present.Row, len(rule.Components))
+		for i, c := range rule.Components {
+			rows[i] = present.Row{
+				Cells: []string{fmt.Sprintf("%d", i+1), c.Component, c.Type},
+			}
+		}
+		sections = append(sections, &present.TableSection{
+			Headers: []string{"#", "COMPONENT", "TYPE"},
+			Rows:    rows,
+		})
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// PresentStateChanged creates a success message for a state transition.
+func (AutomationPresenter) PresentStateChanged(name, fromState, toState string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Rule %q: %s → %s", name, fromState, toState),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentNoChange creates an advisory message when rule is already in desired state.
+// Routes to stderr because no mutation occurred.
+func (AutomationPresenter) PresentNoChange(name, state string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("Rule %q is already %s", name, state),
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// PresentCreated creates a success message for rule creation with name.
+func (AutomationPresenter) PresentCreated(name, uuid string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Created automation rule: %s (UUID: %s)", name, uuid),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentCreatedMinimal creates a success message for rule creation without name.
+func (AutomationPresenter) PresentCreatedMinimal(uuid string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Created automation rule (UUID: %s)", uuid),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentCreatedUnparsed creates a success message when response couldn't be parsed.
+func (AutomationPresenter) PresentCreatedUnparsed() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: "Created automation rule (could not parse response for details)",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentUpdated creates a success message for rule update.
+func (AutomationPresenter) PresentUpdated(ruleID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Updated automation rule %s", ruleID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentUpdateProgress creates an advisory message showing update progress.
+func (AutomationPresenter) PresentUpdateProgress(name, uuid, state string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("Updating rule: %s (UUID: %s, State: %s)", name, uuid, state),
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// PresentUpdateComplete creates progress + success as single output.
+func (AutomationPresenter) PresentUpdateComplete(name, uuid, state, ruleID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("Updating rule: %s (UUID: %s, State: %s)", name, uuid, state),
+				Stream:  present.StreamStderr,
+			},
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Updated automation rule %s", ruleID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDeleted creates a success message for rule deletion.
+func (AutomationPresenter) PresentDeleted(name, ruleID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Deleted automation rule %q (%s)", name, ruleID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDeleteCancelled creates an info message for cancelled deletion.
+func (AutomationPresenter) PresentDeleteCancelled() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "Deletion cancelled.",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message for empty automation list.
+func (AutomationPresenter) PresentEmpty() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "No automation rules found",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentList creates a table view of automation rules.
+func (AutomationPresenter) PresentList(rules []api.AutomationRuleSummary) *present.OutputModel {
+	rows := make([]present.Row, len(rules))
+	for i, r := range rules {
+		rows[i] = present.Row{
+			Cells: []string{r.Identifier(), r.Name, r.State},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"UUID", "NAME", "STATE"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// SummarizeComponents creates a compact summary of rule components.
+// Exported for testing.
+func SummarizeComponents(components []api.RuleComponent) string {
+	if len(components) == 0 {
+		return "none"
+	}
+
+	triggers, conditions, actions := 0, 0, 0
+	for _, c := range components {
+		switch c.Component {
+		case "TRIGGER":
+			triggers++
+		case "CONDITION":
+			conditions++
+		case "ACTION":
+			actions++
+		}
+	}
+
+	parts := make([]string, 0, 3)
+	if triggers > 0 {
+		parts = append(parts, fmt.Sprintf("%d trigger(s)", triggers))
+	}
+	if conditions > 0 {
+		parts = append(parts, fmt.Sprintf("%d condition(s)", conditions))
+	}
+	if actions > 0 {
+		parts = append(parts, fmt.Sprintf("%d action(s)", actions))
+	}
+
+	return fmt.Sprintf("%d total — %s", len(components), strings.Join(parts, ", "))
+}

--- a/tools/jtk/internal/present/automation_test.go
+++ b/tools/jtk/internal/present/automation_test.go
@@ -1,0 +1,175 @@
+package present
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestAutomationPresenter_PresentDetail(t *testing.T) {
+	t.Parallel()
+	rule := &api.AutomationRule{
+		ID:          json.Number("123"),
+		RuleKey:     "abc-123",
+		Name:        "Test Rule",
+		State:       "ENABLED",
+		Description: "A test rule",
+		Labels:      []string{"label1", "label2"},
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "issue.created"},
+			{Component: "ACTION", Type: "assign.issue"},
+		},
+	}
+
+	p := AutomationPresenter{}
+	model := p.PresentDetail(rule, false)
+
+	if len(model.Sections) != 1 {
+		t.Fatalf("expected 1 section without components, got %d", len(model.Sections))
+	}
+
+	detail, ok := model.Sections[0].(*present.DetailSection)
+	if !ok {
+		t.Fatalf("expected DetailSection, got %T", model.Sections[0])
+	}
+
+	fieldMap := make(map[string]string)
+	for _, f := range detail.Fields {
+		fieldMap[f.Label] = f.Value
+	}
+
+	if fieldMap["Name"] != "Test Rule" {
+		t.Errorf("expected Name='Test Rule', got %q", fieldMap["Name"])
+	}
+	if fieldMap["State"] != "ENABLED" {
+		t.Errorf("expected State='ENABLED', got %q", fieldMap["State"])
+	}
+}
+
+func TestAutomationPresenter_PresentDetail_WithComponents(t *testing.T) {
+	t.Parallel()
+	rule := &api.AutomationRule{
+		Name:  "Rule",
+		State: "ENABLED",
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "issue.created"},
+			{Component: "ACTION", Type: "assign.issue"},
+		},
+	}
+
+	p := AutomationPresenter{}
+	model := p.PresentDetail(rule, true) // showComponents=true
+
+	// Should have 2 sections: detail + component table
+	if len(model.Sections) != 2 {
+		t.Fatalf("expected 2 sections with components, got %d", len(model.Sections))
+	}
+
+	table, ok := model.Sections[1].(*present.TableSection)
+	if !ok {
+		t.Fatalf("expected TableSection for components, got %T", model.Sections[1])
+	}
+
+	if len(table.Rows) != 2 {
+		t.Errorf("expected 2 component rows, got %d", len(table.Rows))
+	}
+}
+
+func TestAutomationPresenter_PresentUpdateComplete(t *testing.T) {
+	t.Parallel()
+	p := AutomationPresenter{}
+	model := p.PresentUpdateComplete("My Rule", "uuid-123", "ENABLED", "456")
+
+	// Should have 2 sections: progress (stderr) + success (stdout)
+	if len(model.Sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(model.Sections))
+	}
+
+	progress := model.Sections[0].(*present.MessageSection)
+	if progress.Kind != present.MessageInfo {
+		t.Errorf("expected info for progress, got %v", progress.Kind)
+	}
+	if progress.Stream != present.StreamStderr {
+		t.Errorf("progress should go to stderr")
+	}
+
+	success := model.Sections[1].(*present.MessageSection)
+	if success.Kind != present.MessageSuccess {
+		t.Errorf("expected success, got %v", success.Kind)
+	}
+	if success.Stream != present.StreamStdout {
+		t.Errorf("success should go to stdout")
+	}
+}
+
+func TestAutomationPresenter_PresentStateChanged(t *testing.T) {
+	t.Parallel()
+	p := AutomationPresenter{}
+	model := p.PresentStateChanged("My Rule", "DISABLED", "ENABLED")
+
+	if len(model.Sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(model.Sections))
+	}
+
+	msg := model.Sections[0].(*present.MessageSection)
+	if msg.Kind != present.MessageSuccess {
+		t.Errorf("expected success, got %v", msg.Kind)
+	}
+	if msg.Stream != present.StreamStdout {
+		t.Errorf("state change should go to stdout")
+	}
+}
+
+func TestAutomationPresenter_PresentNoChange(t *testing.T) {
+	t.Parallel()
+	p := AutomationPresenter{}
+	model := p.PresentNoChange("My Rule", "ENABLED")
+
+	msg := model.Sections[0].(*present.MessageSection)
+	if msg.Kind != present.MessageInfo {
+		t.Errorf("expected info for no-change, got %v", msg.Kind)
+	}
+	if msg.Stream != present.StreamStderr {
+		t.Errorf("no-change should go to stderr (advisory)")
+	}
+}
+
+func TestSummarizeComponents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		components []api.RuleComponent
+		want       string
+	}{
+		{
+			name:       "empty",
+			components: nil,
+			want:       "none",
+		},
+		{
+			name: "mixed",
+			components: []api.RuleComponent{
+				{Component: "TRIGGER"},
+				{Component: "CONDITION"},
+				{Component: "CONDITION"},
+				{Component: "ACTION"},
+				{Component: "ACTION"},
+				{Component: "ACTION"},
+			},
+			want: "6 total — 1 trigger(s), 2 condition(s), 3 action(s)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SummarizeComponents(tt.components)
+			if got != tt.want {
+				t.Errorf("SummarizeComponents() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/jtk/internal/present/board.go
+++ b/tools/jtk/internal/present/board.go
@@ -1,0 +1,61 @@
+package present
+
+import (
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// BoardPresenter creates presentation models for board data.
+type BoardPresenter struct{}
+
+// PresentDetail creates a detail view for a single board.
+func (BoardPresenter) PresentDetail(board *api.Board) *present.OutputModel {
+	fields := []present.Field{
+		{Label: "ID", Value: FormatInt(board.ID)},
+		{Label: "Name", Value: board.Name},
+		{Label: "Type", Value: board.Type},
+		{Label: "Project", Value: board.Location.ProjectKey},
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{&present.DetailSection{Fields: fields}},
+	}
+}
+
+// PresentList creates a table view for a list of boards.
+func (BoardPresenter) PresentList(boards []api.Board) *present.OutputModel {
+	rows := make([]present.Row, len(boards))
+	for i, b := range boards {
+		rows[i] = present.Row{
+			Cells: []string{
+				FormatInt(b.ID),
+				b.Name,
+				b.Type,
+				b.Location.ProjectKey,
+			},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "NAME", "TYPE", "PROJECT"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message when no boards are found.
+func (BoardPresenter) PresentEmpty() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "No boards found",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/comment.go
+++ b/tools/jtk/internal/present/comment.go
@@ -1,0 +1,107 @@
+// Package present provides presenters that map domain types to presentation models.
+package present
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// CommentPresenter creates presentation models for comment data.
+type CommentPresenter struct{}
+
+// PresentList creates a table view for a list of comments.
+func (CommentPresenter) PresentList(comments []api.Comment) *present.OutputModel {
+	rows := make([]present.Row, len(comments))
+	for i, c := range comments {
+		author := "Unknown"
+		if c.Author.DisplayName != "" {
+			author = c.Author.DisplayName
+		}
+		// Truncate body for table display
+		body := ""
+		if c.Body != nil {
+			body = c.Body.ToPlainText()
+			if len(body) > 100 {
+				body = body[:100] + "... [truncated, use --no-truncate for complete text]"
+			}
+		}
+		rows[i] = present.Row{
+			Cells: []string{c.ID, author, FormatTime(c.Created), body},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "AUTHOR", "CREATED", "BODY"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentListFull creates detail views for comments without truncation.
+// Each comment becomes a DetailSection; the renderer owns spacing between sections.
+func (CommentPresenter) PresentListFull(comments []api.Comment) *present.OutputModel {
+	sections := make([]present.Section, len(comments))
+	for i, c := range comments {
+		author := "Unknown"
+		if c.Author.DisplayName != "" {
+			author = c.Author.DisplayName
+		}
+		body := ""
+		if c.Body != nil {
+			body = c.Body.ToPlainText()
+		}
+		sections[i] = &present.DetailSection{
+			Fields: []present.Field{
+				{Label: "ID", Value: c.ID},
+				{Label: "Author", Value: author},
+				{Label: "Created", Value: FormatTime(c.Created)},
+				{Label: "Body", Value: body},
+			},
+		}
+	}
+	return &present.OutputModel{Sections: sections}
+}
+
+// PresentAdded creates a success message for comment addition.
+func (CommentPresenter) PresentAdded(commentID, issueKey string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Added comment %s to %s", commentID, issueKey),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDeleted creates a success message for comment deletion.
+func (CommentPresenter) PresentDeleted(commentID, issueKey string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Deleted comment %s from %s", commentID, issueKey),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message when no comments are found.
+func (CommentPresenter) PresentEmpty(issueKey string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No comments on %s", issueKey),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/config.go
+++ b/tools/jtk/internal/present/config.go
@@ -1,0 +1,205 @@
+// Package present provides presenters that map domain types to presentation models.
+package present
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// ConfigPresenter creates presentation models for config commands.
+type ConfigPresenter struct{}
+
+// TestResult contains the outcome of a config test operation.
+type TestResult struct {
+	URL         string    // Jira URL being tested (empty if not configured)
+	User        *api.User // User info if auth succeeded, nil otherwise
+	ClientError error     // Error from client creation, nil if successful
+	AuthError   error     // Error from authentication, nil if successful
+}
+
+// PresentTestResult creates a complete output model for the config test command.
+func (ConfigPresenter) PresentTestResult(r TestResult) *present.OutputModel {
+	var sections []present.Section
+
+	// Case 1: No URL configured
+	if r.URL == "" {
+		sections = append(sections,
+			&present.MessageSection{Kind: present.MessageError, Message: "No Jira URL configured", Stream: present.StreamStderr},
+			&present.MessageSection{Kind: present.MessageInfo, Message: "Configure with: jtk init"},
+			&present.MessageSection{Kind: present.MessageInfo, Message: "Or set environment variable: JIRA_URL"},
+		)
+		return &present.OutputModel{Sections: sections}
+	}
+
+	// Show what we're testing
+	sections = append(sections,
+		&present.MessageSection{Kind: present.MessageInfo, Message: fmt.Sprintf("Testing connection to %s...", r.URL)},
+	)
+
+	// Case 2: Client creation failed
+	if r.ClientError != nil {
+		sections = append(sections,
+			&present.MessageSection{Kind: present.MessageError, Message: fmt.Sprintf("Failed to create client: %v", r.ClientError), Stream: present.StreamStderr},
+			&present.MessageSection{Kind: present.MessageInfo, Message: "Check your configuration with: jtk config show"},
+			&present.MessageSection{Kind: present.MessageInfo, Message: "Reconfigure with: jtk init"},
+		)
+		return &present.OutputModel{Sections: sections}
+	}
+
+	// Case 3: Authentication failed
+	if r.AuthError != nil {
+		sections = append(sections,
+			&present.MessageSection{Kind: present.MessageError, Message: fmt.Sprintf("Authentication failed: %v", r.AuthError), Stream: present.StreamStderr},
+			&present.MessageSection{Kind: present.MessageInfo, Message: "Check your credentials with: jtk config show"},
+			&present.MessageSection{Kind: present.MessageInfo, Message: "Reconfigure with: jtk init"},
+		)
+		return &present.OutputModel{Sections: sections}
+	}
+
+	// Case 4: Success
+	sections = append(sections,
+		&present.MessageSection{Kind: present.MessageSuccess, Message: "Authentication successful"},
+		&present.MessageSection{Kind: present.MessageSuccess, Message: "API access verified"},
+	)
+
+	if r.User != nil {
+		sections = append(sections,
+			&present.MessageSection{Kind: present.MessageInfo, Message: fmt.Sprintf("Authenticated as: %s (%s)", r.User.DisplayName, r.User.EmailAddress)},
+			&present.MessageSection{Kind: present.MessageInfo, Message: fmt.Sprintf("Account ID: %s", r.User.AccountID)},
+		)
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// ConfigEntry represents a single configuration entry.
+type ConfigEntry struct {
+	Key    string
+	Value  string
+	Source string
+}
+
+// PresentConfig creates a table presentation model for configuration entries.
+func (ConfigPresenter) PresentConfig(entries []ConfigEntry) *present.OutputModel {
+	rows := make([]present.Row, len(entries))
+	for i, e := range entries {
+		rows[i] = present.Row{
+			Cells: []string{e.Key, e.Value, e.Source},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"KEY", "VALUE", "SOURCE"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentConfigPath creates an info message showing the config file path.
+func (ConfigPresenter) PresentConfigPath(path string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("\nConfig file: %s", path),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentConfigWithPath creates config entries + path info as single output.
+func (ConfigPresenter) PresentConfigWithPath(entries []ConfigEntry, configPath string) *present.OutputModel {
+	rows := make([]present.Row, len(entries))
+	for i, e := range entries {
+		rows[i] = present.Row{
+			Cells: []string{e.Key, e.Value, e.Source},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"KEY", "VALUE", "SOURCE"},
+				Rows:    rows,
+			},
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("\nConfig file: %s", configPath),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentCleared creates a success message for config file removal.
+func (ConfigPresenter) PresentCleared(path string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Configuration file removed: %s", path),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentClearedWithEnvVars creates a success message with env var advisory.
+func (ConfigPresenter) PresentClearedWithEnvVars(path string, envVars []string) *present.OutputModel {
+	sections := []present.Section{
+		&present.MessageSection{
+			Kind:    present.MessageSuccess,
+			Message: fmt.Sprintf("Configuration file removed: %s", path),
+			Stream:  present.StreamStdout,
+		},
+	}
+
+	if len(envVars) > 0 {
+		sections = append(sections,
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("\nNote: The following are still configured via environment variables: %s", strings.Join(envVars, ", ")),
+				Stream:  present.StreamStderr,
+			},
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "These will continue to be used. Unset them if you want to fully clear configuration.",
+				Stream:  present.StreamStderr,
+			},
+		)
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// PresentNoConfig creates an info message when no config file exists.
+func (ConfigPresenter) PresentNoConfig(path string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No configuration file found at %s", path),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentClearCancelled creates an info message for cancelled config clear.
+func (ConfigPresenter) PresentClearCancelled() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "Cancelled.",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/config.go
+++ b/tools/jtk/internal/present/config.go
@@ -13,20 +13,17 @@ import (
 // ConfigPresenter creates presentation models for config commands.
 type ConfigPresenter struct{}
 
-// TestResult contains the outcome of a config test operation.
-type TestResult struct {
-	URL         string    // Jira URL being tested (empty if not configured)
-	User        *api.User // User info if auth succeeded, nil otherwise
-	ClientError error     // Error from client creation, nil if successful
-	AuthError   error     // Error from authentication, nil if successful
-}
-
 // PresentTestResult creates a complete output model for the config test command.
-func (ConfigPresenter) PresentTestResult(r TestResult) *present.OutputModel {
+// Parameters:
+//   - url: Jira URL being tested (empty if not configured)
+//   - user: User info if auth succeeded, nil otherwise
+//   - clientErr: Error from client creation, nil if successful
+//   - authErr: Error from authentication, nil if successful
+func (ConfigPresenter) PresentTestResult(url string, user *api.User, clientErr, authErr error) *present.OutputModel {
 	var sections []present.Section
 
 	// Case 1: No URL configured
-	if r.URL == "" {
+	if url == "" {
 		sections = append(sections,
 			&present.MessageSection{Kind: present.MessageError, Message: "No Jira URL configured", Stream: present.StreamStderr},
 			&present.MessageSection{Kind: present.MessageInfo, Message: "Configure with: jtk init"},
@@ -37,13 +34,13 @@ func (ConfigPresenter) PresentTestResult(r TestResult) *present.OutputModel {
 
 	// Show what we're testing
 	sections = append(sections,
-		&present.MessageSection{Kind: present.MessageInfo, Message: fmt.Sprintf("Testing connection to %s...", r.URL)},
+		&present.MessageSection{Kind: present.MessageInfo, Message: fmt.Sprintf("Testing connection to %s...", url)},
 	)
 
 	// Case 2: Client creation failed
-	if r.ClientError != nil {
+	if clientErr != nil {
 		sections = append(sections,
-			&present.MessageSection{Kind: present.MessageError, Message: fmt.Sprintf("Failed to create client: %v", r.ClientError), Stream: present.StreamStderr},
+			&present.MessageSection{Kind: present.MessageError, Message: fmt.Sprintf("Failed to create client: %v", clientErr), Stream: present.StreamStderr},
 			&present.MessageSection{Kind: present.MessageInfo, Message: "Check your configuration with: jtk config show"},
 			&present.MessageSection{Kind: present.MessageInfo, Message: "Reconfigure with: jtk init"},
 		)
@@ -51,9 +48,9 @@ func (ConfigPresenter) PresentTestResult(r TestResult) *present.OutputModel {
 	}
 
 	// Case 3: Authentication failed
-	if r.AuthError != nil {
+	if authErr != nil {
 		sections = append(sections,
-			&present.MessageSection{Kind: present.MessageError, Message: fmt.Sprintf("Authentication failed: %v", r.AuthError), Stream: present.StreamStderr},
+			&present.MessageSection{Kind: present.MessageError, Message: fmt.Sprintf("Authentication failed: %v", authErr), Stream: present.StreamStderr},
 			&present.MessageSection{Kind: present.MessageInfo, Message: "Check your credentials with: jtk config show"},
 			&present.MessageSection{Kind: present.MessageInfo, Message: "Reconfigure with: jtk init"},
 		)
@@ -66,60 +63,49 @@ func (ConfigPresenter) PresentTestResult(r TestResult) *present.OutputModel {
 		&present.MessageSection{Kind: present.MessageSuccess, Message: "API access verified"},
 	)
 
-	if r.User != nil {
+	if user != nil {
 		sections = append(sections,
-			&present.MessageSection{Kind: present.MessageInfo, Message: fmt.Sprintf("Authenticated as: %s (%s)", r.User.DisplayName, r.User.EmailAddress)},
-			&present.MessageSection{Kind: present.MessageInfo, Message: fmt.Sprintf("Account ID: %s", r.User.AccountID)},
+			&present.MessageSection{Kind: present.MessageInfo, Message: fmt.Sprintf("Authenticated as: %s (%s)", user.DisplayName, user.EmailAddress)},
+			&present.MessageSection{Kind: present.MessageInfo, Message: fmt.Sprintf("Account ID: %s", user.AccountID)},
 		)
 	}
 
 	return &present.OutputModel{Sections: sections}
 }
 
-// ConfigEntry represents a single configuration entry.
-type ConfigEntry struct {
-	Key    string
-	Value  string
-	Source string
+// configEntry represents a single configuration entry (internal use only).
+type configEntry struct {
+	key    string
+	value  string
+	source string
 }
 
-// PresentConfig creates a table presentation model for configuration entries.
-func (ConfigPresenter) PresentConfig(entries []ConfigEntry) *present.OutputModel {
+
+
+// PresentConfigShow creates config table + path info as single output.
+// Accepts pre-computed (value, source) pairs for each config field.
+func (ConfigPresenter) PresentConfigShow(
+	url, urlSrc,
+	email, emailSrc,
+	maskedToken, tokenSrc,
+	defaultProject, projectSrc,
+	authMethod, authMethodSrc,
+	cloudID, cloudIDSrc,
+	configPath string,
+) *present.OutputModel {
+	entries := []configEntry{
+		{key: "url", value: url, source: urlSrc},
+		{key: "email", value: email, source: emailSrc},
+		{key: "api_token", value: maskedToken, source: tokenSrc},
+		{key: "default_project", value: defaultProject, source: projectSrc},
+		{key: "auth_method", value: authMethod, source: authMethodSrc},
+		{key: "cloud_id", value: cloudID, source: cloudIDSrc},
+	}
+
 	rows := make([]present.Row, len(entries))
 	for i, e := range entries {
 		rows[i] = present.Row{
-			Cells: []string{e.Key, e.Value, e.Source},
-		}
-	}
-	return &present.OutputModel{
-		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"KEY", "VALUE", "SOURCE"},
-				Rows:    rows,
-			},
-		},
-	}
-}
-
-// PresentConfigPath creates an info message showing the config file path.
-func (ConfigPresenter) PresentConfigPath(path string) *present.OutputModel {
-	return &present.OutputModel{
-		Sections: []present.Section{
-			&present.MessageSection{
-				Kind:    present.MessageInfo,
-				Message: fmt.Sprintf("\nConfig file: %s", path),
-				Stream:  present.StreamStdout,
-			},
-		},
-	}
-}
-
-// PresentConfigWithPath creates config entries + path info as single output.
-func (ConfigPresenter) PresentConfigWithPath(entries []ConfigEntry, configPath string) *present.OutputModel {
-	rows := make([]present.Row, len(entries))
-	for i, e := range entries {
-		rows[i] = present.Row{
-			Cells: []string{e.Key, e.Value, e.Source},
+			Cells: []string{e.key, e.value, e.source},
 		}
 	}
 	return &present.OutputModel{

--- a/tools/jtk/internal/present/config_test.go
+++ b/tools/jtk/internal/present/config_test.go
@@ -1,0 +1,186 @@
+package present
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestConfigPresenter_PresentTestResult_NoURL(t *testing.T) {
+	t.Parallel()
+
+	p := ConfigPresenter{}
+	model := p.PresentTestResult("", nil, nil, nil)
+
+	testutil.Equal(t, len(model.Sections), 3)
+
+	// First section should be error
+	msg := model.Sections[0].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageError)
+	testutil.Contains(t, msg.Message, "No Jira URL configured")
+	testutil.Equal(t, msg.Stream, present.StreamStderr)
+
+	// Second section should be info with init suggestion
+	msg = model.Sections[1].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageInfo)
+	testutil.Contains(t, msg.Message, "jtk init")
+
+	// Third section should be info with env var suggestion
+	msg = model.Sections[2].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageInfo)
+	testutil.Contains(t, msg.Message, "JIRA_URL")
+}
+
+func TestConfigPresenter_PresentTestResult_ClientError(t *testing.T) {
+	t.Parallel()
+
+	p := ConfigPresenter{}
+	clientErr := errors.New("invalid credentials format")
+	model := p.PresentTestResult("https://test.atlassian.net", nil, clientErr, nil)
+
+	testutil.Equal(t, len(model.Sections), 4)
+
+	// First section: testing connection message
+	msg := model.Sections[0].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageInfo)
+	testutil.Contains(t, msg.Message, "Testing connection to https://test.atlassian.net")
+
+	// Second section: error message
+	msg = model.Sections[1].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageError)
+	testutil.Contains(t, msg.Message, "Failed to create client")
+	testutil.Contains(t, msg.Message, "invalid credentials format")
+	testutil.Equal(t, msg.Stream, present.StreamStderr)
+
+	// Third and fourth sections: help suggestions
+	msg = model.Sections[2].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageInfo)
+	testutil.Contains(t, msg.Message, "jtk config show")
+
+	msg = model.Sections[3].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageInfo)
+	testutil.Contains(t, msg.Message, "jtk init")
+}
+
+func TestConfigPresenter_PresentTestResult_AuthError(t *testing.T) {
+	t.Parallel()
+
+	p := ConfigPresenter{}
+	authErr := errors.New("401 Unauthorized")
+	model := p.PresentTestResult("https://test.atlassian.net", nil, nil, authErr)
+
+	testutil.Equal(t, len(model.Sections), 4)
+
+	// First section: testing connection message
+	msg := model.Sections[0].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageInfo)
+	testutil.Contains(t, msg.Message, "Testing connection")
+
+	// Second section: auth error
+	msg = model.Sections[1].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageError)
+	testutil.Contains(t, msg.Message, "Authentication failed")
+	testutil.Contains(t, msg.Message, "401 Unauthorized")
+	testutil.Equal(t, msg.Stream, present.StreamStderr)
+
+	// Third and fourth: help suggestions
+	msg = model.Sections[2].(*present.MessageSection)
+	testutil.Contains(t, msg.Message, "jtk config show")
+
+	msg = model.Sections[3].(*present.MessageSection)
+	testutil.Contains(t, msg.Message, "jtk init")
+}
+
+func TestConfigPresenter_PresentTestResult_Success(t *testing.T) {
+	t.Parallel()
+
+	p := ConfigPresenter{}
+	user := &api.User{
+		AccountID:    "abc-123",
+		DisplayName:  "Test User",
+		EmailAddress: "test@example.com",
+	}
+	model := p.PresentTestResult("https://test.atlassian.net", user, nil, nil)
+
+	testutil.Equal(t, len(model.Sections), 5)
+
+	// First: testing connection
+	msg := model.Sections[0].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageInfo)
+
+	// Second: auth successful
+	msg = model.Sections[1].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageSuccess)
+	testutil.Contains(t, msg.Message, "Authentication successful")
+
+	// Third: API access verified
+	msg = model.Sections[2].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageSuccess)
+	testutil.Contains(t, msg.Message, "API access verified")
+
+	// Fourth: user display name
+	msg = model.Sections[3].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageInfo)
+	testutil.Contains(t, msg.Message, "Test User")
+	testutil.Contains(t, msg.Message, "test@example.com")
+
+	// Fifth: account ID
+	msg = model.Sections[4].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageInfo)
+	testutil.Contains(t, msg.Message, "abc-123")
+}
+
+func TestConfigPresenter_PresentTestResult_SuccessNoUser(t *testing.T) {
+	t.Parallel()
+
+	p := ConfigPresenter{}
+	// Success but user is nil (edge case)
+	model := p.PresentTestResult("https://test.atlassian.net", nil, nil, nil)
+
+	// Should have: testing message + 2 success messages (no user info)
+	testutil.Equal(t, len(model.Sections), 3)
+
+	msg := model.Sections[1].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageSuccess)
+	testutil.Contains(t, msg.Message, "Authentication successful")
+
+	msg = model.Sections[2].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageSuccess)
+	testutil.Contains(t, msg.Message, "API access verified")
+}
+
+func TestConfigPresenter_PresentConfigShow(t *testing.T) {
+	t.Parallel()
+
+	p := ConfigPresenter{}
+	model := p.PresentConfigShow(
+		"https://test.atlassian.net", "env (JIRA_URL)",
+		"test@example.com", "config",
+		"****token****", "env (JIRA_API_TOKEN)",
+		"PROJ", "config",
+		"basic", "default",
+		"", "-",
+		"/path/to/config.json",
+	)
+
+	testutil.Equal(t, len(model.Sections), 2)
+
+	// First section: table
+	table := model.Sections[0].(*present.TableSection)
+	testutil.Equal(t, table.Headers, []string{"KEY", "VALUE", "SOURCE"})
+	testutil.Equal(t, len(table.Rows), 6)
+
+	// Verify first row (url)
+	testutil.Equal(t, table.Rows[0].Cells[0], "url")
+	testutil.Equal(t, table.Rows[0].Cells[1], "https://test.atlassian.net")
+	testutil.Equal(t, table.Rows[0].Cells[2], "env (JIRA_URL)")
+
+	// Second section: config path message
+	msg := model.Sections[1].(*present.MessageSection)
+	testutil.Equal(t, msg.Kind, present.MessageInfo)
+	testutil.Contains(t, msg.Message, "/path/to/config.json")
+}

--- a/tools/jtk/internal/present/dashboard.go
+++ b/tools/jtk/internal/present/dashboard.go
@@ -1,0 +1,174 @@
+package present
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// DashboardPresenter creates presentation models for dashboard data.
+type DashboardPresenter struct{}
+
+// PresentDetail creates a detail view for a single dashboard with its gadgets.
+func (DashboardPresenter) PresentDetail(d *api.Dashboard, gadgets []api.DashboardGadget) *present.OutputModel {
+	fields := []present.Field{
+		{Label: "ID", Value: d.ID},
+		{Label: "Name", Value: d.Name},
+	}
+	if d.Description != "" {
+		fields = append(fields, present.Field{Label: "Description", Value: d.Description})
+	}
+	if d.Owner != nil {
+		fields = append(fields, present.Field{Label: "Owner", Value: d.Owner.DisplayName})
+	}
+	if d.View != "" {
+		fields = append(fields, present.Field{Label: "URL", Value: d.View})
+	}
+
+	sections := []present.Section{&present.DetailSection{Fields: fields}}
+
+	if len(gadgets) > 0 {
+		rows := make([]present.Row, len(gadgets))
+		for i, g := range gadgets {
+			rows[i] = present.Row{
+				Cells: []string{FormatInt(g.ID), g.Title, g.ModuleID},
+			}
+		}
+		sections = append(sections, &present.TableSection{
+			Headers: []string{"ID", "TITLE", "MODULE"},
+			Rows:    rows,
+		})
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// PresentList creates a table view for a list of dashboards.
+func (DashboardPresenter) PresentList(dashboards []api.Dashboard) *present.OutputModel {
+	rows := make([]present.Row, len(dashboards))
+	for i, d := range dashboards {
+		owner := ""
+		if d.Owner != nil {
+			owner = d.Owner.DisplayName
+		}
+		fav := BoolString(d.IsFavourite)
+		rows[i] = present.Row{
+			Cells: []string{d.ID, d.Name, owner, fav},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "NAME", "OWNER", "FAVOURITE"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentGadgets creates a table view for a list of gadgets.
+func (DashboardPresenter) PresentGadgets(gadgets []api.DashboardGadget) *present.OutputModel {
+	rows := make([]present.Row, len(gadgets))
+	for i, g := range gadgets {
+		pos := ""
+		if g.Position.Row > 0 || g.Position.Column > 0 {
+			pos = FormatInt(g.Position.Row) + "," + FormatInt(g.Position.Column)
+		}
+		rows[i] = present.Row{
+			Cells: []string{FormatInt(g.ID), g.Title, g.ModuleID, pos},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "TITLE", "MODULE", "POSITION"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentCreated creates a success message for dashboard creation.
+func (DashboardPresenter) PresentCreated(name, id string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Created dashboard %s (%s)", name, id),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentCreatedWithURL creates a success message with URL for dashboard creation.
+func (DashboardPresenter) PresentCreatedWithURL(name, id, url string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Created dashboard %s (%s)", name, id),
+				Stream:  present.StreamStdout,
+			},
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("URL: %s", url),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDeleted creates a success message for dashboard deletion.
+func (DashboardPresenter) PresentDeleted(dashboardID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Deleted dashboard %s", dashboardID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentGadgetRemoved creates a success message for gadget removal.
+func (DashboardPresenter) PresentGadgetRemoved(gadgetID int, dashboardID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Removed gadget %d from dashboard %s", gadgetID, dashboardID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message when no dashboards are found.
+func (DashboardPresenter) PresentEmpty() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "No dashboards found",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentNoGadgets creates an info message when no gadgets are on a dashboard.
+func (DashboardPresenter) PresentNoGadgets(dashboardID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No gadgets on dashboard %s", dashboardID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/field.go
+++ b/tools/jtk/internal/present/field.go
@@ -1,0 +1,356 @@
+package present
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// FieldPresenter creates presentation models for field data.
+type FieldPresenter struct{}
+
+// PresentList creates a table view for a list of fields.
+func (FieldPresenter) PresentList(fields []api.Field) *present.OutputModel {
+	rows := make([]present.Row, len(fields))
+	for i, f := range fields {
+		custom := "no"
+		if f.Custom {
+			custom = "yes"
+		}
+		rows[i] = present.Row{
+			Cells: []string{f.ID, f.Name, f.Schema.Type, custom},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "NAME", "TYPE", "CUSTOM"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// EditableField represents a field from issue edit metadata.
+type EditableField struct {
+	ID       string
+	Name     string
+	Type     string
+	Required bool
+}
+
+// PresentEditableFields creates a table view for editable fields.
+func (FieldPresenter) PresentEditableFields(fields []EditableField) *present.OutputModel {
+	rows := make([]present.Row, len(fields))
+	for i, f := range fields {
+		required := "no"
+		if f.Required {
+			required = "yes"
+		}
+		rows[i] = present.Row{
+			Cells: []string{f.ID, f.Name, f.Type, required},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "NAME", "TYPE", "REQUIRED"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// FieldOption represents a field option value.
+type FieldOption struct {
+	ID    string
+	Value string
+}
+
+// PresentFieldOptions creates a table view for field options.
+func (FieldPresenter) PresentFieldOptions(options []FieldOption) *present.OutputModel {
+	rows := make([]present.Row, len(options))
+	for i, opt := range options {
+		rows[i] = present.Row{
+			Cells: []string{opt.ID, opt.Value},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "VALUE"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// FieldContext represents a field context.
+type FieldContext struct {
+	ID              string
+	Name            string
+	IsGlobalContext bool
+	IsAnyIssueType  bool
+}
+
+// PresentContexts creates a table view for field contexts.
+func (FieldPresenter) PresentContexts(contexts []FieldContext) *present.OutputModel {
+	rows := make([]present.Row, len(contexts))
+	for i, ctx := range contexts {
+		global := "no"
+		if ctx.IsGlobalContext {
+			global = "yes"
+		}
+		anyIssueType := "no"
+		if ctx.IsAnyIssueType {
+			anyIssueType = "yes"
+		}
+		rows[i] = present.Row{
+			Cells: []string{ctx.ID, ctx.Name, global, anyIssueType},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "NAME", "GLOBAL", "ANY_ISSUE_TYPE"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// FieldContextOption represents a field context option.
+type FieldContextOption struct {
+	ID       string
+	Value    string
+	Disabled bool
+}
+
+// PresentContextOptions creates a table view for field context options.
+func (FieldPresenter) PresentContextOptions(options []FieldContextOption) *present.OutputModel {
+	rows := make([]present.Row, len(options))
+	for i, opt := range options {
+		disabled := "no"
+		if opt.Disabled {
+			disabled = "yes"
+		}
+		rows[i] = present.Row{
+			Cells: []string{opt.ID, opt.Value, disabled},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "VALUE", "DISABLED"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentCreated creates a success message for field creation.
+func (FieldPresenter) PresentCreated(id, name string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Created field %s (%s)", id, name),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentTrashed creates a success message for field trashing.
+func (FieldPresenter) PresentTrashed(fieldID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Trashed field %s", fieldID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentRestored creates a success message for field restoration.
+func (FieldPresenter) PresentRestored(fieldID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Restored field %s", fieldID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message when no fields are found.
+func (FieldPresenter) PresentEmpty() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "No fields found",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDeleteCancelled creates an info message for cancelled field deletion.
+func (FieldPresenter) PresentDeleteCancelled() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "Deletion cancelled.",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentNoContexts creates an info message when no contexts are found.
+func (FieldPresenter) PresentNoContexts(fieldID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No contexts found for field %s", fieldID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentContextCreated creates a success message for context creation.
+func (FieldPresenter) PresentContextCreated(id, name string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Created context %s (%s)", id, name),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentContextDeleted creates a success message for context deletion.
+func (FieldPresenter) PresentContextDeleted(contextID, fieldID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Deleted context %s from field %s", contextID, fieldID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentNoOptions creates an info message when no options are found.
+func (FieldPresenter) PresentNoOptions(fieldID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No options found for field %s", fieldID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentOptionAdded creates a success message for option addition.
+// If optionID is empty, only the value is shown.
+func (FieldPresenter) PresentOptionAdded(optionID, value string) *present.OutputModel {
+	msg := fmt.Sprintf("Added option %s", value)
+	if optionID != "" {
+		msg = fmt.Sprintf("Added option %s (%s)", optionID, value)
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: msg,
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentOptionUpdated creates a success message for option update.
+func (FieldPresenter) PresentOptionUpdated(optionID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Updated option %s", optionID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentOptionDeleted creates a success message for option deletion.
+func (FieldPresenter) PresentOptionDeleted(optionID, fieldID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Deleted option %s from field %s", optionID, fieldID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// --- Field options with header ---
+
+// PresentOptionsNoContext creates a warning about missing issue context.
+func (FieldPresenter) PresentOptionsNoContext() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageWarning,
+				Message: "Could not get field options without issue context. Use --issue flag for better results.",
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// PresentFieldOptionsWithHeader creates a header + table for field options.
+func (FieldPresenter) PresentFieldOptionsWithHeader(fieldName string, options []FieldOption) *present.OutputModel {
+	rows := make([]present.Row, len(options))
+	for i, opt := range options {
+		rows[i] = present.Row{
+			Cells: []string{opt.ID, opt.Value},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("Allowed values for field '%s':", fieldName),
+				Stream:  present.StreamStdout,
+			},
+			&present.TableSection{
+				Headers: []string{"ID", "VALUE"},
+				Rows:    rows,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/field.go
+++ b/tools/jtk/internal/present/field.go
@@ -34,16 +34,8 @@ func (FieldPresenter) PresentList(fields []api.Field) *present.OutputModel {
 	}
 }
 
-// EditableField represents a field from issue edit metadata.
-type EditableField struct {
-	ID       string
-	Name     string
-	Type     string
-	Required bool
-}
-
 // PresentEditableFields creates a table view for editable fields.
-func (FieldPresenter) PresentEditableFields(fields []EditableField) *present.OutputModel {
+func (FieldPresenter) PresentEditableFields(fields []api.EditFieldMeta) *present.OutputModel {
 	rows := make([]present.Row, len(fields))
 	for i, f := range fields {
 		required := "no"
@@ -65,18 +57,19 @@ func (FieldPresenter) PresentEditableFields(fields []EditableField) *present.Out
 	}
 }
 
-// FieldOption represents a field option value.
-type FieldOption struct {
-	ID    string
-	Value string
-}
-
 // PresentFieldOptions creates a table view for field options.
-func (FieldPresenter) PresentFieldOptions(options []FieldOption) *present.OutputModel {
+func (FieldPresenter) PresentFieldOptions(options []api.FieldOptionValue) *present.OutputModel {
 	rows := make([]present.Row, len(options))
 	for i, opt := range options {
+		value := opt.Value
+		if value == "" {
+			value = opt.Name
+		}
+		if opt.Disabled {
+			value = value + " (disabled)"
+		}
 		rows[i] = present.Row{
-			Cells: []string{opt.ID, opt.Value},
+			Cells: []string{opt.ID, value},
 		}
 	}
 
@@ -90,16 +83,8 @@ func (FieldPresenter) PresentFieldOptions(options []FieldOption) *present.Output
 	}
 }
 
-// FieldContext represents a field context.
-type FieldContext struct {
-	ID              string
-	Name            string
-	IsGlobalContext bool
-	IsAnyIssueType  bool
-}
-
 // PresentContexts creates a table view for field contexts.
-func (FieldPresenter) PresentContexts(contexts []FieldContext) *present.OutputModel {
+func (FieldPresenter) PresentContexts(contexts []api.FieldContext) *present.OutputModel {
 	rows := make([]present.Row, len(contexts))
 	for i, ctx := range contexts {
 		global := "no"
@@ -125,15 +110,8 @@ func (FieldPresenter) PresentContexts(contexts []FieldContext) *present.OutputMo
 	}
 }
 
-// FieldContextOption represents a field context option.
-type FieldContextOption struct {
-	ID       string
-	Value    string
-	Disabled bool
-}
-
 // PresentContextOptions creates a table view for field context options.
-func (FieldPresenter) PresentContextOptions(options []FieldContextOption) *present.OutputModel {
+func (FieldPresenter) PresentContextOptions(options []api.FieldContextOption) *present.OutputModel {
 	rows := make([]present.Row, len(options))
 	for i, opt := range options {
 		disabled := "no"
@@ -332,11 +310,18 @@ func (FieldPresenter) PresentOptionsNoContext() *present.OutputModel {
 }
 
 // PresentFieldOptionsWithHeader creates a header + table for field options.
-func (FieldPresenter) PresentFieldOptionsWithHeader(fieldName string, options []FieldOption) *present.OutputModel {
+func (FieldPresenter) PresentFieldOptionsWithHeader(fieldName string, options []api.FieldOptionValue) *present.OutputModel {
 	rows := make([]present.Row, len(options))
 	for i, opt := range options {
+		value := opt.Value
+		if value == "" {
+			value = opt.Name
+		}
+		if opt.Disabled {
+			value = value + " (disabled)"
+		}
 		rows[i] = present.Row{
-			Cells: []string{opt.ID, opt.Value},
+			Cells: []string{opt.ID, value},
 		}
 	}
 

--- a/tools/jtk/internal/present/helpers.go
+++ b/tools/jtk/internal/present/helpers.go
@@ -1,0 +1,93 @@
+package present
+
+import (
+	"fmt"
+	"time"
+)
+
+// FormatDate formats a time.Time as a short date string.
+// Returns empty string for nil or zero time.
+func FormatDate(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return ""
+	}
+	return t.Format("2006-01-02")
+}
+
+// FormatDateTime formats a time.Time with date and time.
+// Returns empty string for nil or zero time.
+func FormatDateTime(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return ""
+	}
+	return t.Format("2006-01-02 15:04")
+}
+
+// TruncateText truncates text to maxLen characters, adding "..." if truncated.
+func TruncateText(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// BoolString returns "yes" or "no" for a boolean value.
+func BoolString(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// OrDash returns the string or "-" if empty.
+func OrDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// FormatAssignee returns the assignee name or "Unassigned" if empty.
+func FormatAssignee(name string) string {
+	if name == "" {
+		return "Unassigned"
+	}
+	return name
+}
+
+// FormatInt formats an integer as a string.
+func FormatInt(n int) string {
+	return fmt.Sprintf("%d", n)
+}
+
+// FormatSize formats a size in bytes as a human-readable string.
+func FormatSize(bytes int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case bytes >= gb:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/float64(gb))
+	case bytes >= mb:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
+	case bytes >= kb:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+// FormatTime extracts the date portion from an ISO 8601 formatted timestamp string.
+// Jira returns ISO 8601 format, this just shows the date part.
+func FormatTime(t string) string {
+	// Jira returns ISO 8601 format, just show date
+	if len(t) >= 10 {
+		return t[:10]
+	}
+	return t
+}

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -1,0 +1,521 @@
+package present
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// IssuePresenter creates presentation models for issue data.
+type IssuePresenter struct{}
+
+// PresentDetail creates a detail view for a single issue.
+func (IssuePresenter) PresentDetail(issue *api.Issue, issueURL string, noTruncate bool) *present.OutputModel {
+	status := ""
+	if issue.Fields.Status != nil {
+		status = issue.Fields.Status.Name
+	}
+
+	issueType := ""
+	if issue.Fields.IssueType != nil {
+		issueType = issue.Fields.IssueType.Name
+	}
+
+	assignee := "Unassigned"
+	if issue.Fields.Assignee != nil {
+		assignee = issue.Fields.Assignee.DisplayName
+	}
+
+	priority := ""
+	if issue.Fields.Priority != nil {
+		priority = issue.Fields.Priority.Name
+	}
+
+	project := ""
+	if issue.Fields.Project != nil {
+		project = issue.Fields.Project.Key
+	}
+
+	description := ""
+	if issue.Fields.Description != nil {
+		description = issue.Fields.Description.ToPlainText()
+		if !noTruncate && len(description) > 200 {
+			description = description[:200] + "... [truncated, use --no-truncate for complete text]"
+		}
+	}
+
+	fields := []present.Field{
+		{Label: "Key", Value: issue.Key},
+		{Label: "Summary", Value: issue.Fields.Summary},
+		{Label: "Status", Value: status},
+		{Label: "Type", Value: issueType},
+		{Label: "Priority", Value: priority},
+		{Label: "Assignee", Value: assignee},
+		{Label: "Project", Value: project},
+	}
+	if description != "" {
+		fields = append(fields, present.Field{Label: "Description", Value: description})
+	}
+	fields = append(fields, present.Field{Label: "URL", Value: issueURL})
+
+	return &present.OutputModel{
+		Sections: []present.Section{&present.DetailSection{Fields: fields}},
+	}
+}
+
+// PresentList creates a table view for a list of issues.
+func (IssuePresenter) PresentList(issues []api.Issue) *present.OutputModel {
+	rows := make([]present.Row, len(issues))
+	for i, issue := range issues {
+		status := ""
+		if issue.Fields.Status != nil {
+			status = issue.Fields.Status.Name
+		}
+
+		assignee := ""
+		if issue.Fields.Assignee != nil {
+			assignee = issue.Fields.Assignee.DisplayName
+		}
+
+		issueType := ""
+		if issue.Fields.IssueType != nil {
+			issueType = issue.Fields.IssueType.Name
+		}
+
+		rows[i] = present.Row{
+			Cells: []string{
+				issue.Key,
+				TruncateText(issue.Fields.Summary, 50),
+				OrDash(status),
+				FormatAssignee(assignee),
+				OrDash(issueType),
+			},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentTypes creates a table view for issue types.
+func (IssuePresenter) PresentTypes(types []api.IssueType) *present.OutputModel {
+	rows := make([]present.Row, len(types))
+	for i, t := range types {
+		subtask := "no"
+		if t.Subtask {
+			subtask = "yes"
+		}
+		rows[i] = present.Row{
+			Cells: []string{
+				t.ID,
+				t.Name,
+				subtask,
+				TruncateText(t.Description, 60),
+			},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "NAME", "SUBTASK", "DESCRIPTION"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentMoveStatus creates a detail view for a move task status.
+func (IssuePresenter) PresentMoveStatus(status *api.MoveTaskStatus) *present.OutputModel {
+	fields := []present.Field{
+		{Label: "Task ID", Value: status.TaskID},
+		{Label: "Status", Value: status.Status},
+		{Label: "Progress", Value: fmt.Sprintf("%d%%", status.Progress)},
+		{Label: "Submitted", Value: status.SubmittedAt},
+	}
+
+	if status.StartedAt != "" {
+		fields = append(fields, present.Field{Label: "Started", Value: status.StartedAt})
+	}
+	if status.FinishedAt != "" {
+		fields = append(fields, present.Field{Label: "Finished", Value: status.FinishedAt})
+	}
+
+	sections := []present.Section{&present.DetailSection{Fields: fields}}
+
+	// Append result messages if available
+	if status.Result != nil {
+		if len(status.Result.Successful) > 0 {
+			sections = append(sections, &present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Successful: %s", strings.Join(status.Result.Successful, ", ")),
+			})
+		}
+		if len(status.Result.Failed) > 0 {
+			sections = append(sections, &present.MessageSection{
+				Kind:    present.MessageError,
+				Message: "Failed:",
+				Stream:  present.StreamStderr,
+			})
+			for _, failed := range status.Result.Failed {
+				sections = append(sections, &present.MessageSection{
+					Kind:    present.MessageError,
+					Message: fmt.Sprintf("  %s: %s", failed.IssueKey, strings.Join(failed.Errors, ", ")),
+					Stream:  present.StreamStderr,
+				})
+			}
+		}
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// --- Mutation result methods ---
+
+// PresentCreated creates a success message for issue creation.
+func (IssuePresenter) PresentCreated(key, url string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Created issue %s (%s)", key, url),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentUpdated creates a success message for issue update.
+func (IssuePresenter) PresentUpdated(key string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Updated issue %s", key),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDeleted creates a success message for issue deletion.
+func (IssuePresenter) PresentDeleted(key string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Deleted issue %s", key),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentAssigned creates a success message for assignment.
+// If assignee is empty, presents as unassignment.
+func (IssuePresenter) PresentAssigned(key, assignee string) *present.OutputModel {
+	msg := fmt.Sprintf("Unassigned issue %s", key)
+	if assignee != "" {
+		msg = fmt.Sprintf("Assigned issue %s to %s", key, assignee)
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: msg,
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentTypeChanged creates a success message for type change.
+func (IssuePresenter) PresentTypeChanged(key, newType string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Changed %s type to %s", key, newType),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// --- No-change/idempotent methods (route to stderr) ---
+
+// PresentTypeAlreadyCurrent creates an advisory when type is already current.
+func (IssuePresenter) PresentTypeAlreadyCurrent(key, typeName string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("Issue %s is already type %s", key, typeName),
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// --- Empty state methods ---
+
+// PresentEmpty creates an info message for empty issue list.
+func (IssuePresenter) PresentEmpty() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "No issues found",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentNoEditableFields creates an info message for no editable fields.
+func (IssuePresenter) PresentNoEditableFields(key string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No editable fields found for %s", key),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentNoTypes creates an info message for no issue types found.
+func (IssuePresenter) PresentNoTypes(project string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No issue types found for project %s", project),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// --- Cancellation methods ---
+
+// PresentDeleteCancelled creates an info message for cancelled deletion.
+func (IssuePresenter) PresentDeleteCancelled() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "Deletion cancelled.",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// --- Advisory methods (route to stderr) ---
+
+// PresentPaginationHint creates an advisory about more results.
+func (IssuePresenter) PresentPaginationHint() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "More results available (use --next-page-token to fetch next page)",
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// PresentTypeChangeProgress creates an advisory about type change in progress.
+func (IssuePresenter) PresentTypeChangeProgress(key, typeName string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("Changing %s type to %s...", key, typeName),
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// --- Move operations ---
+
+// MoveFailedIssue represents a failed issue in a move operation.
+type MoveFailedIssue struct {
+	Key    string
+	Errors []string
+}
+
+// PresentTypeNotFound creates a multi-section error for type not found with available types.
+func (IssuePresenter) PresentTypeNotFound(targetType, project string, availableTypes []string) *present.OutputModel {
+	sections := []present.Section{
+		&present.MessageSection{
+			Kind:    present.MessageError,
+			Message: fmt.Sprintf("Issue type %q not found in target project", targetType),
+			Stream:  present.StreamStderr,
+		},
+		&present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: fmt.Sprintf("Available types in %s:", project),
+			Stream:  present.StreamStderr,
+		},
+	}
+
+	for _, t := range availableTypes {
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: fmt.Sprintf("  - %s", t),
+			Stream:  present.StreamStderr,
+		})
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// PresentMoveProgress creates an advisory about move in progress.
+func (IssuePresenter) PresentMoveProgress(count int, project, typeName string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("Moving %d issue(s) to %s (%s)...", count, project, typeName),
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// PresentMoveInitiated creates success + hint for async move (no-wait mode).
+func (IssuePresenter) PresentMoveInitiated(taskID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Move initiated (Task ID: %s)", taskID),
+				Stream:  present.StreamStdout,
+			},
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("Check status with: jtk issues move-status %s", taskID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentMoveWaiting creates an advisory about waiting for completion.
+func (IssuePresenter) PresentMoveWaiting() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "Waiting for move to complete...",
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// PresentMovePartialFailure creates warning + errors + successes for partial failure.
+func (IssuePresenter) PresentMovePartialFailure(successful []string, failed []MoveFailedIssue) *present.OutputModel {
+	sections := []present.Section{
+		&present.MessageSection{
+			Kind:    present.MessageWarning,
+			Message: "Move completed with errors",
+			Stream:  present.StreamStderr,
+		},
+	}
+
+	for _, f := range failed {
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageError,
+			Message: fmt.Sprintf("  %s: %s", f.Key, strings.Join(f.Errors, ", ")),
+			Stream:  present.StreamStderr,
+		})
+	}
+
+	if len(successful) > 0 {
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageSuccess,
+			Message: fmt.Sprintf("Successfully moved: %s", strings.Join(successful, ", ")),
+			Stream:  present.StreamStdout,
+		})
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// PresentMoved creates a success message for completed move.
+func (IssuePresenter) PresentMoved(count int, project string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Moved %d issue(s) to %s", count, project),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// --- List with pagination ---
+
+// PresentListWithPagination creates a table with optional pagination hint.
+func (p IssuePresenter) PresentListWithPagination(issues []api.Issue, hasMore bool) *present.OutputModel {
+	rows := make([]present.Row, len(issues))
+	for i, issue := range issues {
+		status := ""
+		if issue.Fields.Status != nil {
+			status = issue.Fields.Status.Name
+		}
+
+		assignee := ""
+		if issue.Fields.Assignee != nil {
+			assignee = issue.Fields.Assignee.DisplayName
+		}
+
+		issueType := ""
+		if issue.Fields.IssueType != nil {
+			issueType = issue.Fields.IssueType.Name
+		}
+
+		rows[i] = present.Row{
+			Cells: []string{
+				issue.Key,
+				TruncateText(issue.Fields.Summary, 50),
+				OrDash(status),
+				FormatAssignee(assignee),
+				OrDash(issueType),
+			},
+		}
+	}
+
+	sections := []present.Section{
+		&present.TableSection{
+			Headers: []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"},
+			Rows:    rows,
+		},
+	}
+
+	if hasMore {
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: "More results available (use --next-page-token to fetch next page)",
+			Stream:  present.StreamStderr,
+		})
+	}
+
+	return &present.OutputModel{Sections: sections}
+}

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -352,12 +352,6 @@ func (IssuePresenter) PresentTypeChangeProgress(key, typeName string) *present.O
 
 // --- Move operations ---
 
-// MoveFailedIssue represents a failed issue in a move operation.
-type MoveFailedIssue struct {
-	Key    string
-	Errors []string
-}
-
 // PresentTypeNotFound creates a multi-section error for type not found with available types.
 func (IssuePresenter) PresentTypeNotFound(targetType, project string, availableTypes []string) *present.OutputModel {
 	sections := []present.Section{
@@ -429,7 +423,7 @@ func (IssuePresenter) PresentMoveWaiting() *present.OutputModel {
 }
 
 // PresentMovePartialFailure creates warning + errors + successes for partial failure.
-func (IssuePresenter) PresentMovePartialFailure(successful []string, failed []MoveFailedIssue) *present.OutputModel {
+func (IssuePresenter) PresentMovePartialFailure(successful []string, failed []api.MoveFailedIssue) *present.OutputModel {
 	sections := []present.Section{
 		&present.MessageSection{
 			Kind:    present.MessageWarning,
@@ -441,7 +435,7 @@ func (IssuePresenter) PresentMovePartialFailure(successful []string, failed []Mo
 	for _, f := range failed {
 		sections = append(sections, &present.MessageSection{
 			Kind:    present.MessageError,
-			Message: fmt.Sprintf("  %s: %s", f.Key, strings.Join(f.Errors, ", ")),
+			Message: fmt.Sprintf("  %s: %s", f.IssueKey, strings.Join(f.Errors, ", ")),
 			Stream:  present.StreamStderr,
 		})
 	}

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -1,0 +1,333 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestIssuePresenter_PresentDetail(t *testing.T) {
+	t.Parallel()
+	issue := &api.Issue{
+		Key: "PROJ-123",
+		Fields: api.IssueFields{
+			Summary:   "Fix the bug",
+			Status:    &api.Status{Name: "In Progress"},
+			IssueType: &api.IssueType{Name: "Bug"},
+			Priority:  &api.Priority{Name: "High"},
+			Assignee:  &api.User{DisplayName: "Alice"},
+			Project:   &api.Project{Key: "PROJ"},
+		},
+	}
+
+	p := IssuePresenter{}
+	model := p.PresentDetail(issue, "https://jira.example.com/browse/PROJ-123", false)
+
+	if len(model.Sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(model.Sections))
+	}
+
+	detail, ok := model.Sections[0].(*present.DetailSection)
+	if !ok {
+		t.Fatalf("expected DetailSection, got %T", model.Sections[0])
+	}
+
+	// Verify key fields are present
+	fieldMap := make(map[string]string)
+	for _, f := range detail.Fields {
+		fieldMap[f.Label] = f.Value
+	}
+
+	if fieldMap["Key"] != "PROJ-123" {
+		t.Errorf("expected Key='PROJ-123', got %q", fieldMap["Key"])
+	}
+	if fieldMap["Summary"] != "Fix the bug" {
+		t.Errorf("expected Summary='Fix the bug', got %q", fieldMap["Summary"])
+	}
+	if fieldMap["Status"] != "In Progress" {
+		t.Errorf("expected Status='In Progress', got %q", fieldMap["Status"])
+	}
+	if fieldMap["Assignee"] != "Alice" {
+		t.Errorf("expected Assignee='Alice', got %q", fieldMap["Assignee"])
+	}
+	if fieldMap["URL"] != "https://jira.example.com/browse/PROJ-123" {
+		t.Errorf("expected URL to be set, got %q", fieldMap["URL"])
+	}
+}
+
+func TestIssuePresenter_PresentDetail_Unassigned(t *testing.T) {
+	t.Parallel()
+	issue := &api.Issue{
+		Key: "PROJ-123",
+		Fields: api.IssueFields{
+			Summary: "Unassigned issue",
+			// Assignee is nil
+		},
+	}
+
+	p := IssuePresenter{}
+	model := p.PresentDetail(issue, "https://jira.example.com/browse/PROJ-123", false)
+
+	detail := model.Sections[0].(*present.DetailSection)
+	fieldMap := make(map[string]string)
+	for _, f := range detail.Fields {
+		fieldMap[f.Label] = f.Value
+	}
+
+	if fieldMap["Assignee"] != "Unassigned" {
+		t.Errorf("expected Assignee='Unassigned' for nil assignee, got %q", fieldMap["Assignee"])
+	}
+}
+
+func TestIssuePresenter_PresentList(t *testing.T) {
+	t.Parallel()
+	issues := []api.Issue{
+		{
+			Key: "PROJ-1",
+			Fields: api.IssueFields{
+				Summary:   "First issue",
+				Status:    &api.Status{Name: "Done"},
+				Assignee:  &api.User{DisplayName: "Bob"},
+				IssueType: &api.IssueType{Name: "Task"},
+			},
+		},
+		{
+			Key: "PROJ-2",
+			Fields: api.IssueFields{
+				Summary:   "Second issue",
+				Status:    &api.Status{Name: "Open"},
+				IssueType: &api.IssueType{Name: "Bug"},
+				// Assignee is nil
+			},
+		},
+	}
+
+	p := IssuePresenter{}
+	model := p.PresentList(issues)
+
+	if len(model.Sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(model.Sections))
+	}
+
+	table, ok := model.Sections[0].(*present.TableSection)
+	if !ok {
+		t.Fatalf("expected TableSection, got %T", model.Sections[0])
+	}
+
+	// Verify headers
+	expectedHeaders := []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Errorf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	}
+	for i, h := range expectedHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+
+	// Verify rows
+	if len(table.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
+	}
+
+	// Row 1
+	if table.Rows[0].Cells[0] != "PROJ-1" {
+		t.Errorf("row 0 key: expected 'PROJ-1', got %q", table.Rows[0].Cells[0])
+	}
+	if table.Rows[0].Cells[3] != "Bob" {
+		t.Errorf("row 0 assignee: expected 'Bob', got %q", table.Rows[0].Cells[3])
+	}
+
+	// Row 2 - unassigned
+	if table.Rows[1].Cells[3] != "Unassigned" {
+		t.Errorf("row 1 assignee: expected 'Unassigned', got %q", table.Rows[1].Cells[3])
+	}
+}
+
+func TestIssuePresenter_PresentTypes(t *testing.T) {
+	t.Parallel()
+	types := []api.IssueType{
+		{ID: "1", Name: "Bug", Subtask: false, Description: "A bug in the software"},
+		{ID: "2", Name: "Sub-task", Subtask: true, Description: "A subtask of another issue"},
+	}
+
+	p := IssuePresenter{}
+	model := p.PresentTypes(types)
+
+	table := model.Sections[0].(*present.TableSection)
+
+	// Headers: ID, NAME, SUBTASK, DESCRIPTION
+	if len(table.Headers) != 4 {
+		t.Errorf("expected 4 headers, got %d", len(table.Headers))
+	}
+	if len(table.Rows) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(table.Rows))
+	}
+
+	// Verify subtask display (lowercase)
+	if table.Rows[0].Cells[2] != "no" {
+		t.Errorf("Bug subtask: expected 'no', got %q", table.Rows[0].Cells[2])
+	}
+	if table.Rows[1].Cells[2] != "yes" {
+		t.Errorf("Sub-task subtask: expected 'yes', got %q", table.Rows[1].Cells[2])
+	}
+
+	// Verify description is included
+	if table.Rows[0].Cells[3] != "A bug in the software" {
+		t.Errorf("Bug description: expected 'A bug in the software', got %q", table.Rows[0].Cells[3])
+	}
+}
+
+func TestIssuePresenter_PresentListWithPagination_NoMore(t *testing.T) {
+	t.Parallel()
+	issues := []api.Issue{
+		{Key: "PROJ-1", Fields: api.IssueFields{Summary: "Issue 1"}},
+	}
+
+	p := IssuePresenter{}
+	model := p.PresentListWithPagination(issues, false)
+
+	// Should have only 1 section (table, no pagination hint)
+	if len(model.Sections) != 1 {
+		t.Errorf("expected 1 section, got %d", len(model.Sections))
+	}
+	if _, ok := model.Sections[0].(*present.TableSection); !ok {
+		t.Errorf("expected TableSection, got %T", model.Sections[0])
+	}
+}
+
+func TestIssuePresenter_PresentListWithPagination_HasMore(t *testing.T) {
+	t.Parallel()
+	issues := []api.Issue{
+		{Key: "PROJ-1", Fields: api.IssueFields{Summary: "Issue 1"}},
+	}
+
+	p := IssuePresenter{}
+	model := p.PresentListWithPagination(issues, true)
+
+	// Should have 2 sections (table + pagination hint)
+	if len(model.Sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(model.Sections))
+	}
+
+	msg, ok := model.Sections[1].(*present.MessageSection)
+	if !ok {
+		t.Fatalf("expected MessageSection for pagination hint, got %T", model.Sections[1])
+	}
+	if msg.Stream != present.StreamStderr {
+		t.Errorf("pagination hint should go to stderr, got %v", msg.Stream)
+	}
+}
+
+func TestIssuePresenter_PresentTypeNotFound(t *testing.T) {
+	t.Parallel()
+	p := IssuePresenter{}
+	model := p.PresentTypeNotFound("Story", "PROJ", []string{"Bug", "Task", "Epic"})
+
+	// Should have: error + "Available types" header + 3 type entries = 5 sections
+	if len(model.Sections) != 5 {
+		t.Fatalf("expected 5 sections, got %d", len(model.Sections))
+	}
+
+	// First section is error
+	errMsg := model.Sections[0].(*present.MessageSection)
+	if errMsg.Kind != present.MessageError {
+		t.Errorf("first section should be error, got %v", errMsg.Kind)
+	}
+	if errMsg.Stream != present.StreamStderr {
+		t.Errorf("error should go to stderr")
+	}
+
+	// All sections should go to stderr
+	for i, s := range model.Sections {
+		msg := s.(*present.MessageSection)
+		if msg.Stream != present.StreamStderr {
+			t.Errorf("section %d should go to stderr", i)
+		}
+	}
+}
+
+func TestIssuePresenter_PresentMoveInitiated(t *testing.T) {
+	t.Parallel()
+	p := IssuePresenter{}
+	model := p.PresentMoveInitiated("task-123")
+
+	// Should have 2 sections: success + info hint
+	if len(model.Sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(model.Sections))
+	}
+
+	success := model.Sections[0].(*present.MessageSection)
+	if success.Kind != present.MessageSuccess {
+		t.Errorf("expected success, got %v", success.Kind)
+	}
+	if success.Stream != present.StreamStdout {
+		t.Errorf("success should go to stdout")
+	}
+
+	info := model.Sections[1].(*present.MessageSection)
+	if info.Kind != present.MessageInfo {
+		t.Errorf("expected info, got %v", info.Kind)
+	}
+	if info.Stream != present.StreamStdout {
+		t.Errorf("info hint should go to stdout")
+	}
+}
+
+func TestIssuePresenter_PresentMovePartialFailure(t *testing.T) {
+	t.Parallel()
+	p := IssuePresenter{}
+	successful := []string{"PROJ-1", "PROJ-2"}
+	failed := []MoveFailedIssue{
+		{Key: "PROJ-3", Errors: []string{"Invalid type"}},
+	}
+	model := p.PresentMovePartialFailure(successful, failed)
+
+	// Should have: warning + 1 error + 1 success = 3 sections
+	if len(model.Sections) != 3 {
+		t.Fatalf("expected 3 sections, got %d", len(model.Sections))
+	}
+
+	// Warning first
+	warn := model.Sections[0].(*present.MessageSection)
+	if warn.Kind != present.MessageWarning {
+		t.Errorf("expected warning, got %v", warn.Kind)
+	}
+	if warn.Stream != present.StreamStderr {
+		t.Errorf("warning should go to stderr")
+	}
+
+	// Error second
+	errMsg := model.Sections[1].(*present.MessageSection)
+	if errMsg.Kind != present.MessageError {
+		t.Errorf("expected error, got %v", errMsg.Kind)
+	}
+	if errMsg.Stream != present.StreamStderr {
+		t.Errorf("error should go to stderr")
+	}
+
+	// Success third
+	success := model.Sections[2].(*present.MessageSection)
+	if success.Kind != present.MessageSuccess {
+		t.Errorf("expected success, got %v", success.Kind)
+	}
+	if success.Stream != present.StreamStdout {
+		t.Errorf("success should go to stdout")
+	}
+}
+
+func TestIssuePresenter_PresentMovePartialFailure_NoSuccessful(t *testing.T) {
+	t.Parallel()
+	p := IssuePresenter{}
+	failed := []MoveFailedIssue{
+		{Key: "PROJ-1", Errors: []string{"Error 1"}},
+	}
+	model := p.PresentMovePartialFailure(nil, failed)
+
+	// Should have: warning + 1 error = 2 sections (no success section)
+	if len(model.Sections) != 2 {
+		t.Errorf("expected 2 sections when no successful, got %d", len(model.Sections))
+	}
+}

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -280,8 +280,8 @@ func TestIssuePresenter_PresentMovePartialFailure(t *testing.T) {
 	t.Parallel()
 	p := IssuePresenter{}
 	successful := []string{"PROJ-1", "PROJ-2"}
-	failed := []MoveFailedIssue{
-		{Key: "PROJ-3", Errors: []string{"Invalid type"}},
+	failed := []api.MoveFailedIssue{
+		{IssueKey: "PROJ-3", Errors: []string{"Invalid type"}},
 	}
 	model := p.PresentMovePartialFailure(successful, failed)
 
@@ -321,8 +321,8 @@ func TestIssuePresenter_PresentMovePartialFailure(t *testing.T) {
 func TestIssuePresenter_PresentMovePartialFailure_NoSuccessful(t *testing.T) {
 	t.Parallel()
 	p := IssuePresenter{}
-	failed := []MoveFailedIssue{
-		{Key: "PROJ-1", Errors: []string{"Error 1"}},
+	failed := []api.MoveFailedIssue{
+		{IssueKey: "PROJ-1", Errors: []string{"Error 1"}},
 	}
 	model := p.PresentMovePartialFailure(nil, failed)
 

--- a/tools/jtk/internal/present/link.go
+++ b/tools/jtk/internal/present/link.go
@@ -1,0 +1,115 @@
+// Package present provides presenters that map domain types to presentation models.
+package present
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// LinkPresenter creates presentation models for issue links.
+type LinkPresenter struct{}
+
+// PresentList creates a table presentation of issue links.
+func (LinkPresenter) PresentList(links []api.IssueLink) *present.OutputModel {
+	rows := make([]present.Row, len(links))
+	for i, l := range links {
+		var direction, key, summary string
+
+		if l.OutwardIssue != nil {
+			// OutwardIssue is set → current issue is the inward side
+			direction = l.Type.Inward
+			key = l.OutwardIssue.Key
+			summary = l.OutwardIssue.Fields.Summary
+		} else if l.InwardIssue != nil {
+			// InwardIssue is set → current issue is the outward side
+			direction = l.Type.Outward
+			key = l.InwardIssue.Key
+			summary = l.InwardIssue.Fields.Summary
+		}
+
+		rows[i] = present.Row{
+			Cells: []string{l.ID, l.Type.Name, direction, key, summary},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "TYPE", "DIRECTION", "ISSUE", "SUMMARY"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentTypes creates a table presentation of issue link types.
+func (LinkPresenter) PresentTypes(types []api.IssueLinkType) *present.OutputModel {
+	rows := make([]present.Row, len(types))
+	for i, t := range types {
+		rows[i] = present.Row{
+			Cells: []string{t.ID, t.Name, t.Outward, t.Inward},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "NAME", "OUTWARD", "INWARD"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentCreated creates a success message for link creation.
+func (LinkPresenter) PresentCreated(linkType, outwardKey, inwardKey string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Created %s link: %s → %s", linkType, outwardKey, inwardKey),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDeleted creates a success message for link deletion.
+func (LinkPresenter) PresentDeleted(linkID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Deleted link %s", linkID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message when no links are found.
+func (LinkPresenter) PresentEmpty(issueKey string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No links on %s", issueKey),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentNoTypes creates an info message when no link types are available.
+func (LinkPresenter) PresentNoTypes() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "No link types available",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/mutation.go
+++ b/tools/jtk/internal/present/mutation.go
@@ -1,0 +1,76 @@
+// Package present provides presenters that map domain types to presentation models.
+package present
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+)
+
+// MutationPresenter creates presentation models for mutation confirmations.
+type MutationPresenter struct{}
+
+// Success creates a success message that goes to stdout (it IS the result).
+func (MutationPresenter) Success(format string, args ...any) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf(format, args...),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// Info creates an informational message that goes to stdout.
+func (MutationPresenter) Info(format string, args ...any) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf(format, args...),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// Advisory creates a non-primary message that goes to stderr (pagination, hints).
+func (MutationPresenter) Advisory(format string, args ...any) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf(format, args...),
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// Warning creates a warning message that goes to stderr.
+func (MutationPresenter) Warning(format string, args ...any) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageWarning,
+				Message: fmt.Sprintf(format, args...),
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// Error creates an error message that goes to stderr.
+func (MutationPresenter) Error(format string, args ...any) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageError,
+				Message: fmt.Sprintf(format, args...),
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/mutation_test.go
+++ b/tools/jtk/internal/present/mutation_test.go
@@ -1,0 +1,88 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+)
+
+func TestMutationPresenter_Success(t *testing.T) {
+	t.Parallel()
+	p := MutationPresenter{}
+	model := p.Success("Created issue %s", "PROJ-123")
+
+	if len(model.Sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(model.Sections))
+	}
+
+	msg, ok := model.Sections[0].(*present.MessageSection)
+	if !ok {
+		t.Fatalf("expected MessageSection, got %T", model.Sections[0])
+	}
+
+	if msg.Kind != present.MessageSuccess {
+		t.Errorf("expected MessageSuccess, got %v", msg.Kind)
+	}
+	if msg.Message != "Created issue PROJ-123" {
+		t.Errorf("expected 'Created issue PROJ-123', got %q", msg.Message)
+	}
+	if msg.Stream != present.StreamStdout {
+		t.Errorf("expected StreamStdout, got %v", msg.Stream)
+	}
+}
+
+func TestMutationPresenter_Info(t *testing.T) {
+	t.Parallel()
+	p := MutationPresenter{}
+	model := p.Info("Processing %d items", 5)
+
+	msg := model.Sections[0].(*present.MessageSection)
+	if msg.Kind != present.MessageInfo {
+		t.Errorf("expected MessageInfo, got %v", msg.Kind)
+	}
+	if msg.Stream != present.StreamStdout {
+		t.Errorf("expected StreamStdout, got %v", msg.Stream)
+	}
+}
+
+func TestMutationPresenter_Advisory(t *testing.T) {
+	t.Parallel()
+	p := MutationPresenter{}
+	model := p.Advisory("More results available")
+
+	msg := model.Sections[0].(*present.MessageSection)
+	if msg.Kind != present.MessageInfo {
+		t.Errorf("expected MessageInfo kind, got %v", msg.Kind)
+	}
+	if msg.Stream != present.StreamStderr {
+		t.Errorf("expected StreamStderr (advisory goes to stderr), got %v", msg.Stream)
+	}
+}
+
+func TestMutationPresenter_Warning(t *testing.T) {
+	t.Parallel()
+	p := MutationPresenter{}
+	model := p.Warning("Deprecated feature")
+
+	msg := model.Sections[0].(*present.MessageSection)
+	if msg.Kind != present.MessageWarning {
+		t.Errorf("expected MessageWarning, got %v", msg.Kind)
+	}
+	if msg.Stream != present.StreamStderr {
+		t.Errorf("expected StreamStderr, got %v", msg.Stream)
+	}
+}
+
+func TestMutationPresenter_Error(t *testing.T) {
+	t.Parallel()
+	p := MutationPresenter{}
+	model := p.Error("Connection failed")
+
+	msg := model.Sections[0].(*present.MessageSection)
+	if msg.Kind != present.MessageError {
+		t.Errorf("expected MessageError, got %v", msg.Kind)
+	}
+	if msg.Stream != present.StreamStderr {
+		t.Errorf("expected StreamStderr, got %v", msg.Stream)
+	}
+}

--- a/tools/jtk/internal/present/project.go
+++ b/tools/jtk/internal/present/project.go
@@ -1,0 +1,183 @@
+// Package present provides presenters that map domain types to presentation models.
+package present
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// ProjectPresenter creates presentation models for project data.
+type ProjectPresenter struct{}
+
+// Present creates a presentation model for text output.
+// Content normalization (if any) happens here, not in the renderer.
+func (ProjectPresenter) Present(p *api.ProjectDetail) *present.OutputModel {
+	lead := "Unassigned"
+	if p.Lead != nil {
+		lead = p.Lead.DisplayName
+	}
+
+	fields := []present.Field{
+		{Label: "Key", Value: p.Key},
+		{Label: "Name", Value: p.Name},
+		{Label: "ID", Value: p.ID.String()},
+		{Label: "Type", Value: p.ProjectTypeKey},
+		{Label: "Lead", Value: lead},
+	}
+
+	if p.Description != "" {
+		fields = append(fields, present.Field{Label: "Description", Value: p.Description})
+	}
+
+	if len(p.IssueTypes) > 0 {
+		var names []string
+		for _, it := range p.IssueTypes {
+			names = append(names, it.Name)
+		}
+		fields = append(fields, present.Field{Label: "Issue Types", Value: fmt.Sprintf("%s", names)})
+	}
+
+	if p.URL != "" {
+		fields = append(fields, present.Field{Label: "URL", Value: p.URL})
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{&present.DetailSection{Fields: fields}},
+	}
+}
+
+// PresentList creates a table view for a list of projects.
+func (ProjectPresenter) PresentList(projects []api.ProjectDetail) *present.OutputModel {
+	rows := make([]present.Row, len(projects))
+	for i, p := range projects {
+		lead := ""
+		if p.Lead != nil {
+			lead = p.Lead.DisplayName
+		}
+		rows[i] = present.Row{
+			Cells: []string{p.Key, p.Name, p.ProjectTypeKey, lead},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"KEY", "NAME", "TYPE", "LEAD"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentTypes creates a table view for a list of project types.
+func (ProjectPresenter) PresentTypes(types []api.ProjectType) *present.OutputModel {
+	rows := make([]present.Row, len(types))
+	for i, t := range types {
+		rows[i] = present.Row{
+			Cells: []string{t.Key, t.FormattedKey},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"KEY", "FORMATTED"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentCreated creates a success message for project creation.
+func (ProjectPresenter) PresentCreated(key, name string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Created project %s (%s)", key, name),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentUpdated creates a success message for project update.
+func (ProjectPresenter) PresentUpdated(key string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Updated project %s", key),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDeleted creates a success message for project deletion.
+func (ProjectPresenter) PresentDeleted(key string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Deleted project %s (moved to trash)", key),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentRestored creates a success message for project restoration.
+func (ProjectPresenter) PresentRestored(key, name string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Restored project %s (%s)", key, name),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message when no projects are found.
+func (ProjectPresenter) PresentEmpty() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "No projects found",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentNoTypes creates an info message when no project types are found.
+func (ProjectPresenter) PresentNoTypes() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "No project types found",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentDeleteCancelled creates an info message for cancelled deletion.
+func (ProjectPresenter) PresentDeleteCancelled() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "Deletion cancelled.",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/sprint.go
+++ b/tools/jtk/internal/present/sprint.go
@@ -1,0 +1,108 @@
+package present
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// SprintPresenter creates presentation models for sprint data.
+type SprintPresenter struct{}
+
+// PresentDetail creates a detail view for a single sprint.
+func (SprintPresenter) PresentDetail(sprint *api.Sprint) *present.OutputModel {
+	fields := []present.Field{
+		{Label: "ID", Value: FormatInt(sprint.ID)},
+		{Label: "Name", Value: sprint.Name},
+		{Label: "State", Value: sprint.State},
+	}
+
+	if sprint.Goal != "" {
+		fields = append(fields, present.Field{Label: "Goal", Value: sprint.Goal})
+	}
+	if sprint.StartDate != nil {
+		fields = append(fields, present.Field{Label: "Start Date", Value: FormatDate(sprint.StartDate)})
+	}
+	if sprint.EndDate != nil {
+		fields = append(fields, present.Field{Label: "End Date", Value: FormatDate(sprint.EndDate)})
+	}
+	if sprint.CompleteDate != nil {
+		fields = append(fields, present.Field{Label: "Complete Date", Value: FormatDate(sprint.CompleteDate)})
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{&present.DetailSection{Fields: fields}},
+	}
+}
+
+// PresentList creates a table view for a list of sprints.
+func (SprintPresenter) PresentList(sprints []api.Sprint) *present.OutputModel {
+	rows := make([]present.Row, len(sprints))
+	for i, sprint := range sprints {
+		rows[i] = present.Row{
+			Cells: []string{
+				FormatInt(sprint.ID),
+				sprint.Name,
+				sprint.State,
+				FormatDate(sprint.StartDate),
+				FormatDate(sprint.EndDate),
+			},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "NAME", "STATE", "START", "END"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentMoved creates a success message for moving issues to a sprint.
+func (SprintPresenter) PresentMoved(issueKeys []string, sprintID int) *present.OutputModel {
+	var msg string
+	if len(issueKeys) == 1 {
+		msg = fmt.Sprintf("Moved %s to sprint %d", issueKeys[0], sprintID)
+	} else {
+		msg = fmt.Sprintf("Moved %d issues to sprint %d", len(issueKeys), sprintID)
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: msg,
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message when no sprints are found.
+func (SprintPresenter) PresentEmpty() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "No sprints found",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentNoIssues creates an info message when no issues are in a sprint.
+func (SprintPresenter) PresentNoIssues() *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: "No issues in sprint",
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/sprint_test.go
+++ b/tools/jtk/internal/present/sprint_test.go
@@ -1,0 +1,135 @@
+package present
+
+import (
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestSprintPresenter_PresentDetail(t *testing.T) {
+	t.Parallel()
+	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2024, 1, 14, 0, 0, 0, 0, time.UTC)
+
+	sprint := &api.Sprint{
+		ID:        42,
+		Name:      "Sprint 1",
+		State:     "active",
+		Goal:      "Complete MVP",
+		StartDate: &startDate,
+		EndDate:   &endDate,
+	}
+
+	p := SprintPresenter{}
+	model := p.PresentDetail(sprint)
+
+	if len(model.Sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(model.Sections))
+	}
+
+	detail, ok := model.Sections[0].(*present.DetailSection)
+	if !ok {
+		t.Fatalf("expected DetailSection, got %T", model.Sections[0])
+	}
+
+	fieldMap := make(map[string]string)
+	for _, f := range detail.Fields {
+		fieldMap[f.Label] = f.Value
+	}
+
+	if fieldMap["ID"] != "42" {
+		t.Errorf("expected ID='42', got %q", fieldMap["ID"])
+	}
+	if fieldMap["Name"] != "Sprint 1" {
+		t.Errorf("expected Name='Sprint 1', got %q", fieldMap["Name"])
+	}
+	if fieldMap["State"] != "active" {
+		t.Errorf("expected State='active', got %q", fieldMap["State"])
+	}
+	if fieldMap["Goal"] != "Complete MVP" {
+		t.Errorf("expected Goal='Complete MVP', got %q", fieldMap["Goal"])
+	}
+	if fieldMap["Start Date"] != "2024-01-01" {
+		t.Errorf("expected Start Date='2024-01-01', got %q", fieldMap["Start Date"])
+	}
+	if fieldMap["End Date"] != "2024-01-14" {
+		t.Errorf("expected End Date='2024-01-14', got %q", fieldMap["End Date"])
+	}
+}
+
+func TestSprintPresenter_PresentDetail_MinimalFields(t *testing.T) {
+	t.Parallel()
+	sprint := &api.Sprint{
+		ID:    1,
+		Name:  "Backlog",
+		State: "future",
+		// No goal, no dates
+	}
+
+	p := SprintPresenter{}
+	model := p.PresentDetail(sprint)
+
+	detail := model.Sections[0].(*present.DetailSection)
+
+	// Should only have ID, Name, State
+	if len(detail.Fields) != 3 {
+		t.Errorf("expected 3 fields for minimal sprint, got %d", len(detail.Fields))
+	}
+}
+
+func TestSprintPresenter_PresentList(t *testing.T) {
+	t.Parallel()
+	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2024, 1, 14, 0, 0, 0, 0, time.UTC)
+
+	sprints := []api.Sprint{
+		{
+			ID:        1,
+			Name:      "Sprint 1",
+			State:     "closed",
+			StartDate: &startDate,
+			EndDate:   &endDate,
+		},
+		{
+			ID:    2,
+			Name:  "Sprint 2",
+			State: "active",
+			// No dates yet
+		},
+	}
+
+	p := SprintPresenter{}
+	model := p.PresentList(sprints)
+
+	table, ok := model.Sections[0].(*present.TableSection)
+	if !ok {
+		t.Fatalf("expected TableSection, got %T", model.Sections[0])
+	}
+
+	// Verify headers
+	expectedHeaders := []string{"ID", "NAME", "STATE", "START", "END"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Errorf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	}
+
+	// Verify rows
+	if len(table.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
+	}
+
+	// Row 1 - with dates
+	if table.Rows[0].Cells[0] != "1" {
+		t.Errorf("row 0 ID: expected '1', got %q", table.Rows[0].Cells[0])
+	}
+	if table.Rows[0].Cells[3] != "2024-01-01" {
+		t.Errorf("row 0 start: expected '2024-01-01', got %q", table.Rows[0].Cells[3])
+	}
+
+	// Row 2 - no dates
+	if table.Rows[1].Cells[3] != "" {
+		t.Errorf("row 1 start: expected empty for nil date, got %q", table.Rows[1].Cells[3])
+	}
+}

--- a/tools/jtk/internal/present/transition.go
+++ b/tools/jtk/internal/present/transition.go
@@ -1,0 +1,132 @@
+// Package present provides presenters that map domain types to presentation models.
+package present
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// TransitionPresenter creates presentation models for transition data.
+type TransitionPresenter struct{}
+
+// PresentList creates a table view for a list of transitions.
+func (TransitionPresenter) PresentList(transitions []api.Transition) *present.OutputModel {
+	rows := make([]present.Row, len(transitions))
+	for i, t := range transitions {
+		toStatus := ""
+		if t.To.Name != "" {
+			toStatus = t.To.Name
+		}
+		rows[i] = present.Row{
+			Cells: []string{t.ID, t.Name, toStatus},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "NAME", "TO STATUS"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentListWithFields creates a table view for transitions with required fields.
+func (TransitionPresenter) PresentListWithFields(transitions []api.Transition) *present.OutputModel {
+	rows := make([]present.Row, len(transitions))
+	for i, t := range transitions {
+		toStatus := ""
+		if t.To.Name != "" {
+			toStatus = t.To.Name
+		}
+		required := getRequiredFields(t)
+		rows[i] = present.Row{
+			Cells: []string{t.ID, t.Name, toStatus, required},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "NAME", "TO STATUS", "REQUIRED FIELDS"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// GetRequiredFieldsForTransition returns a comma-separated list of required field names
+// This is exported for use in transitions command tests
+func GetRequiredFieldsForTransition(t api.Transition) string {
+	var required []string
+	for _, field := range t.Fields {
+		if field.Required {
+			required = append(required, field.Name)
+		}
+	}
+	if len(required) == 0 {
+		return "-"
+	}
+	return strings.Join(required, ", ")
+}
+
+// getRequiredFields returns a comma-separated list of required field names (internal use)
+func getRequiredFields(t api.Transition) string {
+	return GetRequiredFieldsForTransition(t)
+}
+
+// PresentTransitioned creates a success message for a completed transition.
+func (TransitionPresenter) PresentTransitioned(issueKey string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Transitioned %s", issueKey),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message when no transitions are available.
+func (TransitionPresenter) PresentEmpty(issueKey string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No transitions available for %s", issueKey),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentNotFound creates an error with available transitions as context.
+// Both the error and the available options route to stderr.
+func (TransitionPresenter) PresentNotFound(name string, available []api.Transition) *present.OutputModel {
+	sections := []present.Section{
+		&present.MessageSection{
+			Kind:    present.MessageError,
+			Message: fmt.Sprintf("Transition '%s' not found", name),
+			Stream:  present.StreamStderr,
+		},
+		&present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: "Available transitions:",
+			Stream:  present.StreamStderr,
+		},
+	}
+
+	for _, t := range available {
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: fmt.Sprintf("  %s: %s -> %s", t.ID, t.Name, t.To.Name),
+			Stream:  present.StreamStderr,
+		})
+	}
+
+	return &present.OutputModel{Sections: sections}
+}

--- a/tools/jtk/internal/present/user.go
+++ b/tools/jtk/internal/present/user.go
@@ -1,0 +1,67 @@
+// Package present provides presenters that map domain types to presentation models.
+package present
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// UserPresenter creates presentation models for user data.
+type UserPresenter struct{}
+
+// Present creates a presentation model for text output.
+// Content normalization (if any) happens here, not in the renderer.
+func (UserPresenter) Present(user *api.User) *present.OutputModel {
+	fields := []present.Field{
+		{Label: "Account ID", Value: user.AccountID},
+		{Label: "Display Name", Value: user.DisplayName},
+	}
+	if user.EmailAddress != "" {
+		fields = append(fields, present.Field{Label: "Email", Value: user.EmailAddress})
+	}
+	fields = append(fields, present.Field{
+		Label: "Active", Value: BoolString(user.Active),
+	})
+	return &present.OutputModel{
+		Sections: []present.Section{&present.DetailSection{Fields: fields}},
+	}
+}
+
+// PresentList creates a table view for a list of users.
+func (UserPresenter) PresentList(users []api.User) *present.OutputModel {
+	rows := make([]present.Row, len(users))
+	for i, u := range users {
+		active := "yes"
+		if !u.Active {
+			active = "no"
+		}
+		rows[i] = present.Row{
+			Cells: []string{u.AccountID, u.DisplayName, u.EmailAddress, active},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ACCOUNT ID", "NAME", "EMAIL", "ACTIVE"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentEmpty creates an info message when no users are found.
+func (UserPresenter) PresentEmpty(query string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No users found matching '%s'", query),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}

--- a/tools/jtk/internal/present/user_test.go
+++ b/tools/jtk/internal/present/user_test.go
@@ -1,0 +1,98 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestUserPresenter_Present(t *testing.T) {
+	t.Parallel()
+	user := &api.User{
+		AccountID:    "abc123",
+		DisplayName:  "John Doe",
+		EmailAddress: "john@example.com",
+		Active:       true,
+	}
+
+	p := UserPresenter{}
+	model := p.Present(user)
+
+	if len(model.Sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(model.Sections))
+	}
+
+	detail, ok := model.Sections[0].(*present.DetailSection)
+	if !ok {
+		t.Fatalf("expected DetailSection, got %T", model.Sections[0])
+	}
+
+	findField := func(label string) string {
+		for _, f := range detail.Fields {
+			if f.Label == label {
+				return f.Value
+			}
+		}
+		return ""
+	}
+
+	if got := findField("Account ID"); got != "abc123" {
+		t.Errorf("Account ID = %q, want abc123", got)
+	}
+	if got := findField("Display Name"); got != "John Doe" {
+		t.Errorf("Display Name = %q, want John Doe", got)
+	}
+	if got := findField("Email"); got != "john@example.com" {
+		t.Errorf("Email = %q, want john@example.com", got)
+	}
+	if got := findField("Active"); got != "yes" {
+		t.Errorf("Active = %q, want yes", got)
+	}
+}
+
+func TestUserPresenter_OmitsEmptyEmail(t *testing.T) {
+	t.Parallel()
+	user := &api.User{
+		AccountID:   "abc123",
+		DisplayName: "John Doe",
+		Active:      true,
+	}
+
+	p := UserPresenter{}
+	model := p.Present(user)
+
+	detail := model.Sections[0].(*present.DetailSection)
+	for _, f := range detail.Fields {
+		if f.Label == "Email" {
+			t.Error("Email field should be omitted when empty")
+		}
+	}
+}
+
+func TestUserPresenter_InactiveUser(t *testing.T) {
+	t.Parallel()
+	user := &api.User{
+		AccountID:   "abc123",
+		DisplayName: "Jane Doe",
+		Active:      false,
+	}
+
+	p := UserPresenter{}
+	model := p.Present(user)
+
+	detail := model.Sections[0].(*present.DetailSection)
+	findField := func(label string) string {
+		for _, f := range detail.Fields {
+			if f.Label == label {
+				return f.Value
+			}
+		}
+		return ""
+	}
+
+	if got := findField("Active"); got != "no" {
+		t.Errorf("Active = %q, want no", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Eliminates generic presenter methods (`PresentSuccess/Info/Advisory/Warning/Error`) from command code — commands no longer choose wording or message kind
- Eliminates multi-fragment output orchestration — commands pass domain data to a single presenter method that returns a complete `OutputModel`
- Adds 11 domain-specific presenter methods covering move operations, pagination, field options, config show, and automation updates
- Removes 7 generic methods from `issue.go` and `field.go` after all usages are migrated

Replaces #225 (merged prematurely, reverted in 36291b5).

## Test plan

- [ ] `make build && make test && make lint` all pass
- [ ] `jtk config show` shows table + path info (both on stdout)
- [ ] `jtk issues move` with invalid type shows error + available types
- [ ] `jtk automation update` shows progress then success message

[MON-221]