### PR TITLE
feat(jtk): shared --fields projection and name resolution

### DIFF
--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -48,6 +48,18 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		return err
 	}
 
+	// --id wins over --fields: skip projection entirely when --id is set so
+	// we don't waste a GetFields() call on a token whose result will be
+	// thrown away. Also defensively skip JSON + --fields error in this case
+	// — --id also overrides --output json semantics.
+	if opts.EmitIDOnly() {
+		issue, err := client.GetIssue(ctx, issueKey)
+		if err != nil {
+			return err
+		}
+		return jtkpresent.EmitIDs(opts, []string{issue.Key})
+	}
+
 	if fieldsFlag != "" && opts.Output == "json" {
 		return errFieldsWithJSON
 	}
@@ -70,10 +82,6 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	issue, err := client.GetIssue(ctx, issueKey)
 	if err != nil {
 		return err
-	}
-
-	if opts.EmitIDOnly() {
-		return jtkpresent.EmitIDs(opts, []string{issue.Key})
 	}
 
 	// For JSON output, return the projected artifact

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -60,7 +60,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		return jtkpresent.EmitIDs(opts, []string{issue.Key})
 	}
 
-	if fieldsFlag != "" && opts.Output == "json" {
+	if fieldsFlag != "" && v.Format == view.FormatJSON {
 		return errFieldsWithJSON
 	}
 

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -5,15 +5,18 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 func newGetCmd(opts *root.Options) *cobra.Command {
 	var noTruncate bool
+	var fieldsFlag string
 
 	cmd := &cobra.Command{
 		Use:   "get <issue-key>",
@@ -21,20 +24,23 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Long:  "Retrieve and display details for a specific issue.",
 		Example: `  jtk issues get PROJ-123
   jtk issues get PROJ-123 --fulltext
-  jtk issues get PROJ-123 --id`,
+  jtk issues get PROJ-123 --id
+  jtk issues get PROJ-123 --fields Status,Assignee
+  jtk issues get PROJ-123 --fields "Issue Type"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGet(cmd.Context(), opts, args[0], noTruncate || opts.IsFullText())
+			return runGet(cmd.Context(), opts, args[0], noTruncate || opts.IsFullText(), fieldsFlag)
 		},
 	}
 
 	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full description without truncation")
 	_ = cmd.Flags().MarkDeprecated("no-truncate", "use --fulltext instead")
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display fields (labels, Jira field IDs, or human names)")
 
 	return cmd
 }
 
-func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate bool) error {
+func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate bool, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -42,6 +48,25 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		return err
 	}
 
+	if fieldsFlag != "" && opts.Output == "json" {
+		return errFieldsWithJSON
+	}
+
+	selected, projected, err := projection.Resolve(
+		ctx,
+		jtkpresent.IssueDetailSpec,
+		opts.IsExtended(),
+		fieldsFlag,
+		client.GetFields,
+		"issues get",
+	)
+	if err != nil {
+		return err
+	}
+
+	// issues get does not minimize fetch — api.GetIssue has no field-selection
+	// parameter, and adding one is out of scope for #233. Projection is
+	// purely a display-time operation here.
 	issue, err := client.GetIssue(ctx, issueKey)
 	if err != nil {
 		return err
@@ -57,5 +82,19 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	}
 
 	model := jtkpresent.IssuePresenter{}.PresentDetail(issue, client.IssueURL(issue.Key), noTruncate)
+	if projected {
+		projectDetailSectionInModel(model, selected)
+	}
 	return jtkpresent.Emit(opts, model)
+}
+
+// projectDetailSectionInModel rewrites the first DetailSection of model to
+// the selected fields. No-op when there is no DetailSection.
+func projectDetailSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
+	for i, s := range model.Sections {
+		if ds, ok := s.(*present.DetailSection); ok {
+			model.Sections[i] = projection.ProjectDetail(ds, selected)
+			return
+		}
+	}
 }

--- a/tools/jtk/internal/cmd/issues/get_fields_test.go
+++ b/tools/jtk/internal/cmd/issues/get_fields_test.go
@@ -185,3 +185,48 @@ func TestRunGet_FieldsWithIDOnly_IDWins(t *testing.T) {
 		t.Errorf("expected bare key, got %q", stdout.String())
 	}
 }
+
+// Under --id, projection.Resolve is skipped entirely. A human-name --fields
+// token would normally trigger a GetFields() call; --id must suppress it.
+func TestRunGet_IDOnly_SkipsFieldsResolution(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssue(), []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	})
+	defer cs.server.Close()
+
+	opts, _, _ := newGetOpts(t, cs)
+	opts.IDOnly = true
+	err := runGet(context.Background(), opts, "TEST-1", false, "Issue Type")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, 0, cs.fieldsCalls)
+}
+
+func TestRunGet_IDOnly_BypassesFieldsValidation(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssue(), []api.Field{})
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	opts.IDOnly = true
+	err := runGet(context.Background(), opts, "TEST-1", false, "bogus")
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "TEST-1\n" {
+		t.Errorf("expected bare key, got %q", stdout.String())
+	}
+}
+
+func TestRunGet_IDOnly_BypassesJSONFieldsRejection(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssue(), nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	opts.IDOnly = true
+	opts.Output = "json"
+	err := runGet(context.Background(), opts, "TEST-1", false, "Status")
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "TEST-1\n" {
+		t.Errorf("expected bare key, got %q", stdout.String())
+	}
+}

