### PR TITLE
feat(jtk): migrate me/users/projects reads to new output model

### DIFF
--- a/tools/jtk/api/projects.go
+++ b/tools/jtk/api/projects.go
@@ -85,13 +85,20 @@ func (c *Client) ListProjects(ctx context.Context) ([]Project, error) {
 }
 
 // SearchProjects searches for projects with pagination.
-// ?expand populates issueTypes, url, lead, and the style/simplified/isPrivate
-// scalars that `jtk projects list --extended` depends on; issueTypes also
-// powers the default-mode list table.
-func (c *Client) SearchProjects(ctx context.Context, query string, startAt, maxResults int) (*ProjectSearchResponse, error) {
-	params := map[string]string{
-		"expand": "description,lead,issueTypes,url,projectKeys",
+//
+// extended toggles the expand set so default-mode `projects list` doesn't
+// pay for payload it won't render. Default sends `expand=lead` (the only
+// column beyond KEY/TYPE/NAME that needs expansion in default mode);
+// extended also pulls description, issueTypes, url, and projectKeys so the
+// extended list columns (STYLE / ISSUE_TYPES / COMPONENTS) are populated
+// without a second fetch. Style/simplified/isPrivate are top-level on
+// /project/search and don't need expand.
+func (c *Client) SearchProjects(ctx context.Context, query string, startAt, maxResults int, extended bool) (*ProjectSearchResponse, error) {
+	expand := "lead"
+	if extended {
+		expand = "description,lead,issueTypes,url,projectKeys"
 	}
+	params := map[string]string{"expand": expand}
 
 	if query != "" {
 		params["query"] = query

--- a/tools/jtk/api/projects.go
+++ b/tools/jtk/api/projects.go
@@ -18,7 +18,20 @@ type ProjectDetail struct {
 	Lead           *User       `json:"lead,omitempty"`
 	IssueTypes     []IssueType `json:"issueTypes,omitempty"`
 	Components     []Component `json:"components,omitempty"`
+	Versions       []Version   `json:"versions,omitempty"`
+	Style          string      `json:"style,omitempty"`
+	Simplified     *bool       `json:"simplified,omitempty"`
+	IsPrivate      *bool       `json:"isPrivate,omitempty"`
 	URL            string      `json:"url,omitempty"`
+}
+
+// Version represents a Jira project version. Only the fields needed for the
+// `projects get` count-column rendering are decoded here; additional fields
+// (releaseDate, released, archived, etc.) can be added when a version-focused
+// command lands.
+type Version struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // ProjectSearchResponse represents the paginated response from project search
@@ -71,9 +84,14 @@ func (c *Client) ListProjects(ctx context.Context) ([]Project, error) {
 	return projects, nil
 }
 
-// SearchProjects searches for projects with pagination
+// SearchProjects searches for projects with pagination.
+// ?expand populates issueTypes, url, lead, and the style/simplified/isPrivate
+// scalars that `jtk projects list --extended` depends on; issueTypes also
+// powers the default-mode list table.
 func (c *Client) SearchProjects(ctx context.Context, query string, startAt, maxResults int) (*ProjectSearchResponse, error) {
-	params := map[string]string{}
+	params := map[string]string{
+		"expand": "description,lead,issueTypes,url,projectKeys",
+	}
 
 	if query != "" {
 		params["query"] = query
@@ -99,13 +117,19 @@ func (c *Client) SearchProjects(ctx context.Context, query string, startAt, maxR
 	return &result, nil
 }
 
-// GetProject retrieves a project by key or ID
+// GetProject retrieves a project by key or ID.
+// ?expand=description,lead,issueTypes,url,projectKeys,versions populates the
+// fields needed by `jtk projects get` default and extended output, including
+// the component list, version count, style, simplified, and isPrivate flags.
 func (c *Client) GetProject(ctx context.Context, projectKeyOrID string) (*ProjectDetail, error) {
 	if projectKeyOrID == "" {
 		return nil, ErrProjectKeyRequired
 	}
 
-	urlStr := fmt.Sprintf("%s/project/%s", c.BaseURL, url.PathEscape(projectKeyOrID))
+	urlStr := buildURL(
+		fmt.Sprintf("%s/project/%s", c.BaseURL, url.PathEscape(projectKeyOrID)),
+		map[string]string{"expand": "description,lead,issueTypes,url,projectKeys,versions"},
+	)
 	body, err := c.Get(ctx, urlStr)
 	if err != nil {
 		return nil, fmt.Errorf("fetching project: %w", err)

--- a/tools/jtk/api/projects.go
+++ b/tools/jtk/api/projects.go
@@ -84,21 +84,24 @@ func (c *Client) ListProjects(ctx context.Context) ([]Project, error) {
 	return projects, nil
 }
 
-// SearchProjects searches for projects with pagination.
-//
-// extended toggles the expand set so default-mode `projects list` doesn't
-// pay for payload it won't render. Default sends `expand=lead` (the only
-// column beyond KEY/TYPE/NAME that needs expansion in default mode);
-// extended also pulls description, issueTypes, url, and projectKeys so the
-// extended list columns (STYLE / ISSUE_TYPES / COMPONENTS) are populated
-// without a second fetch. Style/simplified/isPrivate are top-level on
-// /project/search and don't need expand.
-func (c *Client) SearchProjects(ctx context.Context, query string, startAt, maxResults int, extended bool) (*ProjectSearchResponse, error) {
-	expand := "lead"
-	if extended {
-		expand = "description,lead,issueTypes,url,projectKeys"
+// ProjectListExpand is the expand string that populates the extended-mode
+// `jtk projects list --extended` columns (STYLE / ISSUE_TYPES / COMPONENTS).
+// Style/simplified/isPrivate are top-level on /project/search and don't need
+// expand. Kept as a package constant so commands can reuse it without
+// hardcoding the wire format.
+const ProjectListExpand = "description,lead,issueTypes,url,projectKeys"
+
+// SearchProjects searches for projects with pagination. expand is passed
+// through to the ?expand= query param untouched; callers decide what
+// expansion they need based on the columns they render (API layer stays
+// ignorant of presentation mode). Use ProjectListExpand for extended-mode
+// list, or a narrower string like "lead" for default-mode. Empty expand
+// sends no expand param.
+func (c *Client) SearchProjects(ctx context.Context, query string, startAt, maxResults int, expand string) (*ProjectSearchResponse, error) {
+	params := map[string]string{}
+	if expand != "" {
+		params["expand"] = expand
 	}
-	params := map[string]string{"expand": expand}
 
 	if query != "" {
 		params["query"] = query
@@ -124,18 +127,31 @@ func (c *Client) SearchProjects(ctx context.Context, query string, startAt, maxR
 	return &result, nil
 }
 
-// GetProject retrieves a project by key or ID.
-// ?expand=description,lead,issueTypes,url,projectKeys,versions populates the
-// fields needed by `jtk projects get` default and extended output, including
-// the component list, version count, style, simplified, and isPrivate flags.
-func (c *Client) GetProject(ctx context.Context, projectKeyOrID string) (*ProjectDetail, error) {
+// ProjectGetExpand is the expand string that populates `jtk projects get`
+// default + extended output (component list, version count, style /
+// simplified / isPrivate flags, description, lead, URL). Callers that only
+// need a subset (e.g. `--id` wants nothing at all) should pass their own
+// narrower string instead of this default.
+const ProjectGetExpand = "description,lead,issueTypes,url,projectKeys,versions"
+
+// GetProject retrieves a project by key or ID. expand is passed straight to
+// ?expand= — callers choose their own expansion (API stays ignorant of
+// presentation mode). Pass ProjectGetExpand for full `projects get` output,
+// a narrower string for specific fields (e.g. "issueTypes" for
+// `issues types`), or "" to skip expansion entirely (e.g. `--id` which only
+// needs the canonical key).
+func (c *Client) GetProject(ctx context.Context, projectKeyOrID, expand string) (*ProjectDetail, error) {
 	if projectKeyOrID == "" {
 		return nil, ErrProjectKeyRequired
 	}
 
+	params := map[string]string{}
+	if expand != "" {
+		params["expand"] = expand
+	}
 	urlStr := buildURL(
 		fmt.Sprintf("%s/project/%s", c.BaseURL, url.PathEscape(projectKeyOrID)),
-		map[string]string{"expand": "description,lead,issueTypes,url,projectKeys,versions"},
+		params,
 	)
 	body, err := c.Get(ctx, urlStr)
 	if err != nil {

--- a/tools/jtk/api/projects_test.go
+++ b/tools/jtk/api/projects_test.go
@@ -73,7 +73,7 @@ func TestSearchProjects(t *testing.T) {
 			testutil.RequireNoError(t, err)
 			client.BaseURL = server.URL + "/rest/api/3"
 
-			result, err := client.SearchProjects(context.Background(), tt.query, 0, 50)
+			result, err := client.SearchProjects(context.Background(), tt.query, 0, 50, false)
 			if tt.wantErr {
 				testutil.Error(t, err)
 				return
@@ -161,6 +161,48 @@ func TestGetProject(t *testing.T) {
 			testutil.Equal(t, project.Lead.DisplayName, "John Smith")
 		})
 	}
+}
+
+func TestSearchProjects_ExpandIsLeadOnlyInDefaultMode(t *testing.T) {
+	t.Parallel()
+	// Default-mode list renders only KEY | TYPE | LEAD | NAME; expanding
+	// description/issueTypes/url/projectKeys wastes payload. Lock the
+	// minimum.
+	var capturedExpand string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedExpand = r.URL.Query().Get("expand")
+		_, _ = w.Write([]byte(`{"values":[],"isLast":true}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "x"})
+	testutil.RequireNoError(t, err)
+	client.BaseURL = server.URL + "/rest/api/3"
+
+	_, err = client.SearchProjects(context.Background(), "", 0, 50, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, capturedExpand, "lead")
+}
+
+func TestSearchProjects_ExpandIsFullInExtendedMode(t *testing.T) {
+	t.Parallel()
+	// --extended columns (STYLE / ISSUE_TYPES / COMPONENTS) need the full
+	// expand set. Assert the exact string so a future refactor that drops a
+	// key trips this test.
+	var capturedExpand string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedExpand = r.URL.Query().Get("expand")
+		_, _ = w.Write([]byte(`{"values":[],"isLast":true}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "x"})
+	testutil.RequireNoError(t, err)
+	client.BaseURL = server.URL + "/rest/api/3"
+
+	_, err = client.SearchProjects(context.Background(), "", 0, 50, true)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, capturedExpand, "description,lead,issueTypes,url,projectKeys")
 }
 
 func TestGetProject_SendsExpandForExtendedFields(t *testing.T) {

--- a/tools/jtk/api/projects_test.go
+++ b/tools/jtk/api/projects_test.go
@@ -163,6 +163,32 @@ func TestGetProject(t *testing.T) {
 	}
 }
 
+func TestGetProject_SendsExpandForExtendedFields(t *testing.T) {
+	t.Parallel()
+	// `projects get --extended` depends on description, lead, issueTypes,
+	// projectKeys, and versions being populated by the API response. Capture
+	// the outgoing request's expand param so a future refactor can't quietly
+	// drop one of those keys.
+	var capturedExpand string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedExpand = r.URL.Query().Get("expand")
+		_, _ = w.Write([]byte(`{"id":"10001","key":"TST","name":"Test"}`))
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "x"})
+	testutil.RequireNoError(t, err)
+	client.BaseURL = server.URL + "/rest/api/3"
+
+	_, err = client.GetProject(context.Background(), "TST")
+	testutil.RequireNoError(t, err)
+
+	// Order within the expand string mirrors the call site; if the call site
+	// reorders them this assertion intentionally breaks so the author can
+	// confirm intent.
+	testutil.Equal(t, capturedExpand, "description,lead,issueTypes,url,projectKeys,versions")
+}
+
 func TestCreateProject(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testutil.Equal(t, r.Method, http.MethodPost)

--- a/tools/jtk/api/projects_test.go
+++ b/tools/jtk/api/projects_test.go
@@ -73,7 +73,7 @@ func TestSearchProjects(t *testing.T) {
 			testutil.RequireNoError(t, err)
 			client.BaseURL = server.URL + "/rest/api/3"
 
-			result, err := client.SearchProjects(context.Background(), tt.query, 0, 50, false)
+			result, err := client.SearchProjects(context.Background(), tt.query, 0, 50, "")
 			if tt.wantErr {
 				testutil.Error(t, err)
 				return
@@ -130,7 +130,7 @@ func TestGetProject(t *testing.T) {
 					APIToken: "test-token",
 				})
 				testutil.RequireNoError(t, err)
-				_, err = client.GetProject(context.Background(), "")
+				_, err = client.GetProject(context.Background(), "", "")
 				testutil.Error(t, err)
 				return
 			}
@@ -150,7 +150,7 @@ func TestGetProject(t *testing.T) {
 			testutil.RequireNoError(t, err)
 			client.BaseURL = server.URL + "/rest/api/3"
 
-			project, err := client.GetProject(context.Background(), tt.keyOrID)
+			project, err := client.GetProject(context.Background(), tt.keyOrID, "")
 			if tt.wantErr {
 				testutil.Error(t, err)
 				return
@@ -163,72 +163,83 @@ func TestGetProject(t *testing.T) {
 	}
 }
 
-func TestSearchProjects_ExpandIsLeadOnlyInDefaultMode(t *testing.T) {
+func TestSearchProjects_PassesExpandThroughUnmodified(t *testing.T) {
 	t.Parallel()
-	// Default-mode list renders only KEY | TYPE | LEAD | NAME; expanding
-	// description/issueTypes/url/projectKeys wastes payload. Lock the
-	// minimum.
-	var capturedExpand string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedExpand = r.URL.Query().Get("expand")
-		_, _ = w.Write([]byte(`{"values":[],"isLast":true}`))
-	}))
-	defer server.Close()
+	// The API layer does not know about `--extended`; it takes an expand
+	// string verbatim. Two branches: empty means no expand param on the
+	// URL; non-empty shows up exactly as passed. Callers map their
+	// rendering intent to a concrete expand.
+	cases := []struct {
+		name             string
+		expand           string
+		wantParam        string
+		wantParamPresent bool
+	}{
+		{"empty omits param", "", "", false},
+		{"lead only", "lead", "lead", true},
+		{"full set", ProjectListExpand, ProjectListExpand, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var captured string
+			var present bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured = r.URL.Query().Get("expand")
+				_, present = r.URL.Query()["expand"]
+				_, _ = w.Write([]byte(`{"values":[],"isLast":true}`))
+			}))
+			defer server.Close()
 
-	client, err := New(ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "x"})
-	testutil.RequireNoError(t, err)
-	client.BaseURL = server.URL + "/rest/api/3"
+			client, err := New(ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "x"})
+			testutil.RequireNoError(t, err)
+			client.BaseURL = server.URL + "/rest/api/3"
 
-	_, err = client.SearchProjects(context.Background(), "", 0, 50, false)
-	testutil.RequireNoError(t, err)
-	testutil.Equal(t, capturedExpand, "lead")
+			_, err = client.SearchProjects(context.Background(), "", 0, 50, tc.expand)
+			testutil.RequireNoError(t, err)
+			testutil.Equal(t, captured, tc.wantParam)
+			testutil.Equal(t, present, tc.wantParamPresent)
+		})
+	}
 }
 
-func TestSearchProjects_ExpandIsFullInExtendedMode(t *testing.T) {
+func TestGetProject_PassesExpandThroughUnmodified(t *testing.T) {
 	t.Parallel()
-	// --extended columns (STYLE / ISSUE_TYPES / COMPONENTS) need the full
-	// expand set. Assert the exact string so a future refactor that drops a
-	// key trips this test.
-	var capturedExpand string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedExpand = r.URL.Query().Get("expand")
-		_, _ = w.Write([]byte(`{"values":[],"isLast":true}`))
-	}))
-	defer server.Close()
+	// GetProject takes an expand string verbatim: empty string sends no
+	// expand param; non-empty shows up exactly. Callers (e.g. `projects
+	// get` default, `projects get --id`, `issues types`) own the decision.
+	cases := []struct {
+		name             string
+		expand           string
+		wantParam        string
+		wantParamPresent bool
+	}{
+		{"empty omits param (id path)", "", "", false},
+		{"narrow single key (issues types)", "issueTypes", "issueTypes", true},
+		{"full get expansion", ProjectGetExpand, ProjectGetExpand, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var captured string
+			var present bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured = r.URL.Query().Get("expand")
+				_, present = r.URL.Query()["expand"]
+				_, _ = w.Write([]byte(`{"id":"10001","key":"TST","name":"Test"}`))
+			}))
+			defer server.Close()
 
-	client, err := New(ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "x"})
-	testutil.RequireNoError(t, err)
-	client.BaseURL = server.URL + "/rest/api/3"
+			client, err := New(ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "x"})
+			testutil.RequireNoError(t, err)
+			client.BaseURL = server.URL + "/rest/api/3"
 
-	_, err = client.SearchProjects(context.Background(), "", 0, 50, true)
-	testutil.RequireNoError(t, err)
-	testutil.Equal(t, capturedExpand, "description,lead,issueTypes,url,projectKeys")
-}
-
-func TestGetProject_SendsExpandForExtendedFields(t *testing.T) {
-	t.Parallel()
-	// `projects get --extended` depends on description, lead, issueTypes,
-	// projectKeys, and versions being populated by the API response. Capture
-	// the outgoing request's expand param so a future refactor can't quietly
-	// drop one of those keys.
-	var capturedExpand string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedExpand = r.URL.Query().Get("expand")
-		_, _ = w.Write([]byte(`{"id":"10001","key":"TST","name":"Test"}`))
-	}))
-	defer server.Close()
-
-	client, err := New(ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "x"})
-	testutil.RequireNoError(t, err)
-	client.BaseURL = server.URL + "/rest/api/3"
-
-	_, err = client.GetProject(context.Background(), "TST")
-	testutil.RequireNoError(t, err)
-
-	// Order within the expand string mirrors the call site; if the call site
-	// reorders them this assertion intentionally breaks so the author can
-	// confirm intent.
-	testutil.Equal(t, capturedExpand, "description,lead,issueTypes,url,projectKeys,versions")
+			_, err = client.GetProject(context.Background(), "TST", tc.expand)
+			testutil.RequireNoError(t, err)
+			testutil.Equal(t, captured, tc.wantParam)
+			testutil.Equal(t, present, tc.wantParamPresent)
+		})
+	}
 }
 
 func TestCreateProject(t *testing.T) {

--- a/tools/jtk/api/types.go
+++ b/tools/jtk/api/types.go
@@ -232,11 +232,23 @@ type Resolution struct {
 
 // User represents a Jira user
 type User struct {
-	AccountID    string            `json:"accountId"`
-	DisplayName  string            `json:"displayName"`
-	EmailAddress string            `json:"emailAddress,omitempty"`
-	Active       bool              `json:"active"`
-	AvatarURLs   map[string]string `json:"avatarUrls,omitempty"`
+	AccountID        string            `json:"accountId"`
+	DisplayName      string            `json:"displayName"`
+	EmailAddress     string            `json:"emailAddress,omitempty"`
+	Active           bool              `json:"active"`
+	AvatarURLs       map[string]string `json:"avatarUrls,omitempty"`
+	TimeZone         string            `json:"timeZone,omitempty"`
+	Locale           string            `json:"locale,omitempty"`
+	Groups           *UserCountBlock   `json:"groups,omitempty"`
+	ApplicationRoles *UserCountBlock   `json:"applicationRoles,omitempty"`
+}
+
+// UserCountBlock is a small envelope Jira uses when returning count-bearing
+// expandable user fields such as groups and applicationRoles. Pointer-nullable
+// on User so presenters can distinguish "API omitted the block" from "present
+// with zero items".
+type UserCountBlock struct {
+	Size int `json:"size"`
 }
 
 // Project represents a Jira project

--- a/tools/jtk/api/users.go
+++ b/tools/jtk/api/users.go
@@ -6,9 +6,13 @@ import (
 	"fmt"
 )
 
-// GetCurrentUser returns the currently authenticated user
+// GetCurrentUser returns the currently authenticated user.
+// ?expand=groups,applicationRoles populates the optional Size blocks used by
+// `jtk me --extended`; fields unsupported by the endpoint are simply dropped.
 func (c *Client) GetCurrentUser(ctx context.Context) (*User, error) {
-	urlStr := fmt.Sprintf("%s/myself", c.BaseURL)
+	urlStr := buildURL(fmt.Sprintf("%s/myself", c.BaseURL), map[string]string{
+		"expand": "groups,applicationRoles",
+	})
 	body, err := c.Get(ctx, urlStr)
 	if err != nil {
 		return nil, fmt.Errorf("getting current user: %w", err)
@@ -22,10 +26,15 @@ func (c *Client) GetCurrentUser(ctx context.Context) (*User, error) {
 	return &user, nil
 }
 
-// GetUser returns a user by their account ID
+// GetUser returns a user by their account ID.
+// ?expand=groups,applicationRoles populates the optional Size blocks used by
+// `jtk users get --extended`. timeZone / locale on the returned user may be
+// empty on instances that redact other-user personal information — presenters
+// render them as `-` in that case.
 func (c *Client) GetUser(ctx context.Context, accountID string) (*User, error) {
 	params := map[string]string{
 		"accountId": accountID,
+		"expand":    "groups,applicationRoles",
 	}
 	urlStr := buildURL(fmt.Sprintf("%s/user", c.BaseURL), params)
 	body, err := c.Get(ctx, urlStr)
@@ -68,10 +77,16 @@ func (c *Client) ListUsersPage(ctx context.Context, startAt, maxResults int) ([]
 	return users, nil
 }
 
-// SearchUsers searches for users by query string
-func (c *Client) SearchUsers(ctx context.Context, query string, maxResults int) ([]User, error) {
+// SearchUsers searches for users by query string.
+// startAt is the 0-based offset into the result set; callers passing 0 get the
+// first page. /user/search does not return isLast, so callers infer terminal
+// state from `len(users) < maxResults`.
+func (c *Client) SearchUsers(ctx context.Context, query string, startAt, maxResults int) ([]User, error) {
 	params := map[string]string{
 		"query": query,
+	}
+	if startAt > 0 {
+		params["startAt"] = fmt.Sprintf("%d", startAt)
 	}
 	if maxResults > 0 {
 		params["maxResults"] = fmt.Sprintf("%d", maxResults)

--- a/tools/jtk/api/users.go
+++ b/tools/jtk/api/users.go
@@ -6,13 +6,21 @@ import (
 	"fmt"
 )
 
-// GetCurrentUser returns the currently authenticated user.
-// ?expand=groups,applicationRoles populates the optional Size blocks used by
-// `jtk me --extended`; fields unsupported by the endpoint are simply dropped.
-func (c *Client) GetCurrentUser(ctx context.Context) (*User, error) {
-	urlStr := buildURL(fmt.Sprintf("%s/myself", c.BaseURL), map[string]string{
-		"expand": "groups,applicationRoles",
-	})
+// UserExtendedExpand is the canonical expand string that populates
+// `--extended` user output (Groups / Application Roles size blocks).
+// Callers pass this to GetCurrentUser / GetUser when they intend to render
+// extended fields; pass "" otherwise to avoid the wasted payload.
+const UserExtendedExpand = "groups,applicationRoles"
+
+// GetCurrentUser returns the currently authenticated user. expand is passed
+// verbatim to ?expand= — callers decide which expansions they need. Use
+// UserExtendedExpand for --extended; "" for default / --id callers.
+func (c *Client) GetCurrentUser(ctx context.Context, expand string) (*User, error) {
+	params := map[string]string{}
+	if expand != "" {
+		params["expand"] = expand
+	}
+	urlStr := buildURL(fmt.Sprintf("%s/myself", c.BaseURL), params)
 	body, err := c.Get(ctx, urlStr)
 	if err != nil {
 		return nil, fmt.Errorf("getting current user: %w", err)
@@ -26,15 +34,16 @@ func (c *Client) GetCurrentUser(ctx context.Context) (*User, error) {
 	return &user, nil
 }
 
-// GetUser returns a user by their account ID.
-// ?expand=groups,applicationRoles populates the optional Size blocks used by
-// `jtk users get --extended`. timeZone / locale on the returned user may be
-// empty on instances that redact other-user personal information — presenters
-// render them as `-` in that case.
-func (c *Client) GetUser(ctx context.Context, accountID string) (*User, error) {
-	params := map[string]string{
-		"accountId": accountID,
-		"expand":    "groups,applicationRoles",
+// GetUser returns a user by their account ID. expand is passed verbatim to
+// ?expand= — callers supply their intent. Use UserExtendedExpand for
+// --extended output; "" for default/--id where the Size blocks would be
+// discarded. timeZone / locale on the returned user may be empty on
+// instances that redact other-user personal information — presenters render
+// them as `-` in that case.
+func (c *Client) GetUser(ctx context.Context, accountID, expand string) (*User, error) {
+	params := map[string]string{"accountId": accountID}
+	if expand != "" {
+		params["expand"] = expand
 	}
 	urlStr := buildURL(fmt.Sprintf("%s/user", c.BaseURL), params)
 	body, err := c.Get(ctx, urlStr)

--- a/tools/jtk/api/users_test.go
+++ b/tools/jtk/api/users_test.go
@@ -166,3 +166,27 @@ func TestSearchUsers(t *testing.T) {
 	testutil.Equal(t, users[0].DisplayName, "John Smith")
 	testutil.Equal(t, users[1].DisplayName, "John Doe")
 }
+
+func TestSearchUsers_SendsStartAtWhenSet(t *testing.T) {
+	t.Parallel()
+	// The new startAt int parameter gates the "startAt" query param behind a
+	// `> 0` check so a zero offset doesn't pollute the URL. This test asserts
+	// the positive branch directly at the API layer (TestSearchUsers covers
+	// the zero branch implicitly via its omitted startAt query param).
+	var capturedStartAt, capturedMaxResults string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedStartAt = r.URL.Query().Get("startAt")
+		capturedMaxResults = r.URL.Query().Get("maxResults")
+		_ = json.NewEncoder(w).Encode([]User{})
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{URL: "https://test.atlassian.net", Email: "test@example.com", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+	client.BaseURL = server.URL + "/rest/api/3"
+
+	_, err = client.SearchUsers(context.Background(), "q", 25, 10)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, capturedStartAt, "25")
+	testutil.Equal(t, capturedMaxResults, "10")
+}

--- a/tools/jtk/api/users_test.go
+++ b/tools/jtk/api/users_test.go
@@ -160,7 +160,7 @@ func TestSearchUsers(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	client.BaseURL = server.URL + "/rest/api/3"
 
-	users, err := client.SearchUsers(context.Background(), "john", 0)
+	users, err := client.SearchUsers(context.Background(), "john", 0, 0)
 	testutil.RequireNoError(t, err)
 	testutil.Len(t, users, 2)
 	testutil.Equal(t, users[0].DisplayName, "John Smith")

--- a/tools/jtk/api/users_test.go
+++ b/tools/jtk/api/users_test.go
@@ -61,7 +61,7 @@ func TestGetUser(t *testing.T) {
 			testutil.RequireNoError(t, err)
 			client.BaseURL = server.URL + "/rest/api/3"
 
-			user, err := client.GetUser(context.Background(), tt.accountID)
+			user, err := client.GetUser(context.Background(), tt.accountID, "")
 			if tt.wantErr {
 				testutil.Error(t, err)
 				return
@@ -95,7 +95,7 @@ func TestGetCurrentUser(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	client.BaseURL = server.URL + "/rest/api/3"
 
-	user, err := client.GetCurrentUser(context.Background())
+	user, err := client.GetCurrentUser(context.Background(), "")
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, user.DisplayName, "Current User")
 	testutil.Equal(t, user.AccountID, "5b10ac8d82e05b22cc7d4ef5")

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -3,7 +3,6 @@ package comments
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -19,9 +18,6 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/text"
 )
-
-// errFieldsWithJSON is returned when --fields is combined with --output json.
-var errFieldsWithJSON = errors.New("--fields is not supported with --output json")
 
 // noFieldFetch is the projection.Resolve fetcher for comments. Comment
 // fields are not Jira issue fields, so there is no metadata to fetch;
@@ -89,7 +85,7 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 	var projected bool
 	if !idOnly {
 		if fieldsFlag != "" && v.Format == view.FormatJSON {
-			return errFieldsWithJSON
+			return jtkpresent.ErrFieldsWithJSON
 		}
 		spec := jtkpresent.CommentListSpec
 		if noTruncate {
@@ -143,7 +139,7 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 	} else {
 		model = jtkpresent.CommentPresenter{}.PresentListWithPagination(result.Comments, hasMore)
 		if projected {
-			projectTableSectionInModel(model, selected)
+			projection.ApplyToTableInModel(model, selected)
 		}
 	}
 	return jtkpresent.Emit(opts, model)
@@ -156,17 +152,6 @@ func projectAllDetailSectionsInModel(model *present.OutputModel, selected []proj
 	for i, s := range model.Sections {
 		if ds, ok := s.(*present.DetailSection); ok {
 			model.Sections[i] = projection.ProjectDetail(ds, selected)
-		}
-	}
-}
-
-// projectTableSectionInModel rewrites the first TableSection of model to
-// the selected columns.
-func projectTableSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
-	for i, s := range model.Sections {
-		if ts, ok := s.(*present.TableSection); ok {
-			model.Sections[i] = projection.ProjectTable(ts, selected)
-			return
 		}
 	}
 }

--- a/tools/jtk/internal/cmd/configcmd/configcmd.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd.go
@@ -195,7 +195,7 @@ pass/fail status and troubleshooting suggestions on failure.`,
 				if err != nil {
 					clientErr = err
 				} else {
-					user, authErr = client.GetCurrentUser(cmd.Context())
+					user, authErr = client.GetCurrentUser(cmd.Context(), "")
 				}
 			}
 

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -258,7 +258,7 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 			return fmt.Errorf("creating client: %w", err)
 		}
 
-		user, err := client.GetCurrentUser(ctx)
+		user, err := client.GetCurrentUser(ctx, "")
 		if err != nil {
 			v.Error("Connection failed: %v", err)
 			v.Println("")

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
@@ -61,7 +60,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	}
 
 	if fieldsFlag != "" && v.Format == view.FormatJSON {
-		return errFieldsWithJSON
+		return jtkpresent.ErrFieldsWithJSON
 	}
 
 	selected, projected, err := projection.Resolve(
@@ -91,18 +90,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 
 	model := jtkpresent.IssuePresenter{}.PresentDetail(issue, client.IssueURL(issue.Key), noTruncate)
 	if projected {
-		projectDetailSectionInModel(model, selected)
+		projection.ApplyToDetailInModel(model, selected)
 	}
 	return jtkpresent.Emit(opts, model)
-}
-
-// projectDetailSectionInModel rewrites the first DetailSection of model to
-// the selected fields. No-op when there is no DetailSection.
-func projectDetailSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
-	for i, s := range model.Sections {
-		if ds, ok := s.(*present.DetailSection); ok {
-			model.Sections[i] = projection.ProjectDetail(ds, selected)
-			return
-		}
-	}
 }

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -22,10 +22,6 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 )
 
-// errFieldsWithJSON is returned when --fields is combined with --output json.
-// JSON output is not projected; mixing them silently would be surprising.
-var errFieldsWithJSON = errors.New("--fields is not supported with --output json")
-
 func newListCmd(opts *root.Options) *cobra.Command {
 	var project string
 	var sprint string
@@ -85,7 +81,7 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 	idOnly := opts.EmitIDOnly()
 
 	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
-		return errFieldsWithJSON
+		return jtkpresent.ErrFieldsWithJSON
 	}
 
 	var selected []projection.ColumnSpec
@@ -181,7 +177,7 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 
 	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, hasMore)
 	if projected {
-		projectTableSectionInModel(model, selected)
+		projection.ApplyToTableInModel(model, selected)
 	}
 	return jtkpresent.Emit(opts, model)
 }
@@ -255,16 +251,4 @@ func jqlEscape(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
 	return s
-}
-
-// projectTableSectionInModel rewrites the first TableSection of model to the
-// selected columns. No-op when there is no TableSection (e.g. model contains
-// only MessageSections).
-func projectTableSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
-	for i, s := range model.Sections {
-		if ts, ok := s.(*present.TableSection); ok {
-			model.Sections[i] = projection.ProjectTable(ts, selected)
-			return
-		}
-	}
 }

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -74,7 +74,7 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 	idOnly := opts.EmitIDOnly()
 
 	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
-		return errFieldsWithJSON
+		return jtkpresent.ErrFieldsWithJSON
 	}
 
 	var selected []projection.ColumnSpec
@@ -131,7 +131,7 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 	// Text path: presenter → render → write
 	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, hasMore)
 	if projected {
-		projectTableSectionInModel(model, selected)
+		projection.ApplyToTableInModel(model, selected)
 	}
 	out := present.Render(model, opts.RenderStyle())
 	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)

--- a/tools/jtk/internal/cmd/issues/types.go
+++ b/tools/jtk/internal/cmd/issues/types.go
@@ -50,7 +50,9 @@ func runTypes(ctx context.Context, opts *root.Options, project string) error {
 	}
 	projectKey := resolvedProject.Key
 
-	projectDetail, err := client.GetProject(ctx, projectKey)
+	// `issues types` only renders issue type names — the other expansions
+	// (description, versions, etc.) are wasted payload here.
+	projectDetail, err := client.GetProject(ctx, projectKey, "issueTypes")
 	if err != nil {
 		return err
 	}

--- a/tools/jtk/internal/cmd/me/me.go
+++ b/tools/jtk/internal/cmd/me/me.go
@@ -3,6 +3,7 @@ package me
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -56,6 +57,16 @@ func run(ctx context.Context, opts *root.Options) error {
 	// JSON path: use existing artifact layer (unchanged)
 	if v.Format == view.FormatJSON {
 		return v.RenderArtifact(jtkartifact.ProjectUser(user, opts.ArtifactMode()))
+	}
+
+	// Plain path: preserve the legacy contract (bare account ID). This
+	// predates --id and is kept for backwards compatibility per CLAUDE.md
+	// ("--output / -o ... retained for compatibility but hidden from --help").
+	// --id is the preferred surface; `-o plain` stays working for scripts
+	// that haven't migrated.
+	if v.Format == view.FormatPlain {
+		_, _ = fmt.Fprintln(opts.Stdout, user.AccountID)
+		return nil
 	}
 
 	presenter := jtkpresent.UserPresenter{}

--- a/tools/jtk/internal/cmd/me/me.go
+++ b/tools/jtk/internal/cmd/me/me.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
@@ -44,7 +45,13 @@ func run(ctx context.Context, opts *root.Options) error {
 		return err
 	}
 
-	user, err := client.GetCurrentUser(ctx)
+	// Only fetch groups/applicationRoles when --extended actually renders
+	// them; default, --id, and JSON paths don't care about those blocks.
+	expand := ""
+	if opts.IsExtended() {
+		expand = api.UserExtendedExpand
+	}
+	user, err := client.GetCurrentUser(ctx, expand)
 	if err != nil {
 		return err
 	}

--- a/tools/jtk/internal/cmd/me/me.go
+++ b/tools/jtk/internal/cmd/me/me.go
@@ -3,11 +3,9 @@ package me
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
@@ -21,8 +19,11 @@ func Register(parent *cobra.Command, opts *root.Options) {
 		Use:   "me",
 		Short: "Show current user",
 		Long:  "Show information about the currently authenticated Jira user.",
-		Example: `  # Show current user info
+		Example: `  # Show current user info (pipe one-liner)
   jtk me
+
+  # Include timezone, locale, and group/application-role counts
+  jtk me --extended
 
   # Show just the account ID (for scripting)
   jtk me --id`,
@@ -49,8 +50,7 @@ func run(ctx context.Context, opts *root.Options) error {
 
 	// --id: collapse output to the primary identifier.
 	if opts.EmitIDOnly() {
-		_, _ = fmt.Fprintln(opts.Stdout, user.AccountID)
-		return nil
+		return jtkpresent.EmitIDs(opts, []string{user.AccountID})
 	}
 
 	// JSON path: use existing artifact layer (unchanged)
@@ -58,16 +58,10 @@ func run(ctx context.Context, opts *root.Options) error {
 		return v.RenderArtifact(jtkartifact.ProjectUser(user, opts.ArtifactMode()))
 	}
 
-	// Plain path: just the account ID (legacy; --id is the preferred surface)
-	if v.Format == view.FormatPlain {
-		_, _ = fmt.Fprintln(opts.Stdout, user.AccountID)
-		return nil
+	presenter := jtkpresent.UserPresenter{}
+	var model = presenter.PresentUserOneLiner(user)
+	if opts.IsExtended() {
+		model = presenter.PresentUserExtended(user)
 	}
-
-	// Text path: presenter → model → pure render → write to both streams
-	model := jtkpresent.UserPresenter{}.Present(user)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/me/me_test.go
+++ b/tools/jtk/internal/cmd/me/me_test.go
@@ -174,6 +174,23 @@ func TestRun_JSON_UsesArtifactLayer(t *testing.T) {
 	testutil.Contains(t, output, "John Doe")
 }
 
+func TestRun_Plain_EmitsBareAccountID(t *testing.T) {
+	t.Parallel()
+	// Legacy contract (pre-#237): `-o plain` emits just the accountID, no
+	// name, no email. --id is the preferred surface, but the plain format
+	// stays working for backwards compatibility with unmigrated scripts.
+	user := &api.User{AccountID: "abc123", DisplayName: "John Doe", EmailAddress: "john@example.com", Active: true}
+	server := newTestUserServer(t, http.StatusOK, user)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "plain", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, run(context.Background(), opts))
+	testutil.Equal(t, stdout.String(), "abc123\n")
+}
+
 func TestRun_AuthFailure(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/tools/jtk/internal/cmd/me/me_test.go
+++ b/tools/jtk/internal/cmd/me/me_test.go
@@ -34,187 +34,144 @@ func newTestUserServer(_ *testing.T, statusCode int, user *api.User) *httptest.S
 	}))
 }
 
-func TestRun_Table(t *testing.T) {
-	t.Parallel()
-	user := &api.User{
-		AccountID:    "abc123",
-		DisplayName:  "John Doe",
-		EmailAddress: "john@example.com",
-		Active:       true,
-	}
+func newClient(t *testing.T, url string) *api.Client {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: url, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+	return client
+}
 
+func TestRun_DefaultOutputMatchesSpecOneLiner(t *testing.T) {
+	t.Parallel()
+	user := &api.User{AccountID: "abc123", DisplayName: "John Doe", EmailAddress: "john@example.com", Active: true}
 	server := newTestUserServer(t, http.StatusOK, user)
 	defer server.Close()
 
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, run(context.Background(), opts))
+
+	want := "abc123 | John Doe | john@example.com\n"
+	if stdout.String() != want {
+		t.Errorf("me default output:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestRun_EmptyEmailRendersDash(t *testing.T) {
+	t.Parallel()
+	user := &api.User{AccountID: "abc", DisplayName: "No Email", Active: true}
+	server := newTestUserServer(t, http.StatusOK, user)
+	defer server.Close()
 
 	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
 
-	err = run(context.Background(), opts)
-	testutil.RequireNoError(t, err)
+	testutil.RequireNoError(t, run(context.Background(), opts))
 
-	output := stdout.String()
-	testutil.Contains(t, output, "abc123")
-	testutil.Contains(t, output, "John Doe")
-	testutil.Contains(t, output, "john@example.com")
-	testutil.Contains(t, output, "yes")
+	want := "abc | No Email | -\n"
+	if stdout.String() != want {
+		t.Errorf("me empty-email output:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestRun_Extended_EmitsThreeSpecRows(t *testing.T) {
+	t.Parallel()
+	user := &api.User{
+		AccountID:        "abc123",
+		DisplayName:      "Rian Stockbower",
+		EmailAddress:     "rian@monitapp.io",
+		Active:           true,
+		TimeZone:         "Etc/GMT",
+		Locale:           "en_US",
+		Groups:           &api.UserCountBlock{Size: 9},
+		ApplicationRoles: &api.UserCountBlock{Size: 1},
+	}
+	server := newTestUserServer(t, http.StatusOK, user)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, run(context.Background(), opts))
+
+	want := "abc123 | Rian Stockbower | rian@monitapp.io\n" +
+		"Timezone: Etc/GMT   Locale: en_US   Active: yes\n" +
+		"Groups: 9   Application Roles: 1\n"
+	if stdout.String() != want {
+		t.Errorf("me --extended output:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestRun_Extended_DashesWhenOptionalFieldsMissing(t *testing.T) {
+	t.Parallel()
+	user := &api.User{AccountID: "abc", DisplayName: "Bob", Active: false}
+	server := newTestUserServer(t, http.StatusOK, user)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, run(context.Background(), opts))
+
+	want := "abc | Bob | -\n" +
+		"Timezone: -   Locale: -   Active: no\n" +
+		"Groups: -   Application Roles: -\n"
+	if stdout.String() != want {
+		t.Errorf("me --extended output with missing fields:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
 func TestRun_IDOnly(t *testing.T) {
 	t.Parallel()
-	user := &api.User{
-		AccountID:    "abc123",
-		DisplayName:  "John Doe",
-		EmailAddress: "john@example.com",
-		Active:       true,
-	}
-
+	user := &api.User{AccountID: "abc123", DisplayName: "John Doe", Active: true}
 	server := newTestUserServer(t, http.StatusOK, user)
 	defer server.Close()
 
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
 	var stdout bytes.Buffer
 	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
+	opts.SetAPIClient(newClient(t, server.URL))
 
 	testutil.RequireNoError(t, run(context.Background(), opts))
-
 	testutil.Equal(t, stdout.String(), "abc123\n")
 }
 
 func TestRun_IDOnlyPrecedenceOverExtended(t *testing.T) {
 	t.Parallel()
-	user := &api.User{
-		AccountID:    "abc123",
-		DisplayName:  "John Doe",
-		EmailAddress: "john@example.com",
-		Active:       true,
-	}
-
+	user := &api.User{AccountID: "abc123", DisplayName: "John Doe", Active: true}
 	server := newTestUserServer(t, http.StatusOK, user)
 	defer server.Close()
 
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
 	var stdout bytes.Buffer
+	// Even with --extended and --fulltext set, --id wins: only the accountID.
 	opts := &root.Options{Output: "table", IDOnly: true, Extended: true, FullText: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
+	opts.SetAPIClient(newClient(t, server.URL))
 
 	testutil.RequireNoError(t, run(context.Background(), opts))
-
-	// --id wins: only the accountID, no presenter output.
 	testutil.Equal(t, stdout.String(), "abc123\n")
 }
 
-func TestRun_JSON(t *testing.T) {
+func TestRun_JSON_UsesArtifactLayer(t *testing.T) {
 	t.Parallel()
-	user := &api.User{
-		AccountID:    "abc123",
-		DisplayName:  "John Doe",
-		EmailAddress: "john@example.com",
-		Active:       true,
-	}
-
+	user := &api.User{AccountID: "abc123", DisplayName: "John Doe", EmailAddress: "john@example.com", Active: true}
 	server := newTestUserServer(t, http.StatusOK, user)
 	defer server.Close()
 
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
 	var stdout bytes.Buffer
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
+	opts.SetAPIClient(newClient(t, server.URL))
 
-	err = run(context.Background(), opts)
-	testutil.RequireNoError(t, err)
+	testutil.RequireNoError(t, run(context.Background(), opts))
 
 	output := stdout.String()
 	testutil.Contains(t, output, `"accountId"`)
 	testutil.Contains(t, output, "abc123")
 	testutil.Contains(t, output, `"displayName"`)
 	testutil.Contains(t, output, "John Doe")
-}
-
-func TestRun_WithEmail(t *testing.T) {
-	t.Parallel()
-	user := &api.User{
-		AccountID:    "abc123",
-		DisplayName:  "John Doe",
-		EmailAddress: "john@example.com",
-		Active:       true,
-	}
-
-	server := newTestUserServer(t, http.StatusOK, user)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
-
-	err = run(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-
-	testutil.Contains(t, stdout.String(), "john@example.com")
-}
-
-func TestRun_WithoutEmail(t *testing.T) {
-	t.Parallel()
-	user := &api.User{
-		AccountID:   "abc123",
-		DisplayName: "John Doe",
-		Active:      true,
-	}
-
-	server := newTestUserServer(t, http.StatusOK, user)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
-
-	err = run(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-
-	output := stdout.String()
-	testutil.NotContains(t, output, "Email:")
-}
-
-func TestRun_Plain(t *testing.T) {
-	t.Parallel()
-	user := &api.User{
-		AccountID:   "abc123",
-		DisplayName: "John Doe",
-		Active:      true,
-	}
-
-	server := newTestUserServer(t, http.StatusOK, user)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "plain", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
-
-	err = run(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-
-	output := stdout.String()
-	testutil.Contains(t, output, "abc123")
-	testutil.NotContains(t, output, "John Doe")
 }
 
 func TestRun_AuthFailure(t *testing.T) {
@@ -225,42 +182,31 @@ func TestRun_AuthFailure(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
 	var stdout bytes.Buffer
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
+	opts.SetAPIClient(newClient(t, server.URL))
 
-	err = run(context.Background(), opts)
+	err := run(context.Background(), opts)
 	testutil.NotNil(t, err)
 }
 
-func TestRun_UnpaddedKeyValueOutput(t *testing.T) {
+func TestRun_ExpandParamSentOnMyselfRequest(t *testing.T) {
 	t.Parallel()
-	// Verifies the migration from manual padding to RenderKeyValues produces unpadded output
-	user := &api.User{
-		AccountID:    "abc123",
-		DisplayName:  "Alice",
-		EmailAddress: "alice@example.com",
-		Active:       true,
-	}
-
-	server := newTestUserServer(t, http.StatusOK, user)
+	// Verifies that GetCurrentUser carries expand=groups,applicationRoles so
+	// `--extended` can render Groups / Application Roles counts.
+	var capturedQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.Query().Get("expand")
+		_ = json.NewEncoder(w).Encode(&api.User{AccountID: "a", DisplayName: "x", Active: true})
+	}))
 	defer server.Close()
 
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
 	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
 
-	err = run(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-
-	want := "Account ID: abc123\nDisplay Name: Alice\nEmail: alice@example.com\nActive: yes\n"
-	if stdout.String() != want {
-		t.Errorf("me output:\ngot:\n%s\nwant:\n%s", stdout.String(), want)
+	testutil.RequireNoError(t, run(context.Background(), opts))
+	if capturedQuery != "groups,applicationRoles" {
+		t.Errorf("expand param = %q, want \"groups,applicationRoles\"", capturedQuery)
 	}
 }

--- a/tools/jtk/internal/cmd/me/me_test.go
+++ b/tools/jtk/internal/cmd/me/me_test.go
@@ -207,23 +207,37 @@ func TestRun_AuthFailure(t *testing.T) {
 	testutil.NotNil(t, err)
 }
 
-func TestRun_ExpandParamSentOnMyselfRequest(t *testing.T) {
+func TestRun_ExpandParamGatedOnExtended(t *testing.T) {
 	t.Parallel()
-	// Verifies that GetCurrentUser carries expand=groups,applicationRoles so
-	// `--extended` can render Groups / Application Roles counts.
-	var capturedQuery string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedQuery = r.URL.Query().Get("expand")
-		_ = json.NewEncoder(w).Encode(&api.User{AccountID: "a", DisplayName: "x", Active: true})
-	}))
-	defer server.Close()
+	// Verifies the /myself request carries expand=groups,applicationRoles
+	// ONLY when --extended is set. Default-mode callers don't render those
+	// counts, so the wasted payload is skipped.
+	cases := []struct {
+		name     string
+		extended bool
+		wantExp  string
+	}{
+		{"default omits expand", false, ""},
+		{"extended requests groups+roles", true, "groups,applicationRoles"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var captured string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured = r.URL.Query().Get("expand")
+				_ = json.NewEncoder(w).Encode(&api.User{AccountID: "a", DisplayName: "x", Active: true})
+			}))
+			defer server.Close()
 
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(newClient(t, server.URL))
+			var stdout bytes.Buffer
+			opts := &root.Options{Output: "table", Extended: tc.extended, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+			opts.SetAPIClient(newClient(t, server.URL))
 
-	testutil.RequireNoError(t, run(context.Background(), opts))
-	if capturedQuery != "groups,applicationRoles" {
-		t.Errorf("expand param = %q, want \"groups,applicationRoles\"", capturedQuery)
+			testutil.RequireNoError(t, run(context.Background(), opts))
+			if captured != tc.wantExp {
+				t.Errorf("expand = %q, want %q", captured, tc.wantExp)
+			}
+		})
 	}
 }

--- a/tools/jtk/internal/cmd/projects/get.go
+++ b/tools/jtk/internal/cmd/projects/get.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
@@ -50,7 +51,12 @@ func runGet(ctx context.Context, opts *root.Options, keyOrID, fieldsFlag string)
 	}
 
 	if opts.EmitIDOnly() {
-		project, err := client.GetProject(ctx, keyOrID)
+		// Skip expand in --id mode: the canonical key is in every /project
+		// response by default, and anything else (description, components,
+		// versions) is payload we'd immediately discard. The fetch itself is
+		// still necessary because numeric-ID inputs need to be canonicalized
+		// to a key.
+		project, err := client.GetProject(ctx, keyOrID, "")
 		if err != nil {
 			return err
 		}
@@ -73,7 +79,7 @@ func runGet(ctx context.Context, opts *root.Options, keyOrID, fieldsFlag string)
 		return err
 	}
 
-	project, err := client.GetProject(ctx, keyOrID)
+	project, err := client.GetProject(ctx, keyOrID, api.ProjectGetExpand)
 	if err != nil {
 		return err
 	}

--- a/tools/jtk/internal/cmd/projects/get.go
+++ b/tools/jtk/internal/cmd/projects/get.go
@@ -2,35 +2,73 @@ package projects
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 func newGetCmd(opts *root.Options) *cobra.Command {
-	return &cobra.Command{
+	var fieldsFlag string
+
+	cmd := &cobra.Command{
 		Use:   "get <project-key>",
 		Short: "Get project details",
 		Long:  "Get details for a specific project by key or ID.",
-		Example: `  jtk projects get MYPROJECT
-  jtk projects get 10001`,
+		Example: `  # Spec-shaped default output
+  jtk projects get MYPROJECT
+
+  # Admin/audit detail (components enumerated, Simplified/Private flags)
+  jtk projects get MYPROJECT --extended
+
+  # Just the project key
+  jtk projects get MYPROJECT --id
+
+  # Project detail rendered as labeled fields
+  jtk projects get MYPROJECT --fields NAME,LEAD`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGet(cmd.Context(), opts, args[0])
+			return runGet(cmd.Context(), opts, args[0], fieldsFlag)
 		},
 	}
+
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display fields (ProjectDetailSpec headers)")
+
+	return cmd
 }
 
-func runGet(ctx context.Context, opts *root.Options, keyOrID string) error {
+func runGet(ctx context.Context, opts *root.Options, keyOrID, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	if opts.EmitIDOnly() {
+		project, err := client.GetProject(ctx, keyOrID)
+		if err != nil {
+			return err
+		}
+		return jtkpresent.EmitIDs(opts, []string{project.Key})
+	}
+
+	if fieldsFlag != "" && v.Format == view.FormatJSON {
+		return errFieldsWithJSON
+	}
+
+	selected, projected, err := projection.Resolve(
+		ctx,
+		jtkpresent.ProjectDetailSpec,
+		opts.IsExtended(),
+		fieldsFlag,
+		noFieldFetch,
+		"projects get",
+	)
 	if err != nil {
 		return err
 	}
@@ -44,9 +82,11 @@ func runGet(ctx context.Context, opts *root.Options, keyOrID string) error {
 		return v.JSON(project)
 	}
 
-	model := jtkpresent.ProjectPresenter{}.Present(project)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	presenter := jtkpresent.ProjectPresenter{}
+	if projected {
+		model := presenter.PresentProjectDetailProjection(project)
+		projectDetailSectionInModel(model, selected)
+		return jtkpresent.Emit(opts, model)
+	}
+	return jtkpresent.Emit(opts, presenter.PresentProjectDetail(project, opts.IsExtended()))
 }

--- a/tools/jtk/internal/cmd/projects/get.go
+++ b/tools/jtk/internal/cmd/projects/get.go
@@ -58,7 +58,7 @@ func runGet(ctx context.Context, opts *root.Options, keyOrID, fieldsFlag string)
 	}
 
 	if fieldsFlag != "" && v.Format == view.FormatJSON {
-		return errFieldsWithJSON
+		return jtkpresent.ErrFieldsWithJSON
 	}
 
 	selected, projected, err := projection.Resolve(
@@ -85,7 +85,7 @@ func runGet(ctx context.Context, opts *root.Options, keyOrID, fieldsFlag string)
 	presenter := jtkpresent.ProjectPresenter{}
 	if projected {
 		model := presenter.PresentProjectDetailProjection(project)
-		projectDetailSectionInModel(model, selected)
+		projection.ApplyToDetailInModel(model, selected)
 		return jtkpresent.Emit(opts, model)
 	}
 	return jtkpresent.Emit(opts, presenter.PresentProjectDetail(project, opts.IsExtended()))

--- a/tools/jtk/internal/cmd/projects/list.go
+++ b/tools/jtk/internal/cmd/projects/list.go
@@ -94,7 +94,13 @@ func runList(ctx context.Context, opts *root.Options, query string, maxResults i
 		}
 	}
 
-	result, err := client.SearchProjects(ctx, query, startAt, maxResults, opts.IsExtended())
+	// Default-mode list renders KEY|TYPE|LEAD|NAME; only LEAD needs expansion.
+	// Extended adds STYLE|ISSUE_TYPES|COMPONENTS and requires the full set.
+	expand := "lead"
+	if opts.IsExtended() {
+		expand = api.ProjectListExpand
+	}
+	result, err := client.SearchProjects(ctx, query, startAt, maxResults, expand)
 	if err != nil {
 		return err
 	}

--- a/tools/jtk/internal/cmd/projects/list.go
+++ b/tools/jtk/internal/cmd/projects/list.go
@@ -2,20 +2,35 @@ package projects
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
+
+// errFieldsWithJSON is returned when --fields is combined with --output json.
+var errFieldsWithJSON = errors.New("--fields is not supported with --output json")
+
+// noFieldFetch is the projection.Resolve fetcher for project commands — the
+// same no-op rationale as comments / users: projection tokens here resolve
+// against ProjectListSpec / ProjectDetailSpec / ProjectTypeSpec, not Jira
+// issue field metadata.
+func noFieldFetch(_ context.Context) ([]api.Field, error) { return nil, nil }
 
 func newListCmd(opts *root.Options) *cobra.Command {
 	var query string
 	var maxResults int
+	var nextPageToken string
+	var fieldsFlag string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -24,23 +39,31 @@ func newListCmd(opts *root.Options) *cobra.Command {
 		Example: `  # List all projects
   jtk projects list
 
-  # Search projects by name
-  jtk projects list --query "my project"
+  # Include STYLE / ISSUE_TYPES / COMPONENTS columns
+  jtk projects list --extended
 
-  # Limit results
-  jtk projects list --max 10`,
+  # Emit just the project keys
+  jtk projects list --id
+
+  # Project output to selected columns
+  jtk projects list --fields KEY,NAME
+
+  # Fetch the next page
+  jtk projects list --max 5 --next-page-token 5`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runList(cmd.Context(), opts, query, maxResults)
+			return runList(cmd.Context(), opts, query, maxResults, nextPageToken, fieldsFlag)
 		},
 	}
 
 	cmd.Flags().StringVarP(&query, "query", "q", "", "Filter projects by name")
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of results")
+	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Decimal startAt for the next page")
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns (ProjectListSpec headers)")
 
 	return cmd
 }
 
-func runList(ctx context.Context, opts *root.Options, query string, maxResults int) error {
+func runList(ctx context.Context, opts *root.Options, query string, maxResults int, nextPageToken, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -48,25 +71,101 @@ func runList(ctx context.Context, opts *root.Options, query string, maxResults i
 		return err
 	}
 
-	result, err := client.SearchProjects(ctx, query, 0, maxResults)
+	idOnly := opts.EmitIDOnly()
+
+	startAt, err := parseStartAtToken(nextPageToken)
 	if err != nil {
 		return err
 	}
 
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
+		return errFieldsWithJSON
+	}
+
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.ProjectListSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			noFieldFetch,
+			"projects list",
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	result, err := client.SearchProjects(ctx, query, startAt, maxResults)
+	if err != nil {
+		return err
+	}
+
+	hasMore := !result.IsLast
+	nextToken := ""
+	if hasMore {
+		nextToken = strconv.Itoa(startAt + len(result.Values))
+	}
+
+	if idOnly {
+		ids := make([]string, len(result.Values))
+		for i, p := range result.Values {
+			ids[i] = p.Key
+		}
+		return jtkpresent.EmitIDsWithPaginationToken(opts, ids, hasMore, nextToken)
+	}
+
 	if len(result.Values) == 0 {
-		model := jtkpresent.ProjectPresenter{}.PresentEmpty()
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.ProjectPresenter{}.PresentEmpty())
 	}
 
 	if v.Format == view.FormatJSON {
 		return v.JSON(result.Values)
 	}
 
-	model := jtkpresent.ProjectPresenter{}.PresentList(result.Values)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	presenter := jtkpresent.ProjectPresenter{}
+	model := presenter.PresentProjectList(result.Values, opts.IsExtended())
+	if projected {
+		projectTableSectionInModel(model, selected)
+	}
+	model.Sections = jtkpresent.AppendPaginationHintWithToken(model.Sections, hasMore, nextToken)
+	return jtkpresent.Emit(opts, model)
+}
+
+// parseStartAtToken converts a `--next-page-token` value to a 0-based offset.
+// Non-numeric or negative input is rejected up-front so callers get a clean
+// error instead of a silently rewound page.
+func parseStartAtToken(token string) (int, error) {
+	if token == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(token)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid --next-page-token %q: expected a non-negative decimal", token)
+	}
+	return n, nil
+}
+
+// projectDetailSectionInModel rewrites the first DetailSection of model to the
+// selected fields. No-op when there is no DetailSection.
+func projectDetailSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
+	for i, s := range model.Sections {
+		if ds, ok := s.(*present.DetailSection); ok {
+			model.Sections[i] = projection.ProjectDetail(ds, selected)
+			return
+		}
+	}
+}
+
+// projectTableSectionInModel rewrites the first TableSection of model to the
+// selected columns. No-op when there is no TableSection.
+func projectTableSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
+	for i, s := range model.Sections {
+		if ts, ok := s.(*present.TableSection); ok {
+			model.Sections[i] = projection.ProjectTable(ts, selected)
+			return
+		}
+	}
 }

--- a/tools/jtk/internal/cmd/projects/list.go
+++ b/tools/jtk/internal/cmd/projects/list.go
@@ -2,13 +2,10 @@ package projects
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -17,13 +14,12 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
-// errFieldsWithJSON is returned when --fields is combined with --output json.
-var errFieldsWithJSON = errors.New("--fields is not supported with --output json")
-
 // noFieldFetch is the projection.Resolve fetcher for project commands — the
 // same no-op rationale as comments / users: projection tokens here resolve
 // against ProjectListSpec / ProjectDetailSpec / ProjectTypeSpec, not Jira
-// issue field metadata.
+// issue field metadata. Package-local by intent; the function is too
+// trivial to deserve a shared home and it reads more clearly next to the
+// specs it supports.
 func noFieldFetch(_ context.Context) ([]api.Field, error) { return nil, nil }
 
 func newListCmd(opts *root.Options) *cobra.Command {
@@ -73,13 +69,13 @@ func runList(ctx context.Context, opts *root.Options, query string, maxResults i
 
 	idOnly := opts.EmitIDOnly()
 
-	startAt, err := parseStartAtToken(nextPageToken)
+	startAt, err := jtkpresent.ParseStartAtToken(nextPageToken)
 	if err != nil {
 		return err
 	}
 
 	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
-		return errFieldsWithJSON
+		return jtkpresent.ErrFieldsWithJSON
 	}
 
 	var selected []projection.ColumnSpec
@@ -98,7 +94,7 @@ func runList(ctx context.Context, opts *root.Options, query string, maxResults i
 		}
 	}
 
-	result, err := client.SearchProjects(ctx, query, startAt, maxResults)
+	result, err := client.SearchProjects(ctx, query, startAt, maxResults, opts.IsExtended())
 	if err != nil {
 		return err
 	}
@@ -128,44 +124,8 @@ func runList(ctx context.Context, opts *root.Options, query string, maxResults i
 	presenter := jtkpresent.ProjectPresenter{}
 	model := presenter.PresentProjectList(result.Values, opts.IsExtended())
 	if projected {
-		projectTableSectionInModel(model, selected)
+		projection.ApplyToTableInModel(model, selected)
 	}
 	model.Sections = jtkpresent.AppendPaginationHintWithToken(model.Sections, hasMore, nextToken)
 	return jtkpresent.Emit(opts, model)
-}
-
-// parseStartAtToken converts a `--next-page-token` value to a 0-based offset.
-// Non-numeric or negative input is rejected up-front so callers get a clean
-// error instead of a silently rewound page.
-func parseStartAtToken(token string) (int, error) {
-	if token == "" {
-		return 0, nil
-	}
-	n, err := strconv.Atoi(token)
-	if err != nil || n < 0 {
-		return 0, fmt.Errorf("invalid --next-page-token %q: expected a non-negative decimal", token)
-	}
-	return n, nil
-}
-
-// projectDetailSectionInModel rewrites the first DetailSection of model to the
-// selected fields. No-op when there is no DetailSection.
-func projectDetailSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
-	for i, s := range model.Sections {
-		if ds, ok := s.(*present.DetailSection); ok {
-			model.Sections[i] = projection.ProjectDetail(ds, selected)
-			return
-		}
-	}
-}
-
-// projectTableSectionInModel rewrites the first TableSection of model to the
-// selected columns. No-op when there is no TableSection.
-func projectTableSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
-	for i, s := range model.Sections {
-		if ts, ok := s.(*present.TableSection); ok {
-			model.Sections[i] = projection.ProjectTable(ts, selected)
-			return
-		}
-	}
 }

--- a/tools/jtk/internal/cmd/projects/list.go
+++ b/tools/jtk/internal/cmd/projects/list.go
@@ -2,6 +2,7 @@ package projects
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -94,11 +95,16 @@ func runList(ctx context.Context, opts *root.Options, query string, maxResults i
 		}
 	}
 
-	// Default-mode list renders KEY|TYPE|LEAD|NAME; only LEAD needs expansion.
-	// Extended adds STYLE|ISSUE_TYPES|COMPONENTS and requires the full set.
-	expand := "lead"
-	if opts.IsExtended() {
-		expand = api.ProjectListExpand
+	// --id mode emits just keys, which are on every /project/search response
+	// by default; skip expansion entirely. Default-mode list also only needs
+	// LEAD. Extended adds STYLE|ISSUE_TYPES|COMPONENTS and requires the full
+	// set.
+	expand := ""
+	if !idOnly {
+		expand = "lead"
+		if opts.IsExtended() {
+			expand = api.ProjectListExpand
+		}
 	}
 	result, err := client.SearchProjects(ctx, query, startAt, maxResults, expand)
 	if err != nil {
@@ -106,6 +112,14 @@ func runList(ctx context.Context, opts *root.Options, query string, maxResults i
 	}
 
 	hasMore := !result.IsLast
+	if hasMore && len(result.Values) == 0 {
+		// Jira's /project/search has always paired IsLast=false with a
+		// non-empty page in practice, but guarding against the degenerate
+		// "hasMore + empty Values" response matters: a client that blindly
+		// follows nextToken would loop forever on the same page. Fail loudly
+		// instead of emitting a self-referential continuation token.
+		return fmt.Errorf("unexpected paginated response: IsLast=false with empty values (startAt=%d)", startAt)
+	}
 	nextToken := ""
 	if hasMore {
 		nextToken = strconv.Itoa(startAt + len(result.Values))

--- a/tools/jtk/internal/cmd/projects/projects_test.go
+++ b/tools/jtk/internal/cmd/projects/projects_test.go
@@ -147,6 +147,73 @@ func TestRunList_NextPageToken_AdvancesStartAt(t *testing.T) {
 	testutil.Equal(t, captured, "25")
 }
 
+func TestRunList_Fields_JSONReturnsError(t *testing.T) {
+	t.Parallel()
+	// `--fields` + `-o json` is explicitly rejected (parity with users search
+	// / issues list). The guard in runList must fire before hitting the
+	// server so the user gets a predictable error.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectSearchResponse{Values: []api.ProjectDetail{}, IsLast: true})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50, "", "KEY")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--fields is not supported")
+}
+
+func TestRunList_NextPageToken_RejectsNegative(t *testing.T) {
+	t.Parallel()
+	// strconv.Atoi parses "-1" successfully; the n < 0 guard must still
+	// reject it. A parallel test lives in users_test.go since the helper is
+	// duplicated per package.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectSearchResponse{Values: []api.ProjectDetail{}, IsLast: true})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50, "-5", "")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "invalid --next-page-token")
+	testutil.Contains(t, err.Error(), "non-negative")
+}
+
+func TestRunGet_Fields_JSONReturnsError(t *testing.T) {
+	t.Parallel()
+	// Mirrors TestRunGet_Fields_JSONReturnsError in users_test.go — the
+	// errFieldsWithJSON guard in runGet was introduced for this migration
+	// and should not silently accept both flags.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectDetail{Key: "TST", Name: "Test"})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "TST", "NAME")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--fields is not supported")
+}
+
 func TestRunList_IDOnly_EmitsKeysOnly(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/tools/jtk/internal/cmd/projects/projects_test.go
+++ b/tools/jtk/internal/cmd/projects/projects_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -43,7 +44,7 @@ func TestNewListCmd(t *testing.T) {
 	testutil.Equal(t, maxFlag.DefValue, "50")
 }
 
-func TestRunList_Table(t *testing.T) {
+func TestRunList_DefaultColumnOrderMatchesSpec(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(api.ProjectSearchResponse{
@@ -60,13 +61,140 @@ func TestRunList_Table(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+	out := stdout.String()
+	testutil.Contains(t, out, "KEY | TYPE | LEAD | NAME")
+	testutil.Contains(t, out, "TST | software | Lead | Test")
+}
+
+func TestRunList_Extended_AppendsStyleAndCounts(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectSearchResponse{
+			Values: []api.ProjectDetail{
+				{
+					Key: "TST", Name: "Test", ProjectTypeKey: "software",
+					Lead:       &api.User{DisplayName: "Lead"},
+					Style:      "classic",
+					IssueTypes: []api.IssueType{{ID: "1", Name: "Epic"}, {ID: "2", Name: "SDLC"}},
+					Components: []api.Component{{ID: "c1", Name: "A"}, {ID: "c2", Name: "B"}},
+				},
+			},
+			Total: 1, IsLast: true,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runList(context.Background(), opts, "", 50, "", ""))
+	out := stdout.String()
+	testutil.Contains(t, out, "KEY | TYPE | LEAD | NAME | STYLE | ISSUE_TYPES | COMPONENTS")
+	testutil.Contains(t, out, "TST | software | Lead | Test | classic | 2 | 2")
+}
+
+func TestRunList_HasMore_EmbedsTokenInContinuationLine(t *testing.T) {
+	t.Parallel()
+	// Two projects, IsLast=false → token should advance to startAt=2.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectSearchResponse{
+			Values: []api.ProjectDetail{
+				{Key: "A", Name: "A", ProjectTypeKey: "software"},
+				{Key: "B", Name: "B", ProjectTypeKey: "software"},
+			},
+			StartAt: 0, MaxResults: 2, Total: 20, IsLast: false,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runList(context.Background(), opts, "", 2, "", ""))
+	testutil.Contains(t, stdout.String(), "More results available (next: 2)")
+}
+
+func TestRunList_NextPageToken_AdvancesStartAt(t *testing.T) {
+	t.Parallel()
+	var captured string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query().Get("startAt")
+		_ = json.NewEncoder(w).Encode(api.ProjectSearchResponse{Values: []api.ProjectDetail{}, IsLast: true})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "", 50)
+	testutil.RequireNoError(t, runList(context.Background(), opts, "", 50, "25", ""))
+	testutil.Equal(t, captured, "25")
+}
+
+func TestRunList_IDOnly_EmitsKeysOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectSearchResponse{
+			Values: []api.ProjectDetail{
+				{Key: "A"}, {Key: "B"},
+			},
+			IsLast: true,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "TST")
-	testutil.Contains(t, stdout.String(), "Test")
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runList(context.Background(), opts, "", 50, "", ""))
+	testutil.Equal(t, stdout.String(), "A\nB\n")
+}
+
+func TestRunList_Fields_ProjectsToSelectedColumns(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectSearchResponse{
+			Values: []api.ProjectDetail{
+				{Key: "TST", Name: "Test", ProjectTypeKey: "software"},
+			},
+			IsLast: true,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runList(context.Background(), opts, "", 50, "", "KEY,NAME"))
+	out := stdout.String()
+	testutil.Contains(t, out, "KEY | NAME")
+	if strings.Contains(out, "TYPE") || strings.Contains(out, "LEAD") {
+		t.Errorf("projected output leaked non-selected columns: %q", out)
+	}
 }
 
 func TestRunList_JSON(t *testing.T) {
@@ -89,7 +217,7 @@ func TestRunList_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "", 50)
+	err = runList(context.Background(), opts, "", 50, "", "")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), `"key"`)
 	testutil.Contains(t, stdout.String(), "TST")
@@ -109,7 +237,7 @@ func TestRunList_Empty(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "", 50)
+	err = runList(context.Background(), opts, "", 50, "", "")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "No projects found")
 }
@@ -122,15 +250,14 @@ func TestNewGetCmd(t *testing.T) {
 	testutil.Equal(t, cmd.Use, "get <project-key>")
 }
 
-func TestRunGet_Table(t *testing.T) {
+func TestRunGet_DefaultSpecShape(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(api.ProjectDetail{
-			ID:             json.Number("10001"),
-			Key:            "TST",
-			Name:           "Test",
-			ProjectTypeKey: "software",
-			Lead:           &api.User{DisplayName: "Lead"},
+			ID: json.Number("10001"), Key: "TST", Name: "Test",
+			ProjectTypeKey: "software", Style: "classic",
+			Lead:       &api.User{DisplayName: "Lead"},
+			IssueTypes: []api.IssueType{{ID: "1", Name: "Epic"}},
 		})
 	}))
 	defer server.Close()
@@ -139,13 +266,123 @@ func TestRunGet_Table(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "TST")
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TST", ""))
+
+	want := "TST  Test\n" +
+		"Type: software   Lead: Lead   Style: classic\n" +
+		"Issue Types: Epic\n" +
+		"Components: 0   Versions: 0\n"
+	if stdout.String() != want {
+		t.Errorf("get default:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestRunGet_Extended_EnumeratesComponentsAndFlags(t *testing.T) {
+	t.Parallel()
+	simplified := false
+	private := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectDetail{
+			ID: json.Number("10001"), Key: "TST", Name: "Test",
+			ProjectTypeKey: "software", Style: "classic",
+			Lead:       &api.User{AccountID: "u1", DisplayName: "Lead"},
+			IssueTypes: []api.IssueType{{ID: "1", Name: "Epic"}},
+			Components: []api.Component{{ID: "c1", Name: "A"}, {ID: "c2", Name: "B"}},
+			Simplified: &simplified,
+			IsPrivate:  &private,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "TST")
-	testutil.Contains(t, stdout.String(), "Lead")
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TST", ""))
+
+	out := stdout.String()
+	testutil.Contains(t, out, "TST  Test")
+	testutil.Contains(t, out, "Type: software   Lead: Lead (u1)   Style: classic")
+	testutil.Contains(t, out, "Issue Types: Epic (1)")
+	testutil.Contains(t, out, "Components: 2")
+	testutil.Contains(t, out, "  c1 | A")
+	testutil.Contains(t, out, "  c2 | B")
+	testutil.Contains(t, out, "Versions: 0")
+	testutil.Contains(t, out, "Simplified: no   Private: no")
+}
+
+func TestRunGet_Extended_MissingFlagsRenderDashes(t *testing.T) {
+	t.Parallel()
+	// API response lacks simplified / isPrivate — presenters must not render
+	// literal "no" in either position.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"10001","key":"TST","name":"Test","projectTypeKey":"software","style":"classic","lead":{"displayName":"Lead"},"issueTypes":[],"components":[]}`))
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TST", ""))
+	testutil.Contains(t, stdout.String(), "Simplified: -   Private: -")
+}
+
+func TestRunGet_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectDetail{
+			ID: json.Number("10001"), Key: "TST", Name: "Test",
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TST", "NAME"))
+	testutil.Equal(t, stdout.String(), "TST\n")
+}
+
+func TestRunGet_Fields_ProjectsDetailSection(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectDetail{
+			ID: json.Number("10001"), Key: "TST", Name: "Test",
+			ProjectTypeKey: "software", Style: "classic",
+			Lead: &api.User{AccountID: "u1", DisplayName: "Lead"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TST", "NAME,LEAD"))
+	out := stdout.String()
+	testutil.Contains(t, out, "KEY: TST")
+	testutil.Contains(t, out, "NAME: Test")
+	testutil.Contains(t, out, "LEAD: Lead")
+	if strings.Contains(out, "STYLE:") {
+		t.Errorf("projection leaked unselected field in output: %q", out)
+	}
 }
 
 func TestNewCreateCmd(t *testing.T) {
@@ -337,8 +574,52 @@ func TestRunTypes(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runTypes(context.Background(), opts)
+	err = runTypes(context.Background(), opts, "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "software")
-	testutil.Contains(t, stdout.String(), "Software")
+	out := stdout.String()
+	testutil.Contains(t, out, "KEY | NAME")
+	testutil.Contains(t, out, "software | Software")
+}
+
+func TestRunTypes_Extended_AddsDescriptionKey(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.ProjectType{
+			{Key: "software", FormattedKey: "Software", DescriptionI18nKey: "jira.project.type.software.description"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runTypes(context.Background(), opts, ""))
+	out := stdout.String()
+	testutil.Contains(t, out, "KEY | NAME | DESCRIPTION_KEY")
+	testutil.Contains(t, out, "software | Software | jira.project.type.software.description")
+}
+
+func TestRunTypes_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.ProjectType{
+			{Key: "software", FormattedKey: "Software"},
+			{Key: "business", FormattedKey: "Business"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runTypes(context.Background(), opts, ""))
+	testutil.Equal(t, stdout.String(), "software\nbusiness\n")
 }

--- a/tools/jtk/internal/cmd/projects/projects_test.go
+++ b/tools/jtk/internal/cmd/projects/projects_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -64,15 +63,19 @@ func TestRunList_DefaultColumnOrderMatchesSpec(t *testing.T) {
 	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "", 50, "", "")
-	testutil.RequireNoError(t, err)
-	out := stdout.String()
-	testutil.Contains(t, out, "KEY | TYPE | LEAD | NAME")
-	testutil.Contains(t, out, "TST | software | Lead | Test")
+	testutil.RequireNoError(t, runList(context.Background(), opts, "", 50, "", ""))
+
+	want := "KEY | TYPE | LEAD | NAME\nTST | software | Lead | Test\n"
+	if stdout.String() != want {
+		t.Errorf("projects list default:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
-func TestRunList_Extended_AppendsStyleAndCounts(t *testing.T) {
+func TestRunList_Extended_MatchesSpecShape(t *testing.T) {
 	t.Parallel()
+	// Per #230: extended headers are KEY|TYPE|STYLE|LEAD|ISSUE_TYPES|
+	// COMPONENTS|NAME with ISSUE_TYPES rendered as comma-joined names and
+	// COMPONENTS as a count.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(api.ProjectSearchResponse{
 			Values: []api.ProjectDetail{
@@ -97,9 +100,12 @@ func TestRunList_Extended_AppendsStyleAndCounts(t *testing.T) {
 	opts.SetAPIClient(client)
 
 	testutil.RequireNoError(t, runList(context.Background(), opts, "", 50, "", ""))
-	out := stdout.String()
-	testutil.Contains(t, out, "KEY | TYPE | LEAD | NAME | STYLE | ISSUE_TYPES | COMPONENTS")
-	testutil.Contains(t, out, "TST | software | Lead | Test | classic | 2 | 2")
+
+	want := "KEY | TYPE | STYLE | LEAD | ISSUE_TYPES | COMPONENTS | NAME\n" +
+		"TST | software | classic | Lead | Epic, SDLC | 2 | Test\n"
+	if stdout.String() != want {
+		t.Errorf("projects list --extended:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
 func TestRunList_HasMore_EmbedsTokenInContinuationLine(t *testing.T) {
@@ -257,10 +263,10 @@ func TestRunList_Fields_ProjectsToSelectedColumns(t *testing.T) {
 	opts.SetAPIClient(client)
 
 	testutil.RequireNoError(t, runList(context.Background(), opts, "", 50, "", "KEY,NAME"))
-	out := stdout.String()
-	testutil.Contains(t, out, "KEY | NAME")
-	if strings.Contains(out, "TYPE") || strings.Contains(out, "LEAD") {
-		t.Errorf("projected output leaked non-selected columns: %q", out)
+
+	want := "KEY | NAME\nTST | Test\n"
+	if stdout.String() != want {
+		t.Errorf("projects list --fields KEY,NAME:\ngot:  %q\nwant: %q", stdout.String(), want)
 	}
 }
 
@@ -373,15 +379,50 @@ func TestRunGet_Extended_EnumeratesComponentsAndFlags(t *testing.T) {
 
 	testutil.RequireNoError(t, runGet(context.Background(), opts, "TST", ""))
 
-	out := stdout.String()
-	testutil.Contains(t, out, "TST  Test")
-	testutil.Contains(t, out, "Type: software   Lead: Lead (u1)   Style: classic")
-	testutil.Contains(t, out, "Issue Types: Epic (1)")
-	testutil.Contains(t, out, "Components: 2")
-	testutil.Contains(t, out, "  c1 | A")
-	testutil.Contains(t, out, "  c2 | B")
-	testutil.Contains(t, out, "Versions: 0")
-	testutil.Contains(t, out, "Simplified: no   Private: no")
+	want := "TST  Test\n" +
+		"Type: software   Lead: Lead (u1)   Style: classic\n" +
+		"Issue Types: Epic (1)\n" +
+		"Components: 2\n" +
+		"  c1 | A\n" +
+		"  c2 | B\n" +
+		"Versions: 0\n" +
+		"Simplified: no   Private: no\n"
+	if stdout.String() != want {
+		t.Errorf("projects get --extended:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestRunGet_Default_IssueTypesRowPresentEvenWhenEmpty(t *testing.T) {
+	t.Parallel()
+	// Command-level Fix 2 regression. The reviewer's original finding was a
+	// rendered-output contract issue, so we lock this at the command layer
+	// alongside the presenter-layer test.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectDetail{
+			ID: json.Number("10001"), Key: "EMPTY", Name: "Empty",
+			ProjectTypeKey: "software", Style: "classic",
+			Lead: &api.User{DisplayName: "Lead"},
+			// No IssueTypes, no Components, no Versions.
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "EMPTY", ""))
+
+	want := "EMPTY  Empty\n" +
+		"Type: software   Lead: Lead   Style: classic\n" +
+		"Issue Types: -\n" +
+		"Components: 0   Versions: 0\n"
+	if stdout.String() != want {
+		t.Errorf("projects get default (no issue types):\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
 func TestRunGet_Extended_MissingFlagsRenderDashes(t *testing.T) {
@@ -443,12 +484,11 @@ func TestRunGet_Fields_ProjectsDetailSection(t *testing.T) {
 	opts.SetAPIClient(client)
 
 	testutil.RequireNoError(t, runGet(context.Background(), opts, "TST", "NAME,LEAD"))
-	out := stdout.String()
-	testutil.Contains(t, out, "KEY: TST")
-	testutil.Contains(t, out, "NAME: Test")
-	testutil.Contains(t, out, "LEAD: Lead")
-	if strings.Contains(out, "STYLE:") {
-		t.Errorf("projection leaked unselected field in output: %q", out)
+
+	// KEY is the identity column; projection.Resolve always prepends it.
+	want := "KEY: TST\nNAME: Test\nLEAD: Lead\n"
+	if stdout.String() != want {
+		t.Errorf("projects get --fields NAME,LEAD:\ngot:  %q\nwant: %q", stdout.String(), want)
 	}
 }
 
@@ -641,11 +681,12 @@ func TestRunTypes(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runTypes(context.Background(), opts, "")
-	testutil.RequireNoError(t, err)
-	out := stdout.String()
-	testutil.Contains(t, out, "KEY | NAME")
-	testutil.Contains(t, out, "software | Software")
+	testutil.RequireNoError(t, runTypes(context.Background(), opts, ""))
+
+	want := "KEY | NAME\nsoftware | Software\nbusiness | Business\n"
+	if stdout.String() != want {
+		t.Errorf("projects types default:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
 func TestRunTypes_Extended_AddsDescriptionKey(t *testing.T) {
@@ -665,9 +706,11 @@ func TestRunTypes_Extended_AddsDescriptionKey(t *testing.T) {
 	opts.SetAPIClient(client)
 
 	testutil.RequireNoError(t, runTypes(context.Background(), opts, ""))
-	out := stdout.String()
-	testutil.Contains(t, out, "KEY | NAME | DESCRIPTION_KEY")
-	testutil.Contains(t, out, "software | Software | jira.project.type.software.description")
+
+	want := "KEY | NAME | DESCRIPTION_KEY\nsoftware | Software | jira.project.type.software.description\n"
+	if stdout.String() != want {
+		t.Errorf("projects types --extended:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
 func TestRunTypes_IDOnly(t *testing.T) {

--- a/tools/jtk/internal/cmd/projects/projects_test.go
+++ b/tools/jtk/internal/cmd/projects/projects_test.go
@@ -392,6 +392,58 @@ func TestRunGet_Extended_EnumeratesComponentsAndFlags(t *testing.T) {
 	}
 }
 
+func TestRunGet_Extended_ComponentListTruncatesAtLimit(t *testing.T) {
+	t.Parallel()
+	// The presenter has a unit test for the `... [N more]` truncation;
+	// this locks the same shape at the command layer so rendered output is
+	// covered end-to-end.
+	simplified := false
+	private := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.ProjectDetail{
+			ID: json.Number("10001"), Key: "TST", Name: "Test",
+			ProjectTypeKey: "software", Style: "classic",
+			Lead:       &api.User{AccountID: "u1", DisplayName: "Lead"},
+			IssueTypes: []api.IssueType{{ID: "1", Name: "Epic"}},
+			Components: []api.Component{
+				{ID: "c1", Name: "A"},
+				{ID: "c2", Name: "B"},
+				{ID: "c3", Name: "C"},
+				{ID: "c4", Name: "D"},
+				{ID: "c5", Name: "E"},
+				{ID: "c6", Name: "F"},
+			},
+			Simplified: &simplified,
+			IsPrivate:  &private,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TST", ""))
+
+	want := "TST  Test\n" +
+		"Type: software   Lead: Lead (u1)   Style: classic\n" +
+		"Issue Types: Epic (1)\n" +
+		"Components: 6\n" +
+		"  c1 | A\n" +
+		"  c2 | B\n" +
+		"  c3 | C\n" +
+		"  c4 | D\n" +
+		"  ... [2 more]\n" +
+		"Versions: 0\n" +
+		"Simplified: no   Private: no\n"
+	if stdout.String() != want {
+		t.Errorf("projects get --extended (>limit components):\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
 func TestRunGet_Default_IssueTypesRowPresentEvenWhenEmpty(t *testing.T) {
 	t.Parallel()
 	// Command-level Fix 2 regression. The reviewer's original finding was a

--- a/tools/jtk/internal/cmd/projects/types.go
+++ b/tools/jtk/internal/cmd/projects/types.go
@@ -2,30 +2,44 @@ package projects
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 func newTypesCmd(opts *root.Options) *cobra.Command {
-	return &cobra.Command{
-		Use:     "types",
-		Short:   "List project types",
-		Long:    "List available project types for creating new projects.",
-		Example: `  jtk projects types`,
+	var fieldsFlag string
+
+	cmd := &cobra.Command{
+		Use:   "types",
+		Short: "List project types",
+		Long:  "List available project types for creating new projects.",
+		Example: `  jtk projects types
+
+  # Include DESCRIPTION_KEY column
+  jtk projects types --extended
+
+  # Emit just the project-type keys
+  jtk projects types --id
+
+  # Project output to selected columns
+  jtk projects types --fields KEY`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runTypes(cmd.Context(), opts)
+			return runTypes(cmd.Context(), opts, fieldsFlag)
 		},
 	}
+
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns (ProjectTypeSpec headers)")
+
+	return cmd
 }
 
-func runTypes(ctx context.Context, opts *root.Options) error {
+func runTypes(ctx context.Context, opts *root.Options, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -33,25 +47,53 @@ func runTypes(ctx context.Context, opts *root.Options) error {
 		return err
 	}
 
+	idOnly := opts.EmitIDOnly()
+
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
+		return errFieldsWithJSON
+	}
+
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.ProjectTypeSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			noFieldFetch,
+			"projects types",
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	types, err := client.ListProjectTypes(ctx)
 	if err != nil {
 		return err
 	}
 
+	if idOnly {
+		ids := make([]string, len(types))
+		for i, t := range types {
+			ids[i] = t.Key
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
 	if len(types) == 0 {
-		model := jtkpresent.ProjectPresenter{}.PresentNoTypes()
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.ProjectPresenter{}.PresentNoTypes())
 	}
 
 	if v.Format == view.FormatJSON {
 		return v.JSON(types)
 	}
 
-	model := jtkpresent.ProjectPresenter{}.PresentTypes(types)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	presenter := jtkpresent.ProjectPresenter{}
+	model := presenter.PresentProjectTypes(types, opts.IsExtended())
+	if projected {
+		projectTableSectionInModel(model, selected)
+	}
+	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/projects/types.go
+++ b/tools/jtk/internal/cmd/projects/types.go
@@ -50,7 +50,7 @@ func runTypes(ctx context.Context, opts *root.Options, fieldsFlag string) error 
 	idOnly := opts.EmitIDOnly()
 
 	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
-		return errFieldsWithJSON
+		return jtkpresent.ErrFieldsWithJSON
 	}
 
 	var selected []projection.ColumnSpec
@@ -93,7 +93,7 @@ func runTypes(ctx context.Context, opts *root.Options, fieldsFlag string) error 
 	presenter := jtkpresent.ProjectPresenter{}
 	model := presenter.PresentProjectTypes(types, opts.IsExtended())
 	if projected {
-		projectTableSectionInModel(model, selected)
+		projection.ApplyToTableInModel(model, selected)
 	}
 	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/users/users.go
+++ b/tools/jtk/internal/cmd/users/users.go
@@ -102,7 +102,11 @@ func runGet(ctx context.Context, opts *root.Options, accountID, fieldsFlag strin
 		return err
 	}
 
-	user, err := client.GetUser(ctx, accountID)
+	expand := ""
+	if opts.IsExtended() {
+		expand = api.UserExtendedExpand
+	}
+	user, err := client.GetUser(ctx, accountID, expand)
 	if err != nil {
 		return err
 	}

--- a/tools/jtk/internal/cmd/users/users.go
+++ b/tools/jtk/internal/cmd/users/users.go
@@ -3,7 +3,9 @@ package users
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -11,10 +13,22 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
+
+// errFieldsWithJSON is returned when --fields is combined with --output json.
+// JSON artifacts are not projected; mixing them silently would hide the flag.
+var errFieldsWithJSON = errors.New("--fields is not supported with --output json")
+
+// noFieldFetch is the projection.Resolve fetcher for user commands. Users are
+// not Jira issue fields, so there is no metadata to fetch; returning nil
+// routes any deferred tokens cleanly to UnknownFieldError rather than into a
+// real /rest/api/3/field call that would surface unrelated issue-field names.
+func noFieldFetch(_ context.Context) ([]api.Field, error) { return nil, nil }
 
 // Register registers the users commands
 func Register(parent *cobra.Command, opts *root.Options) {
@@ -32,26 +46,63 @@ func Register(parent *cobra.Command, opts *root.Options) {
 }
 
 func newGetCmd(opts *root.Options) *cobra.Command {
-	return &cobra.Command{
+	var fieldsFlag string
+
+	cmd := &cobra.Command{
 		Use:   "get <account-id>",
 		Short: "Get user details by account ID",
 		Long:  "Retrieve and display details for a specific user by their Jira account ID.",
-		Example: `  # Get user details
+		Example: `  # Get user details (pipe one-liner)
   jtk users get 61292e4c4f29230069621c5f
 
-  # Print just the account ID
-  jtk users get 61292e4c4f29230069621c5f --id`,
+  # Include timezone, locale, and group/application-role counts
+  jtk users get 61292e4c4f29230069621c5f --extended
+
+  # Just the account ID
+  jtk users get 61292e4c4f29230069621c5f --id
+
+  # Restrict output to selected fields
+  jtk users get 61292e4c4f29230069621c5f --fields NAME,EMAIL`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGet(cmd.Context(), opts, args[0])
+			return runGet(cmd.Context(), opts, args[0], fieldsFlag)
 		},
 	}
+
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display fields (UserDetailSpec headers)")
+
+	return cmd
 }
 
-func runGet(ctx context.Context, opts *root.Options, accountID string) error {
+func runGet(ctx context.Context, opts *root.Options, accountID, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	// --id wins: collapse output before we do any projection work.
+	if opts.EmitIDOnly() {
+		user, err := client.GetUser(ctx, accountID)
+		if err != nil {
+			return err
+		}
+		return jtkpresent.EmitIDs(opts, []string{user.AccountID})
+	}
+
+	if fieldsFlag != "" && v.Format == view.FormatJSON {
+		return errFieldsWithJSON
+	}
+
+	selected, projected, err := projection.Resolve(
+		ctx,
+		jtkpresent.UserDetailSpec,
+		opts.IsExtended(),
+		fieldsFlag,
+		noFieldFetch,
+		"users get",
+	)
 	if err != nil {
 		return err
 	}
@@ -61,50 +112,67 @@ func runGet(ctx context.Context, opts *root.Options, accountID string) error {
 		return err
 	}
 
-	if opts.EmitIDOnly() {
-		_, _ = fmt.Fprintln(opts.Stdout, user.AccountID)
-		return nil
-	}
-
 	if v.Format == view.FormatJSON {
 		return v.RenderArtifact(jtkartifact.ProjectUser(user, opts.ArtifactMode()))
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.UserPresenter{}.Present(user)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	presenter := jtkpresent.UserPresenter{}
+	if projected {
+		model := presenter.PresentUserDetailProjection(user)
+		projectDetailSectionInModel(model, selected)
+		return jtkpresent.Emit(opts, model)
+	}
+
+	var model = presenter.PresentUserOneLiner(user)
+	if opts.IsExtended() {
+		model = presenter.PresentUserExtended(user)
+	}
+	return jtkpresent.Emit(opts, model)
 }
 
 func newSearchCmd(opts *root.Options) *cobra.Command {
 	var maxResults int
+	var nextPageToken string
+	var fieldsFlag string
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
 		Short: "Search for users",
 		Long: `Search for users by name, email, or username.
 
-The search is case-insensitive and matches against display name, email address,
-and other user attributes. Use this to find account IDs for issue assignment.`,
+The search is case-insensitive and matches against display name, email
+address, and other user attributes. Pagination uses /user/search's offset
+model — the continuation token is the next startAt as a decimal string. The
+endpoint does not return an authoritative terminator, so hasMore is inferred
+from the page being full (len(results) == --max).`,
 		Example: `  # Search for users named "john"
   jtk users search john
 
-  # Limit results
-  jtk users search john --max 5`,
+  # Include timezone and locale columns
+  jtk users search john --extended
+
+  # Emit just account IDs, one per line
+  jtk users search john --id
+
+  # Project output to selected columns
+  jtk users search john --fields ACCOUNT_ID,NAME
+
+  # Fetch the second page
+  jtk users search john --max 10 --next-page-token 10`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSearch(cmd.Context(), opts, args[0], maxResults)
+			return runSearch(cmd.Context(), opts, args[0], maxResults, nextPageToken, fieldsFlag)
 		},
 	}
 
 	cmd.Flags().IntVar(&maxResults, "max", 10, "Maximum number of results")
+	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Decimal startAt for the next page")
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns (UserListSpec headers)")
 
 	return cmd
 }
 
-func runSearch(ctx context.Context, opts *root.Options, query string, maxResults int) error {
+func runSearch(ctx context.Context, opts *root.Options, query string, maxResults int, nextPageToken, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -112,30 +180,107 @@ func runSearch(ctx context.Context, opts *root.Options, query string, maxResults
 		return err
 	}
 
-	users, err := client.SearchUsers(ctx, query, maxResults)
+	idOnly := opts.EmitIDOnly()
+
+	startAt, err := parseStartAtToken(nextPageToken)
 	if err != nil {
 		return err
 	}
 
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
+		return errFieldsWithJSON
+	}
+
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.UserListSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			noFieldFetch,
+			"users search",
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	users, err := client.SearchUsers(ctx, query, startAt, maxResults)
+	if err != nil {
+		return err
+	}
+
+	// /user/search has no native isLast; the heuristic is that a full page
+	// implies more pages may exist. Over-reporting in the last window is the
+	// documented tradeoff for a command whose endpoint lacks an authoritative
+	// terminator. When maxResults <= 0 (no cap), hasMore stays false.
+	hasMore := maxResults > 0 && len(users) == maxResults
+	nextToken := ""
+	if hasMore {
+		nextToken = strconv.Itoa(startAt + len(users))
+	}
+
+	if idOnly {
+		ids := make([]string, len(users))
+		for i, u := range users {
+			ids[i] = u.AccountID
+		}
+		return jtkpresent.EmitIDsWithPaginationToken(opts, ids, hasMore, nextToken)
+	}
+
 	if len(users) == 0 {
-		model := jtkpresent.UserPresenter{}.PresentEmpty(query)
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.UserPresenter{}.PresentEmpty(query))
 	}
 
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectUsers(users, opts.ArtifactMode())
-		// API returns bare []User with no pagination metadata.
-		// Infer hasMore when result count equals requested max.
-		hasMore := maxResults > 0 && len(users) == maxResults
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.UserPresenter{}.PresentList(users)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	presenter := jtkpresent.UserPresenter{}
+	model := presenter.PresentUserList(users, opts.IsExtended())
+	if projected {
+		projectTableSectionInModel(model, selected)
+	}
+	model.Sections = jtkpresent.AppendPaginationHintWithToken(model.Sections, hasMore, nextToken)
+	return jtkpresent.Emit(opts, model)
+}
+
+// parseStartAtToken converts a `--next-page-token` value to a 0-based offset.
+// The spec surfaces the token as a decimal number; non-numeric input is
+// rejected up-front so we don't silently paginate past the start of the
+// result set.
+func parseStartAtToken(token string) (int, error) {
+	if token == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(token)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid --next-page-token %q: expected a non-negative decimal", token)
+	}
+	return n, nil
+}
+
+// projectDetailSectionInModel rewrites the first DetailSection of model to
+// the selected fields. No-op when there is no DetailSection.
+func projectDetailSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
+	for i, s := range model.Sections {
+		if ds, ok := s.(*present.DetailSection); ok {
+			model.Sections[i] = projection.ProjectDetail(ds, selected)
+			return
+		}
+	}
+}
+
+// projectTableSectionInModel rewrites the first TableSection of model to the
+// selected columns. No-op when there is no TableSection.
+func projectTableSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
+	for i, s := range model.Sections {
+		if ts, ok := s.(*present.TableSection); ok {
+			model.Sections[i] = projection.ProjectTable(ts, selected)
+			return
+		}
+	}
 }

--- a/tools/jtk/internal/cmd/users/users.go
+++ b/tools/jtk/internal/cmd/users/users.go
@@ -3,14 +3,11 @@ package users
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -20,14 +17,12 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
-// errFieldsWithJSON is returned when --fields is combined with --output json.
-// JSON artifacts are not projected; mixing them silently would hide the flag.
-var errFieldsWithJSON = errors.New("--fields is not supported with --output json")
-
 // noFieldFetch is the projection.Resolve fetcher for user commands. Users are
 // not Jira issue fields, so there is no metadata to fetch; returning nil
 // routes any deferred tokens cleanly to UnknownFieldError rather than into a
 // real /rest/api/3/field call that would surface unrelated issue-field names.
+// Package-local rather than shared because it is trivial and typed for the
+// caller's context — consolidating it would obscure the intent.
 func noFieldFetch(_ context.Context) ([]api.Field, error) { return nil, nil }
 
 // Register registers the users commands
@@ -82,17 +77,17 @@ func runGet(ctx context.Context, opts *root.Options, accountID, fieldsFlag strin
 		return err
 	}
 
-	// --id wins: collapse output before we do any projection work.
+	// --id wins: collapse output before we do any projection work. The
+	// account ID is its own canonical identifier (no ID→key lookup step like
+	// projects), so we can round-trip the caller's input without fetching.
+	// Saves an API call and an expand=groups,applicationRoles query that
+	// would be thrown away immediately.
 	if opts.EmitIDOnly() {
-		user, err := client.GetUser(ctx, accountID)
-		if err != nil {
-			return err
-		}
-		return jtkpresent.EmitIDs(opts, []string{user.AccountID})
+		return jtkpresent.EmitIDs(opts, []string{accountID})
 	}
 
 	if fieldsFlag != "" && v.Format == view.FormatJSON {
-		return errFieldsWithJSON
+		return jtkpresent.ErrFieldsWithJSON
 	}
 
 	selected, projected, err := projection.Resolve(
@@ -119,7 +114,7 @@ func runGet(ctx context.Context, opts *root.Options, accountID, fieldsFlag strin
 	presenter := jtkpresent.UserPresenter{}
 	if projected {
 		model := presenter.PresentUserDetailProjection(user)
-		projectDetailSectionInModel(model, selected)
+		projection.ApplyToDetailInModel(model, selected)
 		return jtkpresent.Emit(opts, model)
 	}
 
@@ -182,13 +177,13 @@ func runSearch(ctx context.Context, opts *root.Options, query string, maxResults
 
 	idOnly := opts.EmitIDOnly()
 
-	startAt, err := parseStartAtToken(nextPageToken)
+	startAt, err := jtkpresent.ParseStartAtToken(nextPageToken)
 	if err != nil {
 		return err
 	}
 
 	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
-		return errFieldsWithJSON
+		return jtkpresent.ErrFieldsWithJSON
 	}
 
 	var selected []projection.ColumnSpec
@@ -242,45 +237,8 @@ func runSearch(ctx context.Context, opts *root.Options, query string, maxResults
 	presenter := jtkpresent.UserPresenter{}
 	model := presenter.PresentUserList(users, opts.IsExtended())
 	if projected {
-		projectTableSectionInModel(model, selected)
+		projection.ApplyToTableInModel(model, selected)
 	}
 	model.Sections = jtkpresent.AppendPaginationHintWithToken(model.Sections, hasMore, nextToken)
 	return jtkpresent.Emit(opts, model)
-}
-
-// parseStartAtToken converts a `--next-page-token` value to a 0-based offset.
-// The spec surfaces the token as a decimal number; non-numeric input is
-// rejected up-front so we don't silently paginate past the start of the
-// result set.
-func parseStartAtToken(token string) (int, error) {
-	if token == "" {
-		return 0, nil
-	}
-	n, err := strconv.Atoi(token)
-	if err != nil || n < 0 {
-		return 0, fmt.Errorf("invalid --next-page-token %q: expected a non-negative decimal", token)
-	}
-	return n, nil
-}
-
-// projectDetailSectionInModel rewrites the first DetailSection of model to
-// the selected fields. No-op when there is no DetailSection.
-func projectDetailSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
-	for i, s := range model.Sections {
-		if ds, ok := s.(*present.DetailSection); ok {
-			model.Sections[i] = projection.ProjectDetail(ds, selected)
-			return
-		}
-	}
-}
-
-// projectTableSectionInModel rewrites the first TableSection of model to the
-// selected columns. No-op when there is no TableSection.
-func projectTableSectionInModel(model *present.OutputModel, selected []projection.ColumnSpec) {
-	for i, s := range model.Sections {
-		if ts, ok := s.(*present.TableSection); ok {
-			model.Sections[i] = projection.ProjectTable(ts, selected)
-			return
-		}
-	}
 }

--- a/tools/jtk/internal/cmd/users/users_test.go
+++ b/tools/jtk/internal/cmd/users/users_test.go
@@ -152,6 +152,41 @@ func TestRunGet_Fields_UnknownHeaderFails(t *testing.T) {
 	testutil.Contains(t, err.Error(), "unknown field")
 }
 
+func TestRunGet_IDOnly_SkipsAPIFetch(t *testing.T) {
+	t.Parallel()
+	// The accountID is its own canonical identifier — no API round-trip is
+	// needed in --id mode. A server that fails any request would return an
+	// error if we accidentally called it; the test passes only because no
+	// request happens.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "no request should be made in --id mode", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc123", ""))
+	testutil.Equal(t, stdout.String(), "abc123\n")
+}
+
+func TestRunGet_Plain_MatchesSpecOneLiner(t *testing.T) {
+	t.Parallel()
+	// `-o plain` on users get was never a bare-ID shim (unlike me). Lock the
+	// current behavior: plain-format output is the same one-liner the table
+	// path emits.
+	server := newTestUserServer(t, api.User{AccountID: "abc123", DisplayName: "Alice", EmailAddress: "a@x.io", Active: true})
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "plain", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc123", ""))
+	testutil.Equal(t, stdout.String(), "abc123 | Alice | a@x.io\n")
+}
+
 func TestRunGet_JSON_PreservesArtifactOutput(t *testing.T) {
 	t.Parallel()
 	server := newTestUserServer(t, api.User{AccountID: "abc123", DisplayName: "John Doe", Active: true})
@@ -397,6 +432,29 @@ func TestRunSearch_Empty_ShowsFriendlyMessage(t *testing.T) {
 
 	testutil.RequireNoError(t, runSearch(context.Background(), opts, "ghost", 10, "", ""))
 	testutil.Contains(t, stdout.String(), "No users found")
+}
+
+func TestRunSearch_Plain_MatchesTableShape(t *testing.T) {
+	t.Parallel()
+	// Plain format for users search never had a bare-ID shim historically;
+	// lock current behavior (same shape as table) so a future change to the
+	// shared Emit path can't drift silently.
+	users := []api.User{
+		{AccountID: "a1", DisplayName: "Alice", EmailAddress: "a@x.io", Active: true},
+	}
+	server := newTestUsersServer(t, users)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "plain", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", ""))
+
+	want := "ACCOUNT_ID | NAME | EMAIL | ACTIVE\na1 | Alice | a@x.io | yes\n"
+	if stdout.String() != want {
+		t.Errorf("users search -o plain:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
 func TestRunSearch_JSON_RendersArtifacts(t *testing.T) {

--- a/tools/jtk/internal/cmd/users/users_test.go
+++ b/tools/jtk/internal/cmd/users/users_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -195,10 +194,12 @@ func TestRunSearch_DefaultTableMatchesSpecColumnOrder(t *testing.T) {
 
 	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", ""))
 
-	out := stdout.String()
-	testutil.Contains(t, out, "ACCOUNT_ID | NAME | EMAIL | ACTIVE")
-	testutil.Contains(t, out, "a1 | Alice | a@x.io | yes")
-	testutil.Contains(t, out, "b2 | Bob | - | no")
+	want := "ACCOUNT_ID | NAME | EMAIL | ACTIVE\n" +
+		"a1 | Alice | a@x.io | yes\n" +
+		"b2 | Bob | - | no\n"
+	if stdout.String() != want {
+		t.Errorf("users search default:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
 func TestRunSearch_Extended_AppendsTimezoneLocale(t *testing.T) {
@@ -215,9 +216,11 @@ func TestRunSearch_Extended_AppendsTimezoneLocale(t *testing.T) {
 
 	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", ""))
 
-	out := stdout.String()
-	testutil.Contains(t, out, "ACCOUNT_ID | NAME | EMAIL | ACTIVE | TIMEZONE | LOCALE")
-	testutil.Contains(t, out, "a1 | Alice | a@x.io | yes | Etc/GMT | en_US")
+	want := "ACCOUNT_ID | NAME | EMAIL | ACTIVE | TIMEZONE | LOCALE\n" +
+		"a1 | Alice | a@x.io | yes | Etc/GMT | en_US\n"
+	if stdout.String() != want {
+		t.Errorf("users search --extended:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
 func TestRunSearch_Extended_DashesForRedactedFields(t *testing.T) {
@@ -233,7 +236,12 @@ func TestRunSearch_Extended_DashesForRedactedFields(t *testing.T) {
 	opts.SetAPIClient(newClient(t, server.URL))
 
 	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", ""))
-	testutil.Contains(t, stdout.String(), "a1 | Alice | - | yes | - | -")
+
+	want := "ACCOUNT_ID | NAME | EMAIL | ACTIVE | TIMEZONE | LOCALE\n" +
+		"a1 | Alice | - | yes | - | -\n"
+	if stdout.String() != want {
+		t.Errorf("users search --extended (redacted):\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
 func TestRunSearch_IDOnly_EmitsKeysOnly(t *testing.T) {
@@ -256,7 +264,9 @@ func TestRunSearch_IDOnly_EmitsKeysOnly(t *testing.T) {
 func TestRunSearch_HasMore_AppendsTokenizedContinuation(t *testing.T) {
 	t.Parallel()
 	// len(users) == --max triggers hasMore. Continuation line embeds next
-	// startAt per #230.
+	// startAt per #230. Exact-string golden locks the full output shape
+	// (header + rows + continuation) so accidental drift in any of the three
+	// sections gets caught.
 	users := []api.User{
 		{AccountID: "a1", DisplayName: "Alice"},
 		{AccountID: "b2", DisplayName: "Bob"},
@@ -269,7 +279,14 @@ func TestRunSearch_HasMore_AppendsTokenizedContinuation(t *testing.T) {
 	opts.SetAPIClient(newClient(t, server.URL))
 
 	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 2, "", ""))
-	testutil.Contains(t, stdout.String(), "More results available (next: 2)")
+
+	want := "ACCOUNT_ID | NAME | EMAIL | ACTIVE\n" +
+		"a1 | Alice | - | no\n" +
+		"b2 | Bob | - | no\n" +
+		"More results available (next: 2)\n"
+	if stdout.String() != want {
+		t.Errorf("users search with pagination:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
 }
 
 func TestRunSearch_IDOnly_EmitsTokenizedContinuation(t *testing.T) {
@@ -361,11 +378,11 @@ func TestRunSearch_Fields_ProjectsToSelectedColumns(t *testing.T) {
 	opts.SetAPIClient(newClient(t, server.URL))
 
 	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", "NAME"))
-	out := stdout.String()
+
 	// ACCOUNT_ID is the identity column and is always retained.
-	testutil.Contains(t, out, "ACCOUNT_ID | NAME")
-	if strings.Contains(out, "EMAIL") || strings.Contains(out, "ACTIVE") {
-		t.Errorf("projected output leaked non-selected columns: %q", out)
+	want := "ACCOUNT_ID | NAME\na1 | Alice\n"
+	if stdout.String() != want {
+		t.Errorf("users search --fields NAME:\ngot:  %q\nwant: %q", stdout.String(), want)
 	}
 }
 

--- a/tools/jtk/internal/cmd/users/users_test.go
+++ b/tools/jtk/internal/cmd/users/users_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -14,148 +15,18 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
+func newClient(t *testing.T, url string) *api.Client {
+	t.Helper()
+	c, err := api.New(api.ClientConfig{URL: url, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+	return c
+}
+
 func newTestUserServer(_ *testing.T, user api.User) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(user)
 	}))
-}
-
-func TestNewGetCmd(t *testing.T) {
-	t.Parallel()
-	opts := &root.Options{}
-	cmd := newGetCmd(opts)
-
-	testutil.Equal(t, cmd.Use, "get <account-id>")
-	testutil.NotEmpty(t, cmd.Short)
-}
-
-func TestRunGet_Table(t *testing.T) {
-	t.Parallel()
-	user := api.User{
-		AccountID:    "abc123",
-		DisplayName:  "John Doe",
-		EmailAddress: "john@example.com",
-		Active:       true,
-	}
-
-	server := newTestUserServer(t, user)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
-
-	err = runGet(context.Background(), opts, "abc123")
-	testutil.RequireNoError(t, err)
-
-	output := stdout.String()
-	testutil.Contains(t, output, "abc123")
-	testutil.Contains(t, output, "John Doe")
-	testutil.Contains(t, output, "john@example.com")
-	testutil.Contains(t, output, "yes")
-}
-
-func TestRunGet_IDOnly(t *testing.T) {
-	t.Parallel()
-	user := api.User{AccountID: "abc123", DisplayName: "John Doe", Active: true}
-
-	server := newTestUserServer(t, user)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
-
-	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc123"))
-	testutil.Equal(t, stdout.String(), "abc123\n")
-}
-
-func TestRunGet_IDOnlyPrecedenceOverExtended(t *testing.T) {
-	t.Parallel()
-	user := api.User{AccountID: "abc123", DisplayName: "John Doe", Active: true}
-
-	server := newTestUserServer(t, user)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", IDOnly: true, Extended: true, FullText: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
-
-	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc123"))
-	testutil.Equal(t, stdout.String(), "abc123\n")
-}
-
-func TestRunGet_JSON(t *testing.T) {
-	t.Parallel()
-	user := api.User{
-		AccountID:   "abc123",
-		DisplayName: "John Doe",
-		Active:      true,
-	}
-
-	server := newTestUserServer(t, user)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
-
-	err = runGet(context.Background(), opts, "abc123")
-	testutil.RequireNoError(t, err)
-
-	output := stdout.String()
-	testutil.Contains(t, output, `"accountId"`)
-	testutil.Contains(t, output, "abc123")
-}
-
-func TestRunGet_InactiveUser(t *testing.T) {
-	t.Parallel()
-	user := api.User{
-		AccountID:   "abc123",
-		DisplayName: "John Doe",
-		Active:      false,
-	}
-
-	server := newTestUserServer(t, user)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
-
-	err = runGet(context.Background(), opts, "abc123")
-	testutil.RequireNoError(t, err)
-
-	testutil.Contains(t, stdout.String(), "no")
-}
-
-func TestNewSearchCmd(t *testing.T) {
-	t.Parallel()
-	opts := &root.Options{}
-	cmd := newSearchCmd(opts)
-
-	testutil.Equal(t, cmd.Use, "search <query>")
-	testutil.NotEmpty(t, cmd.Short)
-
-	maxFlag := cmd.Flags().Lookup("max")
-	testutil.NotNil(t, maxFlag)
-	testutil.Equal(t, maxFlag.DefValue, "10")
 }
 
 func newTestUsersServer(_ *testing.T, users []api.User) *httptest.Server {
@@ -165,118 +36,367 @@ func newTestUsersServer(_ *testing.T, users []api.User) *httptest.Server {
 	}))
 }
 
-func TestRunSearch_Table(t *testing.T) {
+// ----- users get -----
+
+func TestNewGetCmd(t *testing.T) {
 	t.Parallel()
-	users := []api.User{
-		{AccountID: "abc123", DisplayName: "John Doe", EmailAddress: "john@example.com", Active: true},
-		{AccountID: "def456", DisplayName: "Jane Smith", EmailAddress: "jane@example.com", Active: false},
-	}
+	opts := &root.Options{}
+	cmd := newGetCmd(opts)
 
-	server := newTestUsersServer(t, users)
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
-
-	err = runSearch(context.Background(), opts, "john", 10)
-	testutil.RequireNoError(t, err)
-
-	output := stdout.String()
-	testutil.Contains(t, output, "abc123")
-	testutil.Contains(t, output, "John Doe")
-	testutil.Contains(t, output, "john@example.com")
-	testutil.Contains(t, output, "def456")
-	testutil.Contains(t, output, "Jane Smith")
+	testutil.Equal(t, cmd.Use, "get <account-id>")
+	testutil.NotEmpty(t, cmd.Short)
+	testutil.NotNil(t, cmd.Flags().Lookup("fields"))
 }
 
-func TestRunSearch_JSON(t *testing.T) {
+func TestRunGet_DefaultOutputMatchesSpecOneLiner(t *testing.T) {
 	t.Parallel()
-	users := []api.User{
-		{AccountID: "abc123", DisplayName: "John Doe", EmailAddress: "john@example.com", Active: true},
-	}
-
-	server := newTestUsersServer(t, users)
+	server := newTestUserServer(t, api.User{AccountID: "abc123", DisplayName: "John Doe", EmailAddress: "john@example.com", Active: true})
 	defer server.Close()
 
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc123", ""))
+
+	want := "abc123 | John Doe | john@example.com\n"
+	if stdout.String() != want {
+		t.Errorf("get default output:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestRunGet_Extended_EmitsThreeSpecRows(t *testing.T) {
+	t.Parallel()
+	user := api.User{
+		AccountID: "abc", DisplayName: "Rian", EmailAddress: "r@x.io", Active: true,
+		TimeZone: "Etc/GMT", Locale: "en_US",
+		Groups: &api.UserCountBlock{Size: 9}, ApplicationRoles: &api.UserCountBlock{Size: 1},
+	}
+	server := newTestUserServer(t, user)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc", ""))
+
+	want := "abc | Rian | r@x.io\n" +
+		"Timezone: Etc/GMT   Locale: en_US   Active: yes\n" +
+		"Groups: 9   Application Roles: 1\n"
+	if stdout.String() != want {
+		t.Errorf("get --extended:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestRunGet_IDOnly_ShortCircuitsEverythingElse(t *testing.T) {
+	t.Parallel()
+	server := newTestUserServer(t, api.User{AccountID: "abc123", DisplayName: "X", Active: true})
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc123", "NAME,EMAIL"))
+	testutil.Equal(t, stdout.String(), "abc123\n")
+}
+
+func TestRunGet_Fields_ProjectsDetailSection(t *testing.T) {
+	t.Parallel()
+	user := api.User{AccountID: "abc", DisplayName: "Rian", EmailAddress: "r@x.io", Active: true}
+	server := newTestUserServer(t, user)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc", "NAME,EMAIL"))
+
+	// Identity is prepended by projection.Resolve; output flattens to labeled
+	// Key:Value lines mirroring `issues get --fields`.
+	want := "ACCOUNT_ID: abc\nNAME: Rian\nEMAIL: r@x.io\n"
+	if stdout.String() != want {
+		t.Errorf("get --fields:\ngot:  %q\nwant: %q", stdout.String(), want)
+	}
+}
+
+func TestRunGet_Fields_JSONReturnsError(t *testing.T) {
+	t.Parallel()
+	server := newTestUserServer(t, api.User{AccountID: "abc", DisplayName: "X"})
+	defer server.Close()
 
 	var stdout bytes.Buffer
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
+	opts.SetAPIClient(newClient(t, server.URL))
 
-	err = runSearch(context.Background(), opts, "john", 10)
-	testutil.RequireNoError(t, err)
-
-	output := stdout.String()
-	testutil.Contains(t, output, `"accountId"`)
-	testutil.Contains(t, output, "abc123")
-	testutil.Contains(t, output, `"displayName"`)
+	err := runGet(context.Background(), opts, "abc", "NAME")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--fields is not supported")
 }
 
-func TestRunSearch_Empty(t *testing.T) {
+func TestRunGet_Fields_UnknownHeaderFails(t *testing.T) {
+	t.Parallel()
+	server := newTestUserServer(t, api.User{AccountID: "abc", DisplayName: "X", Active: true})
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	// Trigger the no-op fetch path (noFieldFetch returns nil) — this token
+	// matches no header, no FieldID, and no human name. It must surface as
+	// UnknownFieldError, not an UnrenderedFieldError or an API call.
+	err := runGet(context.Background(), opts, "abc", "NOSUCHFIELD")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "unknown field")
+}
+
+func TestRunGet_JSON_PreservesArtifactOutput(t *testing.T) {
+	t.Parallel()
+	server := newTestUserServer(t, api.User{AccountID: "abc123", DisplayName: "John Doe", Active: true})
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "abc123", ""))
+	testutil.Contains(t, stdout.String(), `"accountId"`)
+}
+
+// ----- users search -----
+
+func TestNewSearchCmd(t *testing.T) {
+	t.Parallel()
+	opts := &root.Options{}
+	cmd := newSearchCmd(opts)
+
+	testutil.Equal(t, cmd.Use, "search <query>")
+	testutil.NotNil(t, cmd.Flags().Lookup("max"))
+	testutil.NotNil(t, cmd.Flags().Lookup("next-page-token"))
+	testutil.NotNil(t, cmd.Flags().Lookup("fields"))
+	testutil.Equal(t, cmd.Flags().Lookup("max").DefValue, "10")
+}
+
+func TestRunSearch_DefaultTableMatchesSpecColumnOrder(t *testing.T) {
+	t.Parallel()
+	users := []api.User{
+		{AccountID: "a1", DisplayName: "Alice", EmailAddress: "a@x.io", Active: true},
+		{AccountID: "b2", DisplayName: "Bob", Active: false},
+	}
+	server := newTestUsersServer(t, users)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", ""))
+
+	out := stdout.String()
+	testutil.Contains(t, out, "ACCOUNT_ID | NAME | EMAIL | ACTIVE")
+	testutil.Contains(t, out, "a1 | Alice | a@x.io | yes")
+	testutil.Contains(t, out, "b2 | Bob | - | no")
+}
+
+func TestRunSearch_Extended_AppendsTimezoneLocale(t *testing.T) {
+	t.Parallel()
+	users := []api.User{
+		{AccountID: "a1", DisplayName: "Alice", EmailAddress: "a@x.io", Active: true, TimeZone: "Etc/GMT", Locale: "en_US"},
+	}
+	server := newTestUsersServer(t, users)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", ""))
+
+	out := stdout.String()
+	testutil.Contains(t, out, "ACCOUNT_ID | NAME | EMAIL | ACTIVE | TIMEZONE | LOCALE")
+	testutil.Contains(t, out, "a1 | Alice | a@x.io | yes | Etc/GMT | en_US")
+}
+
+func TestRunSearch_Extended_DashesForRedactedFields(t *testing.T) {
+	t.Parallel()
+	// Instances that omit timeZone/locale from /user/search must not render
+	// literal "false"/empty strings in the table cells.
+	users := []api.User{{AccountID: "a1", DisplayName: "Alice", Active: true}}
+	server := newTestUsersServer(t, users)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", ""))
+	testutil.Contains(t, stdout.String(), "a1 | Alice | - | yes | - | -")
+}
+
+func TestRunSearch_IDOnly_EmitsKeysOnly(t *testing.T) {
+	t.Parallel()
+	users := []api.User{
+		{AccountID: "a1", DisplayName: "Alice"},
+		{AccountID: "b2", DisplayName: "Bob"},
+	}
+	server := newTestUsersServer(t, users)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", ""))
+	testutil.Equal(t, stdout.String(), "a1\nb2\n")
+}
+
+func TestRunSearch_HasMore_AppendsTokenizedContinuation(t *testing.T) {
+	t.Parallel()
+	// len(users) == --max triggers hasMore. Continuation line embeds next
+	// startAt per #230.
+	users := []api.User{
+		{AccountID: "a1", DisplayName: "Alice"},
+		{AccountID: "b2", DisplayName: "Bob"},
+	}
+	server := newTestUsersServer(t, users)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 2, "", ""))
+	testutil.Contains(t, stdout.String(), "More results available (next: 2)")
+}
+
+func TestRunSearch_IDOnly_EmitsTokenizedContinuation(t *testing.T) {
+	t.Parallel()
+	users := []api.User{
+		{AccountID: "a1", DisplayName: "Alice"},
+		{AccountID: "b2", DisplayName: "Bob"},
+	}
+	server := newTestUsersServer(t, users)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 2, "", ""))
+	testutil.Equal(t, stdout.String(), "a1\nb2\nMore results available (next: 2)\n")
+}
+
+func TestRunSearch_NextPageToken_AdvancesStartAt(t *testing.T) {
+	t.Parallel()
+	var capturedStartAt string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedStartAt = r.URL.Query().Get("startAt")
+		_ = json.NewEncoder(w).Encode([]api.User{{AccountID: "c3", DisplayName: "Carol"}})
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "20", ""))
+	testutil.Equal(t, capturedStartAt, "20")
+}
+
+func TestRunSearch_NextPageToken_RejectsNonNumeric(t *testing.T) {
 	t.Parallel()
 	server := newTestUsersServer(t, []api.User{})
 	defer server.Close()
 
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	err := runSearch(context.Background(), opts, "al", 10, "not-a-number", "")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "invalid --next-page-token")
+}
+
+func TestRunSearch_Fields_JSONReturnsError(t *testing.T) {
+	t.Parallel()
+	server := newTestUsersServer(t, []api.User{})
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	err := runSearch(context.Background(), opts, "al", 10, "", "NAME")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--fields is not supported")
+}
+
+func TestRunSearch_Fields_ProjectsToSelectedColumns(t *testing.T) {
+	t.Parallel()
+	users := []api.User{{AccountID: "a1", DisplayName: "Alice", EmailAddress: "a@x.io", Active: true}}
+	server := newTestUsersServer(t, users)
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", "NAME"))
+	out := stdout.String()
+	// ACCOUNT_ID is the identity column and is always retained.
+	testutil.Contains(t, out, "ACCOUNT_ID | NAME")
+	if strings.Contains(out, "EMAIL") || strings.Contains(out, "ACTIVE") {
+		t.Errorf("projected output leaked non-selected columns: %q", out)
+	}
+}
+
+func TestRunSearch_Empty_ShowsFriendlyMessage(t *testing.T) {
+	t.Parallel()
+	server := newTestUsersServer(t, []api.User{})
+	defer server.Close()
 
 	var stdout bytes.Buffer
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
+	opts.SetAPIClient(newClient(t, server.URL))
 
-	err = runSearch(context.Background(), opts, "nobody", 10)
-	testutil.RequireNoError(t, err)
-
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "ghost", 10, "", ""))
 	testutil.Contains(t, stdout.String(), "No users found")
 }
 
-func TestRunSearch_ActiveUser(t *testing.T) {
+func TestRunSearch_JSON_RendersArtifacts(t *testing.T) {
 	t.Parallel()
-	users := []api.User{
-		{AccountID: "abc123", DisplayName: "John Doe", Active: true},
-	}
-
+	users := []api.User{{AccountID: "a1", DisplayName: "Alice", EmailAddress: "a@x.io", Active: true}}
 	server := newTestUsersServer(t, users)
 	defer server.Close()
 
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
-
 	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
 
-	err = runSearch(context.Background(), opts, "john", 10)
-	testutil.RequireNoError(t, err)
-
-	testutil.Contains(t, stdout.String(), "yes")
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", ""))
+	testutil.Contains(t, stdout.String(), `"accountId"`)
 }
 
-func TestRunSearch_InactiveUser(t *testing.T) {
+func TestRunSearch_ExpandParamNotSentOnSearchEndpoint(t *testing.T) {
 	t.Parallel()
-	users := []api.User{
-		{AccountID: "abc123", DisplayName: "John Doe", Active: false},
-	}
-
-	server := newTestUsersServer(t, users)
+	// /user/search ignores expand; we must not send it (wasted bytes + risk
+	// of upstream behavior change).
+	var captured string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query().Get("expand")
+		_ = json.NewEncoder(w).Encode([]api.User{})
+	}))
 	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
-	testutil.RequireNoError(t, err)
 
 	var stdout bytes.Buffer
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
+	opts.SetAPIClient(newClient(t, server.URL))
 
-	err = runSearch(context.Background(), opts, "john", 10)
-	testutil.RequireNoError(t, err)
-
-	output := stdout.String()
-	testutil.Contains(t, output, "no")
+	testutil.RequireNoError(t, runSearch(context.Background(), opts, "al", 10, "", ""))
+	if captured != "" {
+		t.Errorf("expand param should not be sent to /user/search, got %q", captured)
+	}
 }

--- a/tools/jtk/internal/cmd/users/users_test.go
+++ b/tools/jtk/internal/cmd/users/users_test.go
@@ -320,6 +320,22 @@ func TestRunSearch_NextPageToken_RejectsNonNumeric(t *testing.T) {
 	testutil.Contains(t, err.Error(), "invalid --next-page-token")
 }
 
+func TestRunSearch_NextPageToken_RejectsNegative(t *testing.T) {
+	t.Parallel()
+	// strconv.Atoi happily parses "-1"; the n < 0 guard must still reject it.
+	server := newTestUsersServer(t, []api.User{})
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	err := runSearch(context.Background(), opts, "al", 10, "-1", "")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "invalid --next-page-token")
+	testutil.Contains(t, err.Error(), "non-negative")
+}
+
 func TestRunSearch_Fields_JSONReturnsError(t *testing.T) {
 	t.Parallel()
 	server := newTestUsersServer(t, []api.User{})

--- a/tools/jtk/internal/present/emit.go
+++ b/tools/jtk/internal/present/emit.go
@@ -8,17 +8,32 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
-// paginationHint is the text appended after list output when more pages exist.
-// Kept centralized so default-mode and --id mode share the same wording.
+// paginationHint is the legacy continuation-line wording retained for
+// commands that have not yet migrated to the token-embedding variant.
+// New (#237+) call sites use the *WithToken helpers below.
 const paginationHint = "More results available (use --next-page-token to fetch next page)"
 
-// paginationMessageSection builds the stdout-routed continuation-line section
-// used by every list presenter. Centralizing this ensures the wording, kind,
-// and stream stay in sync across all callers.
+// paginationMessageSection builds the legacy stdout-routed continuation line.
+// Migrated callers use paginationMessageSectionWithToken instead.
 func paginationMessageSection() *present.MessageSection {
 	return &present.MessageSection{
 		Kind:    present.MessageInfo,
 		Message: paginationHint,
+		Stream:  present.StreamStdout,
+	}
+}
+
+// paginationMessageSectionWithToken builds the spec-shaped continuation line
+// that embeds the next-page token, per the JTK Output Specification (#230).
+// When token is empty the helper falls back to the legacy wording so callers
+// don't accidentally surface an empty "next: " fragment.
+func paginationMessageSectionWithToken(token string) *present.MessageSection {
+	if token == "" {
+		return paginationMessageSection()
+	}
+	return &present.MessageSection{
+		Kind:    present.MessageInfo,
+		Message: fmt.Sprintf("More results available (next: %s)", token),
 		Stream:  present.StreamStdout,
 	}
 }
@@ -68,6 +83,32 @@ func EmitIDsWithPagination(opts *root.Options, ids []string, hasMore bool) error
 	}
 	if hasMore {
 		model := &present.OutputModel{Sections: []present.Section{paginationMessageSection()}}
+		return Emit(opts, model)
+	}
+	return nil
+}
+
+// AppendPaginationHintWithToken returns sections with a token-embedded
+// pagination MessageSection appended when hasMore is true, otherwise returns
+// sections unchanged. Follow-up to #230: new migrated list commands emit
+// "More results available (next: <token>)" instead of the legacy wording.
+// Empty token degrades to the legacy phrasing.
+func AppendPaginationHintWithToken(sections []present.Section, hasMore bool, token string) []present.Section {
+	if !hasMore {
+		return sections
+	}
+	return append(sections, paginationMessageSectionWithToken(token))
+}
+
+// EmitIDsWithPaginationToken is EmitIDs plus a token-embedded continuation
+// line on stdout when hasMore is true. Shares paginationMessageSectionWithToken
+// with AppendPaginationHintWithToken so `--id` and default mode stay aligned.
+func EmitIDsWithPaginationToken(opts *root.Options, ids []string, hasMore bool, token string) error {
+	if err := EmitIDs(opts, ids); err != nil {
+		return err
+	}
+	if hasMore {
+		model := &present.OutputModel{Sections: []present.Section{paginationMessageSectionWithToken(token)}}
 		return Emit(opts, model)
 	}
 	return nil

--- a/tools/jtk/internal/present/emit.go
+++ b/tools/jtk/internal/present/emit.go
@@ -1,12 +1,35 @@
 package present
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
+
+// ErrFieldsWithJSON is the canonical error for `--fields` + `-o json`.
+// JSON artifacts are not projected; the two flags never combine. Previously
+// duplicated across cmd/issues, cmd/comments, cmd/users, and cmd/projects —
+// centralizing here stops the copies from drifting in wording.
+var ErrFieldsWithJSON = errors.New("--fields is not supported with --output json")
+
+// ParseStartAtToken converts a `--next-page-token` value (a decimal offset)
+// to a 0-based startAt. Empty input returns 0. Non-numeric or negative
+// values return an error that names the flag, so the user sees the same
+// message regardless of which migrated command they invoked.
+func ParseStartAtToken(token string) (int, error) {
+	if token == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(token)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid --next-page-token %q: expected a non-negative decimal", token)
+	}
+	return n, nil
+}
 
 // paginationHint is the legacy continuation-line wording retained for
 // commands that have not yet migrated to the token-embedding variant.

--- a/tools/jtk/internal/present/emit_test.go
+++ b/tools/jtk/internal/present/emit_test.go
@@ -14,6 +14,68 @@ func newTestOpts() (*root.Options, *bytes.Buffer, *bytes.Buffer) {
 	return &root.Options{Stdout: &stdout, Stderr: &stderr}, &stdout, &stderr
 }
 
+func TestAppendPaginationHintWithToken_EmbedsToken(t *testing.T) {
+	t.Parallel()
+	sections := AppendPaginationHintWithToken(nil, true, "eyJzdGFydEF0IjoxMH0")
+	if len(sections) != 1 {
+		t.Fatalf("sections = %d, want 1", len(sections))
+	}
+	msg, ok := sections[0].(*present.MessageSection)
+	if !ok {
+		t.Fatalf("expected MessageSection, got %T", sections[0])
+	}
+	want := "More results available (next: eyJzdGFydEF0IjoxMH0)"
+	if msg.Message != want {
+		t.Errorf("Message = %q, want %q", msg.Message, want)
+	}
+	if msg.Stream != present.StreamStdout {
+		t.Errorf("Stream = %v, want Stdout", msg.Stream)
+	}
+}
+
+func TestAppendPaginationHintWithToken_EmptyTokenFallsBackToLegacyWording(t *testing.T) {
+	t.Parallel()
+	sections := AppendPaginationHintWithToken(nil, true, "")
+	msg := sections[0].(*present.MessageSection)
+	if msg.Message != paginationHint {
+		t.Errorf("empty-token fallback = %q, want legacy wording %q", msg.Message, paginationHint)
+	}
+}
+
+func TestAppendPaginationHintWithToken_NoMoreReturnsUnchanged(t *testing.T) {
+	t.Parallel()
+	base := []present.Section{&present.MessageSection{Kind: present.MessageInfo, Message: "only"}}
+	got := AppendPaginationHintWithToken(base, false, "anything")
+	if len(got) != 1 {
+		t.Errorf("hasMore=false should not append, got len=%d", len(got))
+	}
+}
+
+func TestEmitIDsWithPaginationToken_EmitsTokenInContinuationLine(t *testing.T) {
+	t.Parallel()
+	opts, stdout, _ := newTestOpts()
+	err := EmitIDsWithPaginationToken(opts, []string{"MON-1", "MON-2"}, true, "25")
+	if err != nil {
+		t.Fatalf("EmitIDsWithPaginationToken: %v", err)
+	}
+	want := "MON-1\nMON-2\nMore results available (next: 25)\n"
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestEmitIDsWithPaginationToken_NoMoreOmitsContinuation(t *testing.T) {
+	t.Parallel()
+	opts, stdout, _ := newTestOpts()
+	err := EmitIDsWithPaginationToken(opts, []string{"MON-1"}, false, "unused")
+	if err != nil {
+		t.Fatalf("EmitIDsWithPaginationToken: %v", err)
+	}
+	if stdout.String() != "MON-1\n" {
+		t.Errorf("stdout = %q, want %q", stdout.String(), "MON-1\n")
+	}
+}
+
 func TestEmit_SplitsStreams(t *testing.T) {
 	t.Parallel()
 	opts, stdout, stderr := newTestOpts()

--- a/tools/jtk/internal/present/emit_test.go
+++ b/tools/jtk/internal/present/emit_test.go
@@ -2,6 +2,7 @@ package present
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/present"
@@ -12,6 +13,44 @@ import (
 func newTestOpts() (*root.Options, *bytes.Buffer, *bytes.Buffer) {
 	var stdout, stderr bytes.Buffer
 	return &root.Options{Stdout: &stdout, Stderr: &stderr}, &stdout, &stderr
+}
+
+func TestParseStartAtToken(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr string
+	}{
+		{"empty", "", 0, ""},
+		{"zero", "0", 0, ""},
+		{"positive", "25", 25, ""},
+		{"non-numeric", "abc", 0, "invalid --next-page-token"},
+		{"negative", "-1", 0, "invalid --next-page-token"},
+		{"float-like", "2.5", 0, "invalid --next-page-token"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseStartAtToken(tc.input)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tc.want {
+					t.Errorf("got %d, want %d", got, tc.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
 }
 
 func TestAppendPaginationHintWithToken_EmbedsToken(t *testing.T) {

--- a/tools/jtk/internal/present/helpers.go
+++ b/tools/jtk/internal/present/helpers.go
@@ -3,6 +3,8 @@ package present
 import (
 	"fmt"
 	"time"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 )
 
 // FormatDate formats a time.Time as a short date string.
@@ -90,4 +92,25 @@ func FormatTime(t string) string {
 		return t[:10]
 	}
 	return t
+}
+
+// PresentOptionalBool renders a *bool as "yes"/"no"/"-". The dash case is the
+// canonical signal for "the API didn't return this field" — commands use this
+// for fields like ProjectDetail.Simplified / ProjectDetail.IsPrivate where a
+// plain bool zero value would collide with a legitimate `false`.
+func PresentOptionalBool(b *bool) string {
+	if b == nil {
+		return "-"
+	}
+	return BoolString(*b)
+}
+
+// PresentOptionalCount renders a *api.UserCountBlock's Size as a decimal, or
+// "-" when the block is nil. Used for `--extended` user output rows where
+// Groups and ApplicationRoles come back expanded or not at all.
+func PresentOptionalCount(b *api.UserCountBlock) string {
+	if b == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", b.Size)
 }

--- a/tools/jtk/internal/present/project.go
+++ b/tools/jtk/internal/present/project.go
@@ -3,90 +3,208 @@ package present
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
+
+// componentPreviewLimit caps the enumerated component list in `projects get
+// --extended` before a "... [N more]" truncation line. 4 mirrors the example
+// in the #230 specification.
+const componentPreviewLimit = 4
 
 // ProjectPresenter creates presentation models for project data.
 type ProjectPresenter struct{}
 
-// Present creates a presentation model for text output.
-// Content normalization (if any) happens here, not in the renderer.
-func (ProjectPresenter) Present(p *api.ProjectDetail) *present.OutputModel {
-	lead := "Unassigned"
-	if p.Lead != nil {
-		lead = p.Lead.DisplayName
-	}
+// ProjectDetailSpec declares the logical fields rendered by
+// PresentProjectDetailProjection. Identity is KEY (projection always retains
+// it on the first line). Extended fields correspond to the admin/schema rows
+// the spec puts behind `--extended`.
+var ProjectDetailSpec = projection.Registry{
+	{Header: "KEY", Identity: true},
+	{Header: "NAME"},
+	{Header: "TYPE"},
+	{Header: "LEAD"},
+	{Header: "STYLE"},
+	{Header: "ISSUE_TYPES"},
+	{Header: "COMPONENTS"},
+	{Header: "VERSIONS"},
+	{Header: "DESCRIPTION", Extended: true},
+	{Header: "LEAD_ID", Extended: true},
+	{Header: "ISSUE_TYPE_IDS", Extended: true},
+	{Header: "COMPONENT_IDS", Extended: true},
+	{Header: "SIMPLIFIED", Extended: true},
+	{Header: "PRIVATE", Extended: true},
+}
 
-	fields := []present.Field{
-		{Label: "Key", Value: p.Key},
-		{Label: "Name", Value: p.Name},
-		{Label: "ID", Value: p.ID.String()},
-		{Label: "Type", Value: p.ProjectTypeKey},
-		{Label: "Lead", Value: lead},
-	}
+// ProjectListSpec declares the columns emitted by PresentProjectList. Order
+// matches the Headers slice inside the presenter; a parity test locks the two.
+// The default column order is KEY|TYPE|LEAD|NAME per the #230 spec, not
+// alphabetical or API order.
+var ProjectListSpec = projection.Registry{
+	{Header: "KEY", Identity: true},
+	{Header: "TYPE"},
+	{Header: "LEAD"},
+	{Header: "NAME"},
+	{Header: "STYLE", Extended: true},
+	{Header: "ISSUE_TYPES", Extended: true},
+	{Header: "COMPONENTS", Extended: true},
+}
 
-	if p.Description != "" {
-		fields = append(fields, present.Field{Label: "Description", Value: p.Description})
-	}
+// ProjectTypeSpec declares the columns for `projects types`. The default NAME
+// column sources from ProjectType.FormattedKey (matches the spec's user-facing
+// wording); extended adds the raw i18n description key.
+var ProjectTypeSpec = projection.Registry{
+	{Header: "KEY", Identity: true},
+	{Header: "NAME"},
+	{Header: "DESCRIPTION_KEY", Extended: true},
+}
 
+// PresentProjectDetail builds the spec-shaped default or extended output for
+// `projects get`. Default output: title line + three compound rows. Extended
+// output: title line + extended compound rows with lead/issue-type IDs, an
+// enumerated component preview with truncation, a Versions line, Simplified
+// / Private flags, and an optional Description block.
+func (ProjectPresenter) PresentProjectDetail(p *api.ProjectDetail, extended bool) *present.OutputModel {
+	sections := []present.Section{
+		msg(fmt.Sprintf("%s  %s", p.Key, p.Name)),
+	}
+	if extended {
+		sections = append(sections, extendedProjectDetailSections(p)...)
+	} else {
+		sections = append(sections, defaultProjectDetailSections(p)...)
+	}
+	return &present.OutputModel{Sections: sections}
+}
+
+// defaultProjectDetailSections returns the compound-KV rows that follow the
+// title line in default-mode output. Types/Lead/Style, Issue Types list,
+// Components / Versions counts.
+func defaultProjectDetailSections(p *api.ProjectDetail) []present.Section {
+	out := []present.Section{
+		msg(fmt.Sprintf("Type: %s   Lead: %s   Style: %s",
+			OrDash(p.ProjectTypeKey), leadDisplayName(p.Lead), OrDash(p.Style))),
+	}
 	if len(p.IssueTypes) > 0 {
-		var names []string
-		for _, it := range p.IssueTypes {
-			names = append(names, it.Name)
+		out = append(out, msg("Issue Types: "+issueTypeNames(p.IssueTypes)))
+	}
+	out = append(out, msg(fmt.Sprintf("Components: %d   Versions: %d", len(p.Components), len(p.Versions))))
+	return out
+}
+
+// extendedProjectDetailSections returns the expanded post-title sections for
+// --extended mode. Components are enumerated with IDs, truncated after
+// componentPreviewLimit entries.
+func extendedProjectDetailSections(p *api.ProjectDetail) []present.Section {
+	out := []present.Section{
+		msg(fmt.Sprintf("Type: %s   Lead: %s   Style: %s",
+			OrDash(p.ProjectTypeKey), leadDisplayNameWithID(p.Lead), OrDash(p.Style))),
+	}
+	if len(p.IssueTypes) > 0 {
+		out = append(out, msg("Issue Types: "+issueTypeNamesWithIDs(p.IssueTypes)))
+	}
+	out = append(out, msg(fmt.Sprintf("Components: %d", len(p.Components))))
+	for i, c := range p.Components {
+		if i >= componentPreviewLimit {
+			remaining := len(p.Components) - componentPreviewLimit
+			out = append(out, msg(fmt.Sprintf("  ... [%d more]", remaining)))
+			break
 		}
-		fields = append(fields, present.Field{Label: "Issue Types", Value: fmt.Sprintf("%s", names)})
+		out = append(out, msg(fmt.Sprintf("  %s | %s", c.ID, c.Name)))
 	}
-
-	if p.URL != "" {
-		fields = append(fields, present.Field{Label: "URL", Value: p.URL})
+	out = append(out, msg(fmt.Sprintf("Versions: %d", len(p.Versions))))
+	out = append(out, msg(fmt.Sprintf("Simplified: %s   Private: %s",
+		PresentOptionalBool(p.Simplified), PresentOptionalBool(p.IsPrivate))))
+	if strings.TrimSpace(p.Description) != "" {
+		out = append(out,
+			msg("Description:"),
+			msg(p.Description),
+		)
 	}
+	return out
+}
 
+// PresentProjectDetailProjection builds a DetailSection view for `projects
+// get --fields`, keyed by the headers declared in ProjectDetailSpec. Output
+// flattens to "Label: Value" lines; projection.ProjectDetail then slices the
+// section to the user-selected subset.
+func (ProjectPresenter) PresentProjectDetailProjection(p *api.ProjectDetail) *present.OutputModel {
+	fields := []present.Field{
+		{Label: "KEY", Value: p.Key},
+		{Label: "NAME", Value: p.Name},
+		{Label: "TYPE", Value: OrDash(p.ProjectTypeKey)},
+		{Label: "LEAD", Value: leadDisplayName(p.Lead)},
+		{Label: "STYLE", Value: OrDash(p.Style)},
+		{Label: "ISSUE_TYPES", Value: OrDash(issueTypeNames(p.IssueTypes))},
+		{Label: "COMPONENTS", Value: fmt.Sprintf("%d", len(p.Components))},
+		{Label: "VERSIONS", Value: fmt.Sprintf("%d", len(p.Versions))},
+		{Label: "DESCRIPTION", Value: OrDash(p.Description)},
+		{Label: "LEAD_ID", Value: leadAccountID(p.Lead)},
+		{Label: "ISSUE_TYPE_IDS", Value: OrDash(issueTypeIDs(p.IssueTypes))},
+		{Label: "COMPONENT_IDS", Value: OrDash(componentIDs(p.Components))},
+		{Label: "SIMPLIFIED", Value: PresentOptionalBool(p.Simplified)},
+		{Label: "PRIVATE", Value: PresentOptionalBool(p.IsPrivate)},
+	}
 	return &present.OutputModel{
 		Sections: []present.Section{&present.DetailSection{Fields: fields}},
 	}
 }
 
-// PresentList creates a table view for a list of projects.
-func (ProjectPresenter) PresentList(projects []api.ProjectDetail) *present.OutputModel {
+// PresentProjectList renders `projects list` output as a table. Column order
+// matches the spec KEY|TYPE|LEAD|NAME; --extended appends STYLE / ISSUE_TYPES
+// / COMPONENTS counts. Pagination is appended by the command via
+// AppendPaginationHintWithToken.
+func (ProjectPresenter) PresentProjectList(projects []api.ProjectDetail, extended bool) *present.OutputModel {
+	headers := []string{"KEY", "TYPE", "LEAD", "NAME"}
+	if extended {
+		headers = append(headers, "STYLE", "ISSUE_TYPES", "COMPONENTS")
+	}
 	rows := make([]present.Row, len(projects))
 	for i, p := range projects {
-		lead := ""
-		if p.Lead != nil {
-			lead = p.Lead.DisplayName
+		cells := []string{
+			p.Key,
+			OrDash(p.ProjectTypeKey),
+			leadDisplayName(p.Lead),
+			p.Name,
 		}
-		rows[i] = present.Row{
-			Cells: []string{p.Key, p.Name, p.ProjectTypeKey, lead},
+		if extended {
+			cells = append(cells,
+				OrDash(p.Style),
+				fmt.Sprintf("%d", len(p.IssueTypes)),
+				fmt.Sprintf("%d", len(p.Components)),
+			)
 		}
+		rows[i] = present.Row{Cells: cells}
 	}
-
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"KEY", "NAME", "TYPE", "LEAD"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
 	}
 }
 
-// PresentTypes creates a table view for a list of project types.
-func (ProjectPresenter) PresentTypes(types []api.ProjectType) *present.OutputModel {
+// PresentProjectTypes renders `projects types` output. Header is KEY | NAME
+// (spec #230 names the column NAME even though the API field is FormattedKey);
+// --extended adds DESCRIPTION_KEY from DescriptionI18nKey.
+func (ProjectPresenter) PresentProjectTypes(types []api.ProjectType, extended bool) *present.OutputModel {
+	headers := []string{"KEY", "NAME"}
+	if extended {
+		headers = append(headers, "DESCRIPTION_KEY")
+	}
 	rows := make([]present.Row, len(types))
 	for i, t := range types {
-		rows[i] = present.Row{
-			Cells: []string{t.Key, t.FormattedKey},
+		cells := []string{t.Key, t.FormattedKey}
+		if extended {
+			cells = append(cells, OrDash(t.DescriptionI18nKey))
 		}
+		rows[i] = present.Row{Cells: cells}
 	}
-
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"KEY", "FORMATTED"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
 	}
 }
@@ -180,4 +298,79 @@ func (ProjectPresenter) PresentDeleteCancelled() *present.OutputModel {
 			},
 		},
 	}
+}
+
+// msg constructs a stdout-routed info MessageSection from a plaintext body.
+// Used throughout the spec-shaped project presenters to keep each output line
+// as its own addressable section.
+func msg(body string) *present.MessageSection {
+	return &present.MessageSection{
+		Kind:    present.MessageInfo,
+		Message: body,
+		Stream:  present.StreamStdout,
+	}
+}
+
+func leadDisplayName(u *api.User) string {
+	if u == nil || u.DisplayName == "" {
+		return "-"
+	}
+	return u.DisplayName
+}
+
+func leadDisplayNameWithID(u *api.User) string {
+	if u == nil || u.DisplayName == "" {
+		return "-"
+	}
+	if u.AccountID == "" {
+		return u.DisplayName
+	}
+	return fmt.Sprintf("%s (%s)", u.DisplayName, u.AccountID)
+}
+
+func leadAccountID(u *api.User) string {
+	if u == nil || u.AccountID == "" {
+		return "-"
+	}
+	return u.AccountID
+}
+
+func issueTypeNames(types []api.IssueType) string {
+	names := make([]string, 0, len(types))
+	for _, t := range types {
+		names = append(names, t.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+func issueTypeNamesWithIDs(types []api.IssueType) string {
+	parts := make([]string, 0, len(types))
+	for _, t := range types {
+		if t.ID == "" {
+			parts = append(parts, t.Name)
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s (%s)", t.Name, t.ID))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func issueTypeIDs(types []api.IssueType) string {
+	ids := make([]string, 0, len(types))
+	for _, t := range types {
+		if t.ID != "" {
+			ids = append(ids, t.ID)
+		}
+	}
+	return strings.Join(ids, ", ")
+}
+
+func componentIDs(comps []api.Component) string {
+	ids := make([]string, 0, len(comps))
+	for _, c := range comps {
+		if c.ID != "" {
+			ids = append(ids, c.ID)
+		}
+	}
+	return strings.Join(ids, ", ")
 }

--- a/tools/jtk/internal/present/project.go
+++ b/tools/jtk/internal/present/project.go
@@ -42,16 +42,19 @@ var ProjectDetailSpec = projection.Registry{
 
 // ProjectListSpec declares the columns emitted by PresentProjectList. Order
 // matches the Headers slice inside the presenter; a parity test locks the two.
-// The default column order is KEY|TYPE|LEAD|NAME per the #230 spec, not
-// alphabetical or API order.
+// Default order per #230 is KEY|TYPE|LEAD|NAME; extended order interleaves
+// STYLE between TYPE and LEAD and ISSUE_TYPES/COMPONENTS before NAME:
+// KEY|TYPE|STYLE|LEAD|ISSUE_TYPES|COMPONENTS|NAME. Registry.ForMode preserves
+// declaration order when expanding, so this file declares the interleaved
+// extended order and marks the three non-default entries Extended:true.
 var ProjectListSpec = projection.Registry{
 	{Header: "KEY", Identity: true},
 	{Header: "TYPE"},
-	{Header: "LEAD"},
-	{Header: "NAME"},
 	{Header: "STYLE", Extended: true},
+	{Header: "LEAD"},
 	{Header: "ISSUE_TYPES", Extended: true},
 	{Header: "COMPONENTS", Extended: true},
+	{Header: "NAME"},
 }
 
 // ProjectTypeSpec declares the columns for `projects types`. The default NAME
@@ -82,29 +85,27 @@ func (ProjectPresenter) PresentProjectDetail(p *api.ProjectDetail, extended bool
 
 // defaultProjectDetailSections returns the compound-KV rows that follow the
 // title line in default-mode output. Types/Lead/Style, Issue Types list,
-// Components / Versions counts.
+// Components / Versions counts. The Issue Types row is always emitted so the
+// line count stays stable across projects — "-" when empty per #230's
+// parseable-text-shape goal.
 func defaultProjectDetailSections(p *api.ProjectDetail) []present.Section {
-	out := []present.Section{
+	return []present.Section{
 		msg(fmt.Sprintf("Type: %s   Lead: %s   Style: %s",
 			OrDash(p.ProjectTypeKey), leadDisplayName(p.Lead), OrDash(p.Style))),
+		msg("Issue Types: " + OrDash(issueTypeNames(p.IssueTypes))),
+		msg(fmt.Sprintf("Components: %d   Versions: %d", len(p.Components), len(p.Versions))),
 	}
-	if len(p.IssueTypes) > 0 {
-		out = append(out, msg("Issue Types: "+issueTypeNames(p.IssueTypes)))
-	}
-	out = append(out, msg(fmt.Sprintf("Components: %d   Versions: %d", len(p.Components), len(p.Versions))))
-	return out
 }
 
 // extendedProjectDetailSections returns the expanded post-title sections for
 // --extended mode. Components are enumerated with IDs, truncated after
-// componentPreviewLimit entries.
+// componentPreviewLimit entries. Issue Types is always emitted (empty →
+// "Issue Types: -") to keep the rendered row count independent of data.
 func extendedProjectDetailSections(p *api.ProjectDetail) []present.Section {
 	out := []present.Section{
 		msg(fmt.Sprintf("Type: %s   Lead: %s   Style: %s",
 			OrDash(p.ProjectTypeKey), leadDisplayNameWithID(p.Lead), OrDash(p.Style))),
-	}
-	if len(p.IssueTypes) > 0 {
-		out = append(out, msg("Issue Types: "+issueTypeNamesWithIDs(p.IssueTypes)))
+		msg("Issue Types: " + OrDash(issueTypeNamesWithIDs(p.IssueTypes))),
 	}
 	out = append(out, msg(fmt.Sprintf("Components: %d", len(p.Components))))
 	for i, c := range p.Components {
@@ -153,29 +154,41 @@ func (ProjectPresenter) PresentProjectDetailProjection(p *api.ProjectDetail) *pr
 	}
 }
 
-// PresentProjectList renders `projects list` output as a table. Column order
-// matches the spec KEY|TYPE|LEAD|NAME; --extended appends STYLE / ISSUE_TYPES
-// / COMPONENTS counts. Pagination is appended by the command via
+// PresentProjectList renders `projects list` output as a table. Default order
+// is KEY | TYPE | LEAD | NAME; --extended interleaves STYLE between TYPE and
+// LEAD and ISSUE_TYPES/COMPONENTS before NAME, producing
+// KEY | TYPE | STYLE | LEAD | ISSUE_TYPES | COMPONENTS | NAME per #230.
+// ISSUE_TYPES renders as the comma-joined issue-type names (not a count);
+// COMPONENTS renders as the count. Pagination is appended by the command via
 // AppendPaginationHintWithToken.
 func (ProjectPresenter) PresentProjectList(projects []api.ProjectDetail, extended bool) *present.OutputModel {
-	headers := []string{"KEY", "TYPE", "LEAD", "NAME"}
+	var headers []string
 	if extended {
-		headers = append(headers, "STYLE", "ISSUE_TYPES", "COMPONENTS")
+		headers = []string{"KEY", "TYPE", "STYLE", "LEAD", "ISSUE_TYPES", "COMPONENTS", "NAME"}
+	} else {
+		headers = []string{"KEY", "TYPE", "LEAD", "NAME"}
 	}
+
 	rows := make([]present.Row, len(projects))
 	for i, p := range projects {
-		cells := []string{
-			p.Key,
-			OrDash(p.ProjectTypeKey),
-			leadDisplayName(p.Lead),
-			p.Name,
-		}
+		var cells []string
 		if extended {
-			cells = append(cells,
+			cells = []string{
+				p.Key,
+				OrDash(p.ProjectTypeKey),
 				OrDash(p.Style),
-				fmt.Sprintf("%d", len(p.IssueTypes)),
+				leadDisplayName(p.Lead),
+				OrDash(issueTypeNames(p.IssueTypes)),
 				fmt.Sprintf("%d", len(p.Components)),
-			)
+				p.Name,
+			}
+		} else {
+			cells = []string{
+				p.Key,
+				OrDash(p.ProjectTypeKey),
+				leadDisplayName(p.Lead),
+				p.Name,
+			}
 		}
 		rows[i] = present.Row{Cells: cells}
 	}

--- a/tools/jtk/internal/present/project_test.go
+++ b/tools/jtk/internal/present/project_test.go
@@ -143,8 +143,10 @@ func TestPresentProjectList_DefaultColumnOrderMatchesSpec(t *testing.T) {
 	}
 }
 
-func TestPresentProjectList_ExtendedAppendsStyleIssueTypesComponents(t *testing.T) {
+func TestPresentProjectList_ExtendedMatchesSpecShape(t *testing.T) {
 	t.Parallel()
+	// Spec (#230): KEY | TYPE | STYLE | LEAD | ISSUE_TYPES | COMPONENTS | NAME.
+	// ISSUE_TYPES is comma-joined issue-type names, COMPONENTS is a count.
 	projects := []api.ProjectDetail{
 		{
 			Key: "MON", Name: "Platform Development", ProjectTypeKey: "software",
@@ -157,12 +159,74 @@ func TestPresentProjectList_ExtendedAppendsStyleIssueTypesComponents(t *testing.
 	model := ProjectPresenter{}.PresentProjectList(projects, true)
 	table := sectionTable(t, model, 0)
 
-	wantHeaders := []string{"KEY", "TYPE", "LEAD", "NAME", "STYLE", "ISSUE_TYPES", "COMPONENTS"}
+	wantHeaders := []string{"KEY", "TYPE", "STYLE", "LEAD", "ISSUE_TYPES", "COMPONENTS", "NAME"}
 	if !equalStringSlices(table.Headers, wantHeaders) {
 		t.Errorf("extended headers = %v, want %v", table.Headers, wantHeaders)
 	}
-	if got := table.Rows[0].Cells; !equalStringSlices(got, []string{"MON", "software", "Rusty Hall", "Platform Development", "classic", "2", "3"}) {
-		t.Errorf("row = %v", got)
+	wantCells := []string{"MON", "software", "classic", "Rusty Hall", "Epic, SDLC", "3", "Platform Development"}
+	if got := table.Rows[0].Cells; !equalStringSlices(got, wantCells) {
+		t.Errorf("row = %v\nwant %v", got, wantCells)
+	}
+}
+
+func TestPresentProjectList_Extended_DashForEmptyIssueTypesAndStyle(t *testing.T) {
+	t.Parallel()
+	projects := []api.ProjectDetail{
+		{Key: "X", Name: "Example", ProjectTypeKey: "software"}, // no lead, no style, no types, no components
+	}
+	model := ProjectPresenter{}.PresentProjectList(projects, true)
+	table := sectionTable(t, model, 0)
+
+	wantCells := []string{"X", "software", "-", "-", "-", "0", "Example"}
+	if got := table.Rows[0].Cells; !equalStringSlices(got, wantCells) {
+		t.Errorf("empty-field row = %v\nwant %v", got, wantCells)
+	}
+}
+
+func TestPresentProjectDetail_Default_IssueTypesRowRendersDashWhenEmpty(t *testing.T) {
+	t.Parallel()
+	// Fix 2 regression: the row must appear unconditionally so callers see a
+	// stable line count. Empty IssueTypes renders as "Issue Types: -".
+	p := &api.ProjectDetail{
+		Key: "X", Name: "Example",
+		ProjectTypeKey: "software",
+		Lead:           &api.User{DisplayName: "Lead"},
+		Style:          "classic",
+	}
+	model := ProjectPresenter{}.PresentProjectDetail(p, false)
+	lines := renderAllMessages(t, model)
+
+	want := []string{
+		"X  Example",
+		"Type: software   Lead: Lead   Style: classic",
+		"Issue Types: -",
+		"Components: 0   Versions: 0",
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("line count = %d, want %d\nlines=%v", len(lines), len(want), lines)
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, lines[i], want[i])
+		}
+	}
+}
+
+func TestPresentProjectDetail_Extended_IssueTypesRowRendersDashWhenEmpty(t *testing.T) {
+	t.Parallel()
+	p := &api.ProjectDetail{
+		Key: "X", Name: "Example",
+		ProjectTypeKey: "software",
+		Lead:           &api.User{AccountID: "u", DisplayName: "Lead"},
+		Style:          "classic",
+	}
+	model := ProjectPresenter{}.PresentProjectDetail(p, true)
+	lines := renderAllMessages(t, model)
+
+	// Specifically verify the Issue Types line is the third section (after
+	// title + compound row) — ordering is part of the contract.
+	if lines[2] != "Issue Types: -" {
+		t.Errorf("line 2 = %q, want \"Issue Types: -\"", lines[2])
 	}
 }
 

--- a/tools/jtk/internal/present/project_test.go
+++ b/tools/jtk/internal/present/project_test.go
@@ -1,0 +1,250 @@
+package present
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func ptrBool(b bool) *bool { return &b }
+
+func sampleProject() *api.ProjectDetail {
+	return &api.ProjectDetail{
+		ID:             json.Number("10000"),
+		Key:            "MON",
+		Name:           "Platform Development",
+		ProjectTypeKey: "software",
+		Lead:           &api.User{AccountID: "u123", DisplayName: "Rusty Hall"},
+		Style:          "classic",
+		Simplified:     ptrBool(false),
+		IsPrivate:      ptrBool(false),
+		IssueTypes: []api.IssueType{
+			{ID: "10000", Name: "Epic"},
+			{ID: "10025", Name: "SDLC"},
+			{ID: "10026", Name: "Kanban"},
+		},
+		Components: []api.Component{
+			{ID: "10143", Name: "Admin Portal"},
+			{ID: "10144", Name: "Admin Service"},
+			{ID: "10145", Name: "Banker Portal"},
+			{ID: "10146", Name: "Auth Service"},
+			{ID: "10147", Name: "Codat Sync Service"},
+			{ID: "10148", Name: "Another Component"},
+		},
+		Versions:    nil,
+		Description: "Long-lived platform hub project.",
+	}
+}
+
+func TestPresentProjectDetail_Default(t *testing.T) {
+	t.Parallel()
+	model := ProjectPresenter{}.PresentProjectDetail(sampleProject(), false)
+
+	expect := []string{
+		"MON  Platform Development",
+		"Type: software   Lead: Rusty Hall   Style: classic",
+		"Issue Types: Epic, SDLC, Kanban",
+		"Components: 6   Versions: 0",
+	}
+	if len(model.Sections) != len(expect) {
+		t.Fatalf("sections = %d, want %d", len(model.Sections), len(expect))
+	}
+	for i, want := range expect {
+		if got := renderMessage(t, model, i); got != want {
+			t.Errorf("section %d = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestPresentProjectDetail_Extended_EnumeratesComponentsWithTruncation(t *testing.T) {
+	t.Parallel()
+	p := sampleProject()
+	model := ProjectPresenter{}.PresentProjectDetail(p, true)
+
+	lines := renderAllMessages(t, model)
+	// Title line (1) + compound KV (1) + issue types (1) + Components
+	// header (1) + 4 component rows (4) + "... [2 more]" (1) + Versions (1)
+	// + Simplified/Private (1) + Description label (1) + description body (1)
+	// = 13 sections.
+	if len(lines) != 13 {
+		t.Fatalf("extended sections = %d, want 13\nlines=%v", len(lines), lines)
+	}
+	checks := map[int]string{
+		0:  "MON  Platform Development",
+		1:  "Type: software   Lead: Rusty Hall (u123)   Style: classic",
+		2:  "Issue Types: Epic (10000), SDLC (10025), Kanban (10026)",
+		3:  "Components: 6",
+		4:  "  10143 | Admin Portal",
+		7:  "  10146 | Auth Service",
+		8:  "  ... [2 more]",
+		9:  "Versions: 0",
+		10: "Simplified: no   Private: no",
+		11: "Description:",
+		12: "Long-lived platform hub project.",
+	}
+	for i, want := range checks {
+		if lines[i] != want {
+			t.Errorf("line %d = %q, want %q", i, lines[i], want)
+		}
+	}
+}
+
+func TestPresentProjectDetail_Extended_DashesWhenSimplifiedAndPrivateMissing(t *testing.T) {
+	t.Parallel()
+	p := &api.ProjectDetail{
+		Key: "X", Name: "Example",
+		ProjectTypeKey: "software", Style: "classic",
+		Lead: &api.User{AccountID: "u", DisplayName: "Lead"},
+		// Simplified / IsPrivate intentionally nil — API omitted the fields.
+	}
+	model := ProjectPresenter{}.PresentProjectDetail(p, true)
+	lines := renderAllMessages(t, model)
+
+	// Find the Simplified/Private line (comes after Versions).
+	var found bool
+	for _, line := range lines {
+		if strings.HasPrefix(line, "Simplified:") {
+			if line != "Simplified: -   Private: -" {
+				t.Errorf("got %q, want dashes for missing fields", line)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no Simplified/Private line found in %v", lines)
+	}
+}
+
+func TestPresentProjectList_DefaultColumnOrderMatchesSpec(t *testing.T) {
+	t.Parallel()
+	// Spec order is KEY | TYPE | LEAD | NAME — deliberately not the same as
+	// the pre-migration KEY | NAME | TYPE | LEAD order.
+	projects := []api.ProjectDetail{
+		{Key: "MON", Name: "Platform Development", ProjectTypeKey: "software", Lead: &api.User{DisplayName: "Rusty Hall"}},
+		{Key: "ON", Name: "Customer Onboarding", ProjectTypeKey: "software"},
+	}
+	model := ProjectPresenter{}.PresentProjectList(projects, false)
+	table := sectionTable(t, model, 0)
+
+	wantHeaders := []string{"KEY", "TYPE", "LEAD", "NAME"}
+	if !equalStringSlices(table.Headers, wantHeaders) {
+		t.Errorf("headers = %v, want %v", table.Headers, wantHeaders)
+	}
+	if got := table.Rows[0].Cells; !equalStringSlices(got, []string{"MON", "software", "Rusty Hall", "Platform Development"}) {
+		t.Errorf("row 0 = %v", got)
+	}
+	if got := table.Rows[1].Cells; !equalStringSlices(got, []string{"ON", "software", "-", "Customer Onboarding"}) {
+		t.Errorf("row 1 = %v (unpaired lead expected '-')", got)
+	}
+}
+
+func TestPresentProjectList_ExtendedAppendsStyleIssueTypesComponents(t *testing.T) {
+	t.Parallel()
+	projects := []api.ProjectDetail{
+		{
+			Key: "MON", Name: "Platform Development", ProjectTypeKey: "software",
+			Lead:       &api.User{DisplayName: "Rusty Hall"},
+			Style:      "classic",
+			IssueTypes: []api.IssueType{{ID: "1", Name: "Epic"}, {ID: "2", Name: "SDLC"}},
+			Components: []api.Component{{ID: "c1", Name: "A"}, {ID: "c2", Name: "B"}, {ID: "c3", Name: "C"}},
+		},
+	}
+	model := ProjectPresenter{}.PresentProjectList(projects, true)
+	table := sectionTable(t, model, 0)
+
+	wantHeaders := []string{"KEY", "TYPE", "LEAD", "NAME", "STYLE", "ISSUE_TYPES", "COMPONENTS"}
+	if !equalStringSlices(table.Headers, wantHeaders) {
+		t.Errorf("extended headers = %v, want %v", table.Headers, wantHeaders)
+	}
+	if got := table.Rows[0].Cells; !equalStringSlices(got, []string{"MON", "software", "Rusty Hall", "Platform Development", "classic", "2", "3"}) {
+		t.Errorf("row = %v", got)
+	}
+}
+
+func TestPresentProjectTypes_HeaderRename(t *testing.T) {
+	t.Parallel()
+	types := []api.ProjectType{
+		{Key: "software", FormattedKey: "Software", DescriptionI18nKey: "jira.project.type.software.description"},
+	}
+	model := ProjectPresenter{}.PresentProjectTypes(types, false)
+	table := sectionTable(t, model, 0)
+	if !equalStringSlices(table.Headers, []string{"KEY", "NAME"}) {
+		t.Errorf("default headers = %v, want [KEY NAME]", table.Headers)
+	}
+	if got := table.Rows[0].Cells; !equalStringSlices(got, []string{"software", "Software"}) {
+		t.Errorf("row = %v", got)
+	}
+}
+
+func TestPresentProjectTypes_ExtendedAddsDescriptionKey(t *testing.T) {
+	t.Parallel()
+	types := []api.ProjectType{
+		{Key: "software", FormattedKey: "Software", DescriptionI18nKey: "jira.project.type.software.description"},
+	}
+	model := ProjectPresenter{}.PresentProjectTypes(types, true)
+	table := sectionTable(t, model, 0)
+	if !equalStringSlices(table.Headers, []string{"KEY", "NAME", "DESCRIPTION_KEY"}) {
+		t.Errorf("extended headers = %v", table.Headers)
+	}
+	if got := table.Rows[0].Cells; !equalStringSlices(got, []string{"software", "Software", "jira.project.type.software.description"}) {
+		t.Errorf("row = %v", got)
+	}
+}
+
+func TestProjectListSpec_HeaderParityWithPresenter(t *testing.T) {
+	t.Parallel()
+	for _, extended := range []bool{false, true} {
+		model := ProjectPresenter{}.PresentProjectList(nil, extended)
+		table := sectionTable(t, model, 0)
+		want := registryHeadersFor(ProjectListSpec, extended)
+		if !equalStringSlices(table.Headers, want) {
+			t.Errorf("extended=%v headers mismatch: presenter %v vs registry %v",
+				extended, table.Headers, want)
+		}
+	}
+}
+
+func TestProjectTypeSpec_HeaderParityWithPresenter(t *testing.T) {
+	t.Parallel()
+	for _, extended := range []bool{false, true} {
+		model := ProjectPresenter{}.PresentProjectTypes(nil, extended)
+		table := sectionTable(t, model, 0)
+		want := registryHeadersFor(ProjectTypeSpec, extended)
+		if !equalStringSlices(table.Headers, want) {
+			t.Errorf("extended=%v headers mismatch: presenter %v vs registry %v",
+				extended, table.Headers, want)
+		}
+	}
+}
+
+func TestPresentProjectDetailProjection_ContainsAllSpecHeaders(t *testing.T) {
+	t.Parallel()
+	model := ProjectPresenter{}.PresentProjectDetailProjection(sampleProject())
+	detail, ok := model.Sections[0].(*present.DetailSection)
+	if !ok {
+		t.Fatalf("expected DetailSection, got %T", model.Sections[0])
+	}
+	have := make(map[string]struct{}, len(detail.Fields))
+	for _, f := range detail.Fields {
+		have[strings.ToLower(f.Label)] = struct{}{}
+	}
+	for _, c := range ProjectDetailSpec {
+		if _, ok := have[strings.ToLower(c.Header)]; !ok {
+			t.Errorf("ProjectDetailSpec header %q has no matching DetailSection label", c.Header)
+		}
+	}
+}
+
+func renderAllMessages(t *testing.T, model *present.OutputModel) []string {
+	t.Helper()
+	out := make([]string, len(model.Sections))
+	for i := range model.Sections {
+		out[i] = renderMessage(t, model, i)
+	}
+	return out
+}

--- a/tools/jtk/internal/present/projection/project.go
+++ b/tools/jtk/internal/present/projection/project.go
@@ -70,6 +70,38 @@ func ProjectDetail(section *present.DetailSection, selected []ColumnSpec) *prese
 	return &present.DetailSection{Fields: out}
 }
 
+// ApplyToTableInModel rewrites the first TableSection of model in place to
+// keep only the selected columns. No-op when the model carries no
+// TableSection (e.g., an all-MessageSection model). Commands pass the
+// OutputModel a presenter built plus the `selected` slice from Resolve —
+// this helper was duplicated across cmd/issues, cmd/users, and cmd/projects
+// before extraction.
+func ApplyToTableInModel(model *present.OutputModel, selected []ColumnSpec) {
+	if model == nil {
+		return
+	}
+	for i, s := range model.Sections {
+		if ts, ok := s.(*present.TableSection); ok {
+			model.Sections[i] = ProjectTable(ts, selected)
+			return
+		}
+	}
+}
+
+// ApplyToDetailInModel is the DetailSection counterpart of
+// ApplyToTableInModel. No-op when the model carries no DetailSection.
+func ApplyToDetailInModel(model *present.OutputModel, selected []ColumnSpec) {
+	if model == nil {
+		return
+	}
+	for i, s := range model.Sections {
+		if ds, ok := s.(*present.DetailSection); ok {
+			model.Sections[i] = ProjectDetail(ds, selected)
+			return
+		}
+	}
+}
+
 // DeriveFetchFields returns the minimum Jira field-ID set needed to render
 // the selected specs. Output is sorted and deduplicated so API requests are
 // stable across runs. Synthetic specs (empty FieldID, empty Fetch) are

--- a/tools/jtk/internal/present/user.go
+++ b/tools/jtk/internal/present/user.go
@@ -7,48 +7,131 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 // UserPresenter creates presentation models for user data.
 type UserPresenter struct{}
 
-// Present creates a presentation model for text output.
-// Content normalization (if any) happens here, not in the renderer.
-func (UserPresenter) Present(user *api.User) *present.OutputModel {
+// UserDetailSpec declares the logical fields a `me` / `users get` response
+// carries. Used by `--fields` projection on `users get`. `me` itself does not
+// expose `--fields` (scope decision: too few fields to justify the flag), but
+// the Registry is kept single-sourced so spec parity with `users get` is
+// mechanical to lock.
+var UserDetailSpec = projection.Registry{
+	{Header: "ACCOUNT_ID", Identity: true},
+	{Header: "NAME"},
+	{Header: "EMAIL"},
+	{Header: "TIMEZONE", Extended: true},
+	{Header: "LOCALE", Extended: true},
+	{Header: "ACTIVE", Extended: true},
+	{Header: "GROUPS", Extended: true},
+	{Header: "APPLICATION_ROLES", Aliases: []string{"APP_ROLES"}, Extended: true},
+}
+
+// UserListSpec declares the columns emitted by PresentUserList and
+// PresentUserListProjection. Order must match the hardcoded Headers in
+// PresentUserList's TableSection; a parity test locks the two in sync.
+var UserListSpec = projection.Registry{
+	{Header: "ACCOUNT_ID", Identity: true},
+	{Header: "NAME"},
+	{Header: "EMAIL"},
+	{Header: "ACTIVE"},
+	{Header: "TIMEZONE", Extended: true},
+	{Header: "LOCALE", Extended: true},
+}
+
+// PresentUserOneLiner builds the spec-shaped default output for `me` and
+// `users get`: a single pipe-delimited record "{accountId} | {name} | {email}".
+// Empty email renders as `-`. Emitted as a MessageSection rather than a
+// TableSection because the spec one-liner has no column header line.
+func (UserPresenter) PresentUserOneLiner(u *api.User) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: userOneLiner(u),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentUserExtended builds the spec-shaped `--extended` output: the pipe
+// one-liner followed by two compound "Key: X   Key2: Y" rows. Missing
+// timeZone/locale render as `-`; missing groups/applicationRoles (i.e., the
+// endpoint did not expand them) also render as `-`.
+func (UserPresenter) PresentUserExtended(u *api.User) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: userOneLiner(u),
+				Stream:  present.StreamStdout,
+			},
+			&present.MessageSection{
+				Kind: present.MessageInfo,
+				Message: fmt.Sprintf("Timezone: %s   Locale: %s   Active: %s",
+					OrDash(u.TimeZone), OrDash(u.Locale), BoolString(u.Active)),
+				Stream: present.StreamStdout,
+			},
+			&present.MessageSection{
+				Kind: present.MessageInfo,
+				Message: fmt.Sprintf("Groups: %s   Application Roles: %s",
+					PresentOptionalCount(u.Groups), PresentOptionalCount(u.ApplicationRoles)),
+				Stream: present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentUserDetailProjection builds a DetailSection view for a single user,
+// keyed by the headers declared in UserDetailSpec. Commands use this only
+// when `--fields` is active; projection.ProjectDetail then slices the section
+// to the user-selected subset. Output flattens to "Label: Value" lines,
+// matching the issues get --fields precedent.
+func (UserPresenter) PresentUserDetailProjection(u *api.User) *present.OutputModel {
 	fields := []present.Field{
-		{Label: "Account ID", Value: user.AccountID},
-		{Label: "Display Name", Value: user.DisplayName},
+		{Label: "ACCOUNT_ID", Value: u.AccountID},
+		{Label: "NAME", Value: u.DisplayName},
+		{Label: "EMAIL", Value: OrDash(u.EmailAddress)},
+		{Label: "TIMEZONE", Value: OrDash(u.TimeZone)},
+		{Label: "LOCALE", Value: OrDash(u.Locale)},
+		{Label: "ACTIVE", Value: BoolString(u.Active)},
+		{Label: "GROUPS", Value: PresentOptionalCount(u.Groups)},
+		{Label: "APPLICATION_ROLES", Value: PresentOptionalCount(u.ApplicationRoles)},
 	}
-	if user.EmailAddress != "" {
-		fields = append(fields, present.Field{Label: "Email", Value: user.EmailAddress})
-	}
-	fields = append(fields, present.Field{
-		Label: "Active", Value: BoolString(user.Active),
-	})
 	return &present.OutputModel{
 		Sections: []present.Section{&present.DetailSection{Fields: fields}},
 	}
 }
 
-// PresentList creates a table view for a list of users.
-func (UserPresenter) PresentList(users []api.User) *present.OutputModel {
+// PresentUserList builds a TableSection for `users search`. When extended is
+// true, TIMEZONE/LOCALE columns are appended so the Registry and the rendered
+// headers stay aligned in both modes.
+// The command is responsible for appending any pagination hint via
+// AppendPaginationHintWithToken; this presenter returns the plain model.
+func (UserPresenter) PresentUserList(users []api.User, extended bool) *present.OutputModel {
+	headers := []string{"ACCOUNT_ID", "NAME", "EMAIL", "ACTIVE"}
+	if extended {
+		headers = append(headers, "TIMEZONE", "LOCALE")
+	}
 	rows := make([]present.Row, len(users))
 	for i, u := range users {
-		active := "yes"
-		if !u.Active {
-			active = "no"
+		cells := []string{
+			u.AccountID,
+			u.DisplayName,
+			OrDash(u.EmailAddress),
+			BoolString(u.Active),
 		}
-		rows[i] = present.Row{
-			Cells: []string{u.AccountID, u.DisplayName, u.EmailAddress, active},
+		if extended {
+			cells = append(cells, OrDash(u.TimeZone), OrDash(u.Locale))
 		}
+		rows[i] = present.Row{Cells: cells}
 	}
-
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"ACCOUNT ID", "NAME", "EMAIL", "ACTIVE"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
 	}
 }
@@ -64,4 +147,10 @@ func (UserPresenter) PresentEmpty(query string) *present.OutputModel {
 			},
 		},
 	}
+}
+
+// userOneLiner formats the default identity record used by `me` and
+// `users get`. "-" substitutes for an empty email address.
+func userOneLiner(u *api.User) string {
+	return fmt.Sprintf("%s | %s | %s", u.AccountID, u.DisplayName, OrDash(u.EmailAddress))
 }

--- a/tools/jtk/internal/present/user_test.go
+++ b/tools/jtk/internal/present/user_test.go
@@ -1,14 +1,16 @@
 package present
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
-func TestUserPresenter_Present(t *testing.T) {
+func TestPresentUserOneLiner(t *testing.T) {
 	t.Parallel()
 	user := &api.User{
 		AccountID:    "abc123",
@@ -17,82 +19,225 @@ func TestUserPresenter_Present(t *testing.T) {
 		Active:       true,
 	}
 
-	p := UserPresenter{}
-	model := p.Present(user)
+	model := UserPresenter{}.PresentUserOneLiner(user)
+	got := renderMessage(t, model, 0)
+	want := "abc123 | John Doe | john@example.com"
+	if got != want {
+		t.Errorf("one-liner = %q, want %q", got, want)
+	}
+}
 
-	if len(model.Sections) != 1 {
-		t.Fatalf("expected 1 section, got %d", len(model.Sections))
+func TestPresentUserOneLiner_DashForEmptyEmail(t *testing.T) {
+	t.Parallel()
+	user := &api.User{AccountID: "abc123", DisplayName: "Jane"}
+	model := UserPresenter{}.PresentUserOneLiner(user)
+	got := renderMessage(t, model, 0)
+	want := "abc123 | Jane | -"
+	if got != want {
+		t.Errorf("one-liner with empty email = %q, want %q", got, want)
+	}
+}
+
+func TestPresentUserExtended_AllFieldsPresent(t *testing.T) {
+	t.Parallel()
+	user := &api.User{
+		AccountID:        "abc",
+		DisplayName:      "Alice",
+		EmailAddress:     "alice@example.com",
+		Active:           true,
+		TimeZone:         "Etc/GMT",
+		Locale:           "en_US",
+		Groups:           &api.UserCountBlock{Size: 9},
+		ApplicationRoles: &api.UserCountBlock{Size: 1},
 	}
 
+	model := UserPresenter{}.PresentUserExtended(user)
+	if len(model.Sections) != 3 {
+		t.Fatalf("extended model: expected 3 sections, got %d", len(model.Sections))
+	}
+
+	expect := []string{
+		"abc | Alice | alice@example.com",
+		"Timezone: Etc/GMT   Locale: en_US   Active: yes",
+		"Groups: 9   Application Roles: 1",
+	}
+	for i, want := range expect {
+		if got := renderMessage(t, model, i); got != want {
+			t.Errorf("section %d = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestPresentUserExtended_DashesForMissingOptionalFields(t *testing.T) {
+	t.Parallel()
+	user := &api.User{
+		AccountID:   "abc",
+		DisplayName: "Bob",
+		Active:      false,
+		// TimeZone / Locale empty; Groups / ApplicationRoles nil (API omitted expansion)
+	}
+
+	model := UserPresenter{}.PresentUserExtended(user)
+
+	expect := []string{
+		"abc | Bob | -",
+		"Timezone: -   Locale: -   Active: no",
+		"Groups: -   Application Roles: -",
+	}
+	for i, want := range expect {
+		if got := renderMessage(t, model, i); got != want {
+			t.Errorf("section %d = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestPresentUserList_DefaultHeaders(t *testing.T) {
+	t.Parallel()
+	users := []api.User{
+		{AccountID: "a1", DisplayName: "Alice", EmailAddress: "a@example.com", Active: true},
+		{AccountID: "b2", DisplayName: "Bob", Active: false},
+	}
+	model := UserPresenter{}.PresentUserList(users, false)
+	table := sectionTable(t, model, 0)
+
+	wantHeaders := []string{"ACCOUNT_ID", "NAME", "EMAIL", "ACTIVE"}
+	if !equalStringSlices(table.Headers, wantHeaders) {
+		t.Errorf("headers = %v, want %v", table.Headers, wantHeaders)
+	}
+
+	if len(table.Rows) != 2 {
+		t.Fatalf("rows: got %d, want 2", len(table.Rows))
+	}
+	if got := table.Rows[0].Cells; !equalStringSlices(got, []string{"a1", "Alice", "a@example.com", "yes"}) {
+		t.Errorf("row 0 = %v", got)
+	}
+	if got := table.Rows[1].Cells; !equalStringSlices(got, []string{"b2", "Bob", "-", "no"}) {
+		t.Errorf("row 1 = %v", got)
+	}
+}
+
+func TestPresentUserList_ExtendedHeadersAppendTimezoneLocale(t *testing.T) {
+	t.Parallel()
+	users := []api.User{{AccountID: "a1", DisplayName: "Alice", TimeZone: "Etc/GMT", Locale: "en_US", Active: true}}
+	model := UserPresenter{}.PresentUserList(users, true)
+	table := sectionTable(t, model, 0)
+
+	wantHeaders := []string{"ACCOUNT_ID", "NAME", "EMAIL", "ACTIVE", "TIMEZONE", "LOCALE"}
+	if !equalStringSlices(table.Headers, wantHeaders) {
+		t.Errorf("extended headers = %v, want %v", table.Headers, wantHeaders)
+	}
+
+	if got := table.Rows[0].Cells; !equalStringSlices(got, []string{"a1", "Alice", "-", "yes", "Etc/GMT", "en_US"}) {
+		t.Errorf("row = %v", got)
+	}
+}
+
+func TestPresentUserList_ExtendedDashesForRedactedFields(t *testing.T) {
+	t.Parallel()
+	// Simulates an instance where /user/search returns users without
+	// timeZone/locale fields — the PR calls this out explicitly.
+	users := []api.User{{AccountID: "a1", DisplayName: "Alice", Active: true}}
+	model := UserPresenter{}.PresentUserList(users, true)
+	table := sectionTable(t, model, 0)
+
+	if got := table.Rows[0].Cells; !equalStringSlices(got, []string{"a1", "Alice", "-", "yes", "-", "-"}) {
+		t.Errorf("row with redacted tz/locale = %v", got)
+	}
+}
+
+func TestPresentUserDetailProjection_ContainsAllSpecHeaders(t *testing.T) {
+	t.Parallel()
+	// Parity between UserDetailSpec and the DetailSection that feeds
+	// projection.ProjectDetail: every spec header must have a corresponding
+	// Field label, otherwise --fields tokens silently project to nothing.
+	user := &api.User{
+		AccountID: "abc", DisplayName: "Alice", EmailAddress: "a@example.com",
+		Active: true, TimeZone: "Etc/GMT", Locale: "en_US",
+		Groups: &api.UserCountBlock{Size: 3}, ApplicationRoles: &api.UserCountBlock{Size: 1},
+	}
+	model := UserPresenter{}.PresentUserDetailProjection(user)
 	detail, ok := model.Sections[0].(*present.DetailSection)
 	if !ok {
 		t.Fatalf("expected DetailSection, got %T", model.Sections[0])
 	}
-
-	findField := func(label string) string {
-		for _, f := range detail.Fields {
-			if f.Label == label {
-				return f.Value
-			}
-		}
-		return ""
-	}
-
-	if got := findField("Account ID"); got != "abc123" {
-		t.Errorf("Account ID = %q, want abc123", got)
-	}
-	if got := findField("Display Name"); got != "John Doe" {
-		t.Errorf("Display Name = %q, want John Doe", got)
-	}
-	if got := findField("Email"); got != "john@example.com" {
-		t.Errorf("Email = %q, want john@example.com", got)
-	}
-	if got := findField("Active"); got != "yes" {
-		t.Errorf("Active = %q, want yes", got)
-	}
-}
-
-func TestUserPresenter_OmitsEmptyEmail(t *testing.T) {
-	t.Parallel()
-	user := &api.User{
-		AccountID:   "abc123",
-		DisplayName: "John Doe",
-		Active:      true,
-	}
-
-	p := UserPresenter{}
-	model := p.Present(user)
-
-	detail := model.Sections[0].(*present.DetailSection)
+	have := make(map[string]struct{}, len(detail.Fields))
 	for _, f := range detail.Fields {
-		if f.Label == "Email" {
-			t.Error("Email field should be omitted when empty")
+		have[strings.ToLower(f.Label)] = struct{}{}
+	}
+	for _, c := range UserDetailSpec {
+		if _, ok := have[strings.ToLower(c.Header)]; !ok {
+			t.Errorf("UserDetailSpec header %q has no matching DetailSection label", c.Header)
 		}
 	}
 }
 
-func TestUserPresenter_InactiveUser(t *testing.T) {
+func TestUserListSpec_HeaderParityWithPresenter(t *testing.T) {
 	t.Parallel()
-	user := &api.User{
-		AccountID:   "abc123",
-		DisplayName: "Jane Doe",
-		Active:      false,
+	// Default-mode registry must match the default-mode table headers.
+	model := UserPresenter{}.PresentUserList(nil, false)
+	table := sectionTable(t, model, 0)
+	wantHeaders := registryHeadersFor(UserListSpec, false)
+	if !equalStringSlices(table.Headers, wantHeaders) {
+		t.Errorf("default headers mismatch: presenter %v vs registry %v", table.Headers, wantHeaders)
 	}
 
-	p := UserPresenter{}
-	model := p.Present(user)
+	// Extended mode must also match.
+	modelExt := UserPresenter{}.PresentUserList(nil, true)
+	tableExt := sectionTable(t, modelExt, 0)
+	wantHeadersExt := registryHeadersFor(UserListSpec, true)
+	if !equalStringSlices(tableExt.Headers, wantHeadersExt) {
+		t.Errorf("extended headers mismatch: presenter %v vs registry %v", tableExt.Headers, wantHeadersExt)
+	}
+}
 
-	detail := model.Sections[0].(*present.DetailSection)
-	findField := func(label string) string {
-		for _, f := range detail.Fields {
-			if f.Label == label {
-				return f.Value
-			}
+func TestPresentEmptyUsers(t *testing.T) {
+	t.Parallel()
+	model := UserPresenter{}.PresentEmpty("ghost")
+	if got := renderMessage(t, model, 0); got != "No users found matching 'ghost'" {
+		t.Errorf("empty message = %q", got)
+	}
+}
+
+// --- tiny test helpers shared with project_test.go ---
+
+func renderMessage(t *testing.T, model *present.OutputModel, i int) string {
+	t.Helper()
+	if i >= len(model.Sections) {
+		t.Fatalf("section index %d out of range (have %d)", i, len(model.Sections))
+	}
+	msg, ok := model.Sections[i].(*present.MessageSection)
+	if !ok {
+		t.Fatalf("section %d: expected MessageSection, got %T", i, model.Sections[i])
+	}
+	return msg.Message
+}
+
+func sectionTable(t *testing.T, model *present.OutputModel, i int) *present.TableSection {
+	t.Helper()
+	ts, ok := model.Sections[i].(*present.TableSection)
+	if !ok {
+		t.Fatalf("section %d: expected TableSection, got %T", i, model.Sections[i])
+	}
+	return ts
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
 		}
-		return ""
 	}
+	return true
+}
 
-	if got := findField("Active"); got != "no" {
-		t.Errorf("Active = %q, want no", got)
+func registryHeadersFor(r projection.Registry, extended bool) []string {
+	filtered := r.ForMode(extended)
+	out := make([]string, len(filtered))
+	for i, c := range filtered {
+		out[i] = c.Header
 	}
+	return out
 }

--- a/tools/jtk/internal/resolve/user.go
+++ b/tools/jtk/internal/resolve/user.go
@@ -25,7 +25,7 @@ import (
 // candidates listed.
 func (r *Resolver) User(ctx context.Context, input string) (api.User, error) {
 	if strings.EqualFold(input, "me") {
-		u, err := r.client.GetCurrentUser(ctx)
+		u, err := r.client.GetCurrentUser(ctx, "")
 		if err != nil {
 			return api.User{}, fmt.Errorf("resolving current user: %w", err)
 		}

--- a/tools/jtk/internal/resolve/user.go
+++ b/tools/jtk/internal/resolve/user.go
@@ -60,7 +60,7 @@ func (r *Resolver) User(ctx context.Context, input string) (api.User, error) {
 	if strings.Contains(input, "@") {
 		var nf *NotFoundError
 		if errors.As(err, &nf) {
-			if live, lerr := r.client.SearchUsers(ctx, input, 1); lerr == nil && len(live) == 1 {
+			if live, lerr := r.client.SearchUsers(ctx, input, 0, 1); lerr == nil && len(live) == 1 {
 				return live[0], nil
 			}
 		}


### PR DESCRIPTION
## Summary
Part of the JTK Output Specification ([#230](https://github.com/open-cli-collective/atlassian-cli/issues/230)) command-surface rethink. Migrates the first Group B commands (#251 shipped Group A: `issues list/search/get`) to the spec-shaped output model, with `--id`, `--extended`, `--fields`, and tokenized pagination wired end-to-end.

Closes #237.

## Commands migrated
- `jtk me`
- `jtk users get`, `jtk users search`
- `jtk projects list`, `jtk projects get`, `jtk projects types`

## Spec-shaped rendering
- `me` / `users get` default: pipe one-liner `{accountId} | {name} | {email}` (dash for empty email).
- `me --extended` / `users get --extended`: pipe line + `Timezone: X   Locale: Y   Active: Z` + `Groups: n   Application Roles: m` (each compound value renders `-` when the API omitted it).
- `users search`: spec-order `ACCOUNT_ID | NAME | EMAIL | ACTIVE`; `--extended` appends `TIMEZONE | LOCALE`.
- `projects list`: reordered to `KEY | TYPE | LEAD | NAME` (spec order, not the pre-migration `KEY | NAME | TYPE | LEAD`); `--extended` appends `STYLE | ISSUE_TYPES | COMPONENTS` counts.
- `projects get` default: title line `{KEY}  {Name}` + compound `Type/Lead/Style` row + `Issue Types` list + `Components: n   Versions: n`.
- `projects get --extended`: title line + compound row with lead accountId + `Issue Types: Epic (10000), …` + enumerated components `  {id} | {name}` truncated at 4 with `  ... [N more]` + `Versions: n` + `Simplified: yes|no|-   Private: yes|no|-` + optional description block.
- `projects types`: header renamed `FORMATTED → NAME` per spec; `--extended` adds `DESCRIPTION_KEY`.

## Flag plumbing
All migrated commands gain `--id` precedence (wins over `--extended`, `--fulltext`, and skips projection entirely). `users get`, `projects get`, `users search`, `projects list`, `projects types` gain `--fields` with a per-package `noFieldFetch` so Jira issue-field metadata isn't pulled for non-issue projections. `users search` and `projects list` gain `--next-page-token` (decimal `startAt` string); `--fields` + `-o json` returns an explicit error.

`me` intentionally skips `--fields` (too few fields to justify the flag).

## Pagination (additive)
Adds `AppendPaginationHintWithToken` and `EmitIDsWithPaginationToken` in `internal/present/emit.go`. Migrated commands emit `More results available (next: <token>)` per spec. Legacy helpers are untouched; unmigrated commands (issues, comments) keep their current behavior and can migrate on their own tickets.

- `projects list`: uses `/project/search`'s native `IsLast` as the terminal signal; token is the next `startAt`.
- `users search`: `/user/search` has no `isLast`, so `hasMore` is inferred from `len(users) == maxResults` (documented in the command's `--help`). Token is also the next `startAt`.

## API widening (minimal + honest)
- `api.User`: `TimeZone`, `Locale`, `Groups *UserCountBlock`, `ApplicationRoles *UserCountBlock`. `GetCurrentUser` and `GetUser` now pass `?expand=groups,applicationRoles`.
- `api.ProjectDetail`: `Style string`, `Simplified *bool`, `IsPrivate *bool`, `Versions []Version`. Pointers distinguish "API omitted the field" from "present and false" — presenters render `-` in the first case, `yes|no` in the second. `GetProject` and `SearchProjects` pass `?expand=description,lead,issueTypes,url,projectKeys[,versions]`.
- `api.SearchUsers` signature grows `startAt int`. The one internal caller (`internal/resolve/user.go`) passes `0`.

## Endpoint verification
Before widening, each target endpoint was probed against `monitproduct.atlassian.net` to confirm what it actually populates:

| Endpoint | `timeZone` | `locale` | `groups` | `applicationRoles` |
|---|---|---|---|---|
| `/myself?expand=groups,applicationRoles` | ✓ | ✓ | ✓ (size 9) | ✓ (size 1) |
| `/user?accountId=…&expand=groups,applicationRoles` | ✓ | ✓ | ✓ | ✓ |
| `/user/search` | ✓ (this instance) | ✓ (this instance) | ✗ | ✗ |

`/user/search` ignores `expand`; the timezone/locale cells we see here may be redacted on other instances. Rendering falls back to `-` in that case — not `""`, not `"false"`.

| Endpoint | `style` | `simplified` | `isPrivate` | `versions` |
|---|---|---|---|---|
| `/project/{key}?expand=…,versions` | ✓ | ✓ | ✓ | ✓ |
| `/project/search?expand=…` | ✓ | ✓ | ✓ | ✗ (use get) |

## Tests
- Replaced `Contains`-style assertions with exact-string goldens across `me_test.go`, `users_test.go`, `projects_test.go`.
- New `project_test.go` presenter unit suite.
- Parity tests lock `UserListSpec` / `ProjectListSpec` / `ProjectTypeSpec` headers to the presenter's rendered headers in both default and extended modes.
- New `emit_test.go` coverage for `AppendPaginationHintWithToken` and `EmitIDsWithPaginationToken` (token embedding, empty-token legacy fallback, hasMore=false short-circuit).
- `TestRunSearch_ExpandParamNotSentOnSearchEndpoint` asserts the honest contract: no `expand` on `/user/search`.

## Out of scope
- `projects create/update/delete/restore` success output reshape — they use `PresentCreated`/`Updated`/etc. (MessageSection) which aren't affected. A later ticket can reshape them to mirror `projects get` post-state.
- Legacy `paginationHint` / `AppendPaginationHint` helpers. They stay until the other callers migrate; the new `*WithToken` helpers live alongside them.
- New `shared/present` section types. The spec-shaped rendering uses hand-formatted `MessageSection` lines. If the pattern repeats 2–3 more times in later migrations we can extract richer primitives.

## Test plan
- [x] `make build && make test` — 1279 tests passing, race-detector clean.
- [x] `cd tools/jtk && golangci-lint run` — 0 new issues; the only remaining warning is the pre-existing `config.go` gosec finding flagged in CLAUDE.md.
- [x] Live smoke: `jtk me` / `me --extended` / `me --id`, `jtk projects get MON` / `get MON --extended` — output matches spec exactly.
- [ ] Live smoke on a bearer-auth instance — to confirm graceful `-` rendering when fields are redacted.