### PR TITLE
feat(jtk): shared presentation primitives for table, block, and id modes

### DIFF
--- a/shared/.golangci.yml
+++ b/shared/.golangci.yml
@@ -12,6 +12,12 @@ linters:
     - gosec
     - errorlint
     - exhaustive
+  settings:
+    revive:
+      # Explicit rule list so behavior is stable across golangci-lint versions
+      # (see tools/jtk/.golangci.yml for context).
+      rules:
+        - name: unused-parameter
   exclusions:
     rules:
       - path: _test\.go

--- a/shared/present/render.go
+++ b/shared/present/render.go
@@ -8,18 +8,27 @@ import (
 
 // Render converts an OutputModel to RenderedOutput with proper stream routing.
 // This is a pure function with no side effects.
+//
+// Block spacing rule: consecutive stdout-bound DetailSections are separated
+// by a blank line so block-mode lists (e.g. one DetailSection per comment)
+// render as distinct blocks rather than running together.
 func Render(model *OutputModel, style Style) RenderedOutput {
 	if model == nil {
 		return RenderedOutput{}
 	}
 	var stdout, stderr bytes.Buffer
+	var prevStdoutWasDetail bool
 	for _, section := range model.Sections {
 		text := renderSection(section, style)
 		if isStderrSection(section) {
 			stderr.WriteString(text)
-		} else {
-			stdout.WriteString(text)
+			continue
 		}
+		if _, isDetail := section.(*DetailSection); isDetail && prevStdoutWasDetail {
+			stdout.WriteByte('\n')
+		}
+		stdout.WriteString(text)
+		_, prevStdoutWasDetail = section.(*DetailSection)
 	}
 	return RenderedOutput{Stdout: stdout.String(), Stderr: stderr.String()}
 }

--- a/shared/present/render_test.go
+++ b/shared/present/render_test.go
@@ -437,6 +437,29 @@ func TestRender_DetailThenTable_NoSeparator(t *testing.T) {
 	}
 }
 
+func TestRender_StdoutMessageBetweenDetails_SuppressesSeparator(t *testing.T) {
+	t.Parallel()
+	// A stdout-bound MessageSection between two DetailSections resets the
+	// separator chain — the second DetailSection is NOT preceded by a blank
+	// line, because the tracker only fires when the immediately-previous
+	// stdout section was a DetailSection. No current code triggers this
+	// pattern; this test locks the behavior so future adopters find it
+	// intentional rather than accidental.
+	model := &OutputModel{
+		Sections: []Section{
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "1"}}},
+			&MessageSection{Kind: MessageInfo, Message: "note", Stream: StreamStdout},
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "2"}}},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	want := "ID: 1\nnote\nID: 2\n"
+	if out.Stdout != want {
+		t.Errorf("stdout:\ngot:\n%q\nwant:\n%q", out.Stdout, want)
+	}
+}
+
 func TestRender_StderrMessageBetweenDetails_StdoutSeparatorStillApplies(t *testing.T) {
 	t.Parallel()
 	// A stderr-routed section between two stdout-bound DetailSections must

--- a/shared/present/render_test.go
+++ b/shared/present/render_test.go
@@ -386,6 +386,115 @@ func TestRender_MessageSection_Error(t *testing.T) {
 	}
 }
 
+func TestRender_ConsecutiveDetailSections_AgentSeparator(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "1"}}},
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "2"}}},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	want := "ID: 1\n\nID: 2\n"
+	if out.Stdout != want {
+		t.Errorf("consecutive detail sections:\ngot:\n%q\nwant:\n%q", out.Stdout, want)
+	}
+}
+
+func TestRender_ConsecutiveDetailSections_HumanSeparator(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "1"}}},
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "2"}}},
+		},
+	}
+
+	out := Render(model, StyleHuman)
+	want := "ID: 1\n\nID: 2\n"
+	if out.Stdout != want {
+		t.Errorf("consecutive detail sections human:\ngot:\n%q\nwant:\n%q", out.Stdout, want)
+	}
+}
+
+func TestRender_DetailThenTable_NoSeparator(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "1"}}},
+			&TableSection{
+				Headers: []string{"K", "V"},
+				Rows:    []Row{{Cells: []string{"a", "b"}}},
+			},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	want := "ID: 1\nK | V\na | b\n"
+	if out.Stdout != want {
+		t.Errorf("detail then table (no separator):\ngot:\n%q\nwant:\n%q", out.Stdout, want)
+	}
+}
+
+func TestRender_DetailThenStderrMessage_NoStdoutSeparator(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "1"}}},
+			&MessageSection{Kind: MessageInfo, Message: "advisory", Stream: StreamStderr},
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "2"}}},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	// Previous stdout-bound section was a DetailSection, so separator applies
+	// even with a stderr message between them (it doesn't affect stdout stream).
+	wantStdout := "ID: 1\n\nID: 2\n"
+	wantStderr := "advisory\n"
+	if out.Stdout != wantStdout {
+		t.Errorf("stdout:\ngot:\n%q\nwant:\n%q", out.Stdout, wantStdout)
+	}
+	if out.Stderr != wantStderr {
+		t.Errorf("stderr:\ngot:\n%q\nwant:\n%q", out.Stderr, wantStderr)
+	}
+}
+
+func TestRender_SingleDetailSection_NoTrailingSeparator(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "1"}}},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	want := "ID: 1\n"
+	if out.Stdout != want {
+		t.Errorf("single detail should not have trailing separator:\ngot:\n%q\nwant:\n%q", out.Stdout, want)
+	}
+}
+
+func TestRender_TableThenDetail_NoSeparator(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&TableSection{
+				Headers: []string{"K", "V"},
+				Rows:    []Row{{Cells: []string{"a", "b"}}},
+			},
+			&DetailSection{Fields: []Field{{Label: "ID", Value: "1"}}},
+		},
+	}
+
+	out := Render(model, StyleAgent)
+	// Separator only applies when BOTH prior and current are DetailSection.
+	want := "K | V\na | b\nID: 1\n"
+	if out.Stdout != want {
+		t.Errorf("table then detail (no separator):\ngot:\n%q\nwant:\n%q", out.Stdout, want)
+	}
+}
+
 func TestRender_Stream_ExplicitRouting(t *testing.T) {
 	t.Parallel()
 	// Test that Stream field controls routing, not Kind

--- a/shared/present/render_test.go
+++ b/shared/present/render_test.go
@@ -437,8 +437,11 @@ func TestRender_DetailThenTable_NoSeparator(t *testing.T) {
 	}
 }
 