--- a/tools/jtk/internal/cmd/issues/get_fields_test.go
+++ b/tools/jtk/internal/cmd/issues/get_fields_test.go
@@ -1,0 +1,187 @@
+package issues
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
+)
+
+// capturingGetServer handles both /issue/* and /field requests. Tests
+// introspect fieldsCalls to verify whether GetFields was invoked.
+type capturingGetServer struct {
+	server      *httptest.Server
+	fieldsCalls int
+	issueCalls  int
+}
+
+func newCapturingGetServer(t *testing.T, issue api.Issue, fieldsResp []api.Field) *capturingGetServer {
+	t.Helper()
+	cs := &capturingGetServer{}
+	cs.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/field") {
+			cs.fieldsCalls++
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(fieldsResp)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/issue/") {
+			cs.issueCalls++
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(issue)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	return cs
+}
+
+func newGetOpts(t *testing.T, cs *capturingGetServer) (*root.Options, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: cs.server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &stderr, Output: "table"}
+	opts.SetAPIClient(client)
+	return opts, &stdout, &stderr
+}
+
+func fullIssue() api.Issue {
+	return api.Issue{
+		Key: "TEST-1",
+		Fields: api.IssueFields{
+			Summary:     "summary text",
+			Description: &api.Description{Text: "desc body"},
+			Status:      &api.Status{Name: "Open"},
+			IssueType:   &api.IssueType{Name: "Task"},
+			Priority:    &api.Priority{Name: "High"},
+			Assignee:    &api.User{DisplayName: "Alice"},
+			Project:     &api.Project{Key: "TEST"},
+		},
+	}
+}
+
+func TestRunGet_Fields_ProjectsDetailToSelected(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssue(), nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	err := runGet(context.Background(), opts, "TEST-1", false, "Status")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	// Identity (Key) must always appear.
+	testutil.Contains(t, output, "Key: TEST-1")
+	testutil.Contains(t, output, "Status: Open")
+	// Dropped fields must NOT appear.
+	if strings.Contains(output, "Assignee") {
+		t.Errorf("Assignee should be dropped when --fields=Status: %q", output)
+	}
+	if strings.Contains(output, "Priority") {
+		t.Errorf("Priority should be dropped when --fields=Status: %q", output)
+	}
+}
+
+func TestRunGet_Fields_URL_SyntheticColumn(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssue(), nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	err := runGet(context.Background(), opts, "TEST-1", false, "URL")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Key: TEST-1")
+	testutil.Contains(t, output, "URL:")
+}
+
+func TestRunGet_Fields_HumanName_TriggersFieldsFetch(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssue(), []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	})
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	err := runGet(context.Background(), opts, "TEST-1", false, "Issue Type")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Key: TEST-1")
+	testutil.Contains(t, output, "Type: Task")
+	if cs.fieldsCalls != 1 {
+		t.Errorf("human-name resolution must trigger GetFields once; got %d", cs.fieldsCalls)
+	}
+}
+
+func TestRunGet_Fields_UnknownToken_Errors(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssue(), []api.Field{})
+	defer cs.server.Close()
+
+	opts, _, _ := newGetOpts(t, cs)
+	err := runGet(context.Background(), opts, "TEST-1", false, "bogus")
+	var ufe *projection.UnknownFieldError
+	if !errors.As(err, &ufe) {
+		t.Fatalf("expected UnknownFieldError, got %v", err)
+	}
+}
+
+func TestRunGet_Fields_UnrenderedField_ByFieldID_Errors(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssue(), []api.Field{
+		{ID: "customfield_99999", Name: "Phantom"},
+	})
+	defer cs.server.Close()
+
+	opts, _, _ := newGetOpts(t, cs)
+	err := runGet(context.Background(), opts, "TEST-1", false, "customfield_99999")
+	var ure *projection.UnrenderedFieldError
+	if !errors.As(err, &ure) {
+		t.Fatalf("expected UnrenderedFieldError, got %v", err)
+	}
+	testutil.Equal(t, "Phantom", ure.JiraName)
+	testutil.Equal(t, "issues get", ure.Command)
+}
+
+func TestRunGet_Fields_WithJSON_Errors(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssue(), nil)
+	defer cs.server.Close()
+
+	opts, _, _ := newGetOpts(t, cs)
+	opts.Output = "json"
+	err := runGet(context.Background(), opts, "TEST-1", false, "Status")
+	if err == nil {
+		t.Fatalf("expected error when --fields combined with --output json")
+	}
+	testutil.Contains(t, err.Error(), "not supported with --output json")
+}
+
+func TestRunGet_FieldsWithIDOnly_IDWins(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssue(), nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	opts.IDOnly = true
+	err := runGet(context.Background(), opts, "TEST-1", false, "Status")
+	testutil.RequireNoError(t, err)
+
+	// Bare key on stdout; nothing else.
+	if stdout.String() != "TEST-1\n" {
+		t.Errorf("expected bare key, got %q", stdout.String())
+	}
+}

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -67,7 +67,7 @@ func TestRunGet_TruncatesDescription(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "TEST-1", false)
+	err = runGet(context.Background(), opts, "TEST-1", false, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -107,7 +107,7 @@ func TestRunGet_FullDescription(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "TEST-1", true)
+	err = runGet(context.Background(), opts, "TEST-1", true, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -224,7 +224,7 @@ func TestRunGet_IDOnly(t *testing.T) {
 	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	testutil.RequireNoError(t, runGet(context.Background(), opts, "TEST-1", false))
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TEST-1", false, ""))
 	testutil.Equal(t, stdout.String(), "TEST-1\n")
 }
 
@@ -252,7 +252,7 @@ func TestRunGet_IDOnlyPrecedenceOverExtendedFullText(t *testing.T) {
 
 	// runGet receives noTruncate derived from RunE; when --id is set, the truncation
 	// value doesn't matter because EmitIDOnly collapses output before presenter runs.
-	testutil.RequireNoError(t, runGet(context.Background(), opts, "TEST-1", true))
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TEST-1", true, ""))
 	testutil.Equal(t, stdout.String(), "TEST-1\n")
 }
 
@@ -286,7 +286,7 @@ func TestRunGet_ShortDescriptionNotTruncated(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "TEST-1", false)
+	err = runGet(context.Background(), opts, "TEST-1", false, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -323,7 +323,7 @@ func TestRunGet_JSONOutputIgnoresFullFlag(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "TEST-1", true)
+	err = runGet(context.Background(), opts, "TEST-1", true, "")
 	testutil.RequireNoError(t, err)
 
 	// Should be valid JSON

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -75,20 +75,31 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 		return err
 	}
 
-	if fieldsFlag != "" && opts.Output == "json" {
+	// --id wins over --fields: skip projection entirely when --id is set so
+	// we don't waste a GetFields() call for a --fields token whose display
+	// result would be thrown away. --id also overrides the JSON + --fields
+	// error since we're not producing JSON.
+	idOnly := opts.EmitIDOnly()
+
+	if !idOnly && fieldsFlag != "" && opts.Output == "json" {
 		return errFieldsWithJSON
 	}
 
-	selected, projected, err := projection.Resolve(
-		ctx,
-		jtkpresent.IssueListSpec,
-		opts.IsExtended(),
-		fieldsFlag,
-		client.GetFields,
-		"issues list",
-	)
-	if err != nil {
-		return err
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		var err error
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.IssueListSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			client.GetFields,
+			"issues list",
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Build JQL query
@@ -132,7 +143,7 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 
 	hasMore := !result.Pagination.IsLast
 
-	if opts.EmitIDOnly() {
+	if idOnly {
 		ids := make([]string, len(result.Issues))
 		for i, issue := range result.Issues {
 			ids[i] = issue.Key

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -2,6 +2,7 @@ package issues
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -14,7 +15,12 @@ import (
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
+
+// errFieldsWithJSON is returned when --fields is combined with --output json.
+// JSON output is not projected; mixing them silently would be surprising.
+var errFieldsWithJSON = errors.New("--fields is not supported with --output json")
 
 func newListCmd(opts *root.Options) *cobra.Command {
 	var project string
@@ -43,8 +49,9 @@ func newListCmd(opts *root.Options) *cobra.Command {
   # List with all fields (includes description)
   jtk issues list --project MYPROJECT --all-fields
 
-  # List with specific fields (e.g. custom fields)
-  jtk issues list --project MYPROJECT --fields summary,status,customfield_10005`,
+  # Project display columns — headers, Jira field IDs, or human names
+  jtk issues list --project MYPROJECT --fields SUMMARY,STATUS
+  jtk issues list --project MYPROJECT --fields "Issue Type"`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runList(cmd.Context(), opts, project, sprint, maxResults, nextPageToken, allFields, fieldsFlag)
 		},
@@ -55,7 +62,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 25, "Maximum number of results to return")
 	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Token for next page of results")
 	cmd.Flags().BoolVar(&allFields, "all-fields", false, "Include all fields (e.g. description)")
-	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated list of fields to return (e.g. summary,customfield_10005)")
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns (headers, Jira field IDs, or human names)")
 
 	return cmd
 }
@@ -64,6 +71,22 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 	v := opts.View()
 
 	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	if fieldsFlag != "" && opts.Output == "json" {
+		return errFieldsWithJSON
+	}
+
+	selected, projected, err := projection.Resolve(
+		ctx,
+		jtkpresent.IssueListSpec,
+		opts.IsExtended(),
+		fieldsFlag,
+		client.GetFields,
+		"issues list",
+	)
 	if err != nil {
 		return err
 	}
@@ -95,7 +118,7 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 		jql += " ORDER BY updated DESC"
 	}
 
-	fields := resolveFields(fieldsFlag, opts.Output, allFields)
+	fields := deriveFetchFields(selected, projected, opts.IsExtended(), allFields, opts.Output)
 
 	result, err := client.SearchPage(ctx, api.SearchPageOptions{
 		JQL:           jql,
@@ -138,5 +161,20 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 	}
 
 	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, hasMore)
+	if projected {
+		projectTableSectionInModel(model, selected)
+	}
 	return jtkpresent.Emit(opts, model)
+}
+
+// projectTableSectionInModel rewrites the first TableSection of model to the
+// selected columns. No-op when there is no TableSection (e.g. model contains
+// only MessageSections).
+func projectTableSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
+	for i, s := range model.Sections {
+		if ts, ok := s.(*present.TableSection); ok {
+			model.Sections[i] = projection.ProjectTable(ts, selected)
+			return
+		}
+	}
 }

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -81,7 +81,7 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 	// error since we're not producing JSON.
 	idOnly := opts.EmitIDOnly()
 
-	if !idOnly && fieldsFlag != "" && opts.Output == "json" {
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
 		return errFieldsWithJSON
 	}
 

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 // listResultServer returns a fixed set of issues with configurable IsLast.
@@ -161,5 +164,225 @@ func TestRunList_EmptyWithIDOnly_EmitsNothing(t *testing.T) {
 	}
 	if stderr.String() != "" {
 		t.Errorf("stderr should be empty, got: %q", stderr.String())
+	}
+}
+
+// capturingServer records each inbound request body plus the path and
+// responds with a canned issues payload. Tests introspect requests to verify
+// fetch-optimization behavior (which Fields were sent to the Search API,
+// whether GetFields was called, etc.).
+type capturingServer struct {
+	server         *httptest.Server
+	searchCaptured *api.SearchRequest
+	fieldsCalls    int
+}
+
+func newCapturingServer(t *testing.T, keys []string, isLast bool, fieldsResp []api.Field) *capturingServer {
+	t.Helper()
+	cs := &capturingServer{searchCaptured: &api.SearchRequest{}}
+	cs.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/field") {
+			cs.fieldsCalls++
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(fieldsResp)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/search") {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, cs.searchCaptured)
+			issues := make([]api.Issue, len(keys))
+			for i, k := range keys {
+				issues[i] = api.Issue{
+					Key: k,
+					Fields: api.IssueFields{
+						Summary:   "summary for " + k,
+						Status:    &api.Status{Name: "Open"},
+						IssueType: &api.IssueType{Name: "Task"},
+						Assignee:  &api.User{DisplayName: "Alice"},
+					},
+				}
+			}
+			result := api.JQLSearchResult{Issues: issues, IsLast: isLast}
+			if !isLast {
+				result.NextPageToken = "next-token"
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(result)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	return cs
+}
+
+func newOptsFor(t *testing.T, cs *capturingServer) (*root.Options, *bytes.Buffer, *bytes.Buffer) {
+	return newListOpts(t, cs.server)
+}
+
+func TestRunList_Fields_HeaderAliases_ProjectsTable(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "SUMMARY,STATUS")
+	testutil.RequireNoError(t, err)
+
+	// Header row in the pipe-delimited agent output should be KEY | SUMMARY | STATUS.
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) == 0 {
+		t.Fatalf("empty output")
+	}
+	if lines[0] != "KEY | SUMMARY | STATUS" {
+		t.Errorf("header mismatch: got %q", lines[0])
+	}
+	if cs.fieldsCalls != 0 {
+		t.Errorf("header aliases must not trigger GetFields; got %d calls", cs.fieldsCalls)
+	}
+	// Derived fetch: identity KEY contributes nothing; SUMMARY→summary, STATUS→status.
+	got := cs.searchCaptured.Fields
+	if len(got) != 2 || got[0] != "status" || got[1] != "summary" {
+		t.Errorf("fetch set: got %v; want [status summary]", got)
+	}
+}
+
+func TestRunList_Fields_JiraFieldIDs_ProjectsTable(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "summary,assignee")
+	testutil.RequireNoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if lines[0] != "KEY | SUMMARY | ASSIGNEE" {
+		t.Errorf("header mismatch: got %q", lines[0])
+	}
+}
+
+func TestRunList_Fields_HumanName_TriggersFieldsFetch(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	})
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "Issue Type")
+	testutil.RequireNoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if lines[0] != "KEY | TYPE" {
+		t.Errorf("header mismatch: got %q", lines[0])
+	}
+	if cs.fieldsCalls != 1 {
+		t.Errorf("human-name resolution must trigger GetFields exactly once; got %d", cs.fieldsCalls)
+	}
+}
+
+func TestRunList_Fields_UnknownToken_Errors(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{})
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "bogus")
+	var ufe *projection.UnknownFieldError
+	if !errors.As(err, &ufe) {
+		t.Fatalf("expected UnknownFieldError, got %v", err)
+	}
+}
+
+func TestRunList_Fields_UnrenderedField_ByHumanName_Errors(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
+		{ID: "customfield_99999", Name: "Phantom"},
+	})
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "Phantom")
+	var ure *projection.UnrenderedFieldError
+	if !errors.As(err, &ure) {
+		t.Fatalf("expected UnrenderedFieldError, got %v", err)
+	}
+	testutil.Equal(t, "Phantom", ure.JiraName)
+	testutil.Equal(t, "issues list", ure.Command)
+}
+
+func TestRunList_Fields_UnrenderedField_ByFieldID_Errors(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
+		{ID: "customfield_99999", Name: "Phantom"},
+	})
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "customfield_99999")
+	var ure *projection.UnrenderedFieldError
+	if !errors.As(err, &ure) {
+		t.Fatalf("expected UnrenderedFieldError, got %v", err)
+	}
+	testutil.Equal(t, "Phantom", ure.JiraName)
+	testutil.Contains(t, err.Error(), "Phantom")
+}
+
+func TestRunList_Fields_WithJSON_Errors(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	opts.Output = "json"
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "SUMMARY")
+	if err == nil {
+		t.Fatalf("expected error when --fields combined with --output json")
+	}
+	testutil.Contains(t, err.Error(), "not supported with --output json")
+}
+
+func TestRunList_FieldsWithIDOnly_IDWins(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1", "TEST-2"}, true, nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	opts.IDOnly = true
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "SUMMARY")
+	testutil.RequireNoError(t, err)
+
+	want := "TEST-1\nTEST-2\n"
+	if stdout.String() != want {
+		t.Errorf("stdout: got %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestRunList_Fields_TrumpsAllFieldsForFetch(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	// Both --fields and --all-fields set; --fields must win for fetch.
+	err := runList(context.Background(), opts, "TEST", "", 25, "", true, "SUMMARY")
+	testutil.RequireNoError(t, err)
+	got := cs.searchCaptured.Fields
+	if len(got) != 1 || got[0] != "summary" {
+		t.Errorf("--fields must drive fetch even when --all-fields is set; got %v", got)
+	}
+}
+
+func TestRunList_AllFieldsWithoutFields_UsesDefaultSearchFields(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", true, "")
+	testutil.RequireNoError(t, err)
+	got := cs.searchCaptured.Fields
+	if len(got) != len(api.DefaultSearchFields) {
+		t.Errorf("--all-fields should request DefaultSearchFields; got %d fields, want %d", len(got), len(api.DefaultSearchFields))
 	}
 }

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -246,6 +246,27 @@ func TestRunList_Fields_HeaderAliases_ProjectsTable(t *testing.T) {
 	}
 }
 
+// Projection must coexist with pagination state: when a --fields projection
+// runs against a multi-page result (hasMore=true), ProjectTable rewrites the
+// TableSection but the pagination hint section must survive untouched. A
+// regression that stripped the hint would only surface at runtime against a
+// multi-page paginated table result.
+func TestRunList_Fields_Projection_PreservesPaginationHint(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, false, nil) // isLast=false → hasMore=true
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "SUMMARY,STATUS")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "KEY | SUMMARY | STATUS")
+	// Pagination hint survives projection — AppendPaginationHint emits a
+	// Message section whose body contains "next-page-token" when hasMore.
+	testutil.Contains(t, out, "next-page-token")
+}
+
 func TestRunList_Fields_JiraFieldIDs_ProjectsTable(t *testing.T) {
 	t.Parallel()
 	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -358,6 +358,56 @@ func TestRunList_FieldsWithIDOnly_IDWins(t *testing.T) {
 	}
 }
 
+// Under --id, projection.Resolve is skipped entirely. A human-name --fields
+// token would normally trigger a GetFields() call; --id must suppress it.
+func TestRunList_IDOnly_SkipsFieldsResolution(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	})
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	opts.IDOnly = true
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "Issue Type")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, 0, cs.fieldsCalls)
+}
+
+// Under --id, even an unknown --fields token must not fail — --id bypasses
+// projection entirely. Without this short-circuit, `--id --fields bogus`
+// would error even though --id would have discarded the projection anyway.
+func TestRunList_IDOnly_BypassesFieldsValidation(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{})
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	opts.IDOnly = true
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "bogus")
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "TEST-1\n" {
+		t.Errorf("expected bare key, got %q", stdout.String())
+	}
+}
+
+// Under --id, the JSON + --fields rejection also must not fire. --id produces
+// plain identifiers, not JSON, so the conflict is moot.
+func TestRunList_IDOnly_BypassesJSONFieldsRejection(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	opts.IDOnly = true
+	opts.Output = "json"
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "SUMMARY")
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "TEST-1\n" {
+		t.Errorf("expected bare key, got %q", stdout.String())
+	}
+}
+
 func TestRunList_Fields_TrumpsAllFieldsForFetch(t *testing.T) {
 	t.Parallel()
 	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -73,7 +73,7 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 	// See list.go for rationale.
 	idOnly := opts.EmitIDOnly()
 
-	if !idOnly && fieldsFlag != "" && opts.Output == "json" {
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
 		return errFieldsWithJSON
 	}
 

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -69,20 +69,29 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 		return err
 	}
 
