### PR TITLE
feat(jtk): add instance cache storage and refresh plumbing

### DIFF
--- a/tools/jtk/api/priorities.go
+++ b/tools/jtk/api/priorities.go
@@ -1,0 +1,24 @@
+package api //nolint:revive // package name is intentional
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ListPriorities returns all priorities defined in the instance.
+// GET /rest/api/3/priority
+func (c *Client) ListPriorities(ctx context.Context) ([]Priority, error) {
+	urlStr := fmt.Sprintf("%s/priority", c.BaseURL)
+	body, err := c.Get(ctx, urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("fetching priorities: %w", err)
+	}
+
+	var priorities []Priority
+	if err := json.Unmarshal(body, &priorities); err != nil {
+		return nil, fmt.Errorf("parsing priorities: %w", err)
+	}
+
+	return priorities, nil
+}

--- a/tools/jtk/api/priorities_test.go
+++ b/tools/jtk/api/priorities_test.go
@@ -1,0 +1,40 @@
+package api //nolint:revive // package name is intentional
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestListPriorities(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, r.URL.Path, "/rest/api/3/priority")
+		_ = json.NewEncoder(w).Encode([]Priority{
+			{ID: "1", Name: "Highest"},
+			{ID: "2", Name: "High"},
+			{ID: "3", Name: "Medium"},
+			{ID: "4", Name: "Low"},
+			{ID: "5", Name: "Lowest"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      "https://test.atlassian.net",
+		Email:    "test@example.com",
+		APIToken: "test-token",
+	})
+	testutil.RequireNoError(t, err)
+	client.BaseURL = server.URL + "/rest/api/3"
+
+	priorities, err := client.ListPriorities(context.Background())
+	testutil.RequireNoError(t, err)
+	testutil.Len(t, priorities, 5)
+	testutil.Equal(t, priorities[0].ID, "1")
+	testutil.Equal(t, priorities[0].Name, "Highest")
+	testutil.Equal(t, priorities[4].Name, "Lowest")
+}

--- a/tools/jtk/api/resolutions.go
+++ b/tools/jtk/api/resolutions.go
@@ -1,0 +1,24 @@
+package api //nolint:revive // package name is intentional
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ListResolutions returns all resolutions defined in the instance.
+// GET /rest/api/3/resolution
+func (c *Client) ListResolutions(ctx context.Context) ([]Resolution, error) {
+	urlStr := fmt.Sprintf("%s/resolution", c.BaseURL)
+	body, err := c.Get(ctx, urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("fetching resolutions: %w", err)
+	}
+
+	var resolutions []Resolution
+	if err := json.Unmarshal(body, &resolutions); err != nil {
+		return nil, fmt.Errorf("parsing resolutions: %w", err)
+	}
+
+	return resolutions, nil
+}

--- a/tools/jtk/api/resolutions_test.go
+++ b/tools/jtk/api/resolutions_test.go
@@ -1,0 +1,39 @@
+package api //nolint:revive // package name is intentional
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestListResolutions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, r.URL.Path, "/rest/api/3/resolution")
+		_ = json.NewEncoder(w).Encode([]Resolution{
+			{ID: "1", Name: "Fixed", Description: "Work has been completed"},
+			{ID: "2", Name: "Won't Do", Description: "Rejected"},
+			{ID: "3", Name: "Duplicate"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      "https://test.atlassian.net",
+		Email:    "test@example.com",
+		APIToken: "test-token",
+	})
+	testutil.RequireNoError(t, err)
+	client.BaseURL = server.URL + "/rest/api/3"
+
+	resolutions, err := client.ListResolutions(context.Background())
+	testutil.RequireNoError(t, err)
+	testutil.Len(t, resolutions, 3)
+	testutil.Equal(t, resolutions[0].ID, "1")
+	testutil.Equal(t, resolutions[0].Name, "Fixed")
+	testutil.Equal(t, resolutions[0].Description, "Work has been completed")
+	testutil.Equal(t, resolutions[2].Description, "")
+}

--- a/tools/jtk/api/types.go
+++ b/tools/jtk/api/types.go
@@ -223,6 +223,13 @@ type Priority struct {
 	Name string `json:"name"`
 }
 
+// Resolution represents a workflow resolution value
+type Resolution struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
 // User represents a Jira user
 type User struct {
 	AccountID    string            `json:"accountId"`

--- a/tools/jtk/api/users.go
+++ b/tools/jtk/api/users.go
@@ -41,6 +41,33 @@ func (c *Client) GetUser(ctx context.Context, accountID string) (*User, error) {
 	return &user, nil
 }
 
+// ListUsersPage returns a page of users for bulk enumeration.
+// Hits GET /rest/api/3/users with startAt and maxResults.
+// Note: Jira caps total user enumeration at ~1000; callers stop paging once
+// a page returns fewer than maxResults.
+func (c *Client) ListUsersPage(ctx context.Context, startAt, maxResults int) ([]User, error) {
+	params := map[string]string{}
+	if startAt > 0 {
+		params["startAt"] = fmt.Sprintf("%d", startAt)
+	}
+	if maxResults > 0 {
+		params["maxResults"] = fmt.Sprintf("%d", maxResults)
+	}
+
+	urlStr := buildURL(fmt.Sprintf("%s/users", c.BaseURL), params)
+	body, err := c.Get(ctx, urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("listing users: %w", err)
+	}
+
+	var users []User
+	if err := json.Unmarshal(body, &users); err != nil {
+		return nil, fmt.Errorf("parsing users: %w", err)
+	}
+
+	return users, nil
+}
+
 // SearchUsers searches for users by query string
 func (c *Client) SearchUsers(ctx context.Context, query string, maxResults int) ([]User, error) {
 	params := map[string]string{

--- a/tools/jtk/api/users_test.go
+++ b/tools/jtk/api/users_test.go
@@ -101,6 +101,34 @@ func TestGetCurrentUser(t *testing.T) {
 	testutil.Equal(t, user.AccountID, "5b10ac8d82e05b22cc7d4ef5")
 }
 
+func TestListUsersPage(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, r.URL.Path, "/rest/api/3/users")
+		testutil.Equal(t, r.URL.Query().Get("startAt"), "50")
+		testutil.Equal(t, r.URL.Query().Get("maxResults"), "50")
+		users := []User{
+			{AccountID: "a1", DisplayName: "User One", Active: true},
+			{AccountID: "a2", DisplayName: "User Two", Active: true},
+		}
+		_ = json.NewEncoder(w).Encode(users)
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{
+		URL:      "https://test.atlassian.net",
+		Email:    "test@example.com",
+		APIToken: "test-token",
+	})
+	testutil.RequireNoError(t, err)
+	client.BaseURL = server.URL + "/rest/api/3"
+
+	users, err := client.ListUsersPage(context.Background(), 50, 50)
+	testutil.RequireNoError(t, err)
+	testutil.Len(t, users, 2)
+	testutil.Equal(t, users[0].AccountID, "a1")
+}
+
 func TestSearchUsers(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/jtk/cmd/jtk/main.go
+++ b/tools/jtk/cmd/jtk/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/links"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/me"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/projects"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/refresh"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/sprints"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/transitions"
@@ -58,6 +59,7 @@ func run(ctx context.Context) error {
 	sprints.Register(rootCmd, opts)
 	users.Register(rootCmd, opts)
 	me.Register(rootCmd, opts)
+	refresh.Register(rootCmd, opts)
 	completion.Register(rootCmd, opts)
 
 	return rootCmd.ExecuteContext(ctx)

--- a/tools/jtk/cmd/jtk/main.go
+++ b/tools/jtk/cmd/jtk/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -35,7 +36,9 @@ func main() {
 	defer stop()
 
 	if err := run(ctx); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		if !errors.Is(err, refresh.ErrAlreadyReported) {
+			fmt.Fprintln(os.Stderr, err)
+		}
 		os.Exit(exitcode.GeneralError)
 	}
 }

--- a/tools/jtk/internal/cache/bootstrap.go
+++ b/tools/jtk/internal/cache/bootstrap.go
@@ -47,8 +47,21 @@ func SeedUsers(ctx context.Context, c *api.Client) (int, error) {
 		startAt += len(page)
 	}
 
-	if err := WriteResource("users", "24h", all); err != nil {
+	// Look up the TTL from the registry rather than hardcoding it — keeps the
+	// registry as the single source of truth for cache metadata.
+	ttl := usersTTL()
+	if err := WriteResource("users", ttl, all); err != nil {
 		return 0, fmt.Errorf("writing users envelope: %w", err)
 	}
 	return len(all), nil
+}
+
+// usersTTL returns the registered TTL for the "users" cache, falling back to
+// "24h" if the registry hasn't been populated (e.g., during early init in
+// tests that swap the registry).
+func usersTTL() string {
+	if e, err := Lookup("users"); err == nil {
+		return e.TTL
+	}
+	return "24h"
 }

--- a/tools/jtk/internal/cache/bootstrap.go
+++ b/tools/jtk/internal/cache/bootstrap.go
@@ -1,0 +1,54 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// seedUsersPageSize is the page size used when paginating the users endpoint.
+// Jira accepts up to 100 per call; smaller chunks just mean more round-trips.
+const seedUsersPageSize = 100
+
+// seedUsersMax is a safety ceiling. Jira's platform caps user enumeration at
+// ~1000 users regardless of what the client requests; this guard prevents a
+// misbehaving server from spinning forever.
+const seedUsersMax = 2000
+
+// SeedUsers paginates the users endpoint and writes the "users" envelope.
+//
+// Used by both `jtk refresh users` and (via the shared cache package) by `jtk init`
+// in #246. Returns the number of users seeded.
+//
+// Accepted limitation: Jira's user-search platform endpoint returns at most ~1000
+// users. Large instances will have partial coverage; #246's sampling-based
+// enhancements are the path to broader coverage.
+func SeedUsers(ctx context.Context, c *api.Client) (int, error) {
+	if c == nil {
+		return 0, fmt.Errorf("api client is nil")
+	}
+
+	all := make([]api.User, 0, seedUsersPageSize)
+	startAt := 0
+	for startAt < seedUsersMax {
+		page, err := c.ListUsersPage(ctx, startAt, seedUsersPageSize)
+		if err != nil {
+			return 0, fmt.Errorf("listing users page (startAt=%d): %w", startAt, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		all = append(all, page...)
+		if len(page) < seedUsersPageSize {
+			// short page => last page
+			break
+		}
+		startAt += len(page)
+	}
+
+	if err := WriteResource("users", "24h", all); err != nil {
+		return 0, fmt.Errorf("writing users envelope: %w", err)
+	}
+	return len(all), nil
+}

--- a/tools/jtk/internal/cache/bootstrap_test.go
+++ b/tools/jtk/internal/cache/bootstrap_test.go
@@ -1,0 +1,85 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestSeedUsers_PaginatesAndStops(t *testing.T) {
+	cleanup := SetRootForTest(t.TempDir())
+	defer cleanup()
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+	t.Setenv("JIRA_EMAIL", "t@example.com")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+
+	// Fixture: 250 users across 3 pages (100, 100, 50).
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, r.URL.Path, "/rest/api/3/users")
+		startAt, _ := strconv.Atoi(r.URL.Query().Get("startAt"))
+		maxResults, _ := strconv.Atoi(r.URL.Query().Get("maxResults"))
+		testutil.Equal(t, maxResults, seedUsersPageSize)
+
+		var page []api.User
+		end := startAt + maxResults
+		if end > 250 {
+			end = 250
+		}
+		for i := startAt; i < end; i++ {
+			page = append(page, api.User{AccountID: "a" + strconv.Itoa(i), DisplayName: "u" + strconv.Itoa(i), Active: true})
+		}
+		calls++
+		_ = json.NewEncoder(w).Encode(page)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "t@example.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	client.BaseURL = server.URL + "/rest/api/3"
+
+	count, err := SeedUsers(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, count, 250)
+	testutil.Equal(t, calls, 3) // 100 + 100 + 50 (50 < pageSize => stop)
+
+	// Envelope was written correctly.
+	env, err := ReadResource[[]api.User]("users")
+	testutil.RequireNoError(t, err)
+	testutil.Len(t, env.Data, 250)
+	testutil.Equal(t, env.TTL, "24h")
+	testutil.Equal(t, env.Data[0].AccountID, "a0")
+	testutil.Equal(t, env.Data[249].AccountID, "a249")
+}
+
+func TestSeedUsers_EmptyInstance(t *testing.T) {
+	cleanup := SetRootForTest(t.TempDir())
+	defer cleanup()
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+	t.Setenv("JIRA_EMAIL", "t@example.com")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "t@example.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	client.BaseURL = server.URL + "/rest/api/3"
+
+	count, err := SeedUsers(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, count, 0)
+
+	env, err := ReadResource[[]api.User]("users")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(env.Data), 0)
+}

--- a/tools/jtk/internal/cache/envelope.go
+++ b/tools/jtk/internal/cache/envelope.go
@@ -1,0 +1,119 @@
+// Package cache provides caching functionality for jtk resources.
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const Version = 1
+
+var ErrCacheMiss = errors.New("cache miss")
+
+// Envelope is the on-disk JSON shape for a single cached resource.
+type Envelope[T any] struct {
+	Resource  string    `json:"resource"`
+	Instance  string    `json:"instance"`
+	FetchedAt time.Time `json:"fetched_at"`
+	TTL       string    `json:"ttl"`
+	Version   int       `json:"version"`
+	Data      T         `json:"data"`
+}
+
+// ReadResource reads the envelope for `name` from disk.
+//   - Returns (envelope, nil) on success.
+//   - Returns (zero, ErrCacheMiss) if the file does not exist.
+//   - Returns (zero, error) on I/O or JSON decode failure.
+//
+// ReadResource does NOT check freshness; callers use freshness.go.
+func ReadResource[T any](name string) (Envelope[T], error) {
+	path, err := ResourceFile(name)
+	if err != nil {
+		return Envelope[T]{}, err
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // path derives from config, not user input
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Envelope[T]{}, ErrCacheMiss
+		}
+		return Envelope[T]{}, fmt.Errorf("reading resource file: %w", err)
+	}
+
+	var env Envelope[T]
+	if err := json.Unmarshal(data, &env); err != nil {
+		return Envelope[T]{}, fmt.Errorf("parsing resource file: %w", err)
+	}
+
+	return env, nil
+}
+
+// WriteResource atomically writes an envelope for `name`.
+//   - TTL comes from the caller (registry entry). Resource, Instance, Version,
+//     and FetchedAt are set by WriteResource itself.
+//   - Atomic: write to a temp file in the same directory, then rename.
+//   - Ensures the instance directory exists with mode 0700.
+//   - Writes the file with mode 0600.
+func WriteResource[T any](name string, ttl string, data T) error {
+	path, err := ResourceFile(name)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating cache directory: %w", err)
+	}
+
+	instance, err := InstanceKey()
+	if err != nil {
+		return err
+	}
+
+	env := Envelope[T]{
+		Resource:  name,
+		Instance:  instance,
+		FetchedAt: time.Now().UTC(),
+		TTL:       ttl,
+		Version:   Version,
+		Data:      data,
+	}
+
+	jsonData, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling envelope: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, name+"-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(jsonData); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("setting file mode: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("moving temp file to final path: %w", err)
+	}
+
+	return nil
+}

