### PR TITLE
feat(jtk): replace legacy output flags with the new global output model

### DIFF
--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Global output flags replaced with `--extended`, `--fulltext`, `--id` per the new output model. The `--full` flag is removed; use `--extended` for admin/schema/audit detail. `--id` takes precedence over `--extended` and `--fulltext`. `--output` / `-o` is hidden but still functional during migration. Per-command `--no-truncate` flags remain as deprecated aliases for `--fulltext`. ([#231](https://github.com/open-cli-collective/atlassian-cli/issues/231))
+- Global output flags replaced with `--extended`, `--fulltext`, `--id` per the new output model. The `--full` flag is removed; use `--extended` for admin/schema/audit detail. `--id` takes precedence over `--extended` and `--fulltext`. `--output` / `-o` is hidden but still functional during migration. Per-command `--no-truncate` flags remain as deprecated aliases for `--fulltext`. Initial `--id` support is wired for `me`, `users get`, and `issues get` — remaining commands parse the flag but do not yet collapse output; broader per-command migration continues under #230 follow-ups. ([#231](https://github.com/open-cli-collective/atlassian-cli/issues/231))
 
 ### Added
 

--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Global output flags replaced with `--extended`, `--fulltext`, `--id` per the new output model. The `--full` flag is removed; use `--extended` for admin/schema/audit detail. `--id` takes precedence over `--extended` and `--fulltext`. `--output` / `-o` is hidden but still functional during migration. Per-command `--no-truncate` flags remain as deprecated aliases for `--fulltext`. ([#231](https://github.com/open-cli-collective/atlassian-cli/issues/231))
+
 ### Added
 
 - `users get <account-id>` subcommand to look up a user by account ID ([#189](https://github.com/open-cli-collective/atlassian-cli/pull/189))

--- a/tools/jtk/CLAUDE.md
+++ b/tools/jtk/CLAUDE.md
@@ -207,16 +207,18 @@ Bearer auth routes requests through `https://api.atlassian.com/ex/jira/{cloudId}
 
 > **Scope limitations:** Scoped tokens lack Agile (boards/sprints), Automation, and Dashboard scopes. These commands are unavailable with bearer auth — this is an Atlassian platform limitation.
 
-## Output Artifact Contract
+## Output Contract
 
-Commands produce intentional artifacts, not raw API payloads. See [docs/ARTIFACT_CONTRACT.md](../../docs/ARTIFACT_CONTRACT.md) for the full specification.
+Commands produce intentional artifacts, not raw API payloads. The surface is controlled by three global flags (per [#230](https://github.com/open-cli-collective/atlassian-cli/issues/230)):
 
-**Representations:**
-- `agent` (default): Action-oriented output with essential fields for LLM/agent consumption
-- `full` (`--full`): Inspection-oriented output with additional fields (dates, authors, versions)
-- `raw` (`--raw`): Source-faithful content. Command-specific (not all commands support this).
+| Flag | Purpose |
+|------|---------|
+| *(none)* | Default: contextually-rich human+agent text. Stable format. |
+| `--extended` | Adds admin/schema/audit detail on top of default. |
+| `--id` | Emits only the primary identifier. Takes precedence over `--extended` and `--fulltext`. |
+| `--fulltext` | Disables truncation of descriptions and comments. |
 
-For jtk, the `agent` artifact for issues includes: key, summary, status, assignee (enough to triage).
+`--output` / `-o` (`table`/`json`/`plain`) is retained for compatibility but hidden from `--help`. Per-command migration to the text-first output model is tracked under #230. The JSON path still functions — removal is scheduled per follow-up.
 
 ## Dependencies
 

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -152,11 +152,15 @@ These flags are available on all commands:
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--output` | `-o` | `table` | Output format: `table`, `json`, `plain` |
+| `--extended` | | `false` | Include admin/schema/audit fields in output |
+| `--fulltext` | | `false` | Disable truncation of descriptions and comments |
+| `--id` | | `false` | Emit only the primary identifier (takes precedence over `--extended` and `--fulltext`) |
 | `--no-color` | | `false` | Disable colored output |
 | `--verbose` | `-v` | `false` | Enable verbose output |
 | `--help` | `-h` | | Show help for command |
 | `--version` | | | Show version (root command only) |
+
+> `--output` / `-o` (`table`/`json`/`plain`) is retained for backward compatibility but is hidden from `--help`. Per-command migration to the text-first output model is tracked under #230.
 
 ---
 
@@ -269,13 +273,14 @@ Get details of a specific issue.
 
 ```bash
 jtk issues get PROJ-123
-jtk issues get PROJ-123 --no-truncate
+jtk issues get PROJ-123 --fulltext
 jtk issues get PROJ-123 -o json
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--no-truncate` | `false` | Show full description without truncation |
+| `--fulltext` | `false` | Show full description without truncation (global) |
+| `--no-truncate` | `false` | Deprecated alias for `--fulltext` (kept during migration) |
 
 **Arguments:**
 - `<issue-key>` - The issue key (e.g., `PROJ-123`) (**required**)
@@ -761,14 +766,15 @@ List comments on an issue.
 
 ```bash
 jtk comments list PROJ-123
-jtk comments list PROJ-123 --no-truncate
+jtk comments list PROJ-123 --fulltext
 jtk comments list PROJ-123 -o json
 ```
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--max` | `-m` | `50` | Maximum number of comments |
-| `--no-truncate` | | `false` | Show full comment bodies without truncation |
+| `--fulltext` | | `false` | Show full comment bodies without truncation (global) |
+| `--no-truncate` | | `false` | Deprecated alias for `--fulltext` (kept during migration) |
 
 **Arguments:**
 - `<issue-key>` - The issue key (**required**)

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -200,8 +200,12 @@ Show information about the currently authenticated user.
 
 ```bash
 jtk me
-jtk me -o json
+jtk me --id     # print just the account ID (for scripting)
 ```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--id` | `false` | Emit only the account ID (global) |
 
 ---
 
@@ -274,11 +278,12 @@ Get details of a specific issue.
 ```bash
 jtk issues get PROJ-123
 jtk issues get PROJ-123 --fulltext
-jtk issues get PROJ-123 -o json
+jtk issues get PROJ-123 --id
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--id` | `false` | Emit only the issue key (global) |
 | `--fulltext` | `false` | Show full description without truncation (global) |
 | `--no-truncate` | `false` | Deprecated alias for `--fulltext` (kept during migration) |
 
@@ -1116,8 +1121,12 @@ Get details for a specific user by account ID.
 
 ```bash
 jtk users get 5b10ac8d82e05b22cc7d4ef5
-jtk users get 5b10ac8d82e05b22cc7d4ef5 -o json
+jtk users get 5b10ac8d82e05b22cc7d4ef5 --id
 ```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--id` | `false` | Emit only the account ID (global) |
 
 **Arguments:**
 - `<account-id>` - The Atlassian account ID (**required**)

--- a/tools/jtk/integration-tests.md
+++ b/tools/jtk/integration-tests.md
@@ -420,7 +420,7 @@ Run these steps in order. Each step depends on the previous.
 
 6b. **Verify escape sequences rendered:**
    ```bash
-   jtk comments list $TEST_ISSUE --no-truncate
+   jtk comments list $TEST_ISSUE --fulltext
    ```
    Expected: Comment body shows actual newlines and tab, not literal `\n` or `\t`
 

--- a/tools/jtk/internal/cmd/attachments/attachments.go
+++ b/tools/jtk/internal/cmd/attachments/attachments.go
@@ -41,10 +41,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
 		Short:   "List attachments on an issue",
 		Long:    "List all attachments on a Jira issue.",
 		Example: `  # List attachments
-  jtk attachments list PROJ-123
-
-  # Output as JSON
-  jtk attachments list PROJ-123 -o json`,
+  jtk attachments list PROJ-123`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(cmd.Context(), opts, args[0])

--- a/tools/jtk/internal/cmd/automation/get.go
+++ b/tools/jtk/internal/cmd/automation/get.go
@@ -28,8 +28,7 @@ labels, tags).
 
 For the exact JSON needed for editing, use 'jtk auto export' instead.`,
 		Example: `  jtk automation get 12345
-  jtk auto get 12345 --show-components
-  jtk auto get 12345 -o json`,
+  jtk auto get 12345 --show-components`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(cmd.Context(), opts, args[0], showComponents)

--- a/tools/jtk/internal/cmd/automation/get.go
+++ b/tools/jtk/internal/cmd/automation/get.go
@@ -23,8 +23,8 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Long: `Retrieve and display details for a specific automation rule.
 
 Shows rule metadata and a summary of components. Use --show-components to see
-component type details. Use -o json for structured output. Use --full for
-additional fields (description, labels, tags).
+component type details. Use --extended for additional fields (description,
+labels, tags).
 
 For the exact JSON needed for editing, use 'jtk auto export' instead.`,
 		Example: `  jtk automation get 12345

--- a/tools/jtk/internal/cmd/automation/list.go
+++ b/tools/jtk/internal/cmd/automation/list.go
@@ -21,8 +21,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
 		Short: "List automation rules",
 		Long:  "List all automation rules with optional state filtering.",
 		Example: `  jtk automation list
-  jtk automation list --state ENABLED
-  jtk auto list -o json`,
+  jtk automation list --state ENABLED`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runList(cmd.Context(), opts, strings.ToUpper(state))
 		},

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -42,15 +42,15 @@ func newListCmd(opts *root.Options) *cobra.Command {
 		Short: "List comments on an issue",
 		Long:  "List all comments on a specific issue.",
 		Example: `  jtk comments list PROJ-123
-  jtk comments list PROJ-123 --no-truncate`,
+  jtk comments list PROJ-123 --fulltext`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), opts, args[0], maxResults, noTruncate)
+			return runList(cmd.Context(), opts, args[0], maxResults, noTruncate || opts.IsFullText())
 		},
 	}
 
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of comments")
-	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full comment bodies without truncation")
+	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full comment bodies without truncation (deprecated: use --fulltext)")
 
 	return cmd
 }

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -50,7 +50,8 @@ func newListCmd(opts *root.Options) *cobra.Command {
 	}
 
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of comments")
-	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full comment bodies without truncation (deprecated: use --fulltext)")
+	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full comment bodies without truncation")
+	_ = cmd.Flags().MarkDeprecated("no-truncate", "use --fulltext instead")
 
 	return cmd
 }

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -203,6 +203,60 @@ func TestNewListCmd_FullTextRoutesFromRoot(t *testing.T) {
 	testutil.NotContains(t, output, "[truncated")
 }
 
+// TestNewListCmd_NoTruncateAndFullTextBothSet guards the OR-combined path:
+// both the local --no-truncate flag and the global --fulltext must produce
+// the same result when set together (prevents accidental && regression).
+func TestNewListCmd_NoTruncateAndFullTextBothSet(t *testing.T) {
+	t.Parallel()
+	longText := strings.Repeat("B", 200)
+	comments := []api.Comment{
+		{
+			ID:     "1",
+			Author: api.User{DisplayName: "Alice"},
+			Body: &api.ADFDocument{
+				Type:    "doc",
+				Version: 1,
+				Content: []*api.ADFNode{
+					{
+						Type: "paragraph",
+						Content: []*api.ADFNode{
+							{Type: "text", Text: longText},
+						},
+					},
+				},
+			},
+			Created: "2024-01-15T10:00:00.000Z",
+		},
+	}
+
+	server := newTestCommentsServer(t, comments)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output:   "table",
+		FullText: true,
+		Stdout:   &stdout,
+		Stderr:   &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	cmd := newListCmd(opts)
+	cmd.SetArgs([]string{"TEST-1", "--no-truncate"})
+	testutil.RequireNoError(t, cmd.Execute())
+
+	output := stdout.String()
+	testutil.Contains(t, output, longText)
+	testutil.NotContains(t, output, "[truncated")
+}
+
 func TestRunList_ShortCommentNotTruncated(t *testing.T) {
 	t.Parallel()
 	comments := []api.Comment{

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -92,7 +92,7 @@ func TestRunList_TruncatesCommentBody(t *testing.T) {
 
 	output := stdout.String()
 	testutil.Contains(t, output, "Alice")
-	testutil.Contains(t, output, "[truncated, use --no-truncate for complete text]")
+	testutil.Contains(t, output, "[truncated, use --fulltext for complete text]")
 	testutil.NotContains(t, output, longText)
 }
 
@@ -147,6 +147,60 @@ func TestRunList_FullCommentBody(t *testing.T) {
 	testutil.Contains(t, output, "ID:")
 	testutil.Contains(t, output, "Author:")
 	testutil.Contains(t, output, "Body:")
+}
+
+// TestNewListCmd_FullTextRoutesFromRoot verifies that --fulltext on the root
+// Options flows through the RunE wrapper to disable truncation, even when the
+// local --no-truncate flag is not set.
+func TestNewListCmd_FullTextRoutesFromRoot(t *testing.T) {
+	t.Parallel()
+	longText := strings.Repeat("B", 200)
+	comments := []api.Comment{
+		{
+			ID:     "1",
+			Author: api.User{DisplayName: "Alice"},
+			Body: &api.ADFDocument{
+				Type:    "doc",
+				Version: 1,
+				Content: []*api.ADFNode{
+					{
+						Type: "paragraph",
+						Content: []*api.ADFNode{
+							{Type: "text", Text: longText},
+						},
+					},
+				},
+			},
+			Created: "2024-01-15T10:00:00.000Z",
+		},
+	}
+
+	server := newTestCommentsServer(t, comments)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output:   "table",
+		FullText: true,
+		Stdout:   &stdout,
+		Stderr:   &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	cmd := newListCmd(opts)
+	cmd.SetArgs([]string{"TEST-1"}) // no --no-truncate locally
+	testutil.RequireNoError(t, cmd.Execute())
+
+	output := stdout.String()
+	testutil.Contains(t, output, longText)
+	testutil.NotContains(t, output, "[truncated")
 }
 
 func TestRunList_ShortCommentNotTruncated(t *testing.T) {

--- a/tools/jtk/internal/cmd/dashboards/dashboards.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards.go
@@ -116,8 +116,7 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Use:   "get <dashboard-id>",
 		Short: "Get dashboard details",
 		Long:  "Get details of a specific dashboard including its gadgets.",
-		Example: `  jtk dashboards get 10001
-  jtk dashboards get 10001 -o json`,
+		Example: `  jtk dashboards get 10001`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(cmd.Context(), opts, args[0])
@@ -274,8 +273,7 @@ func newGadgetsListCmd(opts *root.Options) *cobra.Command {
 		Use:   "list <dashboard-id>",
 		Short: "List gadgets on a dashboard",
 		Long:  "List all gadgets on a specific dashboard.",
-		Example: `  jtk dashboards gadgets list 10001
-  jtk dashboards gadgets list 10001 -o json`,
+		Example: `  jtk dashboards gadgets list 10001`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGadgetsList(cmd.Context(), opts, args[0])

--- a/tools/jtk/internal/cmd/dashboards/dashboards.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards.go
@@ -113,11 +113,11 @@ func runList(_ context.Context, opts *root.Options, search string, maxResults in
 
 func newGetCmd(opts *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get <dashboard-id>",
-		Short: "Get dashboard details",
-		Long:  "Get details of a specific dashboard including its gadgets.",
+		Use:     "get <dashboard-id>",
+		Short:   "Get dashboard details",
+		Long:    "Get details of a specific dashboard including its gadgets.",
 		Example: `  jtk dashboards get 10001`,
-		Args: cobra.ExactArgs(1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(cmd.Context(), opts, args[0])
 		},
@@ -270,11 +270,11 @@ func newGadgetsCmd(opts *root.Options) *cobra.Command {
 
 func newGadgetsListCmd(opts *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list <dashboard-id>",
-		Short: "List gadgets on a dashboard",
-		Long:  "List all gadgets on a specific dashboard.",
+		Use:     "list <dashboard-id>",
+		Short:   "List gadgets on a dashboard",
+		Long:    "List all gadgets on a specific dashboard.",
 		Example: `  jtk dashboards gadgets list 10001`,
-		Args: cobra.ExactArgs(1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGadgetsList(cmd.Context(), opts, args[0])
 		},

--- a/tools/jtk/internal/cmd/fields/fields.go
+++ b/tools/jtk/internal/cmd/fields/fields.go
@@ -50,10 +50,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
   jtk fields list --custom
 
   # Search for fields by name
-  jtk fields list --name "story point"
-
-  # List fields as JSON
-  jtk fields list -o json`,
+  jtk fields list --name "story point"`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runList(cmd.Context(), opts, customOnly, nameFilter)
 		},

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -30,7 +30,8 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full description without truncation (deprecated: use --fulltext)")
+	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full description without truncation")
+	_ = cmd.Flags().MarkDeprecated("no-truncate", "use --fulltext instead")
 
 	return cmd
 }

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -22,15 +22,15 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Short: "Get issue details",
 		Long:  "Retrieve and display details for a specific issue.",
 		Example: `  jtk issues get PROJ-123
-  jtk issues get PROJ-123 --no-truncate
+  jtk issues get PROJ-123 --fulltext
   jtk issues get PROJ-123 -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGet(cmd.Context(), opts, args[0], noTruncate)
+			return runGet(cmd.Context(), opts, args[0], noTruncate || opts.IsFullText())
 		},
 	}
 
-	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full description without truncation")
+	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full description without truncation (deprecated: use --fulltext)")
 
 	return cmd
 }

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -23,7 +23,7 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Long:  "Retrieve and display details for a specific issue.",
 		Example: `  jtk issues get PROJ-123
   jtk issues get PROJ-123 --fulltext
-  jtk issues get PROJ-123 -o json`,
+  jtk issues get PROJ-123 --id`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(cmd.Context(), opts, args[0], noTruncate || opts.IsFullText())
@@ -46,6 +46,11 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	issue, err := client.GetIssue(ctx, issueKey)
 	if err != nil {
 		return err
+	}
+
+	if opts.EmitIDOnly() {
+		_, _ = fmt.Fprintln(opts.Stdout, issue.Key)
+		return nil
 	}
 
 	// For JSON output, return the projected artifact

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -159,6 +159,50 @@ func TestNewGetCmd_FullTextRoutesFromRoot(t *testing.T) {
 	testutil.NotContains(t, output, "[truncated")
 }
 
+// TestNewGetCmd_NoTruncateAndFullTextBothSet guards the OR-combined path:
+// both the local --no-truncate flag and the global --fulltext must produce
+// the same result when set together (prevents accidental && regression).
+func TestNewGetCmd_NoTruncateAndFullTextBothSet(t *testing.T) {
+	t.Parallel()
+	longText := strings.Repeat("A", 300)
+	issue := api.Issue{
+		Key: "TEST-1",
+		Fields: api.IssueFields{
+			Summary:     "Test issue",
+			Description: &api.Description{Text: longText},
+			Status:      &api.Status{Name: "Open"},
+			IssueType:   &api.IssueType{Name: "Task"},
+		},
+	}
+
+	server := newTestIssueServer(t, issue)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output:   "table",
+		FullText: true,
+		Stdout:   &stdout,
+		Stderr:   &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	cmd := newGetCmd(opts)
+	cmd.SetArgs([]string{"TEST-1", "--no-truncate"})
+	testutil.RequireNoError(t, cmd.Execute())
+
+	output := stdout.String()
+	testutil.Contains(t, output, longText)
+	testutil.NotContains(t, output, "[truncated")
+}
+
 func TestRunGet_ShortDescriptionNotTruncated(t *testing.T) {
 	t.Parallel()
 	issue := api.Issue{

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -72,7 +72,7 @@ func TestRunGet_TruncatesDescription(t *testing.T) {
 
 	output := stdout.String()
 	testutil.Contains(t, output, "TEST-1")
-	testutil.Contains(t, output, "[truncated, use --no-truncate for complete text]")
+	testutil.Contains(t, output, "[truncated, use --fulltext for complete text]")
 	testutil.NotContains(t, output, longText)
 }
 
@@ -109,6 +109,50 @@ func TestRunGet_FullDescription(t *testing.T) {
 
 	err = runGet(context.Background(), opts, "TEST-1", true)
 	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, longText)
+	testutil.NotContains(t, output, "[truncated")
+}
+
+// TestNewGetCmd_FullTextRoutesFromRoot verifies that when --fulltext is set on
+// the root Options (as the persistent --fulltext flag does), runGet is invoked
+// with noTruncate=true even though the local --no-truncate flag is not set.
+func TestNewGetCmd_FullTextRoutesFromRoot(t *testing.T) {
+	t.Parallel()
+	longText := strings.Repeat("A", 300)
+	issue := api.Issue{
+		Key: "TEST-1",
+		Fields: api.IssueFields{
+			Summary:     "Test issue",
+			Description: &api.Description{Text: longText},
+			Status:      &api.Status{Name: "Open"},
+			IssueType:   &api.IssueType{Name: "Task"},
+		},
+	}
+
+	server := newTestIssueServer(t, issue)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Output:   "table",
+		FullText: true, // global --fulltext
+		Stdout:   &stdout,
+		Stderr:   &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	cmd := newGetCmd(opts)
+	cmd.SetArgs([]string{"TEST-1"}) // no --no-truncate locally
+	testutil.RequireNoError(t, cmd.Execute())
 
 	output := stdout.String()
 	testutil.Contains(t, output, longText)

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -203,6 +203,59 @@ func TestNewGetCmd_NoTruncateAndFullTextBothSet(t *testing.T) {
 	testutil.NotContains(t, output, "[truncated")
 }
 
+func TestRunGet_IDOnly(t *testing.T) {
+	t.Parallel()
+	issue := api.Issue{
+		Key: "TEST-1",
+		Fields: api.IssueFields{
+			Summary:   "Test issue",
+			Status:    &api.Status{Name: "Open"},
+			IssueType: &api.IssueType{Name: "Task"},
+		},
+	}
+
+	server := newTestIssueServer(t, issue)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TEST-1", false))
+	testutil.Equal(t, stdout.String(), "TEST-1\n")
+}
+
+func TestRunGet_IDOnlyPrecedenceOverExtendedFullText(t *testing.T) {
+	t.Parallel()
+	issue := api.Issue{
+		Key: "TEST-1",
+		Fields: api.IssueFields{
+			Summary:     "Test issue",
+			Description: &api.Description{Text: strings.Repeat("A", 300)},
+			Status:      &api.Status{Name: "Open"},
+			IssueType:   &api.IssueType{Name: "Task"},
+		},
+	}
+
+	server := newTestIssueServer(t, issue)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Extended: true, FullText: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	// runGet receives noTruncate derived from RunE; when --id is set, the truncation
+	// value doesn't matter because EmitIDOnly collapses output before presenter runs.
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TEST-1", true))
+	testutil.Equal(t, stdout.String(), "TEST-1\n")
+}
+
 func TestRunGet_ShortDescriptionNotTruncated(t *testing.T) {
 	t.Parallel()
 	issue := api.Issue{

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -44,7 +44,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
   jtk issues list --project MYPROJECT --all-fields
 
   # List with specific fields (e.g. custom fields)
-  jtk issues list --project MYPROJECT --fields summary,status,customfield_10005 -o json`,
+  jtk issues list --project MYPROJECT --fields summary,status,customfield_10005`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runList(cmd.Context(), opts, project, sprint, maxResults, nextPageToken, allFields, fieldsFlag)
 		},

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -43,7 +43,7 @@ func newSearchCmd(opts *root.Options) *cobra.Command {
   jtk issues search --jql "project = MYPROJECT" --all-fields
 
   # Search with specific fields (e.g. custom fields)
-  jtk issues search --jql "project = MYPROJECT" --fields summary,status,customfield_10005 -o json`,
+  jtk issues search --jql "project = MYPROJECT" --fields summary,status,customfield_10005`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runSearch(cmd.Context(), opts, jql, maxResults, nextPageToken, allFields, fieldsFlag)
 		},

--- a/tools/jtk/internal/cmd/links/links.go
+++ b/tools/jtk/internal/cmd/links/links.go
@@ -37,8 +37,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
 		Use:   "list <issue-key>",
 		Short: "List links on an issue",
 		Long:  "List all links on a specific issue.",
-		Example: `  jtk links list PROJ-123
-  jtk links list PROJ-123 -o json`,
+		Example: `  jtk links list PROJ-123`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runList(opts, args[0])
@@ -203,8 +202,7 @@ func newTypesCmd(opts *root.Options) *cobra.Command {
 		Use:   "types",
 		Short: "List available link types",
 		Long:  "List all available issue link types in the Jira instance.",
-		Example: `  jtk links types
-  jtk links types -o json`,
+		Example: `  jtk links types`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runTypes(opts)
 		},

--- a/tools/jtk/internal/cmd/links/links.go
+++ b/tools/jtk/internal/cmd/links/links.go
@@ -34,11 +34,11 @@ func Register(parent *cobra.Command, opts *root.Options) {
 
 func newListCmd(opts *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list <issue-key>",
-		Short: "List links on an issue",
-		Long:  "List all links on a specific issue.",
+		Use:     "list <issue-key>",
+		Short:   "List links on an issue",
+		Long:    "List all links on a specific issue.",
 		Example: `  jtk links list PROJ-123`,
-		Args: cobra.ExactArgs(1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runList(opts, args[0])
 		},
@@ -199,9 +199,9 @@ func runDelete(opts *root.Options, linkID string) error {
 
 func newTypesCmd(opts *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "types",
-		Short: "List available link types",
-		Long:  "List all available issue link types in the Jira instance.",
+		Use:     "types",
+		Short:   "List available link types",
+		Long:    "List all available issue link types in the Jira instance.",
 		Example: `  jtk links types`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runTypes(opts)

--- a/tools/jtk/internal/cmd/me/me.go
+++ b/tools/jtk/internal/cmd/me/me.go
@@ -25,7 +25,7 @@ func Register(parent *cobra.Command, opts *root.Options) {
   jtk me
 
   # Show just the account ID (for scripting)
-  jtk me -o plain`,
+  jtk me --id`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return run(cmd.Context(), opts)
 		},
@@ -47,12 +47,18 @@ func run(ctx context.Context, opts *root.Options) error {
 		return err
 	}
 
+	// --id: collapse output to the primary identifier.
+	if opts.EmitIDOnly() {
+		_, _ = fmt.Fprintln(opts.Stdout, user.AccountID)
+		return nil
+	}
+
 	// JSON path: use existing artifact layer (unchanged)
 	if v.Format == view.FormatJSON {
 		return v.RenderArtifact(jtkartifact.ProjectUser(user, opts.ArtifactMode()))
 	}
 
-	// Plain path: just the account ID
+	// Plain path: just the account ID (legacy; --id is the preferred surface)
 	if v.Format == view.FormatPlain {
 		_, _ = fmt.Fprintln(opts.Stdout, user.AccountID)
 		return nil

--- a/tools/jtk/internal/cmd/me/me_test.go
+++ b/tools/jtk/internal/cmd/me/me_test.go
@@ -63,6 +63,55 @@ func TestRun_Table(t *testing.T) {
 	testutil.Contains(t, output, "yes")
 }
 
+func TestRun_IDOnly(t *testing.T) {
+	t.Parallel()
+	user := &api.User{
+		AccountID:    "abc123",
+		DisplayName:  "John Doe",
+		EmailAddress: "john@example.com",
+		Active:       true,
+	}
+
+	server := newTestUserServer(t, http.StatusOK, user)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, run(context.Background(), opts))
+
+	testutil.Equal(t, stdout.String(), "abc123\n")
+}
+
+func TestRun_IDOnlyPrecedenceOverExtended(t *testing.T) {
+	t.Parallel()
+	user := &api.User{
+		AccountID:    "abc123",
+		DisplayName:  "John Doe",
+		EmailAddress: "john@example.com",
+		Active:       true,
+	}
+
+	server := newTestUserServer(t, http.StatusOK, user)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Extended: true, FullText: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, run(context.Background(), opts))
+
+	// --id wins: only the accountID, no presenter output.
+	testutil.Equal(t, stdout.String(), "abc123\n")
+}
+
 func TestRun_JSON(t *testing.T) {
 	t.Parallel()
 	user := &api.User{

--- a/tools/jtk/internal/cmd/root/root.go
+++ b/tools/jtk/internal/cmd/root/root.go
@@ -18,13 +18,15 @@ import (
 
 // Options contains global options for commands
 type Options struct {
-	Output  string
-	NoColor bool
-	Full    bool
-	Verbose bool
-	Stdin   io.Reader
-	Stdout  io.Writer
-	Stderr  io.Writer
+	Output   string // Legacy output format (table/json/plain); flag is hidden during migration.
+	NoColor  bool
+	Extended bool // --extended: include admin/schema/audit fields.
+	FullText bool // --fulltext: disable truncation of descriptions/comments.
+	IDOnly   bool // --id: emit only the primary identifier; takes precedence over Extended/FullText.
+	Verbose  bool
+	Stdin    io.Reader
+	Stdout   io.Writer
+	Stderr   io.Writer
 
 	// testClient is used for testing; if set, APIClient() returns this instead
 	testClient *api.Client
@@ -32,6 +34,15 @@ type Options struct {
 	// cachedClient caches the API client after first construction
 	cachedClient *api.Client
 }
+
+// EmitIDOnly reports whether output should collapse to the primary identifier.
+func (o *Options) EmitIDOnly() bool { return o.IDOnly }
+
+// IsExtended reports whether extended output is requested, honoring --id precedence (--id wins).
+func (o *Options) IsExtended() bool { return !o.IDOnly && o.Extended }
+
+// IsFullText reports whether body truncation is disabled, honoring --id precedence (--id wins).
+func (o *Options) IsFullText() bool { return !o.IDOnly && o.FullText }
 
 // View returns a configured View instance, deriving policy from RenderMode.
 func (o *Options) View() *view.View {
@@ -45,9 +56,10 @@ func (o *Options) View() *view.View {
 	return v
 }
 
-// ArtifactMode returns the artifact type based on the --full flag.
+// ArtifactMode returns the artifact type based on the --extended flag,
+// honoring --id precedence (--id collapses output, so Extended is ignored).
 func (o *Options) ArtifactMode() artifact.Type {
-	return artifact.Mode(o.Full)
+	return artifact.Mode(o.IsExtended())
 }
 
 // RenderMode returns the authoritative rendering mode.
@@ -115,8 +127,11 @@ func NewCmd() (*cobra.Command, *Options) {
 
 	// Global flags - bound to opts struct
 	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "table", "Output format: table, json, plain")
+	_ = cmd.PersistentFlags().MarkHidden("output")
 	cmd.PersistentFlags().BoolVar(&opts.NoColor, "no-color", false, "Disable colored output")
-	cmd.PersistentFlags().BoolVar(&opts.Full, "full", false, "Show full inspection-oriented output (default: agent)")
+	cmd.PersistentFlags().BoolVar(&opts.Extended, "extended", false, "Include admin/schema/audit fields in output")
+	cmd.PersistentFlags().BoolVar(&opts.FullText, "fulltext", false, "Disable truncation of descriptions and comments")
+	cmd.PersistentFlags().BoolVar(&opts.IDOnly, "id", false, "Emit only the primary identifier (takes precedence over --extended and --fulltext)")
 	cmd.PersistentFlags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Enable verbose output")
 
 	return cmd, opts
@@ -133,16 +148,20 @@ func RegisterCommands(root *cobra.Command, opts *Options, registrars ...func(*co
 func GetOptions(cmd *cobra.Command) *Options {
 	output, _ := cmd.Root().PersistentFlags().GetString("output")
 	noColor, _ := cmd.Root().PersistentFlags().GetBool("no-color")
-	full, _ := cmd.Root().PersistentFlags().GetBool("full")
+	extended, _ := cmd.Root().PersistentFlags().GetBool("extended")
+	fullText, _ := cmd.Root().PersistentFlags().GetBool("fulltext")
+	idOnly, _ := cmd.Root().PersistentFlags().GetBool("id")
 	verbose, _ := cmd.Root().PersistentFlags().GetBool("verbose")
 
 	return &Options{
-		Output:  output,
-		NoColor: noColor,
-		Full:    full,
-		Verbose: verbose,
-		Stdin:   os.Stdin,
-		Stdout:  os.Stdout,
-		Stderr:  os.Stderr,
+		Output:   output,
+		NoColor:  noColor,
+		Extended: extended,
+		FullText: fullText,
+		IDOnly:   idOnly,
+		Verbose:  verbose,
+		Stdin:    os.Stdin,
+		Stdout:   os.Stdout,
+		Stderr:   os.Stderr,
 	}
 }

--- a/tools/jtk/internal/cmd/root/root_test.go
+++ b/tools/jtk/internal/cmd/root/root_test.go
@@ -45,7 +45,9 @@ func TestNewCmd_Flags(t *testing.T) {
 	}{
 		{"output flag", "output"},
 		{"no-color flag", "no-color"},
-		{"full flag", "full"},
+		{"extended flag", "extended"},
+		{"fulltext flag", "fulltext"},
+		{"id flag", "id"},
 		{"verbose flag", "verbose"},
 	}
 
@@ -58,6 +60,22 @@ func TestNewCmd_Flags(t *testing.T) {
 	}
 }
 
+func TestNewCmd_FullFlagRemoved(t *testing.T) {
+	t.Parallel()
+	cmd, _ := NewCmd()
+	if f := cmd.PersistentFlags().Lookup("full"); f != nil {
+		t.Errorf("--full should have been removed; still registered as %q", f.Name)
+	}
+}
+
+func TestNewCmd_OutputFlagHidden(t *testing.T) {
+	t.Parallel()
+	cmd, _ := NewCmd()
+	f := cmd.PersistentFlags().Lookup("output")
+	testutil.NotNil(t, f)
+	testutil.True(t, f.Hidden)
+}
+
 func TestNewCmd_FlagDefaults(t *testing.T) {
 	t.Parallel()
 	cmd, _ := NewCmd()
@@ -68,8 +86,14 @@ func TestNewCmd_FlagDefaults(t *testing.T) {
 	noColorFlag := cmd.PersistentFlags().Lookup("no-color")
 	testutil.Equal(t, noColorFlag.DefValue, "false")
 
-	fullFlag := cmd.PersistentFlags().Lookup("full")
-	testutil.Equal(t, fullFlag.DefValue, "false")
+	extendedFlag := cmd.PersistentFlags().Lookup("extended")
+	testutil.Equal(t, extendedFlag.DefValue, "false")
+
+	fullTextFlag := cmd.PersistentFlags().Lookup("fulltext")
+	testutil.Equal(t, fullTextFlag.DefValue, "false")
+
+	idFlag := cmd.PersistentFlags().Lookup("id")
+	testutil.Equal(t, idFlag.DefValue, "false")
 
 	verboseFlag := cmd.PersistentFlags().Lookup("verbose")
 	testutil.Equal(t, verboseFlag.DefValue, "false")
@@ -125,16 +149,52 @@ func TestRegisterCommands(t *testing.T) {
 func TestOptions_ArtifactMode(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns Agent when Full is false", func(t *testing.T) {
+	t.Run("returns Agent when Extended is false", func(t *testing.T) {
 		t.Parallel()
-		opts := &Options{Full: false}
+		opts := &Options{Extended: false}
 		testutil.Equal(t, opts.ArtifactMode(), artifact.Agent)
 	})
 
-	t.Run("returns Full when Full is true", func(t *testing.T) {
+	t.Run("returns Full when Extended is true", func(t *testing.T) {
 		t.Parallel()
-		opts := &Options{Full: true}
+		opts := &Options{Extended: true}
 		testutil.Equal(t, opts.ArtifactMode(), artifact.Full)
+	})
+
+	t.Run("returns Agent when IDOnly overrides Extended", func(t *testing.T) {
+		t.Parallel()
+		opts := &Options{Extended: true, IDOnly: true}
+		testutil.Equal(t, opts.ArtifactMode(), artifact.Agent)
+	})
+}
+
+func TestOptions_IDPrecedence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmitIDOnly reflects IDOnly field", func(t *testing.T) {
+		t.Parallel()
+		testutil.True(t, (&Options{IDOnly: true}).EmitIDOnly())
+		testutil.False(t, (&Options{IDOnly: false}).EmitIDOnly())
+	})
+
+	t.Run("IsExtended is false when IDOnly is set", func(t *testing.T) {
+		t.Parallel()
+		testutil.False(t, (&Options{IDOnly: true, Extended: true}).IsExtended())
+	})
+
+	t.Run("IsExtended is true when Extended is set and IDOnly is not", func(t *testing.T) {
+		t.Parallel()
+		testutil.True(t, (&Options{IDOnly: false, Extended: true}).IsExtended())
+	})
+
+	t.Run("IsFullText is false when IDOnly is set", func(t *testing.T) {
+		t.Parallel()
+		testutil.False(t, (&Options{IDOnly: true, FullText: true}).IsFullText())
+	})
+
+	t.Run("IsFullText is true when FullText is set and IDOnly is not", func(t *testing.T) {
+		t.Parallel()
+		testutil.True(t, (&Options{IDOnly: false, FullText: true}).IsFullText())
 	})
 }
 

--- a/tools/jtk/internal/cmd/users/users.go
+++ b/tools/jtk/internal/cmd/users/users.go
@@ -39,8 +39,8 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Example: `  # Get user details
   jtk users get 61292e4c4f29230069621c5f
 
-  # Get as JSON
-  jtk users get 61292e4c4f29230069621c5f -o json`,
+  # Print just the account ID
+  jtk users get 61292e4c4f29230069621c5f --id`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(cmd.Context(), opts, args[0])
@@ -59,6 +59,11 @@ func runGet(ctx context.Context, opts *root.Options, accountID string) error {
 	user, err := client.GetUser(ctx, accountID)
 	if err != nil {
 		return err
+	}
+
+	if opts.EmitIDOnly() {
+		_, _ = fmt.Fprintln(opts.Stdout, user.AccountID)
+		return nil
 	}
 
 	if v.Format == view.FormatJSON {
@@ -85,9 +90,6 @@ The search is case-insensitive and matches against display name, email address,
 and other user attributes. Use this to find account IDs for issue assignment.`,
 		Example: `  # Search for users named "john"
   jtk users search john
-
-  # Get results as JSON
-  jtk users search john -o json
 
   # Limit results
   jtk users search john --max 5`,

--- a/tools/jtk/internal/cmd/users/users_test.go
+++ b/tools/jtk/internal/cmd/users/users_test.go
@@ -59,6 +59,42 @@ func TestRunGet_Table(t *testing.T) {
 	testutil.Contains(t, output, "yes")
 }
 
+func TestRunGet_IDOnly(t *testing.T) {
+	t.Parallel()
+	user := api.User{AccountID: "abc123", DisplayName: "John Doe", Active: true}
+
+	server := newTestUserServer(t, user)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc123"))
+	testutil.Equal(t, stdout.String(), "abc123\n")
+}
+
+func TestRunGet_IDOnlyPrecedenceOverExtended(t *testing.T) {
+	t.Parallel()
+	user := api.User{AccountID: "abc123", DisplayName: "John Doe", Active: true}
+
+	server := newTestUserServer(t, user)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Extended: true, FullText: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc123"))
+	testutil.Equal(t, stdout.String(), "abc123\n")
+}
+
 func TestRunGet_JSON(t *testing.T) {
 	t.Parallel()
 	user := api.User{

--- a/tools/jtk/internal/present/comment.go
+++ b/tools/jtk/internal/present/comment.go
@@ -25,7 +25,7 @@ func (CommentPresenter) PresentList(comments []api.Comment) *present.OutputModel
 		if c.Body != nil {
 			body = c.Body.ToPlainText()
 			if len(body) > 100 {
-				body = body[:100] + "... [truncated, use --no-truncate for complete text]"
+				body = body[:100] + "... [truncated, use --fulltext for complete text]"
 			}
 		}
 		rows[i] = present.Row{

--- a/tools/jtk/internal/present/config.go
+++ b/tools/jtk/internal/present/config.go
@@ -80,8 +80,6 @@ type configEntry struct {
 	source string
 }
 
-
-
 // PresentConfigShow creates config table + path info as single output.
 // Accepts pre-computed (value, source) pairs for each config field.
 func (ConfigPresenter) PresentConfigShow(

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -43,7 +43,7 @@ func (IssuePresenter) PresentDetail(issue *api.Issue, issueURL string, noTruncat
 	if issue.Fields.Description != nil {
 		description = issue.Fields.Description.ToPlainText()
 		if !noTruncate && len(description) > 200 {
-			description = description[:200] + "... [truncated, use --no-truncate for complete text]"
+			description = description[:200] + "... [truncated, use --fulltext for complete text]"
 		}
 	}
 


### PR DESCRIPTION
## Summary

Introduces the new global output model flags (`--extended`, `--fulltext`, `--id`) per the #230 output specification, replacing the legacy `--full` flag and hiding `--output`/`-o` from help during per-command migration.

- `--extended` — include admin/schema/audit fields (replaces `--full`)
- `--fulltext` — disable truncation of descriptions and comments (new global)
- `--id` — emit only the primary identifier; takes precedence over `--extended` and `--fulltext`
- `--output`/`-o` — retained but `MarkHidden`ed; legacy JSON paths still function (removal is follow-up under #230)

**Scope of `--id` in this PR:** initial support is wired for `me`, `users get`, and `issues get`. Remaining commands parse the flag but do not yet collapse output — broader per-command migration continues under #230 follow-ups (#237, #238, #239). The root help advertises `--id` globally; non-migrated commands will be brought up to that promise one command group at a time.

## Implementation notes

- `root.Options` grows `Extended`, `FullText`, `IDOnly` fields; `Full` is removed.
- Precedence is enforced via three helpers: `EmitIDOnly()`, `IsExtended()`, `IsFullText()`. `--id` collapses extended/fulltext to false so every consumer sees consistent state regardless of flag order.
- `ArtifactMode()` now derives from `IsExtended()` (not `Full`), so `--id` also overrides artifact depth.
- Commands with local `--no-truncate` (`issues get`, `comments list`) keep the flag but OR it with `opts.IsFullText()`, so the new global flag works immediately. Locals are marked deprecated; removal is follow-up.
- Truncation markers in `present/issue.go` and `present/comment.go` now tell the user to pass `--fulltext`.
- Subcommand help examples no longer advertise `-o json` / `-o plain` (the flag still works; we just stop steering users at the hidden legacy surface).

## Out of scope (follow-ups under #230)

- `--id` on list commands and the other single-resource commands (projects, boards, sprints, comments, attachments, links, transitions, automation, dashboards, fields).
- Removing `--output`/`-o` and migrating the 18+ `opts.Output == "json"` branches.
- Removing the per-command `--no-truncate` aliases.
- Per-command output content migration to the Default/Extended/ID shapes.

## Test plan

- [x] `make test` — all unit tests pass, including `--id` tests on `me`, `users get`, and `issues get` (with precedence cases), `--fulltext` routing on `issues get` and `comments list`, and the combined `--no-truncate || --fulltext` OR path.
- [x] `make lint` — no new issues introduced.
- [x] `make build-jtk` — binary compiles.
- [x] `bin/jtk me --id` — prints just the account ID.
- [x] `bin/jtk users get <id> --id` — prints just the account ID.
- [x] `bin/jtk issues get PROJ-123 --id` — prints just the issue key.
- [x] `bin/jtk me --id --extended` — still just the account ID (precedence).
- [x] `bin/jtk --help` — shows `--extended`, `--fulltext`, `--id`; no `--full` or `--output`.
- [x] Subcommand `--help` — no `-o json` / `-o plain` in examples.

Closes #231