### PR TITLE
feat(jtk): body-field gating for --fields and --fulltext

### DIFF
--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -3,6 +3,7 @@ package comments
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -11,11 +12,23 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/text"
 )
+
+// errFieldsWithJSON is returned when --fields is combined with --output json.
+var errFieldsWithJSON = errors.New("--fields is not supported with --output json")
+
+// noFieldFetch is the projection.Resolve fetcher for comments. Comment
+// fields are not Jira issue fields, so there is no metadata to fetch;
+// returning nil routes deferred tokens cleanly to UnknownFieldError
+// rather than UnrenderedFieldError or a real network call against
+// /rest/api/3/field.
+func noFieldFetch(_ context.Context) ([]api.Field, error) { return nil, nil }
 
 // Register registers the comments commands
 func Register(parent *cobra.Command, opts *root.Options) {
@@ -36,27 +49,31 @@ func Register(parent *cobra.Command, opts *root.Options) {
 func newListCmd(opts *root.Options) *cobra.Command {
 	var maxResults int
 	var noTruncate bool
+	var fieldsFlag string
 
 	cmd := &cobra.Command{
 		Use:   "list <issue-key>",
 		Short: "List comments on an issue",
 		Long:  "List all comments on a specific issue.",
 		Example: `  jtk comments list PROJ-123
-  jtk comments list PROJ-123 --fulltext`,
+  jtk comments list PROJ-123 --fulltext
+  jtk comments list PROJ-123 --fields ID,AUTHOR
+  jtk comments list PROJ-123 --fulltext --fields Body`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), opts, args[0], maxResults, noTruncate || opts.IsFullText())
+			return runList(cmd.Context(), opts, args[0], maxResults, noTruncate || opts.IsFullText(), fieldsFlag)
 		},
 	}
 
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of comments")
 	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full comment bodies without truncation")
 	_ = cmd.Flags().MarkDeprecated("no-truncate", "use --fulltext instead")
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display fields (labels)")
 
 	return cmd
 }
 
-func runList(ctx context.Context, opts *root.Options, issueKey string, maxResults int, noTruncate bool) error {
+func runList(ctx context.Context, opts *root.Options, issueKey string, maxResults int, noTruncate bool, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -71,12 +88,35 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 
 	hasMore := commentsHasMore(result.Total, result.StartAt, len(result.Comments), maxResults)
 
+	// --id wins: skip projection and JSON-vs-fields gating entirely. A
+	// --fields token that would otherwise trigger metadata work must be a
+	// no-op under --id.
 	if opts.EmitIDOnly() {
 		ids := make([]string, len(result.Comments))
 		for i, c := range result.Comments {
 			ids[i] = c.ID
 		}
 		return jtkpresent.EmitIDsWithPagination(opts, ids, hasMore)
+	}
+
+	if fieldsFlag != "" && v.Format == view.FormatJSON {
+		return errFieldsWithJSON
+	}
+
+	spec := jtkpresent.CommentListSpec
+	if noTruncate {
+		spec = jtkpresent.CommentDetailSpec
+	}
+	selected, projected, err := projection.Resolve(
+		ctx,
+		spec,
+		opts.IsExtended(),
+		fieldsFlag,
+		noFieldFetch,
+		"comments list",
+	)
+	if err != nil {
+		return err
 	}
 
 	if len(result.Comments) == 0 {
@@ -93,10 +133,38 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 	var model *present.OutputModel
 	if noTruncate {
 		model = jtkpresent.CommentPresenter{}.PresentListFullWithPagination(result.Comments, hasMore)
+		if projected {
+			projectAllDetailSectionsInModel(model, selected)
+		}
 	} else {
 		model = jtkpresent.CommentPresenter{}.PresentListWithPagination(result.Comments, hasMore)
+		if projected {
+			projectTableSectionInModel(model, selected)
+		}
 	}
 	return jtkpresent.Emit(opts, model)
+}
+
+// projectAllDetailSectionsInModel rewrites every DetailSection of model
+// to the selected fields, leaving non-Detail sections (e.g. the
+// pagination MessageSection) untouched.
+func projectAllDetailSectionsInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
+	for i, s := range model.Sections {
+		if ds, ok := s.(*present.DetailSection); ok {
+			model.Sections[i] = projection.ProjectDetail(ds, selected)
+		}
+	}
+}
+
+// projectTableSectionInModel rewrites the first TableSection of model to
+// the selected columns.
+func projectTableSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
+	for i, s := range model.Sections {
+		if ts, ok := s.(*present.TableSection); ok {
+			model.Sections[i] = projection.ProjectTable(ts, selected)
+			return
+		}
+	}
 }
 
 // commentsHasMore computes pagination using the authoritative API metadata,

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -81,6 +81,33 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 		return err
 	}
 
+	// Validate flag combinations and resolve --fields before any network call,
+	// mirroring runGet ordering. --id suppresses both gates (projection and
+	// JSON-vs-fields) because it collapses output to bare IDs regardless.
+	idOnly := opts.EmitIDOnly()
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		if fieldsFlag != "" && v.Format == view.FormatJSON {
+			return errFieldsWithJSON
+		}
+		spec := jtkpresent.CommentListSpec
+		if noTruncate {
+			spec = jtkpresent.CommentDetailSpec
+		}
+		selected, projected, err = projection.Resolve(
+			ctx,
+			spec,
+			opts.IsExtended(),
+			fieldsFlag,
+			noFieldFetch,
+			"comments list",
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	result, err := client.GetComments(ctx, issueKey, 0, maxResults)
 	if err != nil {
 		return err
@@ -88,35 +115,12 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 
 	hasMore := commentsHasMore(result.Total, result.StartAt, len(result.Comments), maxResults)
 
-	// --id wins: skip projection and JSON-vs-fields gating entirely. A
-	// --fields token that would otherwise trigger metadata work must be a
-	// no-op under --id.
-	if opts.EmitIDOnly() {
+	if idOnly {
 		ids := make([]string, len(result.Comments))
 		for i, c := range result.Comments {
 			ids[i] = c.ID
 		}
 		return jtkpresent.EmitIDsWithPagination(opts, ids, hasMore)
-	}
-
-	if fieldsFlag != "" && v.Format == view.FormatJSON {
-		return errFieldsWithJSON
-	}
-
-	spec := jtkpresent.CommentListSpec
-	if noTruncate {
-		spec = jtkpresent.CommentDetailSpec
-	}
-	selected, projected, err := projection.Resolve(
-		ctx,
-		spec,
-		opts.IsExtended(),
-		fieldsFlag,
-		noFieldFetch,
-		"comments list",
-	)
-	if err != nil {
-		return err
 	}
 
 	if len(result.Comments) == 0 {

--- a/tools/jtk/internal/cmd/comments/comments_fields_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_fields_test.go
@@ -1,14 +1,19 @@
 package comments
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
@@ -149,6 +154,37 @@ func TestRunList_Fields_UnknownToken_Errors(t *testing.T) {
 	var ufe *projection.UnknownFieldError
 	if !errors.As(err, &ufe) {
 		t.Fatalf("expected UnknownFieldError, got %v", err)
+	}
+}
+
+// Validation (Resolve) must happen BEFORE the GetComments network call.
+// An invalid --fields token must produce UnknownFieldError without making
+// any API requests — the flag is a display contract validated on the
+// client before any fetch, mirroring the runGet ordering.
+func TestRunList_Fields_InvalidToken_ErrorsBeforeFetch(t *testing.T) {
+	t.Parallel()
+	var commentCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/comment") {
+			commentCalls++
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(api.CommentsResponse{})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+	opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	runErr := runList(context.Background(), opts, "TEST-1", 50, false, "bogus")
+	var ufe *projection.UnknownFieldError
+	if !errors.As(runErr, &ufe) {
+		t.Fatalf("expected UnknownFieldError, got %v", runErr)
+	}
+	if commentCalls != 0 {
+		t.Errorf("GetComments should not be called when --fields is invalid; got %d call(s)", commentCalls)
 	}
 }
 

--- a/tools/jtk/internal/cmd/comments/comments_fields_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_fields_test.go
@@ -1,0 +1,201 @@
+package comments
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
+)
+
+// longBodyText is sized past PresentList's 100-char body truncation so the
+// truncation marker is observable in table-mode tests.
+const longBodyText = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+
+func longBodyComment(id, author string) api.Comment {
+	return plainComment(id, author, longBodyText)
+}
+
+// AC2 (table mode): --fields ID,AUTHOR drops the BODY column entirely. Long
+// body text MUST NOT appear anywhere in the output.
+func TestRunList_Fields_TableMode_DropsBodyColumn(t *testing.T) {
+	t.Parallel()
+	server := newTestCommentsServer(t, []api.Comment{longBodyComment("1", "Alice")})
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "ID,AUTHOR")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "ID")
+	testutil.Contains(t, output, "AUTHOR")
+	testutil.Contains(t, output, "Alice")
+	if strings.Contains(output, "BODY") {
+		t.Errorf("BODY header should be absent: %q", output)
+	}
+	if strings.Contains(output, "BBB") {
+		t.Errorf("body text leaked into projected table output: %q", output)
+	}
+}
+
+// AC3 (table mode): selecting BODY without --fulltext keeps the existing
+// 100-char truncation. Projection must not silently bypass truncation.
+func TestRunList_Fields_TableMode_BodyTruncatedWithoutFullText(t *testing.T) {
+	t.Parallel()
+	server := newTestCommentsServer(t, []api.Comment{longBodyComment("1", "Alice")})
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "ID,AUTHOR,BODY")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "BODY")
+	testutil.Contains(t, output, "[truncated, use --fulltext for complete text]")
+	testutil.NotContains(t, output, longBodyText)
+}
+
+// AC2 (block mode): --fields ID,Author with --fulltext drops Body from each
+// per-comment DetailSection.
+func TestRunList_Fields_BlockMode_DropsBodyField(t *testing.T) {
+	t.Parallel()
+	server := newTestCommentsServer(t, []api.Comment{longBodyComment("1", "Alice")})
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 50, true, "ID,Author")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "ID:")
+	testutil.Contains(t, output, "Author:")
+	if strings.Contains(output, "Body:") {
+		t.Errorf("Body label should be absent: %q", output)
+	}
+	if strings.Contains(output, "BBB") {
+		t.Errorf("body text leaked into projected block output: %q", output)
+	}
+}
+
+// AC1+AC3 (block mode): --fields Body with --fulltext renders the full body
+// without the truncation marker.
+func TestRunList_Fields_BlockMode_BodySelectedWithFullText(t *testing.T) {
+	t.Parallel()
+	server := newTestCommentsServer(t, []api.Comment{longBodyComment("1", "Alice")})
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 50, true, "Body")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Body:")
+	testutil.Contains(t, output, longBodyText)
+	testutil.NotContains(t, output, "[truncated")
+}
+
+// AC3 (block mode): --fulltext is a no-op for unselected fields. Even with
+// fulltext on, body text MUST NOT appear when Body is not in --fields.
+func TestRunList_Fields_BlockMode_FullTextNoOp_WhenBodyNotSelected(t *testing.T) {
+	t.Parallel()
+	server := newTestCommentsServer(t, []api.Comment{longBodyComment("1", "Alice")})
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 50, true, "ID,Author")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	if strings.Contains(output, "BBB") {
+		t.Errorf("body text leaked even though Body not selected: %q", output)
+	}
+}
+
+// AC2 + helper coverage: in block mode with hasMore=true, projecting Body
+// out of every comment must not strip the trailing pagination MessageSection.
+// Guards against projectAllDetailSectionsInModel accidentally rewriting
+// non-Detail sections.
+func TestRunList_Fields_BlockMode_PreservesPaginationHint(t *testing.T) {
+	t.Parallel()
+	// Total=2 with one comment returned forces commentsHasMore to true.
+	server := commentsServerWithTotal([]api.Comment{longBodyComment("1", "Alice")}, 2)
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 50, true, "ID,Author")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	if strings.Contains(output, "Body:") {
+		t.Errorf("Body label should be projected away: %q", output)
+	}
+	testutil.Contains(t, output, "More results available")
+}
+
+// Unknown --fields token must surface as UnknownFieldError. The no-op
+// fetcher prevents UnrenderedFieldError or a real /field call.
+func TestRunList_Fields_UnknownToken_Errors(t *testing.T) {
+	t.Parallel()
+	server := newTestCommentsServer(t, []api.Comment{longBodyComment("1", "Alice")})
+	defer server.Close()
+
+	opts, _, _ := newCommentsOpts(t, server)
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "bogus")
+	var ufe *projection.UnknownFieldError
+	if !errors.As(err, &ufe) {
+		t.Fatalf("expected UnknownFieldError, got %v", err)
+	}
+}
+
+// --id wins over --fields: bare IDs only, no projection or metadata work.
+func TestRunList_IDOnly_OverridesFields(t *testing.T) {
+	t.Parallel()
+	server := newTestCommentsServer(t, []api.Comment{longBodyComment("1", "Alice")})
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	opts.IDOnly = true
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "Body")
+	testutil.RequireNoError(t, err)
+
+	if stdout.String() != "1\n" {
+		t.Errorf("expected bare ID, got %q", stdout.String())
+	}
+}
+
+// --fields combined with --output json is rejected, mirroring runGet.
+func TestRunList_Fields_WithJSON_Errors(t *testing.T) {
+	t.Parallel()
+	server := newTestCommentsServer(t, []api.Comment{longBodyComment("1", "Alice")})
+	defer server.Close()
+
+	opts, _, _ := newCommentsOpts(t, server)
+	opts.Output = "json"
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "ID")
+	if err == nil {
+		t.Fatalf("expected error when --fields combined with --output json")
+	}
+	testutil.Contains(t, err.Error(), "not supported with --output json")
+}
+
+// --id combined with --output json + --fields must let --id win without
+// triggering the JSON-vs-fields rejection (parity with runGet).
+func TestRunList_IDOnly_BypassesJSONFieldsRejection(t *testing.T) {
+	t.Parallel()
+	server := newTestCommentsServer(t, []api.Comment{longBodyComment("1", "Alice")})
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	opts.IDOnly = true
+	opts.Output = "json"
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "Body")
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "1\n" {
+		t.Errorf("expected bare ID, got %q", stdout.String())
+	}
+}

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -87,7 +87,7 @@ func TestRunList_TruncatesCommentBody(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "TEST-1", 50, false)
+	err = runList(context.Background(), opts, "TEST-1", 50, false, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -137,7 +137,7 @@ func TestRunList_FullCommentBody(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "TEST-1", 50, true)
+	err = runList(context.Background(), opts, "TEST-1", 50, true, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -297,7 +297,7 @@ func TestRunList_ShortCommentNotTruncated(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "TEST-1", 50, false)
+	err = runList(context.Background(), opts, "TEST-1", 50, false, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -325,7 +325,7 @@ func TestRunList_NoComments(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "TEST-1", 50, false)
+	err = runList(context.Background(), opts, "TEST-1", 50, false, "")
 	testutil.RequireNoError(t, err)
 
 	combined := stdout.String() + stderr.String()
@@ -382,7 +382,7 @@ func TestRunList_FullTextBlockSpacing(t *testing.T) {
 	defer server.Close()
 
 	opts, stdout, _ := newCommentsOpts(t, server)
-	err := runList(context.Background(), opts, "TEST-1", 50, true)
+	err := runList(context.Background(), opts, "TEST-1", 50, true, "")
 	testutil.RequireNoError(t, err)
 
 	out := stdout.String()
@@ -401,7 +401,7 @@ func TestRunList_FullTextPaginationOnStdout(t *testing.T) {
 	defer server.Close()
 
 	opts, stdout, stderr := newCommentsOpts(t, server)
-	err := runList(context.Background(), opts, "TEST-1", 1, true)
+	err := runList(context.Background(), opts, "TEST-1", 1, true, "")
 	testutil.RequireNoError(t, err)
 
 	if !strings.Contains(stdout.String(), "More results available") {
@@ -423,7 +423,7 @@ func TestRunList_IDOnlyEmitsIDsOnePerLine(t *testing.T) {
 
 	opts, stdout, stderr := newCommentsOpts(t, server)
 	opts.IDOnly = true
-	err := runList(context.Background(), opts, "TEST-1", 50, false)
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "")
 	testutil.RequireNoError(t, err)
 
 	want := "11\n22\n"
@@ -443,7 +443,7 @@ func TestRunList_IDOnlyWithMoreResultsAppendsContinuation(t *testing.T) {
 
 	opts, stdout, _ := newCommentsOpts(t, server)
 	opts.IDOnly = true
-	err := runList(context.Background(), opts, "TEST-1", 1, false)
+	err := runList(context.Background(), opts, "TEST-1", 1, false, "")
 	testutil.RequireNoError(t, err)
 
 	want := "1\nMore results available (use --next-page-token to fetch next page)\n"
@@ -462,7 +462,7 @@ func TestRunList_EmptyNeverEmitsSpuriousPaginationHint(t *testing.T) {
 	defer server.Close()
 
 	opts, stdout, stderr := newCommentsOpts(t, server)
-	err := runList(context.Background(), opts, "TEST-1", 50, false)
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "")
 	testutil.RequireNoError(t, err)
 
 	if strings.Contains(stdout.String(), "More results available") {
@@ -480,7 +480,7 @@ func TestRunList_EmptyWithIDOnly_EmitsNothing(t *testing.T) {
 
 	opts, stdout, stderr := newCommentsOpts(t, server)
 	opts.IDOnly = true
-	err := runList(context.Background(), opts, "TEST-1", 50, false)
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "")
 	testutil.RequireNoError(t, err)
 
 	if stdout.String() != "" {
@@ -497,7 +497,7 @@ func TestRunList_EmptyDefaultGoesToStdout(t *testing.T) {
 	defer server.Close()
 
 	opts, stdout, stderr := newCommentsOpts(t, server)
-	err := runList(context.Background(), opts, "TEST-1", 50, false)
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "")
 	testutil.RequireNoError(t, err)
 
 	if !strings.Contains(stdout.String(), "No comments on TEST-1") {
@@ -582,7 +582,7 @@ func TestRunList_MultipleCommentsFullMode(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "TEST-1", 50, true)
+	err = runList(context.Background(), opts, "TEST-1", 50, true, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -31,6 +31,11 @@ func TestNewListCmd(t *testing.T) {
 	maxFlag := cmd.Flags().Lookup("max")
 	testutil.NotNil(t, maxFlag)
 	testutil.Equal(t, maxFlag.DefValue, "50")
+
+	// Check that fields flag exists
+	fieldsFlag := cmd.Flags().Lookup("fields")
+	testutil.NotNil(t, fieldsFlag)
+	testutil.Equal(t, fieldsFlag.DefValue, "")
 }
 
 func newTestCommentsServer(_ *testing.T, comments []api.Comment) *httptest.Server {

--- a/tools/jtk/internal/cmd/issues/get_fields_test.go
+++ b/tools/jtk/internal/cmd/issues/get_fields_test.go
@@ -230,3 +230,87 @@ func TestRunGet_IDOnly_BypassesJSONFieldsRejection(t *testing.T) {
 		t.Errorf("expected bare key, got %q", stdout.String())
 	}
 }
+
+// fullIssueWithLongDescription returns a TEST-1 fixture whose Description
+// exceeds the 200-char truncation threshold so the body-vs-fulltext
+// interaction is observable.
+func fullIssueWithLongDescription() api.Issue {
+	issue := fullIssue()
+	issue.Fields.Description = &api.Description{Text: strings.Repeat("D", 300)}
+	return issue
+}
+
+// AC1 (issues get): description suppressed by --fields when not selected.
+// Long description text MUST be absent from output.
+func TestRunGet_Fields_SuppressesDescription_WhenNotSelected(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssueWithLongDescription(), nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	err := runGet(context.Background(), opts, "TEST-1", false, "Summary,Status")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Key: TEST-1")
+	testutil.Contains(t, output, "Status: Open")
+	if strings.Contains(output, "Description") {
+		t.Errorf("Description label should not appear: %q", output)
+	}
+	if strings.Contains(output, "DDDD") {
+		t.Errorf("Description body text leaked into output: %q", output)
+	}
+}
+
+// AC1 (issues get): description selected without --fulltext is truncated.
+func TestRunGet_Fields_Description_TruncatedWithoutFullText(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssueWithLongDescription(), nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	err := runGet(context.Background(), opts, "TEST-1", false, "Description")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Description:")
+	testutil.Contains(t, output, "[truncated, use --fulltext for complete text]")
+}
+
+// AC1+AC3 (issues get): description selected WITH --fulltext shows full body
+// and no truncation marker.
+func TestRunGet_Fields_Description_FullTextWhenSelected(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssueWithLongDescription(), nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	err := runGet(context.Background(), opts, "TEST-1", true, "Description")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Description:")
+	testutil.Contains(t, output, strings.Repeat("D", 300))
+	testutil.NotContains(t, output, "[truncated")
+}
+
+// AC3 (issues get): --fulltext is a no-op when Description is not selected.
+// Output must not contain description text even though noTruncate=true.
+func TestRunGet_Fields_FullTextNoOp_WhenDescriptionNotSelected(t *testing.T) {
+	t.Parallel()
+	cs := newCapturingGetServer(t, fullIssueWithLongDescription(), nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	err := runGet(context.Background(), opts, "TEST-1", true, "Summary")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Summary:")
+	if strings.Contains(output, "Description") {
+		t.Errorf("Description label should not appear: %q", output)
+	}
+	if strings.Contains(output, "DDDD") {
+		t.Errorf("Description body text leaked even though Description not selected: %q", output)
+	}
+}

--- a/tools/jtk/internal/present/comment.go
+++ b/tools/jtk/internal/present/comment.go
@@ -8,10 +8,33 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 // CommentPresenter creates presentation models for comment data.
 type CommentPresenter struct{}
+
+// CommentListSpec declares the columns emitted by PresentList /
+// PresentListWithPagination. Order MUST match the hardcoded Headers in
+// PresentList. None of these have a Jira FieldID — comment fields are
+// not Jira issue fields, so resolve.go's slow path will never find a
+// match and unknown tokens correctly return UnknownFieldError.
+var CommentListSpec = projection.Registry{
+	{Header: "ID", Identity: true},
+	{Header: "AUTHOR"},
+	{Header: "CREATED"},
+	{Header: "BODY"},
+}
+
+// CommentDetailSpec declares the Fields emitted by PresentListFull /
+// PresentListFullWithPagination. Order MUST match the per-comment field
+// order in PresentListFull.
+var CommentDetailSpec = projection.Registry{
+	{Header: "ID", Identity: true},
+	{Header: "Author"},
+	{Header: "Created"},
+	{Header: "Body"},
+}
 
 // PresentList creates a table view for a list of comments.
 func (CommentPresenter) PresentList(comments []api.Comment) *present.OutputModel {

--- a/tools/jtk/internal/present/comment_test.go
+++ b/tools/jtk/internal/present/comment_test.go
@@ -1,0 +1,143 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func singleComment() []api.Comment {
+	return []api.Comment{
+		{
+			ID:     "42",
+			Author: api.User{DisplayName: "Alice"},
+			Body: &api.ADFDocument{
+				Type:    "doc",
+				Version: 1,
+				Content: []*api.ADFNode{
+					{Type: "paragraph", Content: []*api.ADFNode{{Type: "text", Text: "body text"}}},
+				},
+			},
+			Created: "2024-01-15T10:00:00.000Z",
+		},
+	}
+}
+
+// TestCommentListSpec_MatchesPresentListHeaders locks CommentListSpec against
+// the hardcoded headers in PresentList and PresentListWithPagination.
+// ProjectTable is header-string-driven; silent drift between the spec and the
+// presenter would break --fields at runtime.
+func TestCommentListSpec_MatchesPresentListHeaders(t *testing.T) {
+	t.Parallel()
+	comments := singleComment()
+
+	cases := []struct {
+		name  string
+		model *present.OutputModel
+	}{
+		{"PresentList", CommentPresenter{}.PresentList(comments)},
+		{"PresentListWithPagination_NoMore", CommentPresenter{}.PresentListWithPagination(comments, false)},
+		{"PresentListWithPagination_HasMore", CommentPresenter{}.PresentListWithPagination(comments, true)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var table *present.TableSection
+			for _, s := range tc.model.Sections {
+				if ts, ok := s.(*present.TableSection); ok {
+					table = ts
+					break
+				}
+			}
+			if table == nil {
+				t.Fatalf("no TableSection in %s output", tc.name)
+			}
+			if len(table.Headers) != len(CommentListSpec) {
+				t.Fatalf("header count mismatch: spec has %d, table has %d", len(CommentListSpec), len(table.Headers))
+			}
+			for i, spec := range CommentListSpec {
+				if table.Headers[i] != spec.Header {
+					t.Errorf("index %d: spec Header=%q, table header=%q", i, spec.Header, table.Headers[i])
+				}
+			}
+		})
+	}
+}
+
+// TestCommentDetailSpec_MatchesPresentDetailLabels locks CommentDetailSpec
+// against the Field labels emitted by PresentListFull, both directions:
+//   - Every spec entry must appear as a rendered Field label.
+//   - Every rendered Field label must have a matching spec entry — otherwise
+//     --fields projection would silently drop that field.
+//
+// Order is checked too: ProjectDetail relies on the spec order being the same
+// as the presenter's Field order for deterministic projection output.
+func TestCommentDetailSpec_MatchesPresentDetailLabels(t *testing.T) {
+	t.Parallel()
+	comments := singleComment()
+
+	cases := []struct {
+		name  string
+		model *present.OutputModel
+	}{
+		{"PresentListFull", CommentPresenter{}.PresentListFull(comments)},
+		{"PresentListFullWithPagination_NoMore", CommentPresenter{}.PresentListFullWithPagination(comments, false)},
+		{"PresentListFullWithPagination_HasMore", CommentPresenter{}.PresentListFullWithPagination(comments, true)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var detail *present.DetailSection
+			for _, s := range tc.model.Sections {
+				if ds, ok := s.(*present.DetailSection); ok {
+					detail = ds
+					break
+				}
+			}
+			if detail == nil {
+				t.Fatalf("no DetailSection in %s output", tc.name)
+			}
+
+			// Spec → rendered: every spec entry has a rendered field.
+			renderedLabels := make(map[string]bool, len(detail.Fields))
+			for _, f := range detail.Fields {
+				renderedLabels[f.Label] = true
+			}
+			for _, spec := range CommentDetailSpec {
+				if !renderedLabels[spec.Header] {
+					t.Errorf("spec Header %q not emitted by %s", spec.Header, tc.name)
+				}
+			}
+
+			// Rendered → spec: every rendered field has a spec entry.
+			specLabels := make(map[string]bool, len(CommentDetailSpec))
+			for _, spec := range CommentDetailSpec {
+				specLabels[spec.Header] = true
+			}
+			for _, f := range detail.Fields {
+				if !specLabels[f.Label] {
+					t.Errorf("rendered field %q has no matching CommentDetailSpec entry", f.Label)
+				}
+			}
+
+			// Order: spec order must match presenter Field order.
+			specOrder := make([]string, 0, len(CommentDetailSpec))
+			for _, spec := range CommentDetailSpec {
+				specOrder = append(specOrder, spec.Header)
+			}
+			renderedOrder := make([]string, 0, len(detail.Fields))
+			for _, f := range detail.Fields {
+				renderedOrder = append(renderedOrder, f.Label)
+			}
+			testutil.Equal(t, len(specOrder), len(renderedOrder))
+			for i := range specOrder {
+				if specOrder[i] != renderedOrder[i] {
+					t.Errorf("order mismatch at index %d: spec=%q rendered=%q", i, specOrder[i], renderedOrder[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #234. Plan: https://github.com/open-cli-collective/atlassian-cli/issues/234#issuecomment-4273427065

## Summary

- `issues get`: adds the missing test coverage for description gating and the `--fields × --fulltext` interaction. No production change — the gating already worked via `projection.Resolve` + `ProjectDetail`, but nothing asserted the negative case or the fulltext interaction.
- `comments list`: adds `--fields` support across both table mode and `--fulltext` block mode. Body field is now suppressible by `--fields`, and `--fulltext` is a no-op when Body is not selected.

## Implementation notes

- `CommentListSpec` (table headers `ID/AUTHOR/CREATED/BODY`) and `CommentDetailSpec` (block labels `ID/Author/Created/Body`) live alongside the existing presenters in `internal/present/comment.go`.
- `runList` orders gates the same way `runGet` does: `--id` wins first (skips projection and JSON-vs-fields entirely), then `--fields + --output json` rejection, then `projection.Resolve`.
- Comment fields are not Jira issue fields. `noFieldFetch` returns `nil, nil` so unknown tokens land cleanly in `UnknownFieldError` instead of `UnrenderedFieldError` or a real `/field` call (which the comment test servers don't even handle).
- `projectAllDetailSectionsInModel` walks every section but only rewrites `*present.DetailSection`s, leaving the trailing pagination `MessageSection` intact. Test coverage guards that.

## Test plan
- [x] `go test ./tools/jtk/...` — 1062 passed in 24 packages
- [x] `golangci-lint run ./internal/cmd/comments/... ./internal/cmd/issues/... ./internal/present/...` — clean (one pre-existing gosec warning in `internal/config/config.go` unrelated to this change)
- [ ] Manual verification against a live Jira instance:
  - `jtk issues get MON-XXXX --fields Summary,Status` → no Description block
  - `jtk issues get MON-XXXX --fields Description --fulltext` → full description
  - `jtk comments list MON-XXXX --fields ID,AUTHOR` → two-column table
  - `jtk comments list MON-XXXX --fulltext --fields ID,Author` → block mode without Body
  - `jtk comments list MON-XXXX --fulltext --fields Body` → just body per comment