-	if fieldsFlag != "" && opts.Output == "json" {
+	// --id wins over --fields: skip projection entirely when --id is set.
+	// See list.go for rationale.
+	idOnly := opts.EmitIDOnly()
+
+	if !idOnly && fieldsFlag != "" && opts.Output == "json" {
 		return errFieldsWithJSON
 	}
 
-	selected, projected, err := projection.Resolve(
-		ctx,
-		jtkpresent.IssueListSpec,
-		opts.IsExtended(),
-		fieldsFlag,
-		client.GetFields,
-		"issues search",
-	)
-	if err != nil {
-		return err
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		var err error
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.IssueListSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			client.GetFields,
+			"issues search",
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	fields := deriveFetchFields(selected, projected, opts.IsExtended(), allFields, opts.Output)
@@ -99,7 +108,7 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 
 	hasMore := !result.Pagination.IsLast
 
-	if opts.EmitIDOnly() {
+	if idOnly {
 		ids := make([]string, len(result.Issues))
 		for i, issue := range result.Issues {
 			ids[i] = issue.Key

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -14,6 +14,7 @@ import (
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 func newSearchCmd(opts *root.Options) *cobra.Command {
@@ -42,8 +43,9 @@ func newSearchCmd(opts *root.Options) *cobra.Command {
   # Search with all fields (includes description)
   jtk issues search --jql "project = MYPROJECT" --all-fields
 
-  # Search with specific fields (e.g. custom fields)
-  jtk issues search --jql "project = MYPROJECT" --fields summary,status,customfield_10005`,
+  # Project display columns — headers, Jira field IDs, or human names
+  jtk issues search --jql "project = MYPROJECT" --fields SUMMARY,STATUS
+  jtk issues search --jql "project = MYPROJECT" --fields "Issue Type"`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runSearch(cmd.Context(), opts, jql, maxResults, nextPageToken, allFields, fieldsFlag)
 		},
@@ -53,7 +55,7 @@ func newSearchCmd(opts *root.Options) *cobra.Command {
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 25, "Maximum number of results to return")
 	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Token for next page of results")
 	cmd.Flags().BoolVar(&allFields, "all-fields", false, "Include all fields (e.g. description)")
-	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated list of fields to return (e.g. summary,customfield_10005)")
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns (headers, Jira field IDs, or human names)")
 	_ = cmd.MarkFlagRequired("jql")
 
 	return cmd
@@ -67,7 +69,23 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 		return err
 	}
 
-	fields := resolveFields(fieldsFlag, opts.Output, allFields)
+	if fieldsFlag != "" && opts.Output == "json" {
+		return errFieldsWithJSON
+	}
+
+	selected, projected, err := projection.Resolve(
+		ctx,
+		jtkpresent.IssueListSpec,
+		opts.IsExtended(),
+		fieldsFlag,
+		client.GetFields,
+		"issues search",
+	)
+	if err != nil {
+		return err
+	}
+
+	fields := deriveFetchFields(selected, projected, opts.IsExtended(), allFields, opts.Output)
 
 	result, err := client.SearchPage(ctx, api.SearchPageOptions{
 		JQL:           jql,
@@ -79,6 +97,16 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 		return err
 	}
 
+	hasMore := !result.Pagination.IsLast
+
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(result.Issues))
+		for i, issue := range result.Issues {
+			ids[i] = issue.Key
+		}
+		return jtkpresent.EmitIDsWithPagination(opts, ids, hasMore)
+	}
+
 	if len(result.Issues) == 0 {
 		model := jtkpresent.IssuePresenter{}.PresentEmpty()
 		out := present.Render(model, opts.RenderStyle())
@@ -88,13 +116,14 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectIssues(result.Issues, opts.ArtifactMode())
-		hasMore := !result.Pagination.IsLast
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
 	// Text path: presenter → render → write
-	hasMore := !result.Pagination.IsLast
 	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, hasMore)
+	if projected {
+		projectTableSectionInModel(model, selected)
+	}
 	out := present.Render(model, opts.RenderStyle())
 	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)

--- a/tools/jtk/internal/cmd/issues/search_fields.go
+++ b/tools/jtk/internal/cmd/issues/search_fields.go
@@ -1,31 +1,36 @@
 package issues
 
 import (
-	"strings"
-
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
-// resolveFields determines which fields to request from the Jira API based on
-// the --fields flag, output format, and --all-fields flag.
-func resolveFields(fieldsFlag, outputFormat string, allFields bool) []string {
-	if fieldsFlag != "" {
-		parts := strings.Split(fieldsFlag, ",")
-		fields := make([]string, 0, len(parts))
-		for _, p := range parts {
-			if f := strings.TrimSpace(p); f != "" {
-				fields = append(fields, f)
-			}
-		}
-		if len(fields) > 0 {
-			return fields
-		}
-		// Fall through to defaults if all tokens were empty/whitespace
-	}
+// deriveFetchFields computes the Jira API "fields" list for issues list /
+// issues search based on the current command state. Unlike the legacy
+// resolveFields helper, it does NOT accept user --fields input — the
+// display projection is resolved upstream via projection.Resolve, and
+// fetch-pruning is a derived optimization.
+//
+// Precedence:
+//  1. outputFormat == "json" → "*all" (preserves full payload fidelity).
+//  2. projected → projection.DeriveFetchFields(selected) (both extended
+//     and allFields are ignored; the selected specs alone drive fetch).
+//  3. extended || allFields → api.DefaultSearchFields.
+//  4. otherwise → api.ListSearchFields.
+func deriveFetchFields(
+	selected []projection.ColumnSpec,
+	projected bool,
+	extended bool,
+	allFields bool,
+	outputFormat string,
+) []string {
 	if outputFormat == "json" {
 		return []string{"*all"}
 	}
-	if allFields {
+	if projected {
+		return projection.DeriveFetchFields(selected)
+	}
+	if extended || allFields {
 		return append([]string(nil), api.DefaultSearchFields...)
 	}
 	return append([]string(nil), api.ListSearchFields...)

--- a/tools/jtk/internal/cmd/issues/search_fields_test.go
+++ b/tools/jtk/internal/cmd/issues/search_fields_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 // artifactListResult is a helper struct for parsing artifact list output in tests.
@@ -27,97 +28,82 @@ type artifactListResult struct {
 	} `json:"_meta"`
 }
 
-func TestResolveFields(t *testing.T) {
+func TestDeriveFetchFields(t *testing.T) {
 	t.Parallel()
+	selected := []projection.ColumnSpec{
+		{Header: "KEY", Identity: true}, // synthetic — no fetch contribution
+		{Header: "SUMMARY", FieldID: "summary"},
+	}
+
 	tests := []struct {
-		name       string
-		fieldsFlag string
-		output     string
-		full       bool
-		want       []string
+		name      string
+		projected bool
+		extended  bool
+		allFields bool
+		output    string
+		want      []string
 	}{
 		{
-			name:       "explicit fields flag takes precedence",
-			fieldsFlag: "summary,customfield_10005",
-			output:     "json",
-			full:       true,
-			want:       []string{"summary", "customfield_10005"},
+			name:   "json output → *all",
+			output: "json",
+			want:   []string{"*all"},
 		},
 		{
-			name:       "json output without fields flag returns all",
-			fieldsFlag: "",
-			output:     "json",
-			full:       false,
-			want:       []string{"*all"},
+			name:   "json + extended → still *all",
+			output: "json", extended: true,
+			want: []string{"*all"},
 		},
 		{
-			name:       "json output with full flag still returns all",
-			fieldsFlag: "",
-			output:     "json",
-			full:       true,
-			want:       []string{"*all"},
+			name:      "projected → union of selected specs",
+			projected: true,
+			output:    "table",
+			want:      []string{"summary"},
 		},
 		{
-			name:       "full flag returns DefaultSearchFields",
-			fieldsFlag: "",
-			output:     "",
-			full:       true,
-			want:       api.DefaultSearchFields,
+			name:      "projected wins over extended",
+			projected: true, extended: true,
+			output: "table",
+			want:   []string{"summary"},
 		},
 		{
-			name:       "default returns ListSearchFields",
-			fieldsFlag: "",
-			output:     "",
-			full:       false,
-			want:       api.ListSearchFields,
+			name:      "projected wins over allFields",
+			projected: true, allFields: true,
+			output: "table",
+			want:   []string{"summary"},
 		},
 		{
-			name:       "table output returns ListSearchFields",
-			fieldsFlag: "",
-			output:     "table",
-			full:       false,
-			want:       api.ListSearchFields,
+			name:     "extended without projection → DefaultSearchFields",
+			extended: true,
+			output:   "table",
+			want:     api.DefaultSearchFields,
 		},
 		{
-			name:       "single field",
-			fieldsFlag: "summary",
-			output:     "",
-			full:       false,
-			want:       []string{"summary"},
+			name:      "allFields without projection → DefaultSearchFields",
+			allFields: true,
+			output:    "table",
+			want:      api.DefaultSearchFields,
 		},
 		{
-			name:       "trims whitespace around fields",
-			fieldsFlag: "summary , customfield_10005 , status",
-			output:     "",
-			full:       false,
-			want:       []string{"summary", "customfield_10005", "status"},
+			name:     "extended and allFields are idempotent",
+			extended: true, allFields: true,
+			output: "table",
+			want:   api.DefaultSearchFields,
 		},
 		{
-			name:       "drops empty segments from trailing comma",
-			fieldsFlag: "summary,status,",
-			output:     "",
-			full:       false,
-			want:       []string{"summary", "status"},
+			name:   "default → ListSearchFields",
+			output: "table",
+			want:   api.ListSearchFields,
 		},
 		{
-			name:       "all empty tokens falls through to json default",
-			fieldsFlag: ",, ",
-			output:     "json",
-			full:       false,
-			want:       []string{"*all"},
-		},
-		{
-			name:       "all empty tokens falls through to list default",
-			fieldsFlag: ",, ",
-			output:     "",
-			full:       false,
-			want:       api.ListSearchFields,
+			name:   "empty output treated as non-json",
+			output: "",
+			want:   api.ListSearchFields,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveFields(tt.fieldsFlag, tt.output, tt.full)
+			got := deriveFetchFields(selected, tt.projected, tt.extended, tt.allFields, tt.output)
 			testutil.Equal(t, len(tt.want), len(got))
 			for i := range tt.want {
 				testutil.Equal(t, tt.want[i], got[i])
@@ -187,35 +173,6 @@ func TestRunSearch_JSONOutputRequestsAllFields(t *testing.T) {
 	testutil.Equal(t, "*all", captured.Fields[0])
 }
 
-func TestRunSearch_FieldsFlagOverridesJSONDefault(t *testing.T) {
-	t.Parallel()
-	var captured api.SearchRequest
-	server := newSearchServer(t, &captured)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{
-		URL:      server.URL,
-		Email:    "test@example.com",
-		APIToken: "token",
-	})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{
-		Output: "json",
-		Stdout: &stdout,
-		Stderr: &bytes.Buffer{},
-	}
-	opts.SetAPIClient(client)
-
-	err = runSearch(context.Background(), opts, "project = TEST", 25, "", false, "summary,customfield_10005")
-	testutil.RequireNoError(t, err)
-
-	testutil.Equal(t, 2, len(captured.Fields))
-	testutil.Equal(t, "summary", captured.Fields[0])
-	testutil.Equal(t, "customfield_10005", captured.Fields[1])
-}
-
 func TestRunSearch_TableOutputUsesListFields(t *testing.T) {
 	t.Parallel()
 	var captured api.SearchRequest
@@ -272,35 +229,6 @@ func TestRunList_JSONOutputRequestsAllFields(t *testing.T) {
 
 	testutil.Equal(t, 1, len(captured.Fields))
 	testutil.Equal(t, "*all", captured.Fields[0])
-}
-
-func TestRunList_FieldsFlagOverridesJSONDefault(t *testing.T) {
-	t.Parallel()
-	var captured api.SearchRequest
-	server := newSearchServer(t, &captured)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{
-		URL:      server.URL,
-		Email:    "test@example.com",
-		APIToken: "token",
-	})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{
-		Output: "json",
-		Stdout: &stdout,
-		Stderr: &bytes.Buffer{},
-	}
-	opts.SetAPIClient(client)
-
-	err = runList(context.Background(), opts, "TEST", "", 25, "", false, "summary,customfield_10035")
-	testutil.RequireNoError(t, err)
-
-	testutil.Equal(t, 2, len(captured.Fields))
-	testutil.Equal(t, "summary", captured.Fields[0])
-	testutil.Equal(t, "customfield_10035", captured.Fields[1])
 }
 
 // newPaginatedSearchServer creates a server that returns pageSize issues per request

--- a/tools/jtk/internal/cmd/issues/search_test.go
+++ b/tools/jtk/internal/cmd/issues/search_test.go
@@ -81,6 +81,65 @@ func TestRunSearch_Fields_WithJSON_Errors(t *testing.T) {
 	testutil.Contains(t, err.Error(), "not supported with --output json")
 }
 
+// Search and List share deriveFetchFields, but assert here directly so a
+// future divergence in search's fetch wiring does not hide behind list's
+// coverage.
+func TestRunSearch_Fields_DerivesFetchSet(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "SUMMARY,STATUS")
+	testutil.RequireNoError(t, err)
+
+	got := cs.searchCaptured.Fields
+	// KEY has an empty FieldID, so it never appears in the derived set.
+	want := map[string]bool{"summary": true, "status": true}
+	if len(got) != len(want) {
+		t.Fatalf("fetch set length: got %v, want keys %v", got, want)
+	}
+	for _, f := range got {
+		if !want[f] {
+			t.Errorf("unexpected fetch field %q (want only SUMMARY + STATUS IDs)", f)
+		}
+	}
+}
+
+// --id in search is new behavior in this PR. Cover the pagination branch
+// so the idOnly emit path is exercised with hasMore=true.
+func TestRunSearch_FieldsWithIDOnly_Pagination(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1", "TEST-2"}, false, nil) // isLast=false → hasMore=true
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	opts.IDOnly = true
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "SUMMARY")
+	testutil.RequireNoError(t, err)
+
+	// Bare keys plus a pagination hint on stderr; stdout stays parse-friendly.
+	got := stdout.String()
+	testutil.Contains(t, got, "TEST-1\n")
+	testutil.Contains(t, got, "TEST-2\n")
+}
+
+// Empty result set under --id must not emit anything on stdout (no header,
+// no "No issues found" noise — --id is a machine-friendly mode).
+func TestRunSearch_FieldsWithIDOnly_EmptyResults(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{}, true, nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	opts.IDOnly = true
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "SUMMARY")
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "" {
+		t.Errorf("expected empty stdout for --id with no results, got %q", stdout.String())
+	}
+}
+
 func TestRunSearch_FieldsWithIDOnly_IDWins(t *testing.T) {
 	t.Parallel()
 	cs := newCapturingServer(t, []string{"TEST-1", "TEST-2"}, true, nil)

--- a/tools/jtk/internal/cmd/issues/search_test.go
+++ b/tools/jtk/internal/cmd/issues/search_test.go
@@ -96,3 +96,46 @@ func TestRunSearch_FieldsWithIDOnly_IDWins(t *testing.T) {
 		t.Errorf("stdout: got %q, want %q", stdout.String(), want)
 	}
 }
+
+func TestRunSearch_IDOnly_SkipsFieldsResolution(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	})
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	opts.IDOnly = true
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "Issue Type")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, 0, cs.fieldsCalls)
+}
+
+func TestRunSearch_IDOnly_BypassesFieldsValidation(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{})
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	opts.IDOnly = true
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "bogus")
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "TEST-1\n" {
+		t.Errorf("expected bare key, got %q", stdout.String())
+	}
+}
+
+func TestRunSearch_IDOnly_BypassesJSONFieldsRejection(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	opts.IDOnly = true
+	opts.Output = "json"
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "SUMMARY")
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "TEST-1\n" {
+		t.Errorf("expected bare key, got %q", stdout.String())
+	}
+}

--- a/tools/jtk/internal/cmd/issues/search_test.go
+++ b/tools/jtk/internal/cmd/issues/search_test.go
@@ -1,0 +1,98 @@
+package issues
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
+)
+
+// Search and List share projection infrastructure and must stay in lockstep.
+// These tests exercise --fields semantics through runSearch so drift between
+// the two commands surfaces immediately.
+
+func TestRunSearch_Fields_HeaderAliases_ProjectsTable(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "SUMMARY,STATUS")
+	testutil.RequireNoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if lines[0] != "KEY | SUMMARY | STATUS" {
+		t.Errorf("header mismatch: got %q", lines[0])
+	}
+	if cs.fieldsCalls != 0 {
+		t.Errorf("header aliases must not trigger GetFields; got %d calls", cs.fieldsCalls)
+	}
+}
+
+func TestRunSearch_Fields_HumanName_TriggersFieldsFetch(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	})
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "Issue Type")
+	testutil.RequireNoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if lines[0] != "KEY | TYPE" {
+		t.Errorf("header mismatch: got %q", lines[0])
+	}
+	if cs.fieldsCalls != 1 {
+		t.Errorf("human-name resolution must trigger GetFields exactly once; got %d", cs.fieldsCalls)
+	}
+}
+
+func TestRunSearch_Fields_UnknownToken_Errors(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{})
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "bogus")
+	var ufe *projection.UnknownFieldError
+	if !errors.As(err, &ufe) {
+		t.Fatalf("expected UnknownFieldError, got %v", err)
+	}
+}
+
+func TestRunSearch_Fields_WithJSON_Errors(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, _, _ := newOptsFor(t, cs)
+	opts.Output = "json"
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "SUMMARY")
+	if err == nil {
+		t.Fatalf("expected error when --fields combined with --output json")
+	}
+	testutil.Contains(t, err.Error(), "not supported with --output json")
+}
+
+func TestRunSearch_FieldsWithIDOnly_IDWins(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingServer(t, []string{"TEST-1", "TEST-2"}, true, nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	opts.IDOnly = true
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "SUMMARY")
+	testutil.RequireNoError(t, err)
+
+	want := "TEST-1\nTEST-2\n"
+	if stdout.String() != want {
+		t.Errorf("stdout: got %q, want %q", stdout.String(), want)
+	}
+}

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -7,10 +7,40 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 // IssuePresenter creates presentation models for issue data.
 type IssuePresenter struct{}