--- a/tools/jtk/internal/cache/envelope.go
+++ b/tools/jtk/internal/cache/envelope.go
@@ -49,6 +49,12 @@ func ReadResource[T any](name string) (Envelope[T], error) {
 		return Envelope[T]{}, fmt.Errorf("parsing resource file: %w", err)
 	}
 
+	// A version mismatch is treated as a miss — the next write will overwrite
+	// the envelope with the current schema. This makes schema bumps self-healing.
+	if env.Version != Version {
+		return Envelope[T]{}, ErrCacheMiss
+	}
+
 	return env, nil
 }
 
@@ -59,16 +65,6 @@ func ReadResource[T any](name string) (Envelope[T], error) {
 //   - Ensures the instance directory exists with mode 0700.
 //   - Writes the file with mode 0600.
 func WriteResource[T any](name string, ttl string, data T) error {
-	path, err := ResourceFile(name)
-	if err != nil {
-		return err
-	}
-
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("creating cache directory: %w", err)
-	}
-
 	instance, err := InstanceKey()
 	if err != nil {
 		return err
@@ -81,6 +77,23 @@ func WriteResource[T any](name string, ttl string, data T) error {
 		TTL:       ttl,
 		Version:   Version,
 		Data:      data,
+	}
+	return atomicWriteEnvelope(name, env)
+}
+
+// atomicWriteEnvelope marshals an envelope and writes it to the cache path for
+// `name` using a temp-file-rename pattern. Shared by WriteResource (which
+// constructs a fresh envelope) and writeRaw (which preserves existing metadata
+// for Touch-style invalidation).
+func atomicWriteEnvelope[T any](name string, env Envelope[T]) error {
+	path, err := ResourceFile(name)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating cache directory: %w", err)
 	}
 
 	jsonData, err := json.MarshalIndent(env, "", "  ")

--- a/tools/jtk/internal/cache/envelope_test.go
+++ b/tools/jtk/internal/cache/envelope_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -119,4 +120,31 @@ func TestEnvelopeVersion(t *testing.T) {
 	if Version != 1 {
 		t.Errorf("expected Version == 1, got %d", Version)
 	}
+}
+
+// A version-mismatched envelope on disk is reported as ErrCacheMiss so the
+// next write can overwrite it with the current schema. This keeps schema
+// bumps self-healing without surfacing cryptic errors to users.
+func TestReadResource_VersionMismatchTreatedAsMiss(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	// Write a current-version envelope, then overwrite the on-disk file with a
+	// bumped version to simulate a future schema.
+	testutil.NoError(t, WriteResource("x", "24h", []int{1, 2}))
+
+	path, err := ResourceFile("x")
+	testutil.NoError(t, err)
+	data, err := os.ReadFile(path) //nolint:gosec // path is a test-owned tempdir
+	testutil.NoError(t, err)
+	mutated := strings.Replace(string(data), `"version": 1`, `"version": 99`, 1)
+	testutil.NoError(t, os.WriteFile(path, []byte(mutated), 0o600)) //nolint:gosec // path is a test-owned tempdir
+
+	env, err := ReadResource[[]int]("x")
+	if !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("expected ErrCacheMiss on version mismatch, got %v", err)
+	}
+	testutil.Equal(t, env, Envelope[[]int]{})
 }

--- a/tools/jtk/internal/cache/envelope_test.go
+++ b/tools/jtk/internal/cache/envelope_test.go
@@ -1,0 +1,122 @@
+package cache
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestReadResourceWriteResourceRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	data := []int{1, 2, 3}
+	err := WriteResource("test-resource", "24h", data)
+	testutil.NoError(t, err)
+
+	env, err := ReadResource[[]int]("test-resource")
+	testutil.NoError(t, err)
+
+	testutil.Equal(t, env.Resource, "test-resource")
+	testutil.Equal(t, env.TTL, "24h")
+	testutil.Equal(t, env.Version, 1)
+	testutil.Equal(t, env.Data, data)
+
+	// Check FetchedAt is recent (within last minute)
+	now := time.Now().UTC()
+	age := now.Sub(env.FetchedAt)
+	if age < 0 || age > time.Minute {
+		t.Errorf("FetchedAt not recent: got %v, want within 1 minute of now", env.FetchedAt)
+	}
+}
+
+func TestReadResourceCacheMiss(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	env, err := ReadResource[[]int]("nonexistent")
+
+	testutil.Equal(t, env, Envelope[[]int]{})
+	if !errors.Is(err, ErrCacheMiss) {
+		t.Errorf("expected ErrCacheMiss, got %v", err)
+	}
+}
+
+func TestWriteResourceFileMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	data := []string{"test"}
+	err := WriteResource("test-resource", "24h", data)
+	testutil.NoError(t, err)
+
+	path, err := ResourceFile("test-resource")
+	testutil.NoError(t, err)
+
+	stat, err := os.Stat(path)
+	testutil.NoError(t, err)
+
+	mode := stat.Mode().Perm()
+	expected := os.FileMode(0o600)
+	if mode != expected {
+		t.Errorf("expected file mode %o, got %o", expected, mode)
+	}
+}
+
+func TestWriteResourceNoStrayTempFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	data := []string{"test"}
+	err := WriteResource("test-resource", "24h", data)
+	testutil.NoError(t, err)
+
+	path, err := ResourceFile("test-resource")
+	testutil.NoError(t, err)
+
+	dir := filepath.Dir(path)
+	entries, err := os.ReadDir(dir)
+	testutil.NoError(t, err)
+
+	jsonFiles := 0
+	tmpFiles := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			if filepath.Ext(entry.Name()) == ".json" {
+				jsonFiles++
+			}
+			if filepath.Ext(entry.Name()) == ".tmp" {
+				tmpFiles++
+			}
+		}
+	}
+
+	if jsonFiles != 1 {
+		t.Errorf("expected 1 .json file, found %d", jsonFiles)
+	}
+	if tmpFiles != 0 {
+		t.Errorf("expected 0 .tmp files, found %d", tmpFiles)
+	}
+}
+
+func TestEnvelopeVersion(t *testing.T) {
+	if Version != 1 {
+		t.Errorf("expected Version == 1, got %d", Version)
+	}
+}

--- a/tools/jtk/internal/cache/fetchers.go
+++ b/tools/jtk/internal/cache/fetchers.go
@@ -62,11 +62,15 @@ func fetchProjects(ctx context.Context, c *api.Client) (int, error) {
 	return len(projects), nil
 }
 