-func TestRender_DetailThenStderrMessage_NoStdoutSeparator(t *testing.T) {
+func TestRender_StderrMessageBetweenDetails_StdoutSeparatorStillApplies(t *testing.T) {
 	t.Parallel()
+	// A stderr-routed section between two stdout-bound DetailSections must
+	// not interrupt the stdout separator chain — the separator rule tracks
+	// the previous stdout-bound section, not the previous section overall.
 	model := &OutputModel{
 		Sections: []Section{
 			&DetailSection{Fields: []Field{{Label: "ID", Value: "1"}}},
@@ -448,8 +451,6 @@ func TestRender_DetailThenStderrMessage_NoStdoutSeparator(t *testing.T) {
 	}
 
 	out := Render(model, StyleAgent)
-	// Previous stdout-bound section was a DetailSection, so separator applies
-	// even with a stderr message between them (it doesn't affect stdout stream).
 	wantStdout := "ID: 1\n\nID: 2\n"
 	wantStderr := "advisory\n"
 	if out.Stdout != wantStdout {

--- a/tools/cfl/.golangci.yml
+++ b/tools/cfl/.golangci.yml
@@ -12,6 +12,12 @@ linters:
     - gosec
     - errorlint
     - exhaustive
+  settings:
+    revive:
+      # Explicit rule list so behavior is stable across golangci-lint versions
+      # (see tools/jtk/.golangci.yml for context).
+      rules:
+        - name: unused-parameter
   exclusions:
     rules:
       - path: _test\.go

--- a/tools/jtk/.golangci.yml
+++ b/tools/jtk/.golangci.yml
@@ -21,6 +21,14 @@ linters:
         - fmt.Fprint
         - fmt.Fprintf
         - fmt.Fprintln
+    revive:
+      # Explicit rule list so behavior is stable across golangci-lint versions
+      # (v2.0.2 used in CI vs. whatever developers install locally). Without
+      # this, revive falls back to defaults that differ between versions —
+      # most visibly, `unused-parameter` flipped between v2.0.2 (enabled)
+      # and later versions (not in the default set on v2.11.4).
+      rules:
+        - name: unused-parameter
   exclusions:
     rules:
       - path: _test\.go

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -80,7 +80,9 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 	}
 
 	if len(result.Comments) == 0 {
-		return jtkpresent.Emit(opts, jtkpresent.CommentPresenter{}.PresentEmpty(issueKey))
+		model := jtkpresent.CommentPresenter{}.PresentEmpty(issueKey)
+		model.Sections = jtkpresent.AppendPaginationHint(model.Sections, hasMore)
+		return jtkpresent.Emit(opts, model)
 	}
 
 	if v.Format == view.FormatJSON {
@@ -100,7 +102,14 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 // commentsHasMore computes pagination using the authoritative API metadata,
 // falling back to a full-page heuristic when Total is unavailable (Jira Cloud
 // occasionally returns Total=0).
+//
+// When got==0 there are definitionally no more pages, even with the
+// heuristic — without this guard, degenerate inputs like (0,0,0,0) would
+// falsely report hasMore=true.
 func commentsHasMore(total, startAt, got, maxResults int) bool {
+	if got == 0 {
+		return false
+	}
 	if total > 0 {
 		return startAt+got < total
 	}

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -69,39 +69,42 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 		return err
 	}
 
+	hasMore := commentsHasMore(result.Total, result.StartAt, len(result.Comments), maxResults)
+
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(result.Comments))
+		for i, c := range result.Comments {
+			ids[i] = c.ID
+		}
+		return jtkpresent.EmitIDsWithPagination(opts, ids, hasMore)
+	}
+
 	if len(result.Comments) == 0 {
-		model := jtkpresent.CommentPresenter{}.PresentEmpty(issueKey)
-		out := present.Render(model, opts.RenderStyle())
-		fmt.Fprint(opts.Stdout, out.Stdout)
-		fmt.Fprint(opts.Stderr, out.Stderr)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.CommentPresenter{}.PresentEmpty(issueKey))
 	}
 
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectComments(result.Comments, opts.ArtifactMode())
-		// Use authoritative pagination metadata from API response.
-		// Guard against Total==0 edge case in Jira Cloud by also checking
-		// if we received a full page of results.
-		hasMore := false
-		if result.Total > 0 {
-			hasMore = result.StartAt+len(result.Comments) < result.Total
-		} else if len(result.Comments) == maxResults {
-			// Total is 0 but we got a full page - likely more results exist
-			hasMore = true
-		}
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
 	var model *present.OutputModel
 	if noTruncate {
-		model = jtkpresent.CommentPresenter{}.PresentListFull(result.Comments)
+		model = jtkpresent.CommentPresenter{}.PresentListFullWithPagination(result.Comments, hasMore)
 	} else {
-		model = jtkpresent.CommentPresenter{}.PresentList(result.Comments)
+		model = jtkpresent.CommentPresenter{}.PresentListWithPagination(result.Comments, hasMore)
 	}
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, model)
+}
+
+// commentsHasMore computes pagination using the authoritative API metadata,
+// falling back to a full-page heuristic when Total is unavailable (Jira Cloud
+// occasionally returns Total=0).
+func commentsHasMore(total, startAt, got, maxResults int) bool {
+	if total > 0 {
+		return startAt+got < total
+	}
+	return got == maxResults
 }
 
 func newAddCmd(opts *root.Options) *cobra.Command {

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -452,6 +452,27 @@ func TestRunList_IDOnlyWithMoreResultsAppendsContinuation(t *testing.T) {
 	}
 }
 