+
+// IssueListSpec declares the columns emitted by PresentList /
+// PresentListWithPagination and the metadata needed for --fields
+// projection and minimum-fetch derivation. Order MUST match the
+// hardcoded Headers in PresentList (locked by a parity test).
+var IssueListSpec = projection.Registry{
+	{Header: "KEY", Identity: true},
+	{Header: "SUMMARY", FieldID: "summary"},
+	{Header: "STATUS", FieldID: "status"},
+	{Header: "ASSIGNEE", FieldID: "assignee"},
+	{Header: "TYPE", FieldID: "issuetype"},
+}
+
+// IssueDetailSpec declares the Fields emitted by PresentDetail and the
+// metadata for --fields projection. Order MUST match the default Field
+// order in PresentDetail at construction time; Description is optional
+// there (only emitted when non-empty) but is still declared here so
+// --fields Description resolves and projects correctly when present.
+var IssueDetailSpec = projection.Registry{
+	{Header: "Key", Identity: true},
+	{Header: "Summary", FieldID: "summary"},
+	{Header: "Status", FieldID: "status"},
+	{Header: "Type", FieldID: "issuetype"},
+	{Header: "Priority", FieldID: "priority"},
+	{Header: "Assignee", FieldID: "assignee"},
+	{Header: "Project", FieldID: "project"},
+	{Header: "Description", FieldID: "description"},
+	{Header: "URL"}, // synthetic; no Jira field ID
+}
 
 // PresentDetail creates a detail view for a single issue.
 func (IssuePresenter) PresentDetail(issue *api.Issue, issueURL string, noTruncate bool) *present.OutputModel {

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -333,3 +333,55 @@ func TestIssuePresenter_PresentMovePartialFailure_NoSuccessful(t *testing.T) {
 		t.Errorf("expected 2 sections when no successful, got %d", len(model.Sections))
 	}
 }
+
+// TestIssueListSpec_MatchesPresentListHeaders locks the IssueListSpec headers
+// against the hardcoded headers in PresentList / PresentListWithPagination.
+// Any drift between presenter output columns and the projection registry is
+// a bug — ProjectTable relies on exact header-name equality.
+func TestIssueListSpec_MatchesPresentListHeaders(t *testing.T) {
+	t.Parallel()
+	issues := []api.Issue{{Key: "PROJ-1", Fields: api.IssueFields{Summary: "x"}}}
+	model := IssuePresenter{}.PresentList(issues)
+	table := model.Sections[0].(*present.TableSection)
+
+	if len(table.Headers) != len(IssueListSpec) {
+		t.Fatalf("header count mismatch: spec has %d, table has %d", len(IssueListSpec), len(table.Headers))
+	}
+	for i, spec := range IssueListSpec {
+		if table.Headers[i] != spec.Header {
+			t.Errorf("index %d: spec Header=%q, table header=%q", i, spec.Header, table.Headers[i])
+		}
+	}
+}
+
+// TestIssueDetailSpec_MatchesPresentDetailLabels locks the IssueDetailSpec
+// entries against the Field labels emitted by PresentDetail. Description is
+// conditional; this test constructs an issue with a description present so
+// all spec entries should be rendered.
+func TestIssueDetailSpec_MatchesPresentDetailLabels(t *testing.T) {
+	t.Parallel()
+	issue := &api.Issue{
+		Key: "PROJ-1",
+		Fields: api.IssueFields{
+			Summary:     "s",
+			Status:      &api.Status{Name: "Open"},
+			IssueType:   &api.IssueType{Name: "Bug"},
+			Priority:    &api.Priority{Name: "High"},
+			Assignee:    &api.User{DisplayName: "Alice"},
+			Project:     &api.Project{Key: "PROJ"},
+			Description: &api.Description{Text: "body text"},
+		},
+	}
+	model := IssuePresenter{}.PresentDetail(issue, "https://example.com/PROJ-1", true)
+	detail := model.Sections[0].(*present.DetailSection)
+
+	renderedLabels := make(map[string]bool, len(detail.Fields))
+	for _, f := range detail.Fields {
+		renderedLabels[f.Label] = true
+	}
+	for _, spec := range IssueDetailSpec {
+		if !renderedLabels[spec.Header] {
+			t.Errorf("spec Header %q not emitted by PresentDetail", spec.Header)
+		}
+	}
+}

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -355,9 +355,17 @@ func TestIssueListSpec_MatchesPresentListHeaders(t *testing.T) {
 }
 
 // TestIssueDetailSpec_MatchesPresentDetailLabels locks the IssueDetailSpec