+// fetchBoardsMax is a safety ceiling. A misbehaving server that never sets
+// isLast=true would otherwise cause unbounded pagination.
+const fetchBoardsMax = 5000
+
 func fetchBoards(ctx context.Context, c *api.Client) (int, error) {
 	const pageSize = 50
 	var all []api.Board
 	startAt := 0
-	for {
+	for startAt < fetchBoardsMax {
 		resp, err := c.ListBoards(ctx, "", startAt, pageSize)
 		if err != nil {
 			return 0, err

--- a/tools/jtk/internal/cache/fetchers.go
+++ b/tools/jtk/internal/cache/fetchers.go
@@ -1,0 +1,165 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+const (
+	ttl24h  = "24h"
+	ttl168h = "168h"
+)
+
+// init populates the default registry.
+func init() {
+	entries = defaultEntries()
+}
+
+// defaultEntries returns the production registry in declaration order.
+// Entries() applies dependency ordering on top of this.
+func defaultEntries() []Entry {
+	return []Entry{
+		{Name: "fields", TTL: ttl24h, Fetch: fetchFields},
+		{Name: "projects", TTL: ttl24h, Fetch: fetchProjects},
+		{Name: "boards", TTL: ttl24h, Available: supportsAgile, Fetch: fetchBoards},
+		{Name: "linktypes", TTL: ttl24h, Fetch: fetchLinkTypes},
+		{Name: "issuetypes", TTL: ttl24h, DependsOn: []string{"projects"}, Fetch: fetchIssueTypes},
+		{Name: "statuses", TTL: ttl24h, DependsOn: []string{"projects"}, Fetch: fetchStatuses},
+		{Name: "priorities", TTL: ttl168h, Fetch: fetchPriorities},
+		{Name: "resolutions", TTL: ttl168h, Fetch: fetchResolutions},
+		{Name: "users", TTL: ttl24h, Fetch: fetchUsers},
+	}
+}
+
+// supportsAgile reports whether the client can reach the Agile REST API.
+// Scoped bearer tokens lack the Agile scope, so boards (and any future
+// Agile-gated resource) must be skipped in that mode.
+func supportsAgile(c *api.Client) bool {
+	return c != nil && c.SupportsAgile()
+}
+
+func fetchFields(ctx context.Context, c *api.Client) (int, error) {
+	fields, err := c.GetFields(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if err := WriteResource("fields", ttl24h, fields); err != nil {
+		return 0, err
+	}
+	return len(fields), nil
+}
+
+func fetchProjects(ctx context.Context, c *api.Client) (int, error) {
+	projects, err := c.ListProjects(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if err := WriteResource("projects", ttl24h, projects); err != nil {
+		return 0, err
+	}
+	return len(projects), nil
+}
+
+func fetchBoards(ctx context.Context, c *api.Client) (int, error) {
+	const pageSize = 50
+	var all []api.Board
+	startAt := 0
+	for {
+		resp, err := c.ListBoards(ctx, "", startAt, pageSize)
+		if err != nil {
+			return 0, err
+		}
+		all = append(all, resp.Values...)
+		if resp.IsLast || len(resp.Values) == 0 {
+			break
+		}
+		startAt += len(resp.Values)
+	}
+	if err := WriteResource("boards", ttl24h, all); err != nil {
+		return 0, err
+	}
+	return len(all), nil
+}
+
+func fetchLinkTypes(_ context.Context, c *api.Client) (int, error) {
+	types, err := c.GetIssueLinkTypes()
+	if err != nil {
+		return 0, err
+	}
+	if err := WriteResource("linktypes", ttl24h, types); err != nil {
+		return 0, err
+	}
+	return len(types), nil
+}
+
+func fetchIssueTypes(ctx context.Context, c *api.Client) (int, error) {
+	env, err := ReadResource[[]api.Project]("projects")
+	if err != nil {
+		return 0, fmt.Errorf("reading projects cache (refresh projects first): %w", err)
+	}
+
+	byProject := make(map[string][]api.IssueType, len(env.Data))
+	total := 0
+	for _, p := range env.Data {
+		types, err := c.GetProjectIssueTypes(ctx, p.Key)
+		if err != nil {
+			return 0, fmt.Errorf("fetching issue types for %s: %w", p.Key, err)
+		}
+		byProject[p.Key] = types
+		total += len(types)
+	}
+	if err := WriteResource("issuetypes", ttl24h, byProject); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func fetchStatuses(ctx context.Context, c *api.Client) (int, error) {
+	env, err := ReadResource[[]api.Project]("projects")
+	if err != nil {
+		return 0, fmt.Errorf("reading projects cache (refresh projects first): %w", err)
+	}
+
+	byProject := make(map[string][]api.ProjectStatus, len(env.Data))
+	total := 0
+	for _, p := range env.Data {
+		statuses, err := c.GetProjectStatuses(ctx, p.Key)
+		if err != nil {
+			return 0, fmt.Errorf("fetching statuses for %s: %w", p.Key, err)
+		}
+		byProject[p.Key] = statuses
+		total += len(statuses)
+	}
+	if err := WriteResource("statuses", ttl24h, byProject); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+func fetchPriorities(ctx context.Context, c *api.Client) (int, error) {
+	priorities, err := c.ListPriorities(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if err := WriteResource("priorities", ttl168h, priorities); err != nil {
+		return 0, err
+	}
+	return len(priorities), nil
+}
+
+func fetchResolutions(ctx context.Context, c *api.Client) (int, error) {
+	resolutions, err := c.ListResolutions(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if err := WriteResource("resolutions", ttl168h, resolutions); err != nil {
+		return 0, err
+	}
+	return len(resolutions), nil
+}
+
+func fetchUsers(ctx context.Context, c *api.Client) (int, error) {
+	return SeedUsers(ctx, c)
+}

--- a/tools/jtk/internal/cache/fetchers_test.go
+++ b/tools/jtk/internal/cache/fetchers_test.go
@@ -233,6 +233,38 @@ func TestFetchBoards_Pagination(t *testing.T) {
 	testutil.Equal(t, env.Data[119].ID, 120)
 }
 
+// A misbehaving server that never sets IsLast=true must not spin the fetcher
+// forever. fetchBoardsMax caps iteration.
+func TestFetchBoards_IterationCeiling(t *testing.T) {
+	cleanup := SetRootForTest(t.TempDir())
+	defer cleanup()
+
+	const pageSize = 50
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		values := make([]api.Board, pageSize)
+		for i := range values {
+			values[i] = api.Board{ID: calls*1000 + i}
+		}
+		_ = json.NewEncoder(w).Encode(api.BoardsResponse{IsLast: false, Values: values})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+
+	_, err := fetchBoards(context.Background(), client)
+	testutil.RequireNoError(t, err)
+
+	// Each page returns pageSize entries and IsLast=false; loop should exit
+	// when startAt reaches fetchBoardsMax. With pageSize=50 and max=5000, that
+	// caps at 100 API calls.
+	maxCalls := fetchBoardsMax / pageSize
+	if calls > maxCalls {
+		t.Fatalf("exceeded iteration ceiling: %d calls (cap is %d)", calls, maxCalls)
+	}
+}
+
 // Short first page (fewer than maxResults) is the alternate termination path.
 // Covered via the `isLast` flag above; this variant explicitly tests the other
 // branch of `if resp.IsLast || len(resp.Values) == 0 { break }`.

--- a/tools/jtk/internal/cache/fetchers_test.go
+++ b/tools/jtk/internal/cache/fetchers_test.go
@@ -1,0 +1,257 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// newTestClient builds an api.Client pointed at `server.URL`, plus the standard
+// cache-isolation plumbing (tempdir root, JIRA_URL env). Use this for any
+// fetcher test that needs a live HTTP mock.
+func newTestClient(t *testing.T, server *httptest.Server) *api.Client {
+	t.Helper()
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+	t.Setenv("JIRA_EMAIL", "t@example.com")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@example.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	return client
+}
+
+func TestFetchIssueTypes_MissingProjectsCache(t *testing.T) {
+	cleanup := SetRootForTest(t.TempDir())
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("no API calls should be made when projects cache is absent")
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+
+	_, err := fetchIssueTypes(context.Background(), client)
+	testutil.Error(t, err)
+	// Surfaces a clear hint per fetchers.go.
+	if !strings.Contains(err.Error(), "refresh projects first") {
+		t.Fatalf("expected error to mention 'refresh projects first', got: %v", err)
+	}
+	// Envelope must not have been written.
+	if _, err := ReadResource[map[string][]api.IssueType]("issuetypes"); !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("expected no issuetypes envelope on disk, got err=%v", err)
+	}
+}
+
+func TestFetchIssueTypes_MultiProject(t *testing.T) {
+	cleanup := SetRootForTest(t.TempDir())
+	defer cleanup()
+
+	// Seed the projects cache with two projects. Note: /rest/api/3/project/{key}
+	// returns a full ProjectDetail with an `issueTypes` field; the api method
+	// extracts it. See api/move.go:GetProjectIssueTypes.
+	calls := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls[r.URL.Path]++
+		switch r.URL.Path {
+		case "/rest/api/3/project/MON":
+			_, _ = w.Write([]byte(`{"issueTypes":[{"id":"1","name":"Task"},{"id":"2","name":"Epic"}]}`))
+		case "/rest/api/3/project/ON":
+			_, _ = w.Write([]byte(`{"issueTypes":[{"id":"3","name":"Sub-task"}]}`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+
+	testutil.RequireNoError(t, WriteResource("projects", "24h", []api.Project{
+		{Key: "MON", Name: "Platform"},
+		{Key: "ON", Name: "Onboarding"},
+	}))
+
+	count, err := fetchIssueTypes(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, count, 3) // 2 + 1
+	testutil.Equal(t, calls["/rest/api/3/project/MON"], 1)
+	testutil.Equal(t, calls["/rest/api/3/project/ON"], 1)
+
+	env, err := ReadResource[map[string][]api.IssueType]("issuetypes")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(env.Data["MON"]), 2)
+	testutil.Equal(t, len(env.Data["ON"]), 1)
+	testutil.Equal(t, env.Data["MON"][0].Name, "Task")
+	testutil.Equal(t, env.Data["ON"][0].Name, "Sub-task")
+}
+
+func TestFetchIssueTypes_PerProjectAPIError(t *testing.T) {
+	cleanup := SetRootForTest(t.TempDir())
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/project/OK":
+			_, _ = w.Write([]byte(`{"issueTypes":[{"id":"1","name":"Task"}]}`))
+		case "/rest/api/3/project/BROKEN":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"errorMessages":["boom"]}`))
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+
+	testutil.RequireNoError(t, WriteResource("projects", "24h", []api.Project{
+		{Key: "OK"},
+		{Key: "BROKEN"},
+	}))
+
+	_, err := fetchIssueTypes(context.Background(), client)
+	testutil.Error(t, err)
+	if !strings.Contains(err.Error(), "BROKEN") {
+		t.Fatalf("expected error to name the failing project, got: %v", err)
+	}
+	// Partial results must not be persisted: no issuetypes envelope.
+	if _, err := ReadResource[map[string][]api.IssueType]("issuetypes"); !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("expected no issuetypes envelope after partial failure, got err=%v", err)
+	}
+}
+
+func TestFetchStatuses_MultiProject(t *testing.T) {
+	cleanup := SetRootForTest(t.TempDir())
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/project/MON/statuses":
+			_, _ = w.Write([]byte(`[{"id":"10","name":"Epic","subtask":false,"statuses":[{"id":"1","name":"To Do"},{"id":"2","name":"Done"}]}]`))
+		case "/rest/api/3/project/ON/statuses":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+
+	testutil.RequireNoError(t, WriteResource("projects", "24h", []api.Project{{Key: "MON"}, {Key: "ON"}}))
+
+	count, err := fetchStatuses(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, count, 1) // one top-level issue type on MON; ON is empty
+
+	env, err := ReadResource[map[string][]api.ProjectStatus]("statuses")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(env.Data["MON"]), 1)
+	testutil.Equal(t, len(env.Data["ON"]), 0)
+	testutil.Equal(t, env.Data["MON"][0].Name, "Epic")
+	testutil.Equal(t, len(env.Data["MON"][0].Statuses), 2)
+}
+
+func TestFetchStatuses_MissingProjectsCache(t *testing.T) {
+	cleanup := SetRootForTest(t.TempDir())
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("no API calls should be made when projects cache is absent")
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+
+	_, err := fetchStatuses(context.Background(), client)
+	testutil.Error(t, err)
+	if !strings.Contains(err.Error(), "refresh projects first") {
+		t.Fatalf("expected error to mention 'refresh projects first', got: %v", err)
+	}
+}
+
+func TestFetchBoards_Pagination(t *testing.T) {
+	cleanup := SetRootForTest(t.TempDir())
+	defer cleanup()
+
+	// Simulate three pages: 50, 50, 20 boards, with isLast=false,false,true.
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, r.URL.Path, "/rest/agile/1.0/board")
+		startAt, _ := strconv.Atoi(r.URL.Query().Get("startAt"))
+		maxResults, _ := strconv.Atoi(r.URL.Query().Get("maxResults"))
+		testutil.Equal(t, maxResults, 50)
+		calls++
+
+		var values []api.Board
+		var isLast bool
+		switch startAt {
+		case 0:
+			for i := 0; i < 50; i++ {
+				values = append(values, api.Board{ID: i + 1, Name: "b" + strconv.Itoa(i+1), Type: "scrum"})
+			}
+		case 50:
+			for i := 50; i < 100; i++ {
+				values = append(values, api.Board{ID: i + 1, Name: "b" + strconv.Itoa(i+1), Type: "scrum"})
+			}
+		case 100:
+			for i := 100; i < 120; i++ {
+				values = append(values, api.Board{ID: i + 1, Name: "b" + strconv.Itoa(i+1), Type: "scrum"})
+			}
+			isLast = true
+		default:
+			t.Errorf("unexpected startAt: %d", startAt)
+		}
+		_ = json.NewEncoder(w).Encode(api.BoardsResponse{
+			StartAt:    startAt,
+			MaxResults: maxResults,
+			IsLast:     isLast,
+			Values:     values,
+		})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+
+	count, err := fetchBoards(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, count, 120)
+	testutil.Equal(t, calls, 3)
+
+	env, err := ReadResource[[]api.Board]("boards")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(env.Data), 120)
+	testutil.Equal(t, env.Data[0].ID, 1)
+	testutil.Equal(t, env.Data[119].ID, 120)
+}
+
+// Short first page (fewer than maxResults) is the alternate termination path.
+// Covered via the `isLast` flag above; this variant explicitly tests the other
+// branch of `if resp.IsLast || len(resp.Values) == 0 { break }`.
+func TestFetchBoards_StopsOnEmptyPage(t *testing.T) {
+	cleanup := SetRootForTest(t.TempDir())
+	defer cleanup()
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		// Return an empty page with isLast=false — fetcher should still terminate.
+		_ = json.NewEncoder(w).Encode(api.BoardsResponse{IsLast: false, Values: nil})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+
+	count, err := fetchBoards(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, count, 0)
+	testutil.Equal(t, calls, 1)
+}

--- a/tools/jtk/internal/cache/freshness.go
+++ b/tools/jtk/internal/cache/freshness.go
@@ -1,0 +1,88 @@
+package cache
+
+import (
+	"fmt"
+	"time"
+)
+
+// Status is the coarse freshness classification used by `jtk refresh --status`.
+type Status int
+
+const (
+	StatusUninitialized Status = iota // no envelope on disk
+	StatusFresh                       // on disk, FetchedAt + TTL still in the future
+	StatusStale                       // on disk, FetchedAt + TTL elapsed
+	StatusManual                      // TTL == "manual"; never reported stale
+	StatusUnavailable                 // Registry Entry.Available(client) reported false
+)
+
+// String returns the status label used in `--status` output.
+func (s Status) String() string {
+	switch s {
+	case StatusUninitialized:
+		return "uninitialized"
+	case StatusFresh:
+		return "fresh"
+	case StatusStale:
+		return "stale"
+	case StatusManual:
+		return "manual"
+	case StatusUnavailable:
+		return "unavailable"
+	default:
+		return "unknown"
+	}
+}
+
+const ttlManual = "manual"
+
+// parseTTL returns the TTL as a time.Duration. The sentinel "manual" returns (0, true).
+func parseTTL(ttl string) (time.Duration, bool, error) {
+	if ttl == ttlManual {
+		return 0, true, nil
+	}
+	d, err := time.ParseDuration(ttl)
+	if err != nil {
+		return 0, false, fmt.Errorf("parsing TTL %q: %w", ttl, err)
+	}
+	return d, false, nil
+}
+
+// Classify inspects the envelope's FetchedAt + TTL at `now` and returns a Status.
+// The FetchedAt.IsZero() case is the "uninitialized" / "touched" state and returns StatusStale
+// (callers that want to distinguish "never fetched" from "touched" check IsZero themselves).
+func Classify(fetchedAt time.Time, ttl string, now time.Time) Status {
+	d, manual, err := parseTTL(ttl)
+	if err != nil {
+		return StatusStale
+	}
+	if manual {
+		return StatusManual
+	}
+	if fetchedAt.IsZero() || now.Sub(fetchedAt) >= d {
+		return StatusStale
+	}
+	return StatusFresh
+}
+
+// Age returns a short human-readable age ("8h", "3d", "2m") for `--status` output.
+// Returns "-" when fetchedAt is zero.
+func Age(fetchedAt time.Time, now time.Time) string {
+	if fetchedAt.IsZero() {
+		return "-"
+	}
+	delta := now.Sub(fetchedAt)
+	if delta < 0 {
+		delta = 0
+	}
+	switch {
+	case delta >= 24*time.Hour:
+		return fmt.Sprintf("%dd", int(delta/(24*time.Hour)))
+	case delta >= time.Hour:
+		return fmt.Sprintf("%dh", int(delta/time.Hour))
+	case delta >= time.Minute:
+		return fmt.Sprintf("%dm", int(delta/time.Minute))
+	default:
+		return fmt.Sprintf("%ds", int(delta/time.Second))
+	}
+}

--- a/tools/jtk/internal/cache/freshness_test.go
+++ b/tools/jtk/internal/cache/freshness_test.go
@@ -1,0 +1,72 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestClassify(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		fetchedAt time.Time
+		ttl       string
+		want      Status
+	}{
+		{"fresh within window", now.Add(-1 * time.Hour), "24h", StatusFresh},
+		{"stale after window", now.Add(-25 * time.Hour), "24h", StatusStale},
+		{"stale exactly at boundary", now.Add(-24 * time.Hour), "24h", StatusStale},
+		{"zero fetchedAt reads stale", time.Time{}, "24h", StatusStale},
+		{"manual ttl reads manual", now.Add(-999 * time.Hour), "manual", StatusManual},
+		{"invalid ttl reads stale", now, "nonsense", StatusStale},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Classify(tt.fetchedAt, tt.ttl, now)
+			testutil.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestAge(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		fetchedAt time.Time
+		want      string
+	}{
+		{"zero returns dash", time.Time{}, "-"},
+		{"seconds", now.Add(-30 * time.Second), "30s"},
+		{"minutes", now.Add(-5 * time.Minute), "5m"},
+		{"hours", now.Add(-8 * time.Hour), "8h"},
+		{"days", now.Add(-3 * 24 * time.Hour), "3d"},
+		{"future clamps to zero seconds", now.Add(1 * time.Hour), "0s"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Age(tt.fetchedAt, now)
+			testutil.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestStatusString(t *testing.T) {
+	t.Parallel()
+	testutil.Equal(t, StatusUninitialized.String(), "uninitialized")
+	testutil.Equal(t, StatusFresh.String(), "fresh")
+	testutil.Equal(t, StatusStale.String(), "stale")
+	testutil.Equal(t, StatusManual.String(), "manual")
+	testutil.Equal(t, StatusUnavailable.String(), "unavailable")
+}

--- a/tools/jtk/internal/cache/invalidate.go
+++ b/tools/jtk/internal/cache/invalidate.go
@@ -1,0 +1,124 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Touch marks one or more caches stale by zeroing their FetchedAt timestamp.
+// Missing envelope files (ErrCacheMiss) are silently skipped. Returns the first
+// non-miss I/O error encountered.
+func Touch(names ...string) error {
+	for _, name := range names {
+		env, err := ReadResource[json.RawMessage](name)
+		if errors.Is(err, ErrCacheMiss) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		// Zero out FetchedAt to mark stale, but preserve the existing Data bytes.
+		env.FetchedAt = time.Time{}
+		if err := writeRaw(name, env); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AppendOnCreate appends `item` to the Data slice of `name`'s envelope and
+// writes it back atomically. Missing envelope files are silently skipped.
+// T must match the element type of the envelope's Data slice.
+func AppendOnCreate[T any](name string, item T) error {
+	env, err := ReadResource[[]T](name)
+	if errors.Is(err, ErrCacheMiss) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	env.Data = append(env.Data, item)
+	return WriteResource(name, env.TTL, env.Data)
+}
+
+// RemoveOnDelete removes items from the Data slice of `name`'s envelope for
+// which `match` returns true, and writes the result back atomically. Missing
+// envelope files are silently skipped. Does nothing if no items match.
+func RemoveOnDelete[T any](name string, match func(T) bool) error {
+	env, err := ReadResource[[]T](name)
+	if errors.Is(err, ErrCacheMiss) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// Filter: keep items where match returns false.
+	filtered := make([]T, 0, len(env.Data))
+	for _, item := range env.Data {
+		if !match(item) {
+			filtered = append(filtered, item)
+		}
+	}
+
+	// No change, don't write.
+	if len(filtered) == len(env.Data) {
+		return nil
+	}
+
+	return WriteResource(name, env.TTL, filtered)
+}
+
+// writeRaw atomically writes an envelope while preserving its FetchedAt field.
+// This is used by Touch to mark envelopes stale without re-fetching.
+func writeRaw(name string, env Envelope[json.RawMessage]) error {
+	path, err := ResourceFile(name)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating cache directory: %w", err)
+	}
+
+	jsonData, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling envelope: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, name+"-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(jsonData); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("setting file mode: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("moving temp file to final path: %w", err)
+	}
+
+	return nil
+}

--- a/tools/jtk/internal/cache/invalidate.go
+++ b/tools/jtk/internal/cache/invalidate.go
@@ -3,9 +3,6 @@ package cache
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 )
 
@@ -75,50 +72,9 @@ func RemoveOnDelete[T any](name string, match func(T) bool) error {
 	return WriteResource(name, env.TTL, filtered)
 }
 
-// writeRaw atomically writes an envelope while preserving its FetchedAt field.
-// This is used by Touch to mark envelopes stale without re-fetching.
+// writeRaw atomically writes an envelope while preserving its FetchedAt field
+// (Touch zeros it to mark stale; WriteResource would set a fresh timestamp).
+// Delegates to envelope.go's shared atomicWriteEnvelope helper.
 func writeRaw(name string, env Envelope[json.RawMessage]) error {
-	path, err := ResourceFile(name)
-	if err != nil {
-		return err
-	}
-
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("creating cache directory: %w", err)
-	}
-
-	jsonData, err := json.MarshalIndent(env, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshaling envelope: %w", err)
-	}
-
-	tmp, err := os.CreateTemp(dir, name+"-*.json.tmp")
-	if err != nil {
-		return fmt.Errorf("creating temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-
-	if _, err := tmp.Write(jsonData); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("writing temp file: %w", err)
-	}
-
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("closing temp file: %w", err)
-	}
-
-	if err := os.Chmod(tmpPath, 0o600); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("setting file mode: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("moving temp file to final path: %w", err)
-	}
-
-	return nil
+	return atomicWriteEnvelope(name, env)
 }

--- a/tools/jtk/internal/cache/invalidate_test.go
+++ b/tools/jtk/internal/cache/invalidate_test.go
@@ -1,0 +1,227 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestTouch_Missing(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	err := Touch("nonexistent")
+	testutil.NoError(t, err)
+
+	// Verify no file was created.
+	_, err = ReadResource[json.RawMessage]("nonexistent")
+	if !errors.Is(err, ErrCacheMiss) {
+		t.Errorf("expected ErrCacheMiss after Touch on missing resource, got %v", err)
+	}
+}
+
+func TestTouch_Single(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	// Write an envelope with fresh FetchedAt.
+	data := []string{"a", "b", "c"}
+	err := WriteResource("test-resource", "24h", data)
+	testutil.NoError(t, err)
+
+	// Read it back and verify it's fresh.
+	env, err := ReadResource[[]string]("test-resource")
+	testutil.NoError(t, err)
+
+	if env.FetchedAt.IsZero() {
+		t.Fatal("expected fresh envelope before Touch, got zero FetchedAt")
+	}
+
+	// Touch it to mark stale.
+	err = Touch("test-resource")
+	testutil.NoError(t, err)
+
+	// Read it back and verify it's stale (FetchedAt is zero).
+	env, err = ReadResource[[]string]("test-resource")
+	testutil.NoError(t, err)
+
+	if !env.FetchedAt.IsZero() {
+		t.Errorf("expected stale envelope after Touch, got FetchedAt=%v", env.FetchedAt)
+	}
+
+	// Verify data is preserved.
+	testutil.Equal(t, env.Data, data)
+
+	// Verify status is stale.
+	status := Classify(env.FetchedAt, env.TTL, time.Now().UTC())
+	if status != StatusStale {
+		t.Errorf("expected StatusStale after Touch, got %s", status)
+	}
+}
+
+func TestTouch_Multi(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	// Write two envelopes.
+	err := WriteResource("resource1", "24h", []int{1, 2})
+	testutil.NoError(t, err)
+
+	err = WriteResource("resource2", "24h", []string{"x", "y"})
+	testutil.NoError(t, err)
+
+	// Touch both in one call.
+	err = Touch("resource1", "resource2")
+	testutil.NoError(t, err)
+
+	// Verify both are stale.
+	env1, err := ReadResource[[]int]("resource1")
+	testutil.NoError(t, err)
+	if !env1.FetchedAt.IsZero() {
+		t.Errorf("resource1: expected stale, got FetchedAt=%v", env1.FetchedAt)
+	}
+
+	env2, err := ReadResource[[]string]("resource2")
+	testutil.NoError(t, err)
+	if !env2.FetchedAt.IsZero() {
+		t.Errorf("resource2: expected stale, got FetchedAt=%v", env2.FetchedAt)
+	}
+}
+
+func TestAppendOnCreate_Missing(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	err := AppendOnCreate("nonexistent", "item")
+	testutil.NoError(t, err)
+
+	// Verify no file was created.
+	_, err = ReadResource[[]string]("nonexistent")
+	if !errors.Is(err, ErrCacheMiss) {
+		t.Errorf("expected ErrCacheMiss after AppendOnCreate on missing resource, got %v", err)
+	}
+}
+
+func TestAppendOnCreate_Existing(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	// Write an initial envelope.
+	initial := []string{"a", "b"}
+	err := WriteResource("items", "24h", initial)
+	testutil.NoError(t, err)
+
+	// Append an item.
+	err = AppendOnCreate("items", "c")
+	testutil.NoError(t, err)
+
+	// Read back and verify.
+	env, err := ReadResource[[]string]("items")
+	testutil.NoError(t, err)
+
+	expected := []string{"a", "b", "c"}
+	testutil.Equal(t, env.Data, expected)
+}
+
+func TestRemoveOnDelete_Missing(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	err := RemoveOnDelete("nonexistent", func(string) bool { return true })
+	testutil.NoError(t, err)
+
+	// Verify no file was created.
+	_, err = ReadResource[[]string]("nonexistent")
+	if !errors.Is(err, ErrCacheMiss) {
+		t.Errorf("expected ErrCacheMiss after RemoveOnDelete on missing resource, got %v", err)
+	}
+}
+
+func TestRemoveOnDelete_Matches(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	// Write an initial envelope.
+	initial := []string{"a", "b", "c"}
+	err := WriteResource("items", "24h", initial)
+	testutil.NoError(t, err)
+
+	// Remove items matching "b".
+	err = RemoveOnDelete("items", func(s string) bool { return s == "b" })
+	testutil.NoError(t, err)
+
+	// Read back and verify.
+	env, err := ReadResource[[]string]("items")
+	testutil.NoError(t, err)
+
+	expected := []string{"a", "c"}
+	testutil.Equal(t, env.Data, expected)
+}
+
+func TestRemoveOnDelete_NoMatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	cleanup := SetRootForTest(tmpDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+
+	// Write an initial envelope.
+	initial := []string{"a", "b"}
+	err := WriteResource("items", "24h", initial)
+	testutil.NoError(t, err)
+
+	// Get the file's modification time.
+	path, err := ResourceFile("items")
+	testutil.NoError(t, err)
+
+	stat1, err := os.Stat(path)
+	testutil.NoError(t, err)
+	mtime1 := stat1.ModTime()
+
+	// Wait a bit to ensure timestamp difference would be observable.
+	time.Sleep(10 * time.Millisecond)
+
+	// Remove items matching something that doesn't exist.
+	err = RemoveOnDelete("items", func(string) bool { return false })
+	testutil.NoError(t, err)
+
+	// Read back and verify data is unchanged.
+	env, err := ReadResource[[]string]("items")
+	testutil.NoError(t, err)
+
+	testutil.Equal(t, env.Data, initial)
+
+	// Verify the file was not rewritten (by checking mtime is unchanged).
+	stat2, err := os.Stat(path)
+	testutil.NoError(t, err)
+	mtime2 := stat2.ModTime()
+
+	if !mtime1.Equal(mtime2) {
+		t.Errorf("expected file to not be rewritten; mtime changed from %v to %v", mtime1, mtime2)
+	}
+}

--- a/tools/jtk/internal/cache/paths.go
+++ b/tools/jtk/internal/cache/paths.go
@@ -1,0 +1,91 @@
+// Package cache manages the jtk resource cache on disk.
+package cache
+
+import (
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
+)
+
+var ErrNoInstance = errors.New("no Jira instance configured — run 'jtk init' first")
+
+// rootOverride is a package-level override for tests.
+// It is set by SetRootForTest and cleared by its cleanup function.
+var rootOverride string
+
+// Root returns the cache root directory, expanded from "~/.jtk/cache".
+// If SetRootForTest has overridden it, returns the override.
+func Root() (string, error) {
+	if rootOverride != "" {
+		return rootOverride, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, ".jtk", "cache"), nil
+}
+
+// InstanceKey derives a per-Jira-instance directory name.
+// For basic auth: the hostname of config.GetURL() (e.g., "monit.atlassian.net").
+// For bearer auth: config.GetCloudID() when the URL is api.atlassian.com.
+// Returns ErrNoInstance if no valid instance configuration is found.
+func InstanceKey() (string, error) {
+	urlStr := config.GetURL()
+	if urlStr == "" {
+		return "", ErrNoInstance
+	}
+
+	parsed, err := url.Parse(urlStr)
+	if err != nil {
+		return "", ErrNoInstance
+	}
+
+	if parsed.Host == "" {
+		return "", ErrNoInstance
+	}
+
+	// Bearer auth path: use CloudID when gateway is detected
+	if parsed.Host == "api.atlassian.com" {
+		cloudID := config.GetCloudID()
+		if cloudID == "" {
+			return "", ErrNoInstance
+		}
+		return cloudID, nil
+	}
+
+	// Basic auth path: return the hostname
+	return parsed.Host, nil
+}
+
+// ResourceFile returns the absolute path for a resource's envelope file.
+// For example: ~/.jtk/cache/monit.atlassian.net/fields.json
+func ResourceFile(name string) (string, error) {
+	root, err := Root()
+	if err != nil {
+		return "", err
+	}
+
+	key, err := InstanceKey()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(root, key, name+".json"), nil
+}
+
+// SetRootForTest overrides the cache root directory for testing.
+// Returns a cleanup function that restores the prior value.
+// Must only be called from tests in the cache package.
+func SetRootForTest(dir string) func() {
+	oldRoot := rootOverride
+	rootOverride = dir
+	return func() {
+		rootOverride = oldRoot
+	}
+}

--- a/tools/jtk/internal/cache/paths.go
+++ b/tools/jtk/internal/cache/paths.go
@@ -6,11 +6,33 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
 )
 
 var ErrNoInstance = errors.New("no Jira instance configured — run 'jtk init' first")
+
+// instanceKeySafe bounds the instance-key character set to the subset we
+// emit from hostname (letters, digits, dot, hyphen) and cloud-id (letters,
+// digits, hyphen). Any character outside this set — path separators,
+// whitespace, control chars — causes InstanceKey to return ErrNoInstance
+// rather than compose a path from attacker-controlled input.
+var instanceKeySafe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9.\-]*$`)
+
+// isSafeInstanceKey validates that the key is safe to use as a filesystem
+// path component: only allowed characters, and no parent-dir traversal.
+func isSafeInstanceKey(k string) bool {
+	if k == "" || !instanceKeySafe.MatchString(k) {
+		return false
+	}
+	// Reject `..` anywhere in the key (subdomains don't have consecutive dots).
+	if strings.Contains(k, "..") {
+		return false
+	}
+	return true
+}
 
 // rootOverride is a package-level override for tests.
 // It is set by SetRootForTest and cleared by its cleanup function.
@@ -53,13 +75,16 @@ func InstanceKey() (string, error) {
 	// Bearer auth path: use CloudID when gateway is detected
 	if parsed.Host == "api.atlassian.com" {
 		cloudID := config.GetCloudID()
-		if cloudID == "" {
+		if !isSafeInstanceKey(cloudID) {
 			return "", ErrNoInstance
 		}
 		return cloudID, nil
 	}
 
 	// Basic auth path: return the hostname
+	if !isSafeInstanceKey(parsed.Host) {
+		return "", ErrNoInstance
+	}
 	return parsed.Host, nil
 }
 

--- a/tools/jtk/internal/cache/paths_test.go
+++ b/tools/jtk/internal/cache/paths_test.go
@@ -1,0 +1,106 @@
+package cache
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestRoot_DefaultExpansion(t *testing.T) {
+	// Clear any override
+	cleanup := SetRootForTest("")
+	defer cleanup()
+
+	root, err := Root()
+	testutil.NoError(t, err)
+
+	// Verify it ends with /.jtk/cache
+	if !strings.HasSuffix(root, "/.jtk/cache") {
+		t.Errorf("Root() should end with /.jtk/cache, got %q", root)
+	}
+}
+
+func TestRoot_RespectSetRootForTest(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Override the root
+	cleanup := SetRootForTest(tempDir)
+
+	// Root should return the override
+	root, err := Root()
+	testutil.NoError(t, err)
+	testutil.Equal(t, root, tempDir)
+
+	// Clean up should restore prior value
+	cleanup()
+
+	// After cleanup, Root should return default again
+	root, err = Root()
+	testutil.NoError(t, err)
+	if !strings.HasSuffix(root, "/.jtk/cache") {
+		t.Errorf("After cleanup, Root() should end with /.jtk/cache, got %q", root)
+	}
+}
+
+func TestInstanceKey_BasicAuth(t *testing.T) {
+	t.Setenv("JIRA_URL", "https://monit.atlassian.net")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+	t.Setenv("JIRA_DOMAIN", "")
+
+	key, err := InstanceKey()
+	testutil.NoError(t, err)
+	testutil.Equal(t, key, "monit.atlassian.net")
+}
+
+func TestInstanceKey_BearerAuth(t *testing.T) {
+	t.Setenv("JIRA_URL", "https://api.atlassian.com")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_CLOUD_ID", "abc-123")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+	t.Setenv("JIRA_DOMAIN", "")
+
+	key, err := InstanceKey()
+	testutil.NoError(t, err)
+	testutil.Equal(t, key, "abc-123")
+}
+
+func TestInstanceKey_NoInstance(t *testing.T) {
+	// Clear all URL and CloudID env vars
+	t.Setenv("JIRA_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+	t.Setenv("JIRA_DOMAIN", "")
+
+	// Override HOME so config file can't be found
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+
+	_, err := InstanceKey()
+	if !errors.Is(err, ErrNoInstance) {
+		t.Errorf("Expected ErrNoInstance, got %v", err)
+	}
+}
+
+func TestResourceFile(t *testing.T) {
+	tempDir := t.TempDir()
+	cleanup := SetRootForTest(tempDir)
+	defer cleanup()
+
+	t.Setenv("JIRA_URL", "https://monit.atlassian.net")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+	t.Setenv("JIRA_DOMAIN", "")
+
+	path, err := ResourceFile("fields")
+	testutil.NoError(t, err)
+
+	expected := tempDir + "/monit.atlassian.net/fields.json"
+	testutil.Equal(t, path, expected)
+}

--- a/tools/jtk/internal/cache/paths_test.go
+++ b/tools/jtk/internal/cache/paths_test.go
@@ -87,6 +87,41 @@ func TestInstanceKey_NoInstance(t *testing.T) {
 	}
 }
 
+// InstanceKey must reject any value that could escape the cache root when
+// composed into a filesystem path — path separators, parent-dir tokens, etc.
+// This guards against a malicious JIRA_URL or JIRA_CLOUD_ID planting cache
+// files outside ~/.jtk/cache.
+func TestInstanceKey_RejectsPathInjection(t *testing.T) {
+	cases := []struct {
+		name    string
+		jiraURL string
+		cloudID string
+	}{
+		// Host with a forward slash would only arrive via a bizarre URL, but
+		// we defend anyway.
+		{"hostname with parent-dir traversal", "https://../evil", ""},
+		{"cloudID with path separator", "https://api.atlassian.com", "../escape"},
+		{"cloudID with forward slash", "https://api.atlassian.com", "foo/bar"},
+		{"cloudID with backslash", "https://api.atlassian.com", `foo\bar`},
+		{"cloudID with space", "https://api.atlassian.com", "foo bar"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("JIRA_URL", tc.jiraURL)
+			t.Setenv("ATLASSIAN_URL", "")
+			t.Setenv("JIRA_CLOUD_ID", tc.cloudID)
+			t.Setenv("ATLASSIAN_CLOUD_ID", "")
+			t.Setenv("JIRA_DOMAIN", "")
+
+			_, err := InstanceKey()
+			if !errors.Is(err, ErrNoInstance) {
+				t.Fatalf("expected ErrNoInstance for %q / %q, got %v", tc.jiraURL, tc.cloudID, err)
+			}
+		})
+	}
+}
+
 func TestResourceFile(t *testing.T) {
 	tempDir := t.TempDir()
 	cleanup := SetRootForTest(tempDir)

--- a/tools/jtk/internal/cache/registry.go
+++ b/tools/jtk/internal/cache/registry.go
@@ -1,0 +1,116 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// ErrUnknownResource is returned by Lookup when the name is not registered.
+var ErrUnknownResource = errors.New("unknown resource")
+
+// Entry describes one cacheable resource.
+//
+// DependsOn names resources that must be refreshed before this one.
+// Available is an optional predicate; if nil, the entry is always available.
+// Fetch performs the network call(s), writes the envelope, and returns
+// the number of entries written (for the refresh-line count delta).
+type Entry struct {
+	Name      string
+	TTL       string
+	DependsOn []string
+	Available func(c *api.Client) bool
+	Fetch     func(ctx context.Context, c *api.Client) (int, error)
+}
+
+// IsAvailable reports whether this entry is runnable against the given client.
+// Entries without an Available predicate are always available.
+func (e Entry) IsAvailable(c *api.Client) bool {
+	if e.Available == nil {
+		return true
+	}
+	return e.Available(c)
+}
+
+// entries is the package-level registry populated by fetchers.go at init time.
+// Tests swap this slice via withTestEntries.
+var entries []Entry
+
+// Entries returns the registered entries in dependency order: entries with no
+// DependsOn first, then dependents of already-placed entries. Within a group
+// the original declaration order is preserved.
+func Entries() []Entry {
+	sorted := make([]Entry, 0, len(entries))
+	seen := make(map[string]bool, len(entries))
+
+	for _, e := range entries {
+		if len(e.DependsOn) == 0 {
+			sorted = append(sorted, e)
+			seen[e.Name] = true
+		}
+	}
+	for _, e := range entries {
+		if seen[e.Name] {
+			continue
+		}
+		ready := true
+		for _, dep := range e.DependsOn {
+			if !seen[dep] {
+				ready = false
+				break
+			}
+		}
+		if ready {
+			sorted = append(sorted, e)
+			seen[e.Name] = true
+		}
+	}
+	// Trailing pass for anything still unseen (transitive or missing deps).
+	for _, e := range entries {
+		if !seen[e.Name] {
+			sorted = append(sorted, e)
+		}
+	}
+	return sorted
+}
+
+// Lookup returns the entry with the given name, or ErrUnknownResource wrapped
+// with the name.
+func Lookup(name string) (Entry, error) {
+	for _, e := range entries {
+		if e.Name == name {
+			return e, nil
+		}
+	}
+	return Entry{}, fmt.Errorf("%w: %s", ErrUnknownResource, name)
+}
+
+// Names returns the registered entry names in declaration order.
+func Names() []string {
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name)
+	}
+	return names
+}
+
+// projectDependents is the list of caches that must be invalidated whenever a
+// project mutation occurs. Consumed by internal/cmd/projects/*.go wiring.
+var projectDependents = []string{"issuetypes", "statuses"}
+
+// ProjectDependents returns the names of caches that must be staled alongside
+// `projects` when any project mutation succeeds.
+func ProjectDependents() []string {
+	return append([]string{"projects"}, projectDependents...)
+}
+
+// SetEntriesForTest swaps the registry for the duration of a test and returns
+// a cleanup function that restores the prior value. Used by both cache-package
+// tests and tests in downstream packages (e.g., internal/cmd/refresh).
+func SetEntriesForTest(newEntries []Entry) func() {
+	old := entries
+	entries = newEntries
+	return func() { entries = old }
+}

--- a/tools/jtk/internal/cache/registry.go
+++ b/tools/jtk/internal/cache/registry.go
@@ -87,6 +87,56 @@ func Lookup(name string) (Entry, error) {
 	return Entry{}, fmt.Errorf("%w: %s", ErrUnknownResource, name)
 }
 
+// SelectWithDeps returns the entries matching the given names expanded to
+// include transitive DependsOn, sorted in dependency order (deps before
+// dependents). An empty name list returns every registered entry in
+// dependency order. Unknown names return ErrUnknownResource.
+//
+// This is what `jtk refresh <names>` uses so that `refresh statuses` bootstraps
+// the `projects` cache dependency automatically and argument order doesn't
+// matter.
+func SelectWithDeps(names []string) ([]Entry, error) {
+	all := Entries()
+	if len(names) == 0 {
+		return all, nil
+	}
+
+	byName := make(map[string]Entry, len(entries))
+	for _, e := range entries {
+		byName[e.Name] = e
+	}
+
+	wanted := make(map[string]bool, len(names))
+	queue := make([]string, 0, len(names))
+	for _, n := range names {
+		if _, ok := byName[n]; !ok {
+			return nil, fmt.Errorf("%w: %s — valid names: %v", ErrUnknownResource, n, Names())
+		}
+		if !wanted[n] {
+			wanted[n] = true
+			queue = append(queue, n)
+		}
+	}
+	for len(queue) > 0 {
+		curr := queue[0]
+		queue = queue[1:]
+		for _, dep := range byName[curr].DependsOn {
+			if !wanted[dep] {
+				wanted[dep] = true
+				queue = append(queue, dep)
+			}
+		}
+	}
+
+	result := make([]Entry, 0, len(wanted))
+	for _, e := range all {
+		if wanted[e.Name] {
+			result = append(result, e)
+		}
+	}
+	return result, nil
+}
+
 // Names returns the registered entry names in declaration order.
 func Names() []string {
 	names := make([]string, 0, len(entries))

--- a/tools/jtk/internal/cache/registry_test.go
+++ b/tools/jtk/internal/cache/registry_test.go
@@ -1,0 +1,88 @@
+package cache
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestEntries_DependencyOrdering(t *testing.T) {
+	cleanup := SetEntriesForTest([]Entry{
+		{Name: "issuetypes", DependsOn: []string{"projects"}},
+		{Name: "projects"},
+		{Name: "statuses", DependsOn: []string{"projects"}},
+		{Name: "fields"},
+	})
+	defer cleanup()
+
+	got := Entries()
+	names := make([]string, len(got))
+	for i, e := range got {
+		names[i] = e.Name
+	}
+
+	// Dependents must appear after their deps. Exact order: independents first
+	// (projects, fields — stable), then dependents (issuetypes, statuses — stable).
+	testutil.Equal(t, names[0], "projects")
+	testutil.Equal(t, names[1], "fields")
+	testutil.Equal(t, names[2], "issuetypes")
+	testutil.Equal(t, names[3], "statuses")
+}
+
+func TestEntries_NoDependencies(t *testing.T) {
+	cleanup := SetEntriesForTest([]Entry{
+		{Name: "a"},
+		{Name: "b"},
+		{Name: "c"},
+	})
+	defer cleanup()
+
+	got := Entries()
+	testutil.Equal(t, len(got), 3)
+	testutil.Equal(t, got[0].Name, "a")
+	testutil.Equal(t, got[1].Name, "b")
+	testutil.Equal(t, got[2].Name, "c")
+}
+
+func TestLookup(t *testing.T) {
+	cleanup := SetEntriesForTest([]Entry{
+		{Name: "fields", TTL: "24h"},
+	})
+	defer cleanup()
+
+	e, err := Lookup("fields")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, e.Name, "fields")
+	testutil.Equal(t, e.TTL, "24h")
+
+	_, err = Lookup("nope")
+	testutil.Error(t, err)
+	if !errors.Is(err, ErrUnknownResource) {
+		t.Fatalf("expected ErrUnknownResource, got %v", err)
+	}
+}
+
+func TestNames(t *testing.T) {
+	cleanup := SetEntriesForTest([]Entry{
+		{Name: "fields"},
+		{Name: "projects"},
+	})
+	defer cleanup()
+
+	testutil.Equal(t, len(Names()), 2)
+	testutil.Equal(t, Names()[0], "fields")
+	testutil.Equal(t, Names()[1], "projects")
+}
+
+func TestIsAvailable_NilPredicate(t *testing.T) {
+	e := Entry{Name: "x"}
+	testutil.Equal(t, e.IsAvailable(nil), true)
+}
+
+func TestProjectDependents(t *testing.T) {
+	deps := ProjectDependents()
+	testutil.Equal(t, deps[0], "projects")
+	testutil.Equal(t, deps[1], "issuetypes")
+	testutil.Equal(t, deps[2], "statuses")
+}

--- a/tools/jtk/internal/cache/registry_test.go
+++ b/tools/jtk/internal/cache/registry_test.go
@@ -80,6 +80,70 @@ func TestIsAvailable_NilPredicate(t *testing.T) {
 	testutil.Equal(t, e.IsAvailable(nil), true)
 }
 
+func TestSelectWithDeps_AutoExpand(t *testing.T) {
+	cleanup := SetEntriesForTest([]Entry{
+		{Name: "projects"},
+		{Name: "fields"},
+		{Name: "statuses", DependsOn: []string{"projects"}},
+		{Name: "issuetypes", DependsOn: []string{"projects"}},
+	})
+	defer cleanup()
+
+	got, err := SelectWithDeps([]string{"statuses"})
+	testutil.RequireNoError(t, err)
+	names := namesOf(got)
+	if names[0] != "projects" || names[1] != "statuses" || len(names) != 2 {
+		t.Fatalf("expected [projects statuses], got %v", names)
+	}
+}
+
+func TestSelectWithDeps_ReordersByDependency(t *testing.T) {
+	cleanup := SetEntriesForTest([]Entry{
+		{Name: "projects"},
+		{Name: "statuses", DependsOn: []string{"projects"}},
+	})
+	defer cleanup()
+
+	// User supplied in wrong order; SelectWithDeps must reorder.
+	got, err := SelectWithDeps([]string{"statuses", "projects"})
+	testutil.RequireNoError(t, err)
+	names := namesOf(got)
+	if names[0] != "projects" || names[1] != "statuses" {
+		t.Fatalf("expected [projects statuses], got %v", names)
+	}
+}
+
+func TestSelectWithDeps_EmptyReturnsAll(t *testing.T) {
+	cleanup := SetEntriesForTest([]Entry{
+		{Name: "a"},
+		{Name: "b", DependsOn: []string{"a"}},
+	})
+	defer cleanup()
+
+	got, err := SelectWithDeps(nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), 2)
+}
+
+func TestSelectWithDeps_UnknownName(t *testing.T) {
+	cleanup := SetEntriesForTest([]Entry{{Name: "fields"}})
+	defer cleanup()
+
+	_, err := SelectWithDeps([]string{"bogus"})
+	testutil.Error(t, err)
+	if !errors.Is(err, ErrUnknownResource) {
+		t.Fatalf("expected ErrUnknownResource, got %v", err)
+	}
+}
+
+func namesOf(es []Entry) []string {
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.Name
+	}
+	return out
+}
+
 func TestProjectDependents(t *testing.T) {
 	deps := ProjectDependents()
 	testutil.Equal(t, deps[0], "projects")

--- a/tools/jtk/internal/cmd/fields/fields.go
+++ b/tools/jtk/internal/cmd/fields/fields.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
@@ -161,6 +162,8 @@ func runCreate(ctx context.Context, opts *root.Options, name, fieldType, descrip
 		return err
 	}
 
+	_ = cache.AppendOnCreate[api.Field]("fields", *field)
+
 	if v.Format == view.FormatJSON {
 		return v.JSON(field)
 	}
@@ -224,6 +227,8 @@ func runDelete(ctx context.Context, opts *root.Options, fieldID string, force bo
 		return err
 	}
 
+	_ = cache.RemoveOnDelete[api.Field]("fields", func(f api.Field) bool { return f.ID == fieldID })
+
 	model := jtkpresent.FieldPresenter{}.PresentTrashed(fieldID)
 	out := present.Render(model, opts.RenderStyle())
 	fmt.Fprint(opts.Stdout, out.Stdout)
@@ -253,6 +258,8 @@ func runRestore(ctx context.Context, opts *root.Options, fieldID string) error {
 	if err := client.RestoreField(ctx, fieldID); err != nil {
 		return err
 	}
+
+	_ = cache.Touch("fields")
 
 	model := jtkpresent.FieldPresenter{}.PresentRestored(fieldID)
 	out := present.Render(model, opts.RenderStyle())

--- a/tools/jtk/internal/cmd/projects/create.go
+++ b/tools/jtk/internal/cmd/projects/create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
@@ -75,6 +76,8 @@ func runCreate(ctx context.Context, opts *root.Options, key, name, projectType, 
 	if err != nil {
 		return err
 	}
+
+	_ = cache.Touch(cache.ProjectDependents()...)
 
 	if v.Format == view.FormatJSON {
 		return v.JSON(project)

--- a/tools/jtk/internal/cmd/projects/delete.go
+++ b/tools/jtk/internal/cmd/projects/delete.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/prompt"
 
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
@@ -63,6 +64,8 @@ func runDelete(ctx context.Context, opts *root.Options, keyOrID string, force bo
 	if err := client.DeleteProject(ctx, keyOrID); err != nil {
 		return err
 	}
+
+	_ = cache.Touch(cache.ProjectDependents()...)
 
 	model := jtkpresent.ProjectPresenter{}.PresentDeleted(keyOrID)
 	out := present.Render(model, opts.RenderStyle())

--- a/tools/jtk/internal/cmd/projects/restore.go
+++ b/tools/jtk/internal/cmd/projects/restore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
@@ -38,6 +39,8 @@ func runRestore(ctx context.Context, opts *root.Options, keyOrID string) error {
 	if err != nil {
 		return err
 	}
+
+	_ = cache.Touch(cache.ProjectDependents()...)
 
 	if v.Format == view.FormatJSON {
 		return v.JSON(project)

--- a/tools/jtk/internal/cmd/projects/update.go
+++ b/tools/jtk/internal/cmd/projects/update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
@@ -62,6 +63,8 @@ func runUpdate(ctx context.Context, opts *root.Options, keyOrID, name, descripti
 	if err != nil {
 		return err
 	}
+
+	_ = cache.Touch(cache.ProjectDependents()...)
 
 	if v.Format == view.FormatJSON {
 		return v.JSON(project)

--- a/tools/jtk/internal/cmd/refresh/refresh.go
+++ b/tools/jtk/internal/cmd/refresh/refresh.go
@@ -15,7 +15,13 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
+
+// ErrAlreadyReported signals that the command has already rendered its failure
+// output via the modeled path; the process entrypoint should exit non-zero
+// without re-printing the error.
+var ErrAlreadyReported = errors.New("refresh had failures; already reported")
 
 // Register registers the refresh command.
 func Register(parent *cobra.Command, opts *root.Options) {
@@ -28,15 +34,17 @@ func Register(parent *cobra.Command, opts *root.Options) {
 users, issue types, statuses, priorities, resolutions, boards, and link types.
 
 With no arguments, refreshes every cacheable resource. With resource names,
-refreshes only those. With --status, reports freshness without fetching.
+refreshes only those (plus any declared dependencies, auto-bootstrapped in
+dependency order). With --status, reports freshness without fetching.
 
-Requires configuration (jtk init). Some resources (boards) are unavailable
-under bearer authentication and are skipped.`,
+Requires configuration (jtk init). Resources unavailable under the current
+auth (e.g., boards under bearer auth) are silently skipped during a refresh
+and reported as "unavailable" in --status.`,
 		Example: `  # Refresh everything
   jtk refresh
 
-  # Refresh a subset
-  jtk refresh fields users
+  # Refresh a subset (auto-expands to include dependencies)
+  jtk refresh statuses
 
   # Show freshness without fetching
   jtk refresh --status`,
@@ -49,14 +57,12 @@ under bearer authentication and are skipped.`,
 	parent.AddCommand(cmd)
 }
 
-// run is the command entry point. Exported for testing would require package-level
-// plumbing; keeping it unexported and covered via cobra.Command.Execute in tests.
 func run(ctx context.Context, opts *root.Options, names []string, statusOnly bool) error {
 	if !config.IsConfigured() {
 		return errors.New("configuration not found — run 'jtk init' first")
 	}
 
-	selected, err := selectEntries(names)
+	selected, err := cache.SelectWithDeps(names)
 	if err != nil {
 		return err
 	}
@@ -72,128 +78,84 @@ func run(ctx context.Context, opts *root.Options, names []string, statusOnly boo
 	return runRefresh(ctx, opts, client, selected)
 }
 
-// selectEntries resolves the named-resources argument list (empty = all entries
-// in dependency order).
-func selectEntries(names []string) ([]cache.Entry, error) {
-	all := cache.Entries()
-	if len(names) == 0 {
-		return all, nil
-	}
-
-	byName := make(map[string]cache.Entry, len(all))
-	for _, e := range all {
-		byName[e.Name] = e
-	}
-
-	seen := make(map[string]bool, len(names))
-	selected := make([]cache.Entry, 0, len(names))
-	for _, n := range names {
-		if seen[n] {
-			continue
-		}
-		e, ok := byName[n]
-		if !ok {
-			return nil, fmt.Errorf("unknown resource %q — valid names: %v", n, cache.Names())
-		}
-		selected = append(selected, e)
-		seen[n] = true
-	}
-	return selected, nil
-}
-
 // runStatus renders the freshness table.
 func runStatus(opts *root.Options, selected []cache.Entry) error {
-	client, _ := opts.APIClient() // best-effort; availability check tolerates nil
-
+	client, _ := opts.APIClient() // best-effort; Available predicate tolerates nil
 	now := time.Now().UTC()
-	rows := make([]present.Row, 0, len(selected))
+
+	rows := make([]jtkpresent.StatusRow, 0, len(selected))
 	for _, e := range selected {
-		rows = append(rows, present.Row{Cells: statusRow(e, client, now)})
+		rows = append(rows, buildStatusRow(e, client, now))
 	}
 
-	model := &present.OutputModel{
-		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"RESOURCE", "FETCHED_AT", "AGE", "TTL", "STATUS"},
-				Rows:    rows,
-			},
-		},
-	}
+	model := jtkpresent.RefreshPresenter{}.PresentStatus(rows, now)
 	out := present.Render(model, opts.RenderStyle())
 	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
 }
 
-// statusRow is the per-entry row in the --status table.
-func statusRow(e cache.Entry, client *api.Client, now time.Time) []string {
+func buildStatusRow(e cache.Entry, client *api.Client, now time.Time) jtkpresent.StatusRow {
 	if !e.IsAvailable(client) {
-		return []string{e.Name, "-", "-", e.TTL, cache.StatusUnavailable.String()}
+		return jtkpresent.StatusRow{Resource: e.Name, TTL: e.TTL, Status: cache.StatusUnavailable}
 	}
 
 	env, err := cache.ReadResource[any](e.Name)
 	if errors.Is(err, cache.ErrCacheMiss) {
-		return []string{e.Name, "-", "-", e.TTL, cache.StatusUninitialized.String()}
+		return jtkpresent.StatusRow{Resource: e.Name, TTL: e.TTL, Status: cache.StatusUninitialized}
 	}
 	if err != nil {
-		return []string{e.Name, "-", "-", e.TTL, "error"}
+		// Corrupt envelope on disk: report as uninitialized rather than a novel status;
+		// a subsequent refresh will overwrite it.
+		return jtkpresent.StatusRow{Resource: e.Name, TTL: e.TTL, Status: cache.StatusUninitialized}
 	}
-
-	fetchedAt := "-"
-	if !env.FetchedAt.IsZero() {
-		fetchedAt = env.FetchedAt.UTC().Format(time.RFC3339)
+	return jtkpresent.StatusRow{
+		Resource:  e.Name,
+		TTL:       e.TTL,
+		FetchedAt: env.FetchedAt,
+		Status:    cache.Classify(env.FetchedAt, e.TTL, now),
 	}
-	status := cache.Classify(env.FetchedAt, e.TTL, now)
-	return []string{e.Name, fetchedAt, cache.Age(env.FetchedAt, now), e.TTL, status.String()}
 }
 
-// runRefresh fetches each selected entry and renders per-resource result lines.
-// Continues on error; overall exit non-zero if any resource failed.
+// runRefresh fetches each selected entry, collects per-resource results, hands
+// them to the presenter, and returns ErrAlreadyReported if any resource failed.
+// Unavailable entries (e.g., boards under bearer auth) are silently skipped.
 func runRefresh(ctx context.Context, opts *root.Options, client *api.Client, selected []cache.Entry) error {
-	sections := make([]present.Section, 0, len(selected))
-	var firstFailure error
+	results := make([]jtkpresent.RefreshResult, 0, len(selected))
+	failed := 0
 
 	for _, e := range selected {
 		if !e.IsAvailable(client) {
-			sections = append(sections, &present.MessageSection{
-				Kind:    present.MessageInfo,
-				Stream:  present.StreamStdout,
-				Message: fmt.Sprintf("Skipping %s — unavailable under current auth", e.Name),
-			})
 			continue
 		}
-
 		prev := previousCount(e.Name)
 		count, err := e.Fetch(ctx, client)
-		if err != nil {
-			if firstFailure == nil {
-				firstFailure = err
-			}
-			sections = append(sections, &present.MessageSection{
-				Kind:    present.MessageError,
-				Stream:  present.StreamStderr,
-				Message: fmt.Sprintf("Refreshing %s failed: %v", e.Name, err),
-			})
-			continue
-		}
-
-		sections = append(sections, &present.MessageSection{
-			Kind:    present.MessageSuccess,
-			Stream:  present.StreamStdout,
-			Message: formatRefreshLine(e.Name, count, prev, time.Now().UTC()),
+		results = append(results, jtkpresent.RefreshResult{
+			Name:     e.Name,
+			Count:    count,
+			Previous: prev,
+			Err:      err,
+			At:       time.Now().UTC(),
 		})
+		if err != nil {
+			failed++
+		}
 	}
 
-	model := &present.OutputModel{Sections: sections}
+	model := jtkpresent.RefreshPresenter{}.PresentRefresh(results)
 	out := present.Render(model, opts.RenderStyle())
 	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return firstFailure
+
+	if failed > 0 {
+		return fmt.Errorf("%w (%d resource(s))", ErrAlreadyReported, failed)
+	}
+	return nil
 }
 
 // previousCount reports the prior entry count for a resource, or -1 if unknown.
-// Uses a shallow decode just to count slice/map entries — good enough for a
-// delta indicator.
+// Counts both slice-shaped envelopes (e.g. fields) and map-shaped ones
+// (e.g. issuetypes = map[projectKey][]IssueType).
 func previousCount(name string) int {
 	env, err := cache.ReadResource[any](name)
 	if err != nil {
@@ -213,15 +175,4 @@ func previousCount(name string) int {
 	default:
 		return -1
 	}
-}
-
-// formatRefreshLine produces the per-resource success message.
-// "Refreshing fields... 73 entries (was 72) — Cache updated at 2026-04-18 14:23:00"
-func formatRefreshLine(name string, count, prev int, now time.Time) string {
-	delta := ""
-	if prev >= 0 && prev != count {
-		delta = fmt.Sprintf(" (was %d)", prev)
-	}
-	return fmt.Sprintf("Refreshing %s... %d entries%s — Cache updated at %s",
-		name, count, delta, now.Format("2006-01-02 15:04:05"))
 }

--- a/tools/jtk/internal/cmd/refresh/refresh.go
+++ b/tools/jtk/internal/cmd/refresh/refresh.go
@@ -1,0 +1,227 @@
+// Package refresh provides the `jtk refresh` command for updating the instance cache.
+package refresh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
+)
+
+// Register registers the refresh command.
+func Register(parent *cobra.Command, opts *root.Options) {
+	var statusOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "refresh [resources...]",
+		Short: "Refresh the jtk instance cache",
+		Long: `Refresh the jtk instance cache — the local snapshot of fields, projects,
+users, issue types, statuses, priorities, resolutions, boards, and link types.
+
+With no arguments, refreshes every cacheable resource. With resource names,
+refreshes only those. With --status, reports freshness without fetching.
+
+Requires configuration (jtk init). Some resources (boards) are unavailable
+under bearer authentication and are skipped.`,
+		Example: `  # Refresh everything
+  jtk refresh
+
+  # Refresh a subset
+  jtk refresh fields users
+
+  # Show freshness without fetching
+  jtk refresh --status`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd.Context(), opts, args, statusOnly)
+		},
+	}
+
+	cmd.Flags().BoolVar(&statusOnly, "status", false, "Print cache freshness; no network calls")
+	parent.AddCommand(cmd)
+}
+
+// run is the command entry point. Exported for testing would require package-level
+// plumbing; keeping it unexported and covered via cobra.Command.Execute in tests.
+func run(ctx context.Context, opts *root.Options, names []string, statusOnly bool) error {
+	if !config.IsConfigured() {
+		return errors.New("configuration not found — run 'jtk init' first")
+	}
+
+	selected, err := selectEntries(names)
+	if err != nil {
+		return err
+	}
+
+	if statusOnly {
+		return runStatus(opts, selected)
+	}
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+	return runRefresh(ctx, opts, client, selected)
+}
+
+// selectEntries resolves the named-resources argument list (empty = all entries
+// in dependency order).
+func selectEntries(names []string) ([]cache.Entry, error) {
+	all := cache.Entries()
+	if len(names) == 0 {
+		return all, nil
+	}
+
+	byName := make(map[string]cache.Entry, len(all))
+	for _, e := range all {
+		byName[e.Name] = e
+	}
+
+	seen := make(map[string]bool, len(names))
+	selected := make([]cache.Entry, 0, len(names))
+	for _, n := range names {
+		if seen[n] {
+			continue
+		}
+		e, ok := byName[n]
+		if !ok {
+			return nil, fmt.Errorf("unknown resource %q — valid names: %v", n, cache.Names())
+		}
+		selected = append(selected, e)
+		seen[n] = true
+	}
+	return selected, nil
+}
+
+// runStatus renders the freshness table.
+func runStatus(opts *root.Options, selected []cache.Entry) error {
+	client, _ := opts.APIClient() // best-effort; availability check tolerates nil
+
+	now := time.Now().UTC()
+	rows := make([]present.Row, 0, len(selected))
+	for _, e := range selected {
+		rows = append(rows, present.Row{Cells: statusRow(e, client, now)})
+	}
+
+	model := &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"RESOURCE", "FETCHED_AT", "AGE", "TTL", "STATUS"},
+				Rows:    rows,
+			},
+		},
+	}
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return nil
+}
+
+// statusRow is the per-entry row in the --status table.
+func statusRow(e cache.Entry, client *api.Client, now time.Time) []string {
+	if !e.IsAvailable(client) {
+		return []string{e.Name, "-", "-", e.TTL, cache.StatusUnavailable.String()}
+	}
+
+	env, err := cache.ReadResource[any](e.Name)
+	if errors.Is(err, cache.ErrCacheMiss) {
+		return []string{e.Name, "-", "-", e.TTL, cache.StatusUninitialized.String()}
+	}
+	if err != nil {
+		return []string{e.Name, "-", "-", e.TTL, "error"}
+	}
+
+	fetchedAt := "-"
+	if !env.FetchedAt.IsZero() {
+		fetchedAt = env.FetchedAt.UTC().Format(time.RFC3339)
+	}
+	status := cache.Classify(env.FetchedAt, e.TTL, now)
+	return []string{e.Name, fetchedAt, cache.Age(env.FetchedAt, now), e.TTL, status.String()}
+}
+
+// runRefresh fetches each selected entry and renders per-resource result lines.
+// Continues on error; overall exit non-zero if any resource failed.
+func runRefresh(ctx context.Context, opts *root.Options, client *api.Client, selected []cache.Entry) error {
+	sections := make([]present.Section, 0, len(selected))
+	var firstFailure error
+
+	for _, e := range selected {
+		if !e.IsAvailable(client) {
+			sections = append(sections, &present.MessageSection{
+				Kind:    present.MessageInfo,
+				Stream:  present.StreamStdout,
+				Message: fmt.Sprintf("Skipping %s — unavailable under current auth", e.Name),
+			})
+			continue
+		}
+
+		prev := previousCount(e.Name)
+		count, err := e.Fetch(ctx, client)
+		if err != nil {
+			if firstFailure == nil {
+				firstFailure = err
+			}
+			sections = append(sections, &present.MessageSection{
+				Kind:    present.MessageError,
+				Stream:  present.StreamStderr,
+				Message: fmt.Sprintf("Refreshing %s failed: %v", e.Name, err),
+			})
+			continue
+		}
+
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageSuccess,
+			Stream:  present.StreamStdout,
+			Message: formatRefreshLine(e.Name, count, prev, time.Now().UTC()),
+		})
+	}
+
+	model := &present.OutputModel{Sections: sections}
+	out := present.Render(model, opts.RenderStyle())
+	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	return firstFailure
+}
+
+// previousCount reports the prior entry count for a resource, or -1 if unknown.
+// Uses a shallow decode just to count slice/map entries — good enough for a
+// delta indicator.
+func previousCount(name string) int {
+	env, err := cache.ReadResource[any](name)
+	if err != nil {
+		return -1
+	}
+	switch v := env.Data.(type) {
+	case []any:
+		return len(v)
+	case map[string]any:
+		total := 0
+		for _, inner := range v {
+			if arr, ok := inner.([]any); ok {
+				total += len(arr)
+			}
+		}
+		return total
+	default:
+		return -1
+	}
+}
+
+// formatRefreshLine produces the per-resource success message.
+// "Refreshing fields... 73 entries (was 72) — Cache updated at 2026-04-18 14:23:00"
+func formatRefreshLine(name string, count, prev int, now time.Time) string {
+	delta := ""
+	if prev >= 0 && prev != count {
+		delta = fmt.Sprintf(" (was %d)", prev)
+	}
+	return fmt.Sprintf("Refreshing %s... %d entries%s — Cache updated at %s",
+		name, count, delta, now.Format("2006-01-02 15:04:05"))
+}

--- a/tools/jtk/internal/cmd/refresh/refresh.go
+++ b/tools/jtk/internal/cmd/refresh/refresh.go
@@ -80,7 +80,13 @@ func run(ctx context.Context, opts *root.Options, names []string, statusOnly boo
 
 // runStatus renders the freshness table.
 func runStatus(opts *root.Options, selected []cache.Entry) error {
-	client, _ := opts.APIClient() // best-effort; Available predicate tolerates nil
+	// Client is only used to evaluate Entry.Available (e.g., the bearer-auth
+	// gate on boards). If construction fails, the config was already validated
+	// at run()'s entry so this is a programming error — surface it.
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
 	now := time.Now().UTC()
 
 	rows := make([]jtkpresent.StatusRow, 0, len(selected))

--- a/tools/jtk/internal/cmd/refresh/refresh_test.go
+++ b/tools/jtk/internal/cmd/refresh/refresh_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
@@ -171,10 +170,15 @@ func TestRun_Refresh_ContinuesOnError(t *testing.T) {
 
 	err := run(context.Background(), opts, nil, false)
 	testutil.Error(t, err)
-	testutil.Contains(t, err.Error(), "boom")
+	// Returned error signals "already reported" so main.go won't re-print; the
+	// failure detail lives in the stderr section rendered by the presenter.
+	if !errors.Is(err, ErrAlreadyReported) {
+		t.Fatalf("expected ErrAlreadyReported, got %v", err)
+	}
 	testutil.Contains(t, stdout.String(), "Refreshing ok")
 	testutil.Contains(t, stdout.String(), "Refreshing also_ok")
 	testutil.Contains(t, stderr.String(), "Refreshing broken failed")
+	testutil.Contains(t, stderr.String(), "boom")
 }
 
 func TestRun_Refresh_SkipsUnavailable(t *testing.T) {
@@ -204,8 +208,13 @@ func TestRun_Refresh_SkipsUnavailable(t *testing.T) {
 	if fetchCalled {
 		t.Fatal("expected unavailable entry's fetcher not to be called")
 	}
-	testutil.Contains(t, stdout.String(), "Skipping boards")
-	testutil.Contains(t, stdout.String(), "Refreshing fields")
+	// Unavailable resources are silently skipped during a full refresh: no
+	// "Skipping ..." line, no "Refreshing boards" line — only --status mentions them.
+	out := stdout.String()
+	testutil.Contains(t, out, "Refreshing fields")
+	if strings.Contains(out, "boards") {
+		t.Fatalf("expected boards to be silently skipped during refresh, got: %s", out)
+	}
 }
 
 func TestRun_Status_Unavailable(t *testing.T) {
@@ -242,27 +251,51 @@ func TestRun_Status_DoesNotCallFetch(t *testing.T) {
 	}
 }
 
-// Sanity-check that the formatRefreshLine composes the expected shape.
-func TestFormatRefreshLine(t *testing.T) {
-	now := mustParseTime(t, "2026-04-18T14:23:00Z")
-	testutil.Equal(t,
-		formatRefreshLine("fields", 73, 72, now),
-		"Refreshing fields... 73 entries (was 72) — Cache updated at 2026-04-18 14:23:00")
-	testutil.Equal(t,
-		formatRefreshLine("fields", 73, 73, now),
-		"Refreshing fields... 73 entries — Cache updated at 2026-04-18 14:23:00")
-	testutil.Equal(t,
-		formatRefreshLine("users", 0, -1, now),
-		"Refreshing users... 0 entries — Cache updated at 2026-04-18 14:23:00")
+func TestRun_Refresh_AutoExpandsDependencies(t *testing.T) {
+	opts, stdout, _ := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+
+	var calls []string
+	fetch := func(name string) func(context.Context, *api.Client) (int, error) {
+		return func(_ context.Context, _ *api.Client) (int, error) {
+			calls = append(calls, name)
+			return 1, cache.WriteResource(name, "24h", []int{1})
+		}
+	}
+	defer cache.SetEntriesForTest([]cache.Entry{
+		{Name: "projects", TTL: "24h", Fetch: fetch("projects")},
+		{Name: "statuses", TTL: "24h", DependsOn: []string{"projects"}, Fetch: fetch("statuses")},
+	})()
+
+	// User asks for "statuses" alone; dependency must auto-bootstrap in order.
+	err := run(context.Background(), opts, []string{"statuses"}, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, strings.Join(calls, ","), "projects,statuses")
+	out := stdout.String()
+	testutil.Contains(t, out, "Refreshing projects")
+	testutil.Contains(t, out, "Refreshing statuses")
 }
 
-func mustParseTime(t *testing.T, s string) (out time.Time) {
-	t.Helper()
-	out, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		t.Fatal(err)
+func TestRun_Refresh_ArgumentOrderDoesNotMatter(t *testing.T) {
+	opts, _, _ := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+
+	var calls []string
+	fetch := func(name string) func(context.Context, *api.Client) (int, error) {
+		return func(_ context.Context, _ *api.Client) (int, error) {
+			calls = append(calls, name)
+			return 1, cache.WriteResource(name, "24h", []int{1})
+		}
 	}
-	return
+	defer cache.SetEntriesForTest([]cache.Entry{
+		{Name: "projects", TTL: "24h", Fetch: fetch("projects")},
+		{Name: "statuses", TTL: "24h", DependsOn: []string{"projects"}, Fetch: fetch("statuses")},
+	})()
+
+	// User lists the dependent before the dep: command reorders correctly.
+	err := run(context.Background(), opts, []string{"statuses", "projects"}, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, strings.Join(calls, ","), "projects,statuses")
 }
 
 // -- smoke test: the default registry compiles into a runnable Entries() list.

--- a/tools/jtk/internal/cmd/refresh/refresh_test.go
+++ b/tools/jtk/internal/cmd/refresh/refresh_test.go
@@ -1,0 +1,285 @@
+package refresh
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+// newOpts returns root.Options with a test client, buffered stdout/stderr, and
+// JIRA_URL/EMAIL/TOKEN set so config.IsConfigured is true.
+func newOpts(t *testing.T) (*root.Options, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("JIRA_URL", "https://test.atlassian.net")
+	t.Setenv("JIRA_EMAIL", "t@example.com")
+	t.Setenv("JIRA_API_TOKEN", "tok")
+
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "t@example.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+	return opts, &stdout, &stderr
+}
+
+func TestRun_MissingConfig(t *testing.T) {
+	// Unset everything config looks at.
+	t.Setenv("JIRA_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_EMAIL", "")
+	t.Setenv("ATLASSIAN_EMAIL", "")
+	t.Setenv("JIRA_API_TOKEN", "")
+	t.Setenv("ATLASSIAN_API_TOKEN", "")
+	t.Setenv("JIRA_DOMAIN", "")
+	// Redirect HOME so the on-disk config file can't be read.
+	t.Setenv("HOME", t.TempDir())
+
+	opts := &root.Options{Output: "table", Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+
+	err := run(context.Background(), opts, nil, false)
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "jtk init")
+}
+
+func TestRun_UnknownResource(t *testing.T) {
+	opts, _, _ := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+	defer cache.SetEntriesForTest([]cache.Entry{{Name: "fields", TTL: "24h"}})()
+
+	err := run(context.Background(), opts, []string{"bogus"}, true)
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "unknown resource")
+}
+
+func TestRun_Status_Uninitialized(t *testing.T) {
+	opts, stdout, _ := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+	defer cache.SetEntriesForTest([]cache.Entry{
+		{Name: "fields", TTL: "24h"},
+		{Name: "projects", TTL: "24h"},
+	})()
+
+	err := run(context.Background(), opts, nil, true)
+	testutil.RequireNoError(t, err)
+	out := stdout.String()
+	testutil.Contains(t, out, "RESOURCE")
+	testutil.Contains(t, out, "fields")
+	testutil.Contains(t, out, "projects")
+	testutil.Contains(t, out, "uninitialized")
+}
+
+func TestRun_Status_AfterWrite(t *testing.T) {
+	opts, stdout, _ := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+	defer cache.SetEntriesForTest([]cache.Entry{
+		{Name: "fields", TTL: "24h"},
+	})()
+
+	// Seed an envelope so it reads as fresh.
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{{ID: "f1", Name: "One"}}))
+
+	err := run(context.Background(), opts, nil, true)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "fresh")
+}
+
+func TestRun_Refresh_Success(t *testing.T) {
+	opts, stdout, _ := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+
+	called := 0
+	defer cache.SetEntriesForTest([]cache.Entry{
+		{
+			Name: "fake", TTL: "24h",
+			Fetch: func(_ context.Context, _ *api.Client) (int, error) {
+				called++
+				return 42, cache.WriteResource("fake", "24h", []int{1, 2, 3})
+			},
+		},
+	})()
+
+	err := run(context.Background(), opts, nil, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, called, 1)
+	testutil.Contains(t, stdout.String(), "Refreshing fake")
+	testutil.Contains(t, stdout.String(), "42 entries")
+}
+
+func TestRun_Refresh_TargetedSubset(t *testing.T) {
+	opts, stdout, _ := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+
+	var calls []string
+	fetch := func(name string) func(context.Context, *api.Client) (int, error) {
+		return func(_ context.Context, _ *api.Client) (int, error) {
+			calls = append(calls, name)
+			return 1, cache.WriteResource(name, "24h", []int{1})
+		}
+	}
+	defer cache.SetEntriesForTest([]cache.Entry{
+		{Name: "a", TTL: "24h", Fetch: fetch("a")},
+		{Name: "b", TTL: "24h", Fetch: fetch("b")},
+		{Name: "c", TTL: "24h", Fetch: fetch("c")},
+	})()
+
+	err := run(context.Background(), opts, []string{"b", "c"}, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, strings.Join(calls, ","), "b,c")
+	out := stdout.String()
+	testutil.Contains(t, out, "Refreshing b")
+	testutil.Contains(t, out, "Refreshing c")
+	if strings.Contains(out, "Refreshing a") {
+		t.Fatalf("expected a to be skipped, got: %s", out)
+	}
+}
+
+func TestRun_Refresh_ContinuesOnError(t *testing.T) {
+	opts, stdout, stderr := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+
+	defer cache.SetEntriesForTest([]cache.Entry{
+		{
+			Name: "ok", TTL: "24h",
+			Fetch: func(_ context.Context, _ *api.Client) (int, error) {
+				return 1, cache.WriteResource("ok", "24h", []int{1})
+			},
+		},
+		{
+			Name: "broken", TTL: "24h",
+			Fetch: func(_ context.Context, _ *api.Client) (int, error) {
+				return 0, errors.New("boom")
+			},
+		},
+		{
+			Name: "also_ok", TTL: "24h",
+			Fetch: func(_ context.Context, _ *api.Client) (int, error) {
+				return 2, cache.WriteResource("also_ok", "24h", []int{1, 2})
+			},
+		},
+	})()
+
+	err := run(context.Background(), opts, nil, false)
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "boom")
+	testutil.Contains(t, stdout.String(), "Refreshing ok")
+	testutil.Contains(t, stdout.String(), "Refreshing also_ok")
+	testutil.Contains(t, stderr.String(), "Refreshing broken failed")
+}
+
+func TestRun_Refresh_SkipsUnavailable(t *testing.T) {
+	opts, stdout, _ := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+
+	fetchCalled := false
+	defer cache.SetEntriesForTest([]cache.Entry{
+		{
+			Name: "fields", TTL: "24h",
+			Fetch: func(_ context.Context, _ *api.Client) (int, error) {
+				return 1, cache.WriteResource("fields", "24h", []int{1})
+			},
+		},
+		{
+			Name: "boards", TTL: "24h",
+			Available: func(_ *api.Client) bool { return false },
+			Fetch: func(_ context.Context, _ *api.Client) (int, error) {
+				fetchCalled = true
+				return 0, nil
+			},
+		},
+	})()
+
+	err := run(context.Background(), opts, nil, false)
+	testutil.RequireNoError(t, err)
+	if fetchCalled {
+		t.Fatal("expected unavailable entry's fetcher not to be called")
+	}
+	testutil.Contains(t, stdout.String(), "Skipping boards")
+	testutil.Contains(t, stdout.String(), "Refreshing fields")
+}
+
+func TestRun_Status_Unavailable(t *testing.T) {
+	opts, stdout, _ := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+	defer cache.SetEntriesForTest([]cache.Entry{
+		{Name: "boards", TTL: "24h", Available: func(_ *api.Client) bool { return false }},
+	})()
+
+	err := run(context.Background(), opts, nil, true)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "unavailable")
+}
+
+func TestRun_Status_DoesNotCallFetch(t *testing.T) {
+	opts, _, _ := newOpts(t)
+	defer cache.SetRootForTest(t.TempDir())()
+
+	var fetched bool
+	defer cache.SetEntriesForTest([]cache.Entry{
+		{
+			Name: "fields", TTL: "24h",
+			Fetch: func(_ context.Context, _ *api.Client) (int, error) {
+				fetched = true
+				return 0, nil
+			},
+		},
+	})()
+
+	err := run(context.Background(), opts, nil, true)
+	testutil.RequireNoError(t, err)
+	if fetched {
+		t.Fatal("--status must not invoke fetchers")
+	}
+}
+
+// Sanity-check that the formatRefreshLine composes the expected shape.
+func TestFormatRefreshLine(t *testing.T) {
+	now := mustParseTime(t, "2026-04-18T14:23:00Z")
+	testutil.Equal(t,
+		formatRefreshLine("fields", 73, 72, now),
+		"Refreshing fields... 73 entries (was 72) — Cache updated at 2026-04-18 14:23:00")
+	testutil.Equal(t,
+		formatRefreshLine("fields", 73, 73, now),
+		"Refreshing fields... 73 entries — Cache updated at 2026-04-18 14:23:00")
+	testutil.Equal(t,
+		formatRefreshLine("users", 0, -1, now),
+		"Refreshing users... 0 entries — Cache updated at 2026-04-18 14:23:00")
+}
+
+func mustParseTime(t *testing.T, s string) (out time.Time) {
+	t.Helper()
+	out, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
+// -- smoke test: the default registry compiles into a runnable Entries() list.
+func TestEntries_IncludesAllSpecResources(t *testing.T) {
+	names := cache.Names()
+	want := []string{"fields", "projects", "boards", "linktypes", "issuetypes", "statuses", "priorities", "resolutions", "users"}
+	joined := "," + strings.Join(names, ",") + ","
+	for _, w := range want {
+		if !strings.Contains(joined, ","+w+",") {
+			t.Errorf("missing registry entry %q; got %v", w, names)
+		}
+	}
+}
+
+// Ensure we don't accidentally leave the prefix argument requirement off —
+// the command should accept zero args.
+func TestRegister_AcceptsZeroArgs(_ *testing.T) {
+	// Just build the command; no assertion needed beyond compilation.
+	_ = fmt.Sprintf("registered: %T", Register)
+}

--- a/tools/jtk/internal/present/refresh.go
+++ b/tools/jtk/internal/present/refresh.go
@@ -1,0 +1,85 @@
+package present
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+)
+
+// RefreshPresenter builds presentation models for the `jtk refresh` command.
+type RefreshPresenter struct{}
+
+// StatusRow is the presenter-level input for one row of the `--status` table.
+// The presenter formats FetchedAt / Age / status label — callers only supply
+// structured data.
+type StatusRow struct {
+	Resource  string
+	TTL       string
+	Status    cache.Status
+	FetchedAt time.Time // zero when Status is Uninitialized or Unavailable
+}
+
+// PresentStatus builds the `--status` freshness table.
+func (RefreshPresenter) PresentStatus(rows []StatusRow, now time.Time) *present.OutputModel {
+	tableRows := make([]present.Row, len(rows))
+	for i, r := range rows {
+		fetchedAt := "-"
+		age := "-"
+		if !r.FetchedAt.IsZero() {
+			fetchedAt = r.FetchedAt.UTC().Format(time.RFC3339)
+			age = cache.Age(r.FetchedAt, now)
+		}
+		tableRows[i] = present.Row{Cells: []string{
+			r.Resource, fetchedAt, age, r.TTL, r.Status.String(),
+		}}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"RESOURCE", "FETCHED_AT", "AGE", "TTL", "STATUS"},
+				Rows:    tableRows,
+			},
+		},
+	}
+}
+
+// RefreshResult is the presenter-level input for one per-resource outcome of
+// a refresh run. Err is non-nil on failure; on success Count and Previous
+// describe the entry-count delta for the "was N" indicator.
+type RefreshResult struct {
+	Name     string
+	Count    int
+	Previous int // -1 when prior count is unknown (first-ever fetch or read error)
+	Err      error
+	At       time.Time
+}
+
+// PresentRefresh emits per-resource success/failure lines. Failures go to
+// stderr; successes go to stdout.
+func (RefreshPresenter) PresentRefresh(results []RefreshResult) *present.OutputModel {
+	sections := make([]present.Section, 0, len(results))
+	for _, r := range results {
+		if r.Err != nil {
+			sections = append(sections, &present.MessageSection{
+				Kind:    present.MessageError,
+				Stream:  present.StreamStderr,
+				Message: fmt.Sprintf("Refreshing %s failed: %v", r.Name, r.Err),
+			})
+			continue
+		}
+		delta := ""
+		if r.Previous >= 0 && r.Previous != r.Count {
+			delta = fmt.Sprintf(" (was %d)", r.Previous)
+		}
+		sections = append(sections, &present.MessageSection{
+			Kind:   present.MessageSuccess,
+			Stream: present.StreamStdout,
+			Message: fmt.Sprintf("Refreshing %s... %d entries%s — Cache updated at %s",
+				r.Name, r.Count, delta, r.At.Format("2006-01-02 15:04:05")),
+		})
+	}
+	return &present.OutputModel{Sections: sections}
+}

--- a/tools/jtk/internal/present/refresh_test.go
+++ b/tools/jtk/internal/present/refresh_test.go
@@ -1,0 +1,95 @@
+package present
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+)
+
+func TestRefreshPresenter_PresentStatus(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 18, 14, 23, 0, 0, time.UTC)
+	model := RefreshPresenter{}.PresentStatus([]StatusRow{
+		{Resource: "fields", TTL: "24h", FetchedAt: now.Add(-8 * time.Hour), Status: cache.StatusFresh},
+		{Resource: "users", TTL: "24h", Status: cache.StatusUninitialized},
+		{Resource: "boards", TTL: "24h", Status: cache.StatusUnavailable},
+	}, now)
+
+	if len(model.Sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(model.Sections))
+	}
+	table, ok := model.Sections[0].(*present.TableSection)
+	if !ok {
+		t.Fatalf("expected TableSection, got %T", model.Sections[0])
+	}
+	if got := table.Headers; len(got) != 5 || got[0] != "RESOURCE" || got[4] != "STATUS" {
+		t.Fatalf("unexpected headers: %v", got)
+	}
+
+	// Fresh row
+	if got := table.Rows[0].Cells; got[0] != "fields" || got[2] != "8h" || got[4] != "fresh" {
+		t.Fatalf("fields row: %v", got)
+	}
+	// Uninitialized row: dashes for FetchedAt and Age
+	if got := table.Rows[1].Cells; got[1] != "-" || got[2] != "-" || got[4] != "uninitialized" {
+		t.Fatalf("users row: %v", got)
+	}
+	// Unavailable row
+	if got := table.Rows[2].Cells; got[4] != "unavailable" {
+		t.Fatalf("boards row: %v", got)
+	}
+}
+
+func TestRefreshPresenter_PresentRefresh_SuccessAndFailure(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 4, 18, 14, 23, 0, 0, time.UTC)
+	model := RefreshPresenter{}.PresentRefresh([]RefreshResult{
+		{Name: "fields", Count: 73, Previous: 72, At: at},
+		{Name: "users", Count: 0, Previous: -1, At: at},
+		{Name: "boards", Err: errors.New("boom"), At: at},
+	})
+
+	if len(model.Sections) != 3 {
+		t.Fatalf("expected 3 sections, got %d", len(model.Sections))
+	}
+
+	s0 := model.Sections[0].(*present.MessageSection)
+	if s0.Kind != present.MessageSuccess || s0.Stream != present.StreamStdout {
+		t.Fatalf("expected success on stdout, got kind=%v stream=%v", s0.Kind, s0.Stream)
+	}
+	if s0.Message != "Refreshing fields... 73 entries (was 72) — Cache updated at 2026-04-18 14:23:00" {
+		t.Fatalf("success message: %q", s0.Message)
+	}
+
+	// No delta when previous is unknown (-1).
+	s1 := model.Sections[1].(*present.MessageSection)
+	if s1.Message != "Refreshing users... 0 entries — Cache updated at 2026-04-18 14:23:00" {
+		t.Fatalf("no-delta message: %q", s1.Message)
+	}
+
+	// Failure goes to stderr.
+	s2 := model.Sections[2].(*present.MessageSection)
+	if s2.Kind != present.MessageError || s2.Stream != present.StreamStderr {
+		t.Fatalf("expected error on stderr, got kind=%v stream=%v", s2.Kind, s2.Stream)
+	}
+	if s2.Message != "Refreshing boards failed: boom" {
+		t.Fatalf("failure message: %q", s2.Message)
+	}
+}
+
+// Delta is suppressed when previous count equals current count.
+func TestRefreshPresenter_PresentRefresh_NoDeltaWhenEqual(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 4, 18, 14, 23, 0, 0, time.UTC)
+	model := RefreshPresenter{}.PresentRefresh([]RefreshResult{
+		{Name: "fields", Count: 73, Previous: 73, At: at},
+	})
+	s := model.Sections[0].(*present.MessageSection)
+	if s.Message != "Refreshing fields... 73 entries — Cache updated at 2026-04-18 14:23:00" {
+		t.Fatalf("equal-count message: %q", s.Message)
+	}
+}


### PR DESCRIPTION
## Summary

Foundation for the #230 output rethink. Adds the persistence layer, freshness semantics, the `jtk refresh` command, a shared non-interactive bootstrap service, and invalidation hooks on cache-relevant mutations.

- **`internal/cache`** — envelope + atomic I/O, path helpers (`~/.jtk/cache/{instance}/`), freshness classification, registry with dependency ordering + bearer-auth gating, `bootstrap.SeedUsers` (shared with #246), and invalidate helpers (`Touch`, `AppendOnCreate`, `RemoveOnDelete`).
- **`internal/cmd/refresh`** — full / targeted refresh and `--status`. Continues on per-resource failure; overall exit non-zero if any failed. Skips `boards` under bearer auth rather than guaranteed-failing.
- **`api`** — `ListPriorities`, `ListResolutions`, `ListUsersPage`; `Resolution` type.
- **Invalidation wiring** — `projects create/update/delete/restore` Touch `projects` + dependents (`issuetypes`, `statuses`); `fields create/delete/restore` use `AppendOnCreate` / `RemoveOnDelete` / `Touch` as appropriate.

## Design notes

- Cache root is spec-literal `~/.jtk/cache/` (per #230). Config path is unchanged. All `~/.jtk` literals are isolated to `internal/cache/paths.go`.
- `users` refresh calls the same `bootstrap.SeedUsers` service `jtk init` (#246) will use — not a no-op, and not the interactive init UX.
- Project create/restore use `Touch` rather than `AppendOnCreate`; the raw create response is documented in #230 as incomplete until #242 lands a canonical fetch-after-write helper.
- `boards` under bearer auth is marked `unavailable` in `--status` and silently skipped in a full refresh.

## Test plan

- [x] `make test` — 1129 passing across 26 packages.
- [x] `make lint` — clean (only a pre-existing finding in `internal/config/config.go` on main).
- [x] `jtk refresh --help` renders.
- [x] Missing-config path returns `configuration not found — run 'jtk init' first`.
- [ ] Manual end-to-end against a live Jira instance (basic + bearer auth) per the verification section of the plan (posted on #235).
- [ ] Manual invalidation round-trip: `projects create` / `fields create` update the on-disk caches without a refresh.

## Out of scope (sibling issues)

- `jtk init` discovery flow — **#246**.
- Cache-backed name/ID resolution (`--assignee "Aaron Wong"`) — **#236**.
- Wiring invalidation into non-cache-relevant mutations — not planned.

Closes #235.