+func TestRunList_EmptyNeverEmitsSpuriousPaginationHint(t *testing.T) {
+	t.Parallel()
+	// Even when the API reports Total>0, an empty page means we cannot
+	// meaningfully continue paging (no cursor advances). commentsHasMore's
+	// got==0 guard ensures the pagination hint is NOT emitted — no false
+	// "there are more" signal on stdout or stderr.
+	server := commentsServerWithTotal(nil, 5)
+	defer server.Close()
+
+	opts, stdout, stderr := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 50, false)
+	testutil.RequireNoError(t, err)
+
+	if strings.Contains(stdout.String(), "More results available") {
+		t.Errorf("pagination hint should NOT appear for empty page; got stdout=%q", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "More results available") {
+		t.Errorf("pagination hint should NOT appear on stderr either; got stderr=%q", stderr.String())
+	}
+}
+
 func TestRunList_EmptyWithIDOnly_EmitsNothing(t *testing.T) {
 	t.Parallel()
 	server := commentsServerWithTotal(nil, 0)
@@ -499,6 +520,9 @@ func TestCommentsHasMore(t *testing.T) {
 		{"total zero and full page (heuristic true)", 0, 0, 5, 5, true},
 		{"total zero and partial page", 0, 0, 3, 5, false},
 		{"later page, more remain", 20, 10, 5, 5, true},
+		{"empty page, total zero (no more)", 0, 0, 0, 5, false},
+		{"empty page, total nonzero (no more)", 10, 10, 0, 5, false},
+		{"degenerate all-zeros", 0, 0, 0, 0, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -332,6 +332,167 @@ func TestRunList_NoComments(t *testing.T) {
 	testutil.Contains(t, combined, "No comments")
 }
 
+// commentsServerWithTotal is like newTestCommentsServer but lets the caller
+// set Total independently from len(comments), so pagination hasMore can be
+// exercised explicitly.
+func commentsServerWithTotal(comments []api.Comment, total int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		response := api.CommentsResponse{
+			StartAt:    0,
+			MaxResults: 50,
+			Total:      total,
+			Comments:   comments,
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+}
+
+func plainComment(id, author, text string) api.Comment {
+	return api.Comment{
+		ID:     id,
+		Author: api.User{DisplayName: author},
+		Body: &api.ADFDocument{
+			Type: "doc", Version: 1,
+			Content: []*api.ADFNode{
+				{Type: "paragraph", Content: []*api.ADFNode{{Type: "text", Text: text}}},
+			},
+		},
+		Created: "2024-01-15T10:00:00.000Z",
+	}
+}
+
+func newCommentsOpts(t *testing.T, server *httptest.Server) (*root.Options, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+	return opts, &stdout, &stderr
+}
+
+func TestRunList_FullTextBlockSpacing(t *testing.T) {
+	t.Parallel()
+	comments := []api.Comment{
+		plainComment("11", "Alice", "First comment body"),
+		plainComment("22", "Bob", "Second comment body"),
+	}
+	server := commentsServerWithTotal(comments, 2)
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 50, true)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	// Each comment block ends with "Body: <text>\n" and the second block starts with "ID: 22".
+	// A blank line between blocks means "Body: First comment body\n\nID: 22" appears.
+	if !strings.Contains(out, "First comment body\n\nID: 22") {
+		t.Errorf("expected blank line between comment blocks; got:\n%s", out)
+	}
+}
+
+func TestRunList_FullTextPaginationOnStdout(t *testing.T) {
+	t.Parallel()
+	comments := []api.Comment{plainComment("1", "Alice", "hello")}
+	// Total=5 means there are more pages after this one.
+	server := commentsServerWithTotal(comments, 5)
+	defer server.Close()
+
+	opts, stdout, stderr := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 1, true)
+	testutil.RequireNoError(t, err)
+
+	if !strings.Contains(stdout.String(), "More results available") {
+		t.Errorf("pagination hint should appear on stdout, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "More results available") {
+		t.Errorf("pagination hint should NOT appear on stderr: %q", stderr.String())
+	}
+}
+
+func TestRunList_IDOnlyEmitsIDsOnePerLine(t *testing.T) {
+	t.Parallel()
+	comments := []api.Comment{
+		plainComment("11", "Alice", "first"),
+		plainComment("22", "Bob", "second"),
+	}
+	server := commentsServerWithTotal(comments, 2)
+	defer server.Close()
+
+	opts, stdout, stderr := newCommentsOpts(t, server)
+	opts.IDOnly = true
+	err := runList(context.Background(), opts, "TEST-1", 50, false)
+	testutil.RequireNoError(t, err)
+
+	want := "11\n22\n"
+	if stdout.String() != want {
+		t.Errorf("stdout:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
+func TestRunList_IDOnlyWithMoreResultsAppendsContinuation(t *testing.T) {
+	t.Parallel()
+	comments := []api.Comment{plainComment("1", "Alice", "a")}
+	server := commentsServerWithTotal(comments, 5)
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	opts.IDOnly = true
+	err := runList(context.Background(), opts, "TEST-1", 1, false)
+	testutil.RequireNoError(t, err)
+
+	want := "1\nMore results available (use --next-page-token to fetch next page)\n"
+	if stdout.String() != want {
+		t.Errorf("stdout:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestRunList_EmptyDefaultGoesToStdout(t *testing.T) {
+	t.Parallel()
+	server := commentsServerWithTotal(nil, 0)
+	defer server.Close()
+
+	opts, stdout, stderr := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 50, false)
+	testutil.RequireNoError(t, err)
+
+	if !strings.Contains(stdout.String(), "No comments on TEST-1") {
+		t.Errorf("expected 'No comments on TEST-1' on stdout, got: %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
+func TestCommentsHasMore(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name                        string
+		total, startAt, got, maxRes int
+		want                        bool
+	}{
+		{"total exceeds page", 10, 0, 5, 5, true},
+		{"total reached", 5, 0, 5, 5, false},
+		{"total zero and full page (heuristic true)", 0, 0, 5, 5, true},
+		{"total zero and partial page", 0, 0, 3, 5, false},
+		{"later page, more remain", 20, 10, 5, 5, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := commentsHasMore(tc.total, tc.startAt, tc.got, tc.maxRes)
+			if got != tc.want {
+				t.Errorf("commentsHasMore(total=%d startAt=%d got=%d maxRes=%d) = %v, want %v",
+					tc.total, tc.startAt, tc.got, tc.maxRes, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRunList_MultipleCommentsFullMode(t *testing.T) {
 	t.Parallel()
 	comments := []api.Comment{

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -452,6 +452,24 @@ func TestRunList_IDOnlyWithMoreResultsAppendsContinuation(t *testing.T) {
 	}
 }
 
+func TestRunList_EmptyWithIDOnly_EmitsNothing(t *testing.T) {
+	t.Parallel()
+	server := commentsServerWithTotal(nil, 0)
+	defer server.Close()
+
+	opts, stdout, stderr := newCommentsOpts(t, server)
+	opts.IDOnly = true
+	err := runList(context.Background(), opts, "TEST-1", 50, false)
+	testutil.RequireNoError(t, err)
+
+	if stdout.String() != "" {
+		t.Errorf("stdout should be empty under --id with zero comments, got: %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
 func TestRunList_EmptyDefaultGoesToStdout(t *testing.T) {
 	t.Parallel()
 	server := commentsServerWithTotal(nil, 0)

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -48,7 +48,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	}
 
 	if opts.EmitIDOnly() {
-		return jtkpresent.EmitIDs(opts, issue.Key)
+		return jtkpresent.EmitIDs(opts, []string{issue.Key})
 	}
 
 	// For JSON output, return the projected artifact

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -2,11 +2,9 @@ package issues
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
@@ -50,8 +48,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	}
 
 	if opts.EmitIDOnly() {
-		_, _ = fmt.Fprintln(opts.Stdout, issue.Key)
-		return nil
+		return jtkpresent.EmitIDs(opts, issue.Key)
 	}
 
 	// For JSON output, return the projected artifact
@@ -59,10 +56,6 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		return v.RenderArtifact(jtkartifact.ProjectIssue(issue, opts.ArtifactMode()))
 	}
 
-	// Text path: presenter → render → write
 	model := jtkpresent.IssuePresenter{}.PresentDetail(issue, client.IssueURL(issue.Key), noTruncate)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -107,26 +106,26 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 		return err
 	}
 
+	hasMore := !result.Pagination.IsLast
+
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(result.Issues))
+		for i, issue := range result.Issues {
+			ids[i] = issue.Key
+		}
+		return jtkpresent.EmitIDsWithPagination(opts, ids, hasMore)
+	}
+
 	if len(result.Issues) == 0 {
-		model := jtkpresent.IssuePresenter{}.PresentEmpty()
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentEmpty())
 	}
 
 	// For JSON output, return the projected artifacts
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectIssues(result.Issues, opts.ArtifactMode())
-		hasMore := !result.Pagination.IsLast
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	// Text path: presenter → render → write
-	hasMore := !result.Pagination.IsLast
 	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, hasMore)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-
-	return nil
+	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -117,9 +118,17 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 	}
 
 	if len(result.Issues) == 0 {
-		model := jtkpresent.IssuePresenter{}.PresentEmpty()
-		model.Sections = jtkpresent.AppendPaginationHint(model.Sections, hasMore)
-		return jtkpresent.Emit(opts, model)
+		// Two cases, each with a single unambiguous message:
+		//   hasMore=false → "No issues found" (the query's result set is empty)
+		//   hasMore=true  → pagination hint only (this page is empty but more
+		//                    pages exist; the agent should keep paging)
+		// Emitting both together would contradict itself; pick one.
+		if hasMore {
+			return jtkpresent.Emit(opts, &present.OutputModel{
+				Sections: jtkpresent.AppendPaginationHint(nil, true),
+			})
+		}
+		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentEmpty())
 	}
 
 	// For JSON output, return the projected artifacts

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -117,7 +117,9 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 	}
 
 	if len(result.Issues) == 0 {
-		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentEmpty())
+		model := jtkpresent.IssuePresenter{}.PresentEmpty()
+		model.Sections = jtkpresent.AppendPaginationHint(model.Sections, hasMore)
+		return jtkpresent.Emit(opts, model)
 	}
 
 	// For JSON output, return the projected artifacts

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -19,7 +19,7 @@ import (
 // `keys` drives which issue keys the mock returns.
 func listResultServer(t *testing.T, keys []string, isLast bool) *httptest.Server {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		issues := make([]api.Issue, len(keys))
 		for i, k := range keys {
 			issues[i] = api.Issue{

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -122,6 +122,24 @@ func TestRunList_EmptyDefault_NoIssuesFoundOnStdout(t *testing.T) {
 	}
 }
 
+func TestRunList_EmptyWithMoreResults_StillEmitsPaginationHint(t *testing.T) {
+	t.Parallel()
+	// Edge case: empty page but IsLast=false (more pages exist). The
+	// continuation hint must still reach stdout in default mode so agents
+	// don't terminate prematurely on a mid-stream empty page.
+	server := listResultServer(t, nil, false)
+	defer server.Close()
+
+	opts, stdout, stderr := newListOpts(t, server)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "")
+	testutil.RequireNoError(t, err)
+
+	if !strings.Contains(stdout.String(), "More results available") {
+		t.Errorf("pagination hint should appear on stdout for empty page with hasMore=true; got stdout=%q stderr=%q",
+			stdout.String(), stderr.String())
+	}
+}
+
 func TestRunList_EmptyWithIDOnly_EmitsNothing(t *testing.T) {
 	t.Parallel()
 	server := listResultServer(t, nil, true)

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -122,11 +122,12 @@ func TestRunList_EmptyDefault_NoIssuesFoundOnStdout(t *testing.T) {
 	}
 }
 
-func TestRunList_EmptyWithMoreResults_StillEmitsPaginationHint(t *testing.T) {
+func TestRunList_EmptyWithMoreResults_EmitsOnlyPaginationHint(t *testing.T) {
 	t.Parallel()
-	// Edge case: empty page but IsLast=false (more pages exist). The
-	// continuation hint must still reach stdout in default mode so agents
-	// don't terminate prematurely on a mid-stream empty page.
+	// Empty page with IsLast=false (more pages exist). The continuation hint
+	// alone reaches stdout so agents keep paging; the "No issues found"
+	// message is suppressed because the result set is not actually empty —
+	// only this page is. Emitting both would self-contradict.
 	server := listResultServer(t, nil, false)
 	defer server.Close()
 
@@ -135,8 +136,13 @@ func TestRunList_EmptyWithMoreResults_StillEmitsPaginationHint(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	if !strings.Contains(stdout.String(), "More results available") {
-		t.Errorf("pagination hint should appear on stdout for empty page with hasMore=true; got stdout=%q stderr=%q",
-			stdout.String(), stderr.String())
+		t.Errorf("pagination hint should appear on stdout; got %q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "No issues found") {
+		t.Errorf("'No issues found' must not co-occur with pagination hint; got %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
 	}
 }
 

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -1,0 +1,141 @@
+package issues
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+// listResultServer returns a fixed set of issues with configurable IsLast.
+// `keys` drives which issue keys the mock returns.
+func listResultServer(t *testing.T, keys []string, isLast bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		issues := make([]api.Issue, len(keys))
+		for i, k := range keys {
+			issues[i] = api.Issue{
+				Key: k,
+				Fields: api.IssueFields{
+					Summary:   "summary for " + k,
+					Status:    &api.Status{Name: "Open"},
+					IssueType: &api.IssueType{Name: "Task"},
+				},
+			}
+		}
+		result := api.JQLSearchResult{Issues: issues, IsLast: isLast}
+		if !isLast {
+			result.NextPageToken = "next-token"
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(result)
+	}))
+}
+
+func newListOpts(t *testing.T, server *httptest.Server) (*root.Options, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+	return opts, &stdout, &stderr
+}
+
+func TestRunList_DefaultPaginationOnStdout(t *testing.T) {
+	t.Parallel()
+	server := listResultServer(t, []string{"TEST-1", "TEST-2"}, false)
+	defer server.Close()
+
+	opts, stdout, stderr := newListOpts(t, server)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "")
+	testutil.RequireNoError(t, err)
+
+	if !strings.Contains(stdout.String(), "TEST-1") {
+		t.Errorf("stdout missing issue key: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "More results available") {
+		t.Errorf("pagination hint should be on stdout, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if strings.Contains(stderr.String(), "More results available") {
+		t.Errorf("pagination hint should NOT be on stderr: %q", stderr.String())
+	}
+}
+
+func TestRunList_IDOnlyEmitsKeysOnePerLine(t *testing.T) {
+	t.Parallel()
+	server := listResultServer(t, []string{"TEST-1", "TEST-2", "TEST-3"}, true)
+	defer server.Close()
+
+	opts, stdout, stderr := newListOpts(t, server)
+	opts.IDOnly = true
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "")
+	testutil.RequireNoError(t, err)
+
+	want := "TEST-1\nTEST-2\nTEST-3\n"
+	if stdout.String() != want {
+		t.Errorf("stdout:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
+func TestRunList_IDOnlyWithMoreResultsAppendsContinuation(t *testing.T) {
+	t.Parallel()
+	server := listResultServer(t, []string{"TEST-1", "TEST-2"}, false)
+	defer server.Close()
+
+	opts, stdout, _ := newListOpts(t, server)
+	opts.IDOnly = true
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "")
+	testutil.RequireNoError(t, err)
+
+	want := "TEST-1\nTEST-2\nMore results available (use --next-page-token to fetch next page)\n"
+	if stdout.String() != want {
+		t.Errorf("stdout:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestRunList_EmptyDefault_NoIssuesFoundOnStdout(t *testing.T) {
+	t.Parallel()
+	server := listResultServer(t, nil, true)
+	defer server.Close()
+
+	opts, stdout, stderr := newListOpts(t, server)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "")
+	testutil.RequireNoError(t, err)
+
+	if !strings.Contains(stdout.String(), "No issues found") {
+		t.Errorf("expected 'No issues found' on stdout, got: %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
+func TestRunList_EmptyWithIDOnly_EmitsNothing(t *testing.T) {
+	t.Parallel()
+	server := listResultServer(t, nil, true)
+	defer server.Close()
+
+	opts, stdout, stderr := newListOpts(t, server)
+	opts.IDOnly = true
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "")
+	testutil.RequireNoError(t, err)
+
+	if stdout.String() != "" {
+		t.Errorf("stdout should be empty under --id with zero results, got: %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}

--- a/tools/jtk/internal/present/comment.go
+++ b/tools/jtk/internal/present/comment.go
@@ -3,6 +3,7 @@ package present
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 
@@ -53,7 +54,10 @@ func (CommentPresenter) PresentListFull(comments []api.Comment) *present.OutputM
 		}
 		body := ""
 		if c.Body != nil {
-			body = c.Body.ToPlainText()
+			// ADF rendering can append a trailing newline; trim it so each
+			// block has consistent termination and the renderer's block
+			// separator produces exactly one blank line between comments.
+			body = strings.TrimRight(c.Body.ToPlainText(), "\n")
 		}
 		sections[i] = &present.DetailSection{
 			Fields: []present.Field{
@@ -65,6 +69,30 @@ func (CommentPresenter) PresentListFull(comments []api.Comment) *present.OutputM
 		}
 	}
 	return &present.OutputModel{Sections: sections}
+}
+
+// PresentListWithPagination wraps PresentList and appends a stdout-bound
+// pagination hint when hasMore is true.
+func (p CommentPresenter) PresentListWithPagination(comments []api.Comment, hasMore bool) *present.OutputModel {
+	return withPaginationHint(p.PresentList(comments), hasMore)
+}
+
+// PresentListFullWithPagination wraps PresentListFull and appends a
+// stdout-bound pagination hint when hasMore is true.
+func (p CommentPresenter) PresentListFullWithPagination(comments []api.Comment, hasMore bool) *present.OutputModel {
+	return withPaginationHint(p.PresentListFull(comments), hasMore)
+}
+
+func withPaginationHint(model *present.OutputModel, hasMore bool) *present.OutputModel {
+	if !hasMore {
+		return model
+	}
+	model.Sections = append(model.Sections, &present.MessageSection{
+		Kind:    present.MessageInfo,
+		Message: paginationHint,
+		Stream:  present.StreamStdout,
+	})
+	return model
 }
 
 // PresentAdded creates a success message for comment addition.

--- a/tools/jtk/internal/present/comment.go
+++ b/tools/jtk/internal/present/comment.go
@@ -75,7 +75,7 @@ func (CommentPresenter) PresentListFull(comments []api.Comment) *present.OutputM
 // pagination hint when hasMore is true.
 func (p CommentPresenter) PresentListWithPagination(comments []api.Comment, hasMore bool) *present.OutputModel {
 	model := p.PresentList(comments)
-	model.Sections = appendPaginationHint(model.Sections, hasMore)
+	model.Sections = AppendPaginationHint(model.Sections, hasMore)
 	return model
 }
 
@@ -83,7 +83,7 @@ func (p CommentPresenter) PresentListWithPagination(comments []api.Comment, hasM
 // stdout-bound pagination hint when hasMore is true.
 func (p CommentPresenter) PresentListFullWithPagination(comments []api.Comment, hasMore bool) *present.OutputModel {
 	model := p.PresentListFull(comments)
-	model.Sections = appendPaginationHint(model.Sections, hasMore)
+	model.Sections = AppendPaginationHint(model.Sections, hasMore)
 	return model
 }
 

--- a/tools/jtk/internal/present/comment.go
+++ b/tools/jtk/internal/present/comment.go
@@ -74,24 +74,16 @@ func (CommentPresenter) PresentListFull(comments []api.Comment) *present.OutputM
 // PresentListWithPagination wraps PresentList and appends a stdout-bound
 // pagination hint when hasMore is true.
 func (p CommentPresenter) PresentListWithPagination(comments []api.Comment, hasMore bool) *present.OutputModel {
-	return withPaginationHint(p.PresentList(comments), hasMore)
+	model := p.PresentList(comments)
+	model.Sections = appendPaginationHint(model.Sections, hasMore)
+	return model
 }
 
 // PresentListFullWithPagination wraps PresentListFull and appends a
 // stdout-bound pagination hint when hasMore is true.
 func (p CommentPresenter) PresentListFullWithPagination(comments []api.Comment, hasMore bool) *present.OutputModel {
-	return withPaginationHint(p.PresentListFull(comments), hasMore)
-}
-
-func withPaginationHint(model *present.OutputModel, hasMore bool) *present.OutputModel {
-	if !hasMore {
-		return model
-	}
-	model.Sections = append(model.Sections, &present.MessageSection{
-		Kind:    present.MessageInfo,
-		Message: paginationHint,
-		Stream:  present.StreamStdout,
-	})
+	model := p.PresentListFull(comments)
+	model.Sections = appendPaginationHint(model.Sections, hasMore)
 	return model
 }
 

--- a/tools/jtk/internal/present/emit.go
+++ b/tools/jtk/internal/present/emit.go
@@ -27,6 +27,11 @@ func paginationMessageSection() *present.MessageSection {
 // appended when hasMore is true, otherwise returns sections unchanged.
 // Every model-building pagination call site funnels through this so
 // wording, kind, and stream stay in sync across presenters and commands.
+//
+// Follows Go's standard append semantics: the returned slice may share
+// its backing array with the input. Callers that pass a slice with spare
+// capacity beyond its length should treat the input as consumed, or
+// allocate a fresh slice before calling.
 func AppendPaginationHint(sections []present.Section, hasMore bool) []present.Section {
 	if !hasMore {
 		return sections

--- a/tools/jtk/internal/present/emit.go
+++ b/tools/jtk/internal/present/emit.go
@@ -23,10 +23,11 @@ func paginationMessageSection() *present.MessageSection {
 	}
 }
 
-// appendPaginationHint returns sections with a pagination MessageSection
+// AppendPaginationHint returns sections with a pagination MessageSection
 // appended when hasMore is true, otherwise returns sections unchanged.
-// Every model-building pagination call site should funnel through this.
-func appendPaginationHint(sections []present.Section, hasMore bool) []present.Section {
+// Every model-building pagination call site funnels through this so
+// wording, kind, and stream stay in sync across presenters and commands.
+func AppendPaginationHint(sections []present.Section, hasMore bool) []present.Section {
 	if !hasMore {
 		return sections
 	}
@@ -43,9 +44,9 @@ func Emit(opts *root.Options, model *present.OutputModel) error {
 	return nil
 }
 
-// EmitIDs writes one identifier per line to opts.Stdout. Empty input emits
+// EmitIDs writes one identifier per line to opts.Stdout. Empty slice emits
 // nothing. Matches `kubectl get -o name` / `ls -1` semantics.
-func EmitIDs(opts *root.Options, ids ...string) error {
+func EmitIDs(opts *root.Options, ids []string) error {
 	for _, id := range ids {
 		_, _ = fmt.Fprintln(opts.Stdout, id)
 	}
@@ -57,7 +58,7 @@ func EmitIDs(opts *root.Options, ids ...string) error {
 // model-building presenters via paginationMessageSection() so `--id` and
 // default mode can never drift on wording or stream.
 func EmitIDsWithPagination(opts *root.Options, ids []string, hasMore bool) error {
-	if err := EmitIDs(opts, ids...); err != nil {
+	if err := EmitIDs(opts, ids); err != nil {
 		return err
 	}
 	if hasMore {

--- a/tools/jtk/internal/present/emit.go
+++ b/tools/jtk/internal/present/emit.go
@@ -12,6 +12,27 @@ import (
 // Kept centralized so default-mode and --id mode share the same wording.
 const paginationHint = "More results available (use --next-page-token to fetch next page)"
 
+// paginationMessageSection builds the stdout-routed continuation-line section
+// used by every list presenter. Centralizing this ensures the wording, kind,
+// and stream stay in sync across all callers.
+func paginationMessageSection() *present.MessageSection {
+	return &present.MessageSection{
+		Kind:    present.MessageInfo,
+		Message: paginationHint,
+		Stream:  present.StreamStdout,
+	}
+}
+
+// appendPaginationHint returns sections with a pagination MessageSection
+// appended when hasMore is true, otherwise returns sections unchanged.
+// Every model-building pagination call site should funnel through this.
+func appendPaginationHint(sections []present.Section, hasMore bool) []present.Section {
+	if !hasMore {
+		return sections
+	}
+	return append(sections, paginationMessageSection())
+}
+
 // Emit applies jtk output policy: renders the model and writes the split
 // streams to opts.Stdout / opts.Stderr. Returns nil so commands can
 // `return Emit(...)` at the end of RunE.
@@ -32,14 +53,16 @@ func EmitIDs(opts *root.Options, ids ...string) error {
 }
 
 // EmitIDsWithPagination is EmitIDs plus a continuation line on stdout when
-// hasMore is true. The continuation line matches the default-mode pagination
-// policy so `--id` and default read from the same stream.
+// hasMore is true. The continuation line shares construction with the
+// model-building presenters via paginationMessageSection() so `--id` and
+// default mode can never drift on wording or stream.
 func EmitIDsWithPagination(opts *root.Options, ids []string, hasMore bool) error {
 	if err := EmitIDs(opts, ids...); err != nil {
 		return err
 	}
 	if hasMore {
-		_, _ = fmt.Fprintln(opts.Stdout, paginationHint)
+		model := &present.OutputModel{Sections: []present.Section{paginationMessageSection()}}
+		return Emit(opts, model)
 	}
 	return nil
 }

--- a/tools/jtk/internal/present/emit.go
+++ b/tools/jtk/internal/present/emit.go
@@ -1,0 +1,45 @@
+package present
+
+import (
+	"fmt"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+// paginationHint is the text appended after list output when more pages exist.
+// Kept centralized so default-mode and --id mode share the same wording.
+const paginationHint = "More results available (use --next-page-token to fetch next page)"
+
+// Emit applies jtk output policy: renders the model and writes the split
+// streams to opts.Stdout / opts.Stderr. Returns nil so commands can
+// `return Emit(...)` at the end of RunE.
+func Emit(opts *root.Options, model *present.OutputModel) error {
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
+}
+
+// EmitIDs writes one identifier per line to opts.Stdout. Empty input emits
+// nothing. Matches `kubectl get -o name` / `ls -1` semantics.
+func EmitIDs(opts *root.Options, ids ...string) error {
+	for _, id := range ids {
+		_, _ = fmt.Fprintln(opts.Stdout, id)
+	}
+	return nil
+}
+
+// EmitIDsWithPagination is EmitIDs plus a continuation line on stdout when
+// hasMore is true. The continuation line matches the default-mode pagination
+// policy so `--id` and default read from the same stream.
+func EmitIDsWithPagination(opts *root.Options, ids []string, hasMore bool) error {
+	if err := EmitIDs(opts, ids...); err != nil {
+		return err
+	}
+	if hasMore {
+		_, _ = fmt.Fprintln(opts.Stdout, paginationHint)
+	}
+	return nil
+}

--- a/tools/jtk/internal/present/emit_test.go
+++ b/tools/jtk/internal/present/emit_test.go
@@ -1,0 +1,136 @@
+package present
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+func newTestOpts() (*root.Options, *bytes.Buffer, *bytes.Buffer) {
+	var stdout, stderr bytes.Buffer
+	return &root.Options{Stdout: &stdout, Stderr: &stderr}, &stdout, &stderr
+}
+
+func TestEmit_SplitsStreams(t *testing.T) {
+	t.Parallel()
+	opts, stdout, stderr := newTestOpts()
+
+	model := &present.OutputModel{
+		Sections: []present.Section{
+			&present.DetailSection{Fields: []present.Field{{Label: "ID", Value: "1"}}},
+			&present.MessageSection{Kind: present.MessageInfo, Message: "diag", Stream: present.StreamStderr},
+		},
+	}
+
+	if err := Emit(opts, model); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+
+	wantStdout := "ID: 1\n"
+	wantStderr := "diag\n"
+	if stdout.String() != wantStdout {
+		t.Errorf("stdout:\ngot:  %q\nwant: %q", stdout.String(), wantStdout)
+	}
+	if stderr.String() != wantStderr {
+		t.Errorf("stderr:\ngot:  %q\nwant: %q", stderr.String(), wantStderr)
+	}
+}
+
+func TestEmitIDs_OnePerLine(t *testing.T) {
+	t.Parallel()
+	opts, stdout, stderr := newTestOpts()
+
+	if err := EmitIDs(opts, "MON-1", "MON-2", "MON-3"); err != nil {
+		t.Fatalf("EmitIDs returned error: %v", err)
+	}
+
+	want := "MON-1\nMON-2\nMON-3\n"
+	if stdout.String() != want {
+		t.Errorf("stdout:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
+func TestEmitIDs_EmptyEmitsNothing(t *testing.T) {
+	t.Parallel()
+	opts, stdout, stderr := newTestOpts()
+
+	if err := EmitIDs(opts); err != nil {
+		t.Fatalf("EmitIDs returned error: %v", err)
+	}
+
+	if stdout.String() != "" {
+		t.Errorf("stdout should be empty, got: %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
+func TestEmitIDsWithPagination_HasMoreAppendsContinuation(t *testing.T) {
+	t.Parallel()
+	opts, stdout, stderr := newTestOpts()
+
+	if err := EmitIDsWithPagination(opts, []string{"MON-1", "MON-2"}, true); err != nil {
+		t.Fatalf("EmitIDsWithPagination returned error: %v", err)
+	}
+
+	want := "MON-1\nMON-2\nMore results available (use --next-page-token to fetch next page)\n"
+	if stdout.String() != want {
+		t.Errorf("stdout:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
+func TestEmitIDsWithPagination_NoMoreOmitsContinuation(t *testing.T) {
+	t.Parallel()
+	opts, stdout, _ := newTestOpts()
+
+	if err := EmitIDsWithPagination(opts, []string{"MON-1"}, false); err != nil {
+		t.Fatalf("EmitIDsWithPagination returned error: %v", err)
+	}
+
+	want := "MON-1\n"
+	if stdout.String() != want {
+		t.Errorf("stdout:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestEmitIDsWithPagination_EmptyAndNoMore(t *testing.T) {
+	t.Parallel()
+	opts, stdout, stderr := newTestOpts()
+
+	if err := EmitIDsWithPagination(opts, nil, false); err != nil {
+		t.Fatalf("EmitIDsWithPagination returned error: %v", err)
+	}
+
+	if stdout.String() != "" {
+		t.Errorf("stdout should be empty, got: %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
+func TestEmitIDsWithPagination_EmptyButHasMore(t *testing.T) {
+	t.Parallel()
+	// Edge case: zero results on this page but more pages exist. Emit only
+	// the continuation line so the caller can keep paging.
+	opts, stdout, _ := newTestOpts()
+
+	if err := EmitIDsWithPagination(opts, nil, true); err != nil {
+		t.Fatalf("EmitIDsWithPagination returned error: %v", err)
+	}
+
+	want := "More results available (use --next-page-token to fetch next page)\n"
+	if stdout.String() != want {
+		t.Errorf("stdout:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}

--- a/tools/jtk/internal/present/emit_test.go
+++ b/tools/jtk/internal/present/emit_test.go
@@ -43,7 +43,7 @@ func TestEmitIDs_OnePerLine(t *testing.T) {
 	t.Parallel()
 	opts, stdout, stderr := newTestOpts()
 
-	if err := EmitIDs(opts, "MON-1", "MON-2", "MON-3"); err != nil {
+	if err := EmitIDs(opts, []string{"MON-1", "MON-2", "MON-3"}); err != nil {
 		t.Fatalf("EmitIDs returned error: %v", err)
 	}
 
@@ -60,7 +60,7 @@ func TestEmitIDs_EmptyEmitsNothing(t *testing.T) {
 	t.Parallel()
 	opts, stdout, stderr := newTestOpts()
 
-	if err := EmitIDs(opts); err != nil {
+	if err := EmitIDs(opts, nil); err != nil {
 		t.Fatalf("EmitIDs returned error: %v", err)
 	}
 
@@ -141,12 +141,12 @@ func TestAppendPaginationHint(t *testing.T) {
 		&present.TableSection{Headers: []string{"K"}, Rows: []present.Row{{Cells: []string{"v"}}}},
 	}
 
-	same := appendPaginationHint(base, false)
+	same := AppendPaginationHint(base, false)
 	if len(same) != 1 {
 		t.Errorf("no-op when hasMore=false: got %d sections, want 1", len(same))
 	}
 
-	withHint := appendPaginationHint(base, true)
+	withHint := AppendPaginationHint(base, true)
 	if len(withHint) != 2 {
 		t.Fatalf("hasMore=true: got %d sections, want 2", len(withHint))
 	}

--- a/tools/jtk/internal/present/emit_test.go
+++ b/tools/jtk/internal/present/emit_test.go
@@ -119,6 +119,46 @@ func TestEmitIDsWithPagination_EmptyAndNoMore(t *testing.T) {
 	}
 }
 
+func TestPaginationMessageSection_Canonical(t *testing.T) {
+	t.Parallel()
+	// Every pagination call site funnels through this helper; drift would
+	// de-sync wording, kind, or stream across the three migrated commands.
+	msg := paginationMessageSection()
+	if msg.Kind != present.MessageInfo {
+		t.Errorf("kind: got %v, want MessageInfo", msg.Kind)
+	}
+	if msg.Stream != present.StreamStdout {
+		t.Errorf("stream: got %v, want StreamStdout", msg.Stream)
+	}
+	if msg.Message != paginationHint {
+		t.Errorf("message: got %q, want %q", msg.Message, paginationHint)
+	}
+}
+
+func TestAppendPaginationHint(t *testing.T) {
+	t.Parallel()
+	base := []present.Section{
+		&present.TableSection{Headers: []string{"K"}, Rows: []present.Row{{Cells: []string{"v"}}}},
+	}
+
+	same := appendPaginationHint(base, false)
+	if len(same) != 1 {
+		t.Errorf("no-op when hasMore=false: got %d sections, want 1", len(same))
+	}
+
+	withHint := appendPaginationHint(base, true)
+	if len(withHint) != 2 {
+		t.Fatalf("hasMore=true: got %d sections, want 2", len(withHint))
+	}
+	msg, ok := withHint[1].(*present.MessageSection)
+	if !ok {
+		t.Fatalf("second section should be *MessageSection, got %T", withHint[1])
+	}
+	if msg.Stream != present.StreamStdout || msg.Message != paginationHint {
+		t.Errorf("appended section mismatch: stream=%v msg=%q", msg.Stream, msg.Message)
+	}
+}
+
 func TestEmitIDsWithPagination_EmptyButHasMore(t *testing.T) {
 	t.Parallel()
 	// Edge case: zero results on this page but more pages exist. Emit only

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -324,20 +324,6 @@ func (IssuePresenter) PresentDeleteCancelled() *present.OutputModel {
 
 // --- Advisory methods (route to stderr) ---
 
-// PresentPaginationHint returns the continuation line that follows a list
-// when more pages exist. Routed to stdout so agents parse a single stream.
-func (IssuePresenter) PresentPaginationHint() *present.OutputModel {
-	return &present.OutputModel{
-		Sections: []present.Section{
-			&present.MessageSection{
-				Kind:    present.MessageInfo,
-				Message: paginationHint,
-				Stream:  present.StreamStdout,
-			},
-		},
-	}
-}
-
 // PresentTypeChangeProgress creates an advisory about type change in progress.
 func (IssuePresenter) PresentTypeChangeProgress(key, typeName string) *present.OutputModel {
 	return &present.OutputModel{
@@ -504,13 +490,5 @@ func (p IssuePresenter) PresentListWithPagination(issues []api.Issue, hasMore bo
 		},
 	}
 
-	if hasMore {
-		sections = append(sections, &present.MessageSection{
-			Kind:    present.MessageInfo,
-			Message: paginationHint,
-			Stream:  present.StreamStdout,
-		})
-	}
-
-	return &present.OutputModel{Sections: sections}
+	return &present.OutputModel{Sections: appendPaginationHint(sections, hasMore)}
 }

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -490,5 +490,5 @@ func (p IssuePresenter) PresentListWithPagination(issues []api.Issue, hasMore bo
 		},
 	}
 
-	return &present.OutputModel{Sections: appendPaginationHint(sections, hasMore)}
+	return &present.OutputModel{Sections: AppendPaginationHint(sections, hasMore)}
 }

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -324,14 +324,15 @@ func (IssuePresenter) PresentDeleteCancelled() *present.OutputModel {
 
 // --- Advisory methods (route to stderr) ---
 
-// PresentPaginationHint creates an advisory about more results.
+// PresentPaginationHint returns the continuation line that follows a list
+// when more pages exist. Routed to stdout so agents parse a single stream.
 func (IssuePresenter) PresentPaginationHint() *present.OutputModel {
 	return &present.OutputModel{
 		Sections: []present.Section{
 			&present.MessageSection{
 				Kind:    present.MessageInfo,
-				Message: "More results available (use --next-page-token to fetch next page)",
-				Stream:  present.StreamStderr,
+				Message: paginationHint,
+				Stream:  present.StreamStdout,
 			},
 		},
 	}
@@ -506,8 +507,8 @@ func (p IssuePresenter) PresentListWithPagination(issues []api.Issue, hasMore bo
 	if hasMore {
 		sections = append(sections, &present.MessageSection{
 			Kind:    present.MessageInfo,
-			Message: "More results available (use --next-page-token to fetch next page)",
-			Stream:  present.StreamStderr,
+			Message: paginationHint,
+			Stream:  present.StreamStdout,
 		})
 	}
 

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -216,8 +216,10 @@ func TestIssuePresenter_PresentListWithPagination_HasMore(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected MessageSection for pagination hint, got %T", model.Sections[1])
 	}
-	if msg.Stream != present.StreamStderr {
-		t.Errorf("pagination hint should go to stderr, got %v", msg.Stream)
+	// Pagination continuation routes to stdout (inline with data rows) per #230
+	// so agents reading a single stream see both data and the hint.
+	if msg.Stream != present.StreamStdout {
+		t.Errorf("pagination hint should go to stdout, got %v", msg.Stream)
 	}
 }
 

--- a/tools/jtk/internal/present/mutation.go
+++ b/tools/jtk/internal/present/mutation.go
@@ -36,7 +36,8 @@ func (MutationPresenter) Info(format string, args ...any) *present.OutputModel {
 	}
 }
 
-// Advisory creates a non-primary message that goes to stderr (pagination, hints).
+// Advisory creates a non-primary message that goes to stderr (for genuine
+// diagnostics that should not mix with primary output).
 func (MutationPresenter) Advisory(format string, args ...any) *present.OutputModel {
 	return &present.OutputModel{
 		Sections: []present.Section{
@@ -44,6 +45,21 @@ func (MutationPresenter) Advisory(format string, args ...any) *present.OutputMod
 				Kind:    present.MessageInfo,
 				Message: fmt.Sprintf(format, args...),
 				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
+// Pagination creates a continuation-line message that goes to stdout, inline
+// with the primary output. Matches the #230 spec policy where an agent reading
+// a single stream sees both data rows and the pagination hint.
+func (MutationPresenter) Pagination(format string, args ...any) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf(format, args...),
+				Stream:  present.StreamStdout,
 			},
 		},
 	}

--- a/tools/jtk/internal/present/mutation.go
+++ b/tools/jtk/internal/present/mutation.go
@@ -50,21 +50,6 @@ func (MutationPresenter) Advisory(format string, args ...any) *present.OutputMod
 	}
 }
 
-// Pagination creates a continuation-line message that goes to stdout, inline
-// with the primary output. Matches the #230 spec policy where an agent reading
-// a single stream sees both data rows and the pagination hint.
-func (MutationPresenter) Pagination(format string, args ...any) *present.OutputModel {
-	return &present.OutputModel{
-		Sections: []present.Section{
-			&present.MessageSection{
-				Kind:    present.MessageInfo,
-				Message: fmt.Sprintf(format, args...),
-				Stream:  present.StreamStdout,
-			},
-		},
-	}
-}
-
 // Warning creates a warning message that goes to stderr.
 func (MutationPresenter) Warning(format string, args ...any) *present.OutputModel {
 	return &present.OutputModel{

--- a/tools/jtk/internal/present/mutation_test.go
+++ b/tools/jtk/internal/present/mutation_test.go
@@ -59,6 +59,23 @@ func TestMutationPresenter_Advisory(t *testing.T) {
 	}
 }
 
+func TestMutationPresenter_Pagination(t *testing.T) {
+	t.Parallel()
+	p := MutationPresenter{}
+	model := p.Pagination("More results available (next: %s)", "TOKEN")
+
+	msg := model.Sections[0].(*present.MessageSection)
+	if msg.Kind != present.MessageInfo {
+		t.Errorf("expected MessageInfo kind, got %v", msg.Kind)
+	}
+	if msg.Stream != present.StreamStdout {
+		t.Errorf("expected StreamStdout (pagination goes inline with data), got %v", msg.Stream)
+	}
+	if msg.Message != "More results available (next: TOKEN)" {
+		t.Errorf("unexpected message: %q", msg.Message)
+	}
+}
+
 func TestMutationPresenter_Warning(t *testing.T) {
 	t.Parallel()
 	p := MutationPresenter{}

--- a/tools/jtk/internal/present/mutation_test.go
+++ b/tools/jtk/internal/present/mutation_test.go
@@ -59,23 +59,6 @@ func TestMutationPresenter_Advisory(t *testing.T) {
 	}
 }
 
-func TestMutationPresenter_Pagination(t *testing.T) {
-	t.Parallel()
-	p := MutationPresenter{}
-	model := p.Pagination("More results available (next: %s)", "TOKEN")
-
-	msg := model.Sections[0].(*present.MessageSection)
-	if msg.Kind != present.MessageInfo {
-		t.Errorf("expected MessageInfo kind, got %v", msg.Kind)
-	}
-	if msg.Stream != present.StreamStdout {
-		t.Errorf("expected StreamStdout (pagination goes inline with data), got %v", msg.Stream)
-	}
-	if msg.Message != "More results available (next: TOKEN)" {
-		t.Errorf("unexpected message: %q", msg.Message)
-	}
-}
-
 func TestMutationPresenter_Warning(t *testing.T) {
 	t.Parallel()
 	p := MutationPresenter{}


### PR DESCRIPTION
Closes #232.

## Summary

- Adds minimal shared presentation primitives (`Emit`, `EmitIDs`, `EmitIDsWithPagination`) so jtk commands can delegate output policy rather than re-invent the render + split-streams boilerplate.
- Renderer change (`shared/present`): consecutive stdout-bound `DetailSection`s render with a blank line between them, enabling block-mode lists (e.g. `comments list --fulltext`) without a new `Section` type.
- Pagination continuation line routes to **stdout** (inline with data rows), matching the #230 spec examples and making single-stream agent parsing straightforward. Every pagination call site — the two `IssuePresenter.PresentListWithPagination`/`CommentPresenter.PresentList*WithPagination` presenters and the `EmitIDsWithPagination` direct-write path — funnels through `paginationMessageSection()` + `appendPaginationHint()` in `tools/jtk/internal/present/emit.go`, so wording, kind, and stream cannot drift.
- Adopts the primitives in three flagship commands proving each mode:
  - `issues get` — single-entity block
  - `issues list` — table + pagination + `--id`
  - `comments list` — block-mode list (`--fulltext`) + pagination + `--id`
- `comments list` text path previously discarded `hasMore`; it now renders the continuation line like `issues list`.

Remaining ~25 jtk commands continue to work via their existing paths; per-command migration to `Emit`/`EmitIDs` is tracked under #230 follow-ups.

## Behavior changes

- **Breaking (minor):** `jtk <list> 2>/dev/null` no longer suppresses the pagination hint — it now lives on stdout with the data rows.
- `--id` on list commands emits one identifier per line, with a continuation line appended on stdout when more pages exist (matches default-mode policy).
- Empty result sets continue to go to stdout via the existing `PresentEmpty()` helpers (behavior unchanged; now covered by command-level tests to lock the contract).

## Test plan

- [x] `make build` — clean
- [x] `make test` — full suite passes (`shared/present`: 25; `tools/jtk/internal/present`: 44; `tools/jtk/internal/cmd/issues`: 68; `tools/jtk/internal/cmd/comments`: 20 top-level funcs)
- [x] `make lint` — no new findings (8 pre-existing gosec issues in cfl/shared untouched)
- [ ] Manual smoke against a live instance:
  - `jtk issues get MON-... --id` → single key
  - `jtk issues list -p MON` → table with pagination hint on stdout when `| wc -l` includes the hint
  - `jtk issues list -p MON --id` → keys one per line + continuation line when hasMore
  - `jtk comments list MON-... --fulltext` → one block per comment, blank line between
  - `jtk comments list MON-... --id` → comment IDs one per line

## New / changed test coverage

- `shared/present/render_test.go`: 5 cases locking the consecutive-DetailSection separator rule
- `tools/jtk/internal/present/emit_test.go`: `Emit` / `EmitIDs` / `EmitIDsWithPagination` behavior including empty-and-hasMore edge, plus `TestPaginationMessageSection_Canonical` and `TestAppendPaginationHint` locking the centralized pagination builder/mutator
- `tools/jtk/internal/present/issue_test.go`: pagination hint now asserted on stdout (policy flip lock-in)
- `tools/jtk/internal/cmd/issues/list_test.go` (new): pagination + `--id` + empty behavior for `issues list`
- `tools/jtk/internal/cmd/comments/comments_test.go`: block spacing, pagination-on-stdout, `--id` per-line, `--id` + continuation, empty + default, empty + `--id`, `commentsHasMore` table test