-// entries against the Field labels emitted by PresentDetail. Description is
-// conditional; this test constructs an issue with a description present so
-// all spec entries should be rendered.
+// entries against the Field labels emitted by PresentDetail, both directions:
+//   - Every spec entry must appear in the rendered output.
+//   - Every rendered field must have a matching spec entry — otherwise
+//     --fields projection would silently drop it.
+//
+// Order is also checked: IssueDetailSpec's doc comment claims the spec order
+// matches the PresentDetail Field order, and ProjectDetail relies on that
+// for deterministic projection output.
+//
+// Description is conditional in PresentDetail; this test constructs an issue
+// with a description present so all spec entries should be rendered.
 func TestIssueDetailSpec_MatchesPresentDetailLabels(t *testing.T) {
 	t.Parallel()
 	issue := &api.Issue{
@@ -375,6 +383,7 @@ func TestIssueDetailSpec_MatchesPresentDetailLabels(t *testing.T) {
 	model := IssuePresenter{}.PresentDetail(issue, "https://example.com/PROJ-1", true)
 	detail := model.Sections[0].(*present.DetailSection)
 
+	// Spec → rendered: every spec entry has a corresponding rendered field.
 	renderedLabels := make(map[string]bool, len(detail.Fields))
 	for _, f := range detail.Fields {
 		renderedLabels[f.Label] = true
@@ -382,6 +391,38 @@ func TestIssueDetailSpec_MatchesPresentDetailLabels(t *testing.T) {
 	for _, spec := range IssueDetailSpec {
 		if !renderedLabels[spec.Header] {
 			t.Errorf("spec Header %q not emitted by PresentDetail", spec.Header)
+		}
+	}
+
+	// Rendered → spec: every rendered field has a corresponding spec entry.
+	// Without this, a new field added to PresentDetail would be silently
+	// unreachable via --fields.
+	specLabels := make(map[string]bool, len(IssueDetailSpec))
+	for _, spec := range IssueDetailSpec {
+		specLabels[spec.Header] = true
+	}
+	for _, f := range detail.Fields {
+		if !specLabels[f.Label] {
+			t.Errorf("rendered field %q has no matching IssueDetailSpec entry", f.Label)
+		}
+	}
+
+	// Order: the spec must list entries in the same relative order as
+	// PresentDetail's Field order, so ProjectDetail output is deterministic.
+	specOrder := make([]string, 0, len(IssueDetailSpec))
+	for _, spec := range IssueDetailSpec {
+		specOrder = append(specOrder, spec.Header)
+	}
+	renderedOrder := make([]string, 0, len(detail.Fields))
+	for _, f := range detail.Fields {
+		renderedOrder = append(renderedOrder, f.Label)
+	}
+	if len(specOrder) != len(renderedOrder) {
+		t.Fatalf("spec has %d entries, rendered has %d", len(specOrder), len(renderedOrder))
+	}
+	for i := range specOrder {
+		if specOrder[i] != renderedOrder[i] {
+			t.Errorf("order mismatch at index %d: spec=%q rendered=%q", i, specOrder[i], renderedOrder[i])
 		}
 	}
 }

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -335,22 +335,44 @@ func TestIssuePresenter_PresentMovePartialFailure_NoSuccessful(t *testing.T) {
 }
 
 // TestIssueListSpec_MatchesPresentListHeaders locks the IssueListSpec headers
-// against the hardcoded headers in PresentList / PresentListWithPagination.
-// Any drift between presenter output columns and the projection registry is
-// a bug — ProjectTable relies on exact header-name equality.
+// against the hardcoded headers in PresentList AND PresentListWithPagination.
+// Commands call PresentListWithPagination (not PresentList); drift between
+// the two method implementations and the registry would silently break
+// ProjectTable in production.
 func TestIssueListSpec_MatchesPresentListHeaders(t *testing.T) {
 	t.Parallel()
 	issues := []api.Issue{{Key: "PROJ-1", Fields: api.IssueFields{Summary: "x"}}}
-	model := IssuePresenter{}.PresentList(issues)
-	table := model.Sections[0].(*present.TableSection)
 
-	if len(table.Headers) != len(IssueListSpec) {
-		t.Fatalf("header count mismatch: spec has %d, table has %d", len(IssueListSpec), len(table.Headers))
+	cases := []struct {
+		name  string
+		model *present.OutputModel
+	}{
+		{"PresentList", IssuePresenter{}.PresentList(issues)},
+		{"PresentListWithPagination_NoMore", IssuePresenter{}.PresentListWithPagination(issues, false)},
+		{"PresentListWithPagination_HasMore", IssuePresenter{}.PresentListWithPagination(issues, true)},
 	}
-	for i, spec := range IssueListSpec {
-		if table.Headers[i] != spec.Header {
-			t.Errorf("index %d: spec Header=%q, table header=%q", i, spec.Header, table.Headers[i])
-		}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var table *present.TableSection
+			for _, s := range tc.model.Sections {
+				if ts, ok := s.(*present.TableSection); ok {
+					table = ts
+					break
+				}
+			}
+			if table == nil {
+				t.Fatalf("no TableSection in %s output", tc.name)
+			}
+			if len(table.Headers) != len(IssueListSpec) {
+				t.Fatalf("header count mismatch: spec has %d, table has %d", len(IssueListSpec), len(table.Headers))
+			}
+			for i, spec := range IssueListSpec {
+				if table.Headers[i] != spec.Header {
+					t.Errorf("index %d: spec Header=%q, table header=%q", i, spec.Header, table.Headers[i])
+				}
+			}
+		})
 	}
 }
 

--- a/tools/jtk/internal/present/projection/project.go
+++ b/tools/jtk/internal/present/projection/project.go
@@ -1,0 +1,107 @@
+package projection
+
+import (
+	"sort"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+)
+
+// ProjectTable returns a new TableSection containing only the columns whose
+// spec Header matches one of selected, in the order of selected. Input is
+// not mutated. Unmatched header positions are dropped.
+//
+// selected is the result of Resolve; it already has identity prepended and
+// is in the user's token order. Callers should only invoke ProjectTable
+// when projectionApplied is true.
+func ProjectTable(section *present.TableSection, selected []ColumnSpec) *present.TableSection {
+	if section == nil {
+		return nil
+	}
+	headerIndex := make(map[string]int, len(section.Headers))
+	for i, h := range section.Headers {
+		headerIndex[h] = i
+	}
+
+	keepIdx := make([]int, 0, len(selected))
+	headers := make([]string, 0, len(selected))
+	for _, c := range selected {
+		idx, ok := headerIndex[c.Header]
+		if !ok {
+			continue
+		}
+		keepIdx = append(keepIdx, idx)
+		headers = append(headers, section.Headers[idx])
+	}
+
+	rows := make([]present.Row, len(section.Rows))
+	for i, r := range section.Rows {
+		cells := make([]string, 0, len(keepIdx))
+		for _, idx := range keepIdx {
+			if idx < len(r.Cells) {
+				cells = append(cells, r.Cells[idx])
+			} else {
+				cells = append(cells, "")
+			}
+		}
+		rows[i] = present.Row{Cells: cells}
+	}
+
+	return &present.TableSection{Headers: headers, Rows: rows}
+}
+
+// ProjectDetail returns a new DetailSection keeping only fields whose Label
+// matches a selected spec Header (case-insensitive). Input is not mutated.
+// Order follows selected, not the original DetailSection order.
+func ProjectDetail(section *present.DetailSection, selected []ColumnSpec) *present.DetailSection {
+	if section == nil {
+		return nil
+	}
+	labelIndex := make(map[string]present.Field, len(section.Fields))
+	for _, f := range section.Fields {
+		labelIndex[lower(f.Label)] = f
+	}
+	out := make([]present.Field, 0, len(selected))
+	for _, c := range selected {
+		if f, ok := labelIndex[lower(c.Header)]; ok {
+			out = append(out, f)
+		}
+	}
+	return &present.DetailSection{Fields: out}
+}
+
+// DeriveFetchFields returns the minimum Jira field-ID set needed to render
+// the selected specs. Output is sorted and deduplicated so API requests are
+// stable across runs. Synthetic specs (empty FieldID, empty Fetch) are
+// ignored.
+//
+// Identity is expected to be part of selected already (Resolve prepends it).
+// No special-casing here.
+func DeriveFetchFields(selected []ColumnSpec) []string {
+	seen := make(map[string]struct{}, len(selected)*2)
+	for _, c := range selected {
+		for _, f := range c.fetchFields() {
+			seen[f] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for f := range seen {
+		out = append(out, f)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func lower(s string) string {
+	// Small helper to avoid importing strings into this file's hot path
+	// repeatedly. Go compiler inlines strings.ToLower reliably; kept here
+	// for readability at call sites.
+	b := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		b[i] = c
+	}
+	return string(b)
+}

--- a/tools/jtk/internal/present/projection/project.go
+++ b/tools/jtk/internal/present/projection/project.go
@@ -2,6 +2,7 @@ package projection
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 )
@@ -58,11 +59,11 @@ func ProjectDetail(section *present.DetailSection, selected []ColumnSpec) *prese
 	}
 	labelIndex := make(map[string]present.Field, len(section.Fields))
 	for _, f := range section.Fields {
-		labelIndex[lower(f.Label)] = f
+		labelIndex[strings.ToLower(f.Label)] = f
 	}
 	out := make([]present.Field, 0, len(selected))
 	for _, c := range selected {
-		if f, ok := labelIndex[lower(c.Header)]; ok {
+		if f, ok := labelIndex[strings.ToLower(c.Header)]; ok {
 			out = append(out, f)
 		}
 	}
@@ -89,19 +90,4 @@ func DeriveFetchFields(selected []ColumnSpec) []string {
 	}
 	sort.Strings(out)
 	return out
-}
-
-func lower(s string) string {
-	// Small helper to avoid importing strings into this file's hot path
-	// repeatedly. Go compiler inlines strings.ToLower reliably; kept here
-	// for readability at call sites.
-	b := make([]byte, len(s))
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c >= 'A' && c <= 'Z' {
-			c += 'a' - 'A'
-		}
-		b[i] = c
-	}
-	return string(b)
 }

--- a/tools/jtk/internal/present/projection/project.go
+++ b/tools/jtk/internal/present/projection/project.go
@@ -20,13 +20,13 @@ func ProjectTable(section *present.TableSection, selected []ColumnSpec) *present
 	}
 	headerIndex := make(map[string]int, len(section.Headers))
 	for i, h := range section.Headers {
-		headerIndex[h] = i
+		headerIndex[strings.ToLower(h)] = i
 	}
 
 	keepIdx := make([]int, 0, len(selected))
 	headers := make([]string, 0, len(selected))
 	for _, c := range selected {
-		idx, ok := headerIndex[c.Header]
+		idx, ok := headerIndex[strings.ToLower(c.Header)]
 		if !ok {
 			continue
 		}

--- a/tools/jtk/internal/present/projection/project_test.go
+++ b/tools/jtk/internal/present/projection/project_test.go
@@ -1,0 +1,90 @@
+package projection
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestProjectTable_KeepsSelectedColumns_InUserOrder(t *testing.T) {
+	t.Parallel()
+	section := &present.TableSection{
+		Headers: []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"},
+		Rows: []present.Row{
+			{Cells: []string{"MON-1", "First", "Backlog", "Aaron", "SDLC"}},
+			{Cells: []string{"MON-2", "Second", "Done", "Rian", "Kanban"}},
+		},
+	}
+	selected := []ColumnSpec{
+		{Header: "KEY", Identity: true},
+		{Header: "STATUS", FieldID: "status"},
+		{Header: "SUMMARY", FieldID: "summary"},
+	}
+
+	out := ProjectTable(section, selected)
+
+	testutil.Equal(t, []string{"KEY", "STATUS", "SUMMARY"}, out.Headers)
+	testutil.Equal(t, []string{"MON-1", "Backlog", "First"}, out.Rows[0].Cells)
+	testutil.Equal(t, []string{"MON-2", "Done", "Second"}, out.Rows[1].Cells)
+
+	// Input unchanged.
+	testutil.Equal(t, 5, len(section.Headers))
+	testutil.Equal(t, "SUMMARY", section.Headers[1])
+}
+
+func TestProjectTable_SkipsHeadersNotInSelection(t *testing.T) {
+	t.Parallel()
+	section := &present.TableSection{
+		Headers: []string{"KEY", "SUMMARY"},
+		Rows:    []present.Row{{Cells: []string{"MON-1", "One"}}},
+	}
+	selected := []ColumnSpec{
+		{Header: "KEY", Identity: true},
+		{Header: "STATUS"}, // not in section
+	}
+	out := ProjectTable(section, selected)
+	testutil.Equal(t, []string{"KEY"}, out.Headers)
+	testutil.Equal(t, []string{"MON-1"}, out.Rows[0].Cells)
+}
+
+func TestProjectDetail_KeepsSelectedFields_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	section := &present.DetailSection{
+		Fields: []present.Field{
+			{Label: "Key", Value: "MON-1"},
+			{Label: "Summary", Value: "First"},
+			{Label: "Status", Value: "Backlog"},
+		},
+	}
+	selected := []ColumnSpec{
+		{Header: "Key", Identity: true},
+		{Header: "Status", FieldID: "status"},
+	}
+	out := ProjectDetail(section, selected)
+	testutil.Equal(t, 2, len(out.Fields))
+	testutil.Equal(t, "Key", out.Fields[0].Label)
+	testutil.Equal(t, "Status", out.Fields[1].Label)
+}
+
+func TestDeriveFetchFields_UnionsAndDedups(t *testing.T) {
+	t.Parallel()
+	selected := []ColumnSpec{
+		{Header: "KEY", Identity: true}, // synthetic (no FieldID)
+		{Header: "SUMMARY", FieldID: "summary"},
+		{Header: "STATUS", FieldID: "status"},
+		{Header: "COMPOSITE", FieldID: "", Fetch: []string{"a", "b", "summary"}}, // dup with SUMMARY
+	}
+	got := DeriveFetchFields(selected)
+	testutil.Equal(t, []string{"a", "b", "status", "summary"}, got)
+}
+
+func TestDeriveFetchFields_SyntheticColumnsContributeNothing(t *testing.T) {
+	t.Parallel()
+	selected := []ColumnSpec{
+		{Header: "KEY", Identity: true},
+		{Header: "URL"}, // synthetic
+	}
+	got := DeriveFetchFields(selected)
+	testutil.Equal(t, 0, len(got))
+}

--- a/tools/jtk/internal/present/projection/resolve.go
+++ b/tools/jtk/internal/present/projection/resolve.go
@@ -145,21 +145,26 @@ func Resolve(
 		}
 	}
 
-	// First-pass resolution: fast path against the mode registry
-	// (header/alias/FieldID) for every token. Any token that misses is
-	// deferred to the slow path so we make at most one fetchFields call
-	// regardless of how many tokens need metadata.
-	type pending struct {
-		index int
-		token string
-	}
-	var deferred []pending
+	// Two-pass resolution that preserves user token order.
+	//
+	// Pass 1 (fast path): try header/alias/FieldID matching for every token
+	// without consulting Jira metadata. Tokens that miss are queued for the
+	// slow path. Resolved specs are stored by their token index so they land
+	// in the user's order even when interleaved with slow-path tokens.
+	//
+	// Pass 2 (slow path): if any tokens deferred, fetchFields() once, then
+	// retry each deferred token against the mode registry (picks up human
+	// names), the full registry (for Extended-only errors), and raw Jira
+	// metadata (for UnrenderedFieldError).
+	resolved := make([]*ColumnSpec, len(tokens))
+	var deferred []int
 	for i, tok := range tokens {
 		if spec, ok := modeRegistry.Match(tok, nil); ok {
-			appendSpec(spec)
+			s := spec
+			resolved[i] = &s
 			continue
 		}
-		deferred = append(deferred, pending{index: i, token: tok})
+		deferred = append(deferred, i)
 	}
 
 	if len(deferred) > 0 {
@@ -169,28 +174,23 @@ func Resolve(
 		}
 
 		var unknown []string
-		for _, p := range deferred {
-			// Retry against the mode registry now that we have Jira metadata
-			// — this picks up human-name matches.
-			if spec, ok := modeRegistry.Match(p.token, fields); ok {
-				appendSpec(spec)
+		for _, i := range deferred {
+			tok := tokens[i]
+			if spec, ok := modeRegistry.Match(tok, fields); ok {
+				s := spec
+				resolved[i] = &s
 				continue
 			}
 
-			// Next: if --extended is off and the token matches an
-			// Extended-only spec (by header, alias, FieldID, *or human
-			// name*), give the most informative error.
 			if !extended {
-				if spec, ok := r.Match(p.token, fields); ok && spec.Extended {
-					return nil, false, &ExtendedOnlyError{Token: p.token, Header: spec.Header}
+				if spec, ok := r.Match(tok, fields); ok && spec.Extended {
+					return nil, false, &ExtendedOnlyError{Token: tok, Header: spec.Header}
 				}
 			}
 
-			// Token resolves to a real Jira field but no registry entry —
-			// projection-scope error, distinct from "unknown".
-			if jf := findJiraField(fields, p.token); jf != nil {
+			if jf := findJiraField(fields, tok); jf != nil {
 				return nil, false, &UnrenderedFieldError{
-					Token:       p.token,
+					Token:       tok,
 					JiraName:    jf.Name,
 					JiraID:      jf.ID,
 					Command:     cmdName,
@@ -198,7 +198,7 @@ func Resolve(
 				}
 			}
 
-			unknown = append(unknown, p.token)
+			unknown = append(unknown, tok)
 		}
 
 		if len(unknown) > 0 {
@@ -206,6 +206,12 @@ func Resolve(
 				Unknown:     unknown,
 				Suggestions: registryHeaders(modeRegistry),
 			}
+		}
+	}
+
+	for _, spec := range resolved {
+		if spec != nil {
+			appendSpec(*spec)
 		}
 	}
 

--- a/tools/jtk/internal/present/projection/resolve.go
+++ b/tools/jtk/internal/present/projection/resolve.go
@@ -34,7 +34,7 @@ func (e *UnknownFieldError) Error() string {
 //
 // This is distinct from UnknownFieldError; callers (commands) print both
 // as prose on stderr, but tests assert on the specific type to verify
-// the scope contract of #233.
+// the projection-scope contract.
 type UnrenderedFieldError struct {
 	Token       string // What the user typed.
 	JiraName    string // api.Field.Name.
@@ -45,7 +45,7 @@ type UnrenderedFieldError struct {
 
 func (e *UnrenderedFieldError) Error() string {
 	return fmt.Sprintf(
-		"field %q (%s) exists but is not rendered by %q (tracked in #234/#239); supported fields: %s",
+		"field %q (%s) exists but is not rendered by %q; supported fields: %s",
 		e.JiraName, e.JiraID, e.Command, strings.Join(e.Suggestions, ", "),
 	)
 }
@@ -145,47 +145,67 @@ func Resolve(
 		}
 	}
 
-	for _, tok := range tokens {
-		// Fast path: mode registry (header/alias/FieldID).
+	// First-pass resolution: fast path against the mode registry
+	// (header/alias/FieldID) for every token. Any token that misses is
+	// deferred to the slow path so we make at most one fetchFields call
+	// regardless of how many tokens need metadata.
+	type pending struct {
+		index int
+		token string
+	}
+	var deferred []pending
+	for i, tok := range tokens {
 		if spec, ok := modeRegistry.Match(tok, nil); ok {
 			appendSpec(spec)
 			continue
 		}
+		deferred = append(deferred, pending{index: i, token: tok})
+	}
 
-		// Check if the token matches an Extended-only spec in the full
-		// registry — better error than "unknown" in that case.
-		if !extended {
-			if spec, ok := r.Match(tok, nil); ok && spec.Extended {
-				return nil, false, &ExtendedOnlyError{Token: tok, Header: spec.Header}
-			}
-		}
-
-		// Slow path: consult Jira metadata.
+	if len(deferred) > 0 {
 		fields, ferr := lookupFields()
 		if ferr != nil {
 			return nil, false, ferr
 		}
 
-		if spec, ok := modeRegistry.Match(tok, fields); ok {
-			appendSpec(spec)
-			continue
+		var unknown []string
+		for _, p := range deferred {
+			// Retry against the mode registry now that we have Jira metadata
+			// — this picks up human-name matches.
+			if spec, ok := modeRegistry.Match(p.token, fields); ok {
+				appendSpec(spec)
+				continue
+			}
+
+			// Next: if --extended is off and the token matches an
+			// Extended-only spec (by header, alias, FieldID, *or human
+			// name*), give the most informative error.
+			if !extended {
+				if spec, ok := r.Match(p.token, fields); ok && spec.Extended {
+					return nil, false, &ExtendedOnlyError{Token: p.token, Header: spec.Header}
+				}
+			}
+
+			// Token resolves to a real Jira field but no registry entry —
+			// projection-scope error, distinct from "unknown".
+			if jf := findJiraField(fields, p.token); jf != nil {
+				return nil, false, &UnrenderedFieldError{
+					Token:       p.token,
+					JiraName:    jf.Name,
+					JiraID:      jf.ID,
+					Command:     cmdName,
+					Suggestions: registryHeaders(modeRegistry),
+				}
+			}
+
+			unknown = append(unknown, p.token)
 		}
 
-		// Not in the mode registry. Check whether the token resolves to a
-		// real Jira field — that changes the error.
-		if jf := findJiraField(fields, tok); jf != nil {
-			return nil, false, &UnrenderedFieldError{
-				Token:       tok,
-				JiraName:    jf.Name,
-				JiraID:      jf.ID,
-				Command:     cmdName,
+		if len(unknown) > 0 {
+			return nil, false, &UnknownFieldError{
+				Unknown:     unknown,
 				Suggestions: registryHeaders(modeRegistry),
 			}
-		}
-
-		return nil, false, &UnknownFieldError{
-			Unknown:     []string{tok},
-			Suggestions: registryHeaders(modeRegistry),
 		}
 	}
 

--- a/tools/jtk/internal/present/projection/resolve.go
+++ b/tools/jtk/internal/present/projection/resolve.go
@@ -1,0 +1,239 @@
+package projection
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// UnknownFieldError reports one or more --fields tokens that matched
+// nothing: not a registry header/alias, not a registry FieldID, and not
+// a live api.Field.Name. Suggestions lists the valid registry headers
+// for the active mode so callers can nudge the user toward the right token.
+type UnknownFieldError struct {
+	Unknown     []string
+	Suggestions []string
+}
+
+func (e *UnknownFieldError) Error() string {
+	if len(e.Unknown) == 1 {
+		return fmt.Sprintf("unknown field %q; supported fields: %s",
+			e.Unknown[0], strings.Join(e.Suggestions, ", "))
+	}
+	return fmt.Sprintf("unknown fields %s; supported fields: %s",
+		quoteAll(e.Unknown), strings.Join(e.Suggestions, ", "))
+}
+
+// UnrenderedFieldError reports a --fields token that resolves to a real
+// Jira field but is not rendered by the current command. The error
+// message uses the Jira human-readable name (from api.Field.Name) even
+// when the user passed a field ID, so the UX is consistent.
+//
+// This is distinct from UnknownFieldError; callers (commands) print both
+// as prose on stderr, but tests assert on the specific type to verify
+// the scope contract of #233.
+type UnrenderedFieldError struct {
+	Token       string // What the user typed.
+	JiraName    string // api.Field.Name.
+	JiraID      string // api.Field.ID.
+	Command     string // e.g. "issues list" — used in the error message.
+	Suggestions []string
+}
+
+func (e *UnrenderedFieldError) Error() string {
+	return fmt.Sprintf(
+		"field %q (%s) exists but is not rendered by %q (tracked in #234/#239); supported fields: %s",
+		e.JiraName, e.JiraID, e.Command, strings.Join(e.Suggestions, ", "),
+	)
+}
+
+// ExtendedOnlyError reports a --fields token that matches an Extended-only
+// spec while --extended is off. The user can fix the command by adding
+// --extended.
+type ExtendedOnlyError struct {
+	Token  string
+	Header string
+}
+
+func (e *ExtendedOnlyError) Error() string {
+	return fmt.Sprintf(
+		"field %q is only available with --extended (matches %q)",
+		e.Token, e.Header,
+	)
+}
+
+// Resolve is the single entrypoint commands call.
+//
+// projectionApplied is the authoritative switch; callers MUST branch on it,
+// not on len(selected). selected carries two meanings depending on the flag:
+//   - projectionApplied == false → selected is the full mode registry
+//     (r.ForMode(extended)). Callers render the full model; do NOT call
+//     ProjectTable/ProjectDetail.
+//   - projectionApplied == true  → selected is the user's chosen subset
+//     (identity-prepended, user order preserved). Callers MUST call
+//     ProjectTable/ProjectDetail to slice the model.
+//
+// Behavior:
+//   - fieldsFlag empty → (r.ForMode(extended), false, nil). fetchFields is
+//     NOT called.
+//   - fieldsFlag non-empty: parse CSV; resolve each token. Tokens that miss
+//     header/alias/FieldID matching trigger a single fetchFields() call
+//     (memoized across tokens in the invocation) and retry against
+//     api.Field.Name (case-insensitive).
+//   - Identity specs are prepended if the user omitted them; dedup preserved.
+//   - If a token matches an Extended-only spec with extended==false, return
+//     ExtendedOnlyError.
+//   - If a token resolves to a real api.Field but no registry entry, return
+//     UnrenderedFieldError using the Jira human-readable name — even when
+//     the user passed the field ID.
+//   - Otherwise, unresolved tokens → UnknownFieldError with registry-based
+//     suggestions.
+//
+// cmdName is the user-visible command label (e.g., "issues list") used in
+// UnrenderedFieldError for clarity; commands pass cmd.CommandPath() or a
+// hardcoded label.
+func Resolve(
+	ctx context.Context,
+	r Registry,
+	extended bool,
+	fieldsFlag string,
+	fetchFields func(context.Context) ([]api.Field, error),
+	cmdName string,
+) (selected []ColumnSpec, projectionApplied bool, err error) {
+	modeRegistry := r.ForMode(extended)
+
+	tokens := parseTokens(fieldsFlag)
+	if len(tokens) == 0 {
+		return modeRegistry, false, nil
+	}
+
+	var cachedFields []api.Field
+	var fieldsFetched bool
+
+	lookupFields := func() ([]api.Field, error) {
+		if fieldsFetched {
+			return cachedFields, nil
+		}
+		fieldsFetched = true
+		fields, err := fetchFields(ctx)
+		if err != nil {
+			return nil, err
+		}
+		cachedFields = fields
+		return fields, nil
+	}
+
+	seen := make(map[string]struct{})
+	out := make([]ColumnSpec, 0, len(tokens)+1)
+
+	appendSpec := func(c ColumnSpec) {
+		if _, ok := seen[c.Header]; ok {
+			return
+		}
+		seen[c.Header] = struct{}{}
+		out = append(out, c)
+	}
+
+	// Identity first — always included, silently prepended if the user
+	// omitted it.
+	for _, c := range modeRegistry {
+		if c.Identity {
+			appendSpec(c)
+		}
+	}
+
+	for _, tok := range tokens {
+		// Fast path: mode registry (header/alias/FieldID).
+		if spec, ok := modeRegistry.Match(tok, nil); ok {
+			appendSpec(spec)
+			continue
+		}
+
+		// Check if the token matches an Extended-only spec in the full
+		// registry — better error than "unknown" in that case.
+		if !extended {
+			if spec, ok := r.Match(tok, nil); ok && spec.Extended {
+				return nil, false, &ExtendedOnlyError{Token: tok, Header: spec.Header}
+			}
+		}
+
+		// Slow path: consult Jira metadata.
+		fields, ferr := lookupFields()
+		if ferr != nil {
+			return nil, false, ferr
+		}
+
+		if spec, ok := modeRegistry.Match(tok, fields); ok {
+			appendSpec(spec)
+			continue
+		}
+
+		// Not in the mode registry. Check whether the token resolves to a
+		// real Jira field — that changes the error.
+		if jf := findJiraField(fields, tok); jf != nil {
+			return nil, false, &UnrenderedFieldError{
+				Token:       tok,
+				JiraName:    jf.Name,
+				JiraID:      jf.ID,
+				Command:     cmdName,
+				Suggestions: registryHeaders(modeRegistry),
+			}
+		}
+
+		return nil, false, &UnknownFieldError{
+			Unknown:     []string{tok},
+			Suggestions: registryHeaders(modeRegistry),
+		}
+	}
+
+	return out, true, nil
+}
+
+// findJiraField looks up a token against the live Jira field metadata by
+// ID (exact) or Name (case-insensitive). Returns nil when neither matches.
+func findJiraField(fields []api.Field, token string) *api.Field {
+	if f := api.FindFieldByID(fields, token); f != nil {
+		return f
+	}
+	if f := api.FindFieldByName(fields, token); f != nil {
+		return f
+	}
+	return nil
+}
+
+// parseTokens splits a --fields CSV, trims whitespace, drops empty segments.
+func parseTokens(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// registryHeaders returns the headers of r in stable order, suitable for
+// error suggestion text.
+func registryHeaders(r Registry) []string {
+	out := make([]string, 0, len(r))
+	for _, c := range r {
+		out = append(out, c.Header)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func quoteAll(ss []string) string {
+	parts := make([]string, len(ss))
+	for i, s := range ss {
+		parts[i] = fmt.Sprintf("%q", s)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/tools/jtk/internal/present/projection/resolve_test.go
+++ b/tools/jtk/internal/present/projection/resolve_test.go
@@ -60,9 +60,15 @@ func TestResolve_HeaderAliases_NoFetch(t *testing.T) {
 func TestResolve_FieldIDs_NoFetch(t *testing.T) {
 	t.Parallel()
 	stub := &fetchStub{err: errors.New("should not be called")}
-	_, _, err := Resolve(context.Background(), testRegistry, false, "summary,assignee", stub.fetch, "issues list")
+	selected, applied, err := Resolve(context.Background(), testRegistry, false, "summary,assignee", stub.fetch, "issues list")
 	testutil.RequireNoError(t, err)
+	testutil.True(t, applied)
 	testutil.Equal(t, 0, stub.calls)
+	// Tokens resolved to the correct specs (identity KEY prepended).
+	testutil.Equal(t, 3, len(selected))
+	testutil.Equal(t, "KEY", selected[0].Header)
+	testutil.Equal(t, "SUMMARY", selected[1].Header)
+	testutil.Equal(t, "ASSIGNEE", selected[2].Header)
 }
 
 func TestResolve_HumanName_TriggersExactlyOneFetch(t *testing.T) {

--- a/tools/jtk/internal/present/projection/resolve_test.go
+++ b/tools/jtk/internal/present/projection/resolve_test.go
@@ -127,6 +127,22 @@ func TestResolve_UserOrderPreserved_AfterIdentity(t *testing.T) {
 	testutil.Equal(t, "SUMMARY", selected[2].Header)
 }
 
+// Mixed fast-path (header) and slow-path (human-name) tokens must land in
+// the user's order, not be grouped by resolution path.
+func TestResolve_UserOrder_MixedFastAndSlowPath(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{fields: []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	}}
+	selected, _, err := Resolve(context.Background(), testRegistry, false, "STATUS,Issue Type,SUMMARY", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, 4, len(selected))
+	testutil.Equal(t, "KEY", selected[0].Header)
+	testutil.Equal(t, "STATUS", selected[1].Header)
+	testutil.Equal(t, "TYPE", selected[2].Header)
+	testutil.Equal(t, "SUMMARY", selected[3].Header)
+}
+
 func TestResolve_UnknownToken_FallbackAttemptedButFails(t *testing.T) {
 	t.Parallel()
 	stub := &fetchStub{fields: []api.Field{

--- a/tools/jtk/internal/present/projection/resolve_test.go
+++ b/tools/jtk/internal/present/projection/resolve_test.go
@@ -168,12 +168,18 @@ func TestResolve_UnrenderedField_ByFieldID_UsesHumanNameInMessage(t *testing.T) 
 
 func TestResolve_ExtendedOnlyToken_WithoutFlag_Errors(t *testing.T) {
 	t.Parallel()
-	stub := &fetchStub{}
+	// Tokens that miss the fast path (POINTS is Extended, so not in the
+	// non-extended mode registry) hit the slow path, which consults Jira
+	// metadata. This is intentional: the human-name variant of this case
+	// requires metadata, so we always fetch once before deciding the
+	// error kind.
+	stub := &fetchStub{fields: []api.Field{
+		{ID: "customfield_10035", Name: "Story Points"},
+	}}
 	_, _, err := Resolve(context.Background(), testRegistry, false, "POINTS", stub.fetch, "issues list")
 	var eoe *ExtendedOnlyError
 	testutil.True(t, errors.As(err, &eoe))
 	testutil.Equal(t, "POINTS", eoe.Header)
-	testutil.Equal(t, 0, stub.calls)
 }
 
 func TestResolve_ExtendedOnlyToken_WithFlag_Resolves(t *testing.T) {
@@ -183,6 +189,36 @@ func TestResolve_ExtendedOnlyToken_WithFlag_Resolves(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.True(t, applied)
 	testutil.Equal(t, 2, len(selected)) // KEY + POINTS
+}
+
+// When the user passes the Jira human name of an Extended-only field
+// without --extended, they should get ExtendedOnlyError (actionable:
+// "add --extended") — not UnknownFieldError or UnrenderedFieldError.
+func TestResolve_ExtendedOnlyToken_ByHumanName_WithoutFlag_Errors(t *testing.T) {
+	t.Parallel()
+	// testRegistry has POINTS with FieldID "customfield_10035" and Extended=true.
+	stub := &fetchStub{fields: []api.Field{
+		{ID: "customfield_10035", Name: "Story Points"},
+	}}
+	_, _, err := Resolve(context.Background(), testRegistry, false, "Story Points", stub.fetch, "issues list")
+	var eoe *ExtendedOnlyError
+	testutil.True(t, errors.As(err, &eoe))
+	testutil.Equal(t, "POINTS", eoe.Header)
+}
+
+// Multiple unknown tokens are batched into a single UnknownFieldError so
+// users see all failures at once, not one-at-a-time.
+func TestResolve_MultipleUnknownTokens_BatchedIntoOneError(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{fields: []api.Field{}}
+	_, _, err := Resolve(context.Background(), testRegistry, false, "bogus1,bogus2,bogus3", stub.fetch, "issues list")
+	var ufe *UnknownFieldError
+	testutil.True(t, errors.As(err, &ufe))
+	testutil.Equal(t, 3, len(ufe.Unknown))
+	testutil.Equal(t, "bogus1", ufe.Unknown[0])
+	testutil.Equal(t, "bogus2", ufe.Unknown[1])
+	testutil.Equal(t, "bogus3", ufe.Unknown[2])
+	testutil.Contains(t, err.Error(), "unknown fields")
 }
 
 func TestResolve_FetchFieldsErrorPropagates(t *testing.T) {

--- a/tools/jtk/internal/present/projection/resolve_test.go
+++ b/tools/jtk/internal/present/projection/resolve_test.go
@@ -1,0 +1,188 @@
+package projection
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// fetchStub returns cannedFields on Nth call, counting invocations.
+type fetchStub struct {
+	calls  int
+	fields []api.Field
+	err    error
+}
+
+func (s *fetchStub) fetch(_ context.Context) ([]api.Field, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.fields, nil
+}
+
+func TestResolve_EmptyFieldsFlag_NoFetch_FullRegistry(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{err: errors.New("should not be called")}
+	selected, applied, err := Resolve(context.Background(), testRegistry, false, "", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.False(t, applied, "projectionApplied must be false when --fields is empty")
+	testutil.Equal(t, 5, len(selected)) // default mode registry (5 of 6)
+	testutil.Equal(t, 0, stub.calls)
+}
+
+func TestResolve_EmptyFieldsFlag_ExtendedRegistry(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{}
+	selected, applied, err := Resolve(context.Background(), testRegistry, true, "", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.False(t, applied)
+	testutil.Equal(t, 6, len(selected)) // extended mode registry (all 6)
+}
+
+func TestResolve_HeaderAliases_NoFetch(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{err: errors.New("should not be called")}
+	selected, applied, err := Resolve(context.Background(), testRegistry, false, "KEY,SUMMARY,STATUS", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.True(t, applied)
+	testutil.Equal(t, 0, stub.calls)
+	testutil.Equal(t, 3, len(selected))
+	testutil.Equal(t, "KEY", selected[0].Header)
+	testutil.Equal(t, "SUMMARY", selected[1].Header)
+	testutil.Equal(t, "STATUS", selected[2].Header)
+}
+
+func TestResolve_FieldIDs_NoFetch(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{err: errors.New("should not be called")}
+	_, _, err := Resolve(context.Background(), testRegistry, false, "summary,assignee", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, 0, stub.calls)
+}
+
+func TestResolve_HumanName_TriggersExactlyOneFetch(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{fields: []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	}}
+	selected, applied, err := Resolve(context.Background(), testRegistry, false, "Issue Type", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.True(t, applied)
+	testutil.Equal(t, 1, stub.calls)
+	testutil.Equal(t, 2, len(selected)) // KEY + TYPE
+	testutil.Equal(t, "KEY", selected[0].Header)
+	testutil.Equal(t, "TYPE", selected[1].Header)
+}
+
+func TestResolve_MultiToken_FetchesOnce(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{fields: []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+		{ID: "assignee", Name: "Assignee"},
+	}}
+	_, _, err := Resolve(context.Background(), testRegistry, false, "Issue Type,Summary,Issue Type", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, 1, stub.calls)
+}
+
+func TestResolve_IdentityAlwaysPrepended(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{}
+	selected, _, err := Resolve(context.Background(), testRegistry, false, "SUMMARY", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, 2, len(selected))
+	testutil.Equal(t, "KEY", selected[0].Header)
+	testutil.Equal(t, "SUMMARY", selected[1].Header)
+}
+
+func TestResolve_IdentityNotDuplicated(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{}
+	selected, _, err := Resolve(context.Background(), testRegistry, false, "KEY,SUMMARY", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, 2, len(selected))
+	testutil.Equal(t, "KEY", selected[0].Header)
+	testutil.Equal(t, "SUMMARY", selected[1].Header)
+}
+
+func TestResolve_UserOrderPreserved_AfterIdentity(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{}
+	selected, _, err := Resolve(context.Background(), testRegistry, false, "STATUS,SUMMARY", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, 3, len(selected))
+	testutil.Equal(t, "KEY", selected[0].Header)
+	testutil.Equal(t, "STATUS", selected[1].Header)
+	testutil.Equal(t, "SUMMARY", selected[2].Header)
+}
+
+func TestResolve_UnknownToken_FallbackAttemptedButFails(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{fields: []api.Field{
+		{ID: "somethingelse", Name: "Something Else"},
+	}}
+	_, _, err := Resolve(context.Background(), testRegistry, false, "bogus", stub.fetch, "issues list")
+	var ufe *UnknownFieldError
+	testutil.True(t, errors.As(err, &ufe))
+	testutil.Equal(t, 1, stub.calls)
+}
+
+func TestResolve_UnrenderedField_ByHumanName(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{fields: []api.Field{
+		{ID: "customfield_99999", Name: "Phantom"},
+	}}
+	_, _, err := Resolve(context.Background(), testRegistry, false, "Phantom", stub.fetch, "issues list")
+	var ure *UnrenderedFieldError
+	testutil.True(t, errors.As(err, &ure))
+	testutil.Equal(t, "Phantom", ure.JiraName)
+	testutil.Equal(t, "customfield_99999", ure.JiraID)
+	testutil.Equal(t, "issues list", ure.Command)
+}
+
+func TestResolve_UnrenderedField_ByFieldID_UsesHumanNameInMessage(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{fields: []api.Field{
+		{ID: "customfield_99999", Name: "Phantom"},
+	}}
+	_, _, err := Resolve(context.Background(), testRegistry, false, "customfield_99999", stub.fetch, "issues list")
+	var ure *UnrenderedFieldError
+	testutil.True(t, errors.As(err, &ure))
+	testutil.Equal(t, "Phantom", ure.JiraName)
+	testutil.Equal(t, "customfield_99999", ure.JiraID)
+	// Error message must resolve the ID to the human-readable name.
+	testutil.Contains(t, err.Error(), "Phantom")
+	testutil.Contains(t, err.Error(), "customfield_99999")
+}
+
+func TestResolve_ExtendedOnlyToken_WithoutFlag_Errors(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{}
+	_, _, err := Resolve(context.Background(), testRegistry, false, "POINTS", stub.fetch, "issues list")
+	var eoe *ExtendedOnlyError
+	testutil.True(t, errors.As(err, &eoe))
+	testutil.Equal(t, "POINTS", eoe.Header)
+	testutil.Equal(t, 0, stub.calls)
+}
+
+func TestResolve_ExtendedOnlyToken_WithFlag_Resolves(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{}
+	selected, applied, err := Resolve(context.Background(), testRegistry, true, "POINTS", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.True(t, applied)
+	testutil.Equal(t, 2, len(selected)) // KEY + POINTS
+}
+
+func TestResolve_FetchFieldsErrorPropagates(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("network down")
+	stub := &fetchStub{err: boom}
+	_, _, err := Resolve(context.Background(), testRegistry, false, "Issue Type", stub.fetch, "issues list")
+	testutil.True(t, errors.Is(err, boom))
+}

--- a/tools/jtk/internal/present/projection/spec.go
+++ b/tools/jtk/internal/present/projection/spec.go
@@ -83,7 +83,6 @@ func (r Registry) ForMode(extended bool) Registry {
 //
 // Returns (spec, true) on success, (_, false) otherwise.
 func (r Registry) Match(token string, fields []api.Field) (ColumnSpec, bool) {
-	tokenLower := strings.ToLower(token)
 	for _, c := range r {
 		if strings.EqualFold(c.Header, token) {
 			return c, true
@@ -113,10 +112,9 @@ func (r Registry) Match(token string, fields []api.Field) (ColumnSpec, bool) {
 				}
 			}
 			// Found in Jira but not in the registry — caller distinguishes
-			// this case via FindJiraField below.
+			// this case via findJiraField in resolve.go.
 			return ColumnSpec{}, false
 		}
 	}
-	_ = tokenLower // keep for future fuzzy suggestions
 	return ColumnSpec{}, false
 }

--- a/tools/jtk/internal/present/projection/spec.go
+++ b/tools/jtk/internal/present/projection/spec.go
@@ -1,0 +1,122 @@
+// Package projection provides shared `--fields` column projection and
+// name resolution for jtk read commands.
+//
+// Per the JTK Output Specification (#230), `--fields a,b,c` is a display
+// projection on list/get commands: it restricts output columns/fields to
+// those named, with name resolution that accepts column headers, Jira
+// field IDs, or cached human names (in that order). KEY/ID is always
+// retained on list outputs; the identifying line is always retained on
+// get outputs.
+//
+// Each flagship presenter exports an ordered Registry of ColumnSpecs.
+// Commands call Resolve to map the user's --fields tokens to specs, then
+// ProjectTable or ProjectDetail to slice the already-built presentation
+// model, and DeriveFetchFields to compute the minimum Jira field-ID set
+// needed to render the selection.
+package projection
+
+import (
+	"strings"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// ColumnSpec describes one display column (table) or field (detail) for
+// projection. Each registered spec knows its presentation header, any
+// user-facing aliases, the Jira field ID (if any) that drives it, and
+// whether it is the identity column (always retained) or an extended-only
+// column (only available when --extended is active).
+type ColumnSpec struct {
+	Header   string
+	Aliases  []string
+	FieldID  string
+	Identity bool
+	Extended bool
+	// Fetch lists Jira field IDs required to render this column.
+	// When empty and FieldID is non-empty, [FieldID] is assumed.
+	// When empty and FieldID is empty, the column contributes nothing
+	// to the fetch set (synthetic columns like a constructed URL).
+	Fetch []string
+}
+
+// fetchFields returns the Jira field IDs required to render this spec.
+// Synthetic specs (FieldID empty, Fetch empty) return nil.
+func (c ColumnSpec) fetchFields() []string {
+	if len(c.Fetch) > 0 {
+		return c.Fetch
+	}
+	if c.FieldID != "" {
+		return []string{c.FieldID}
+	}
+	return nil
+}
+
+// Registry is an ordered list of ColumnSpecs describing the full column
+// set for one entity/output shape. The order is the default display order.
+type Registry []ColumnSpec
+
+// ForMode returns the registry filtered to the active mode. When extended
+// is false, Extended specs are dropped.
+func (r Registry) ForMode(extended bool) Registry {
+	if extended {
+		out := make(Registry, len(r))
+		copy(out, r)
+		return out
+	}
+	out := make(Registry, 0, len(r))
+	for _, c := range r {
+		if c.Extended {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// Match looks up a ColumnSpec by token. Resolution order:
+//  1. Header match (case-insensitive).
+//  2. Any Alias match (case-insensitive).
+//  3. FieldID match (exact, case-sensitive — Jira field IDs are canonical).
+//  4. api.Field.Name match against fields (case-insensitive). This is the
+//     "human name" fallback. fields may be nil when the caller hasn't
+//     fetched Jira metadata yet — in that case the fallback is skipped.
+//
+// Returns (spec, true) on success, (_, false) otherwise.
+func (r Registry) Match(token string, fields []api.Field) (ColumnSpec, bool) {
+	tokenLower := strings.ToLower(token)
+	for _, c := range r {
+		if strings.EqualFold(c.Header, token) {
+			return c, true
+		}
+		for _, a := range c.Aliases {
+			if strings.EqualFold(a, token) {
+				return c, true
+			}
+		}
+	}
+	for _, c := range r {
+		if c.FieldID != "" && c.FieldID == token {
+			return c, true
+		}
+	}
+	if len(fields) == 0 {
+		return ColumnSpec{}, false
+	}
+	// Human-name fallback: find the Jira field whose Name matches the token,
+	// then map its ID back to a ColumnSpec via FieldID.
+	for i := range fields {
+		if strings.EqualFold(fields[i].Name, token) {
+			fieldID := fields[i].ID
+			for _, c := range r {
+				if c.FieldID != "" && c.FieldID == fieldID {
+					return c, true
+				}
+			}
+			// Found in Jira but not in the registry — caller distinguishes
+			// this case via FindJiraField below.
+			return ColumnSpec{}, false
+		}
+	}
+	_ = tokenLower // keep for future fuzzy suggestions
+	return ColumnSpec{}, false
+}

--- a/tools/jtk/internal/present/projection/spec_test.go
+++ b/tools/jtk/internal/present/projection/spec_test.go
@@ -1,0 +1,70 @@
+package projection
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// testRegistry mirrors the shape of IssueListSpec for self-contained tests.
+var testRegistry = Registry{
+	{Header: "KEY", Identity: true},
+	{Header: "SUMMARY", FieldID: "summary"},
+	{Header: "STATUS", FieldID: "status"},
+	{Header: "ASSIGNEE", FieldID: "assignee"},
+	{Header: "TYPE", FieldID: "issuetype"},
+	{Header: "POINTS", FieldID: "customfield_10035", Extended: true},
+}
+
+func TestRegistry_ForMode_FiltersExtended(t *testing.T) {
+	t.Parallel()
+	testutil.Equal(t, 5, len(testRegistry.ForMode(false)))
+	testutil.Equal(t, 6, len(testRegistry.ForMode(true)))
+}
+
+func TestRegistry_Match_HeaderCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	for _, tok := range []string{"KEY", "key", "Key"} {
+		spec, ok := testRegistry.Match(tok, nil)
+		testutil.True(t, ok)
+		testutil.Equal(t, "KEY", spec.Header)
+	}
+}
+
+func TestRegistry_Match_FieldID_NoFetchNeeded(t *testing.T) {
+	t.Parallel()
+	spec, ok := testRegistry.Match("summary", nil)
+	testutil.True(t, ok, "expected match for field ID token")
+	testutil.Equal(t, "SUMMARY", spec.Header)
+}
+
+func TestRegistry_Match_HumanName_UsesFieldsSlice(t *testing.T) {
+	t.Parallel()
+	fields := []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	}
+	// Not a header, alias, or FieldID match; must fall back to api.Field.Name.
+	_, ok := testRegistry.Match("Issue Type", nil)
+	testutil.False(t, ok, "fallback should miss when fields is nil")
+
+	spec, ok := testRegistry.Match("Issue Type", fields)
+	testutil.True(t, ok, "fallback should hit when api.Field.Name matches")
+	testutil.Equal(t, "TYPE", spec.Header)
+}
+
+func TestRegistry_Match_Unknown(t *testing.T) {
+	t.Parallel()
+	_, ok := testRegistry.Match("bogus", []api.Field{{ID: "something", Name: "Something"}})
+	testutil.False(t, ok, "unknown token should not match")
+}
+
+func TestRegistry_Match_HumanNameResolvesToUnrenderedField(t *testing.T) {
+	t.Parallel()
+	// Name matches a Jira field whose ID is not in the registry. Match
+	// returns false — Resolve handles the "exists but not rendered" case.
+	fields := []api.Field{{ID: "customfield_99999", Name: "Phantom"}}
+	_, ok := testRegistry.Match("Phantom", fields)
+	testutil.False(t, ok)
+}


### PR DESCRIPTION
## Summary
- Shared `--fields` display projection across `issues list`, `issues search`, and `issues get`. Accepts display headers, Jira field IDs, or human names (via a one-shot `GetFields()` fallback). Identity column (`KEY` / `Key`) is always retained.
- New `tools/jtk/internal/present/projection` package: `Registry`, `ColumnSpec`, `Resolve`, `ProjectTable`, `ProjectDetail`, `DeriveFetchFields`. `projectionApplied` is the authoritative switch; callers must branch on it, not on `len(selected)`.
- Distinct error types: `UnknownFieldError` (matches nothing); `UnrenderedFieldError` (matches a real Jira field the command doesn't render yet, message always uses the human-readable Jira name); `ExtendedOnlyError` (extended-only token without `--extended`, including its human name).
- `--fields` is scoped local to the three flagship commands, not root-persistent — avoids collision with `transitions list --fields` which is a bool.

## New user-visible capability
- `issues search` gains an `--id` mode (bare issue keys, one per line, with pagination continuation). This matches the existing behavior of `issues list` and is a deliberate addition, not a side-effect of the `--fields` work.

## Breaking changes
- `--fields` on `issues list`/`search` was previously **transport-side** (pruned the Jira API fetch). It is now **display projection**. The API fetch set is derived internally from the selected columns.
- `--fields` combined with `--output json` returns an explicit error. `--id` still short-circuits everything (including `--fields` validation and the JSON + `--fields` conflict).

## Compatibility preserved
- `--all-fields` still honored: when `--fields` is absent, it unions with `--extended` to trigger `DefaultSearchFields`. When `--fields` is present, it's ignored for fetch (selected specs win).
- `--id` takes precedence over `--fields`. `--id --fields bogus` and `--id -o json --fields X` both emit bare keys with no validation.
- `issues get` does not minimize fetch (api.GetIssue has no field-selection parameter — out of scope).

## Scope
- Group A migrated: `issues list`, `issues search`, `issues get`.
- Group B (deferred to #237–#244): everything else that could use `--fields`.
- Group C (confirmations, `automation export`, etc.): never adopt `--fields`.

## Plan
Full plan: #233 (posted as a comment).

## Test plan
- [x] 27 projection unit tests — header/alias/FieldID/human-name resolution, fetch-count invariants, identity retention, error-kind discrimination (including Extended-only by human name and batched unknown tokens)
- [x] Presenter parity tests lock `IssueListSpec` / `IssueDetailSpec` headers against `PresentList` / `PresentDetail` in both directions + order
- [x] Command-level tests on all three commands: projection, JSON-rejection, `--id` precedence (including invalid / unrendered / JSON-mode combinations), unknown/unrendered-field errors, fetch-set derivation
- [x] `make build`, `make test`, `cd tools/jtk && golangci-lint run` — all clean (pre-existing config.go gosec warning on main is untouched)
- [ ] Manual smoke against a live Jira instance

Closes #233