### PR TITLE
Add jtk & cfl Skills

### DIFF
--- a/skills/Confluence/CliReference.md
+++ b/skills/Confluence/CliReference.md
@@ -1,0 +1,201 @@
+# cfl CLI Reference
+
+Reference for the `cfl` command line tool from [open-cli-collective/atlassian-cli](https://github.com/open-cli-collective/atlassian-cli).
+
+## Authentication
+
+**Config file** (recommended): `~/.config/cfl/config.yml`
+
+Set up interactively:
+```bash
+cfl init
+```
+
+Prompts for: Atlassian instance URL, email, API token (from https://id.atlassian.com/manage-profile/security/api-tokens).
+
+Test connectivity:
+```bash
+cfl config test
+```
+
+## Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `-o, --output FORMAT` | Output format (see SKILL.md "Output Representation and Format"): `table` (default), `json`, `plain` |
+| `--full` | Inspection-oriented representation (see SKILL.md). Not a content-truncation flag — for `page view` content truncation, use `--no-truncate`. |
+| `--raw` | Source-faithful representation (see SKILL.md). Command-specific. |
+| `--no-color` | Disable colored output |
+| `-c, --config PATH` | Override config file location (default: `~/.config/cfl/config.yml`) |
+
+## Command Structure
+
+```
+cfl [resource] [action] [ID] [flags]
+```
+
+## Pages
+
+| Command | Description |
+|---------|-------------|
+| `cfl page list --space KEY` | List pages in space |
+| `cfl page view PAGE_ID` | View page content as markdown (truncated at 5000 chars by default) |
+| `cfl page view PAGE_ID --no-truncate` | View full content without truncation |
+| `cfl page view PAGE_ID --content-only` | Output content only (no metadata headers); implies `--no-truncate` |
+| `cfl page view PAGE_ID --raw` | View raw Confluence storage format (XHTML) instead of markdown |
+| `cfl page view PAGE_ID --show-macros` | Show macro placeholders (e.g. `[TOC]`) instead of stripping them |
+| `cfl page view PAGE_ID --web` | Open page in browser |
+| `cfl page view PAGE_ID -o json` | Full JSON output (body always included in full) |
+| `cfl page create --space KEY --title "TEXT"` | Create page (opens editor) |
+| `cfl page create --space KEY --title "TEXT" --file content.md` | Create from file |
+| `cfl page create --space KEY --title "TEXT" --parent PAGE_ID` | Create as child page |
+| `cfl page edit PAGE_ID` | Edit page (opens editor) |
+| `cfl page edit PAGE_ID --file content.md` | Update from file |
+| `cfl page edit PAGE_ID --title "New Title"` | Update title only |
+| `cfl page edit PAGE_ID --parent PAGE_ID` | Move page to new parent |
+| `cfl page copy PAGE_ID --title "Copy Title"` | Copy page |
+| `cfl page copy PAGE_ID --title "Copy" --space OTHER` | Copy to different space |
+| `cfl page delete PAGE_ID` | Delete page (with confirmation) |
+| `cfl page delete PAGE_ID --force` | Delete without confirmation |
+
+### Create/Edit Flags
+
+| Flag | Description |
+|------|-------------|
+| `--space KEY` / `-s` | Space key (required for create) |
+| `--title "TEXT"` / `-t` | Page title (required for create) |
+| `--file PATH` / `-f` | Read content from file |
+| `--parent PAGE_ID` / `-p` | Parent page ID |
+| `--legacy` | Use legacy editor format instead of cloud (ADF) |
+| `--no-markdown` | Disable markdown conversion (use raw XHTML) |
+| `--storage` | Input is Confluence storage format (XHTML); sent via storage representation API regardless of the page's editor type |
+| `--editor` | Open interactive editor |
+
+### Page View Flags
+
+| Flag | Description |
+|------|-------------|
+| `--no-truncate` | Show full content without truncation |
+| `--content-only` | Output only page content (no metadata headers); implies `--no-truncate` |
+| `--raw` | Raw Confluence storage format (XHTML) |
+| `--show-macros` | Show macro placeholders (e.g. `[TOC]`) instead of stripping them |
+| `-w, --web` | Open in browser |
+
+### Page List Flags
+
+| Flag | Description |
+|------|-------------|
+| `--space KEY` / `-s` | Space key (required) |
+| `--limit N` / `-l` | Max results (default 25) |
+| `--status STATUS` | Page status: `current`, `archived`, `trashed` (default `current`) |
+
+### Content Piping & Lossless Round-Trip
+
+Markdown round-trip (lossy — macros and some formatting lost):
+```bash
+# Edit current content via stdin
+cfl page view 12345 --content-only | cfl page edit 12345 --legacy
+```
+
+Storage-format round-trip (lossless — preserves macros and all formatting):
+- Fetch the page with `-o json` (the `content` field holds the raw storage XHTML)
+- Modify the XHTML
+- Send the modified XHTML back: `cfl page edit PAGE_ID --storage` (reads from stdin, or pass via `--file`)
+
+See ViewPage.md for the JSON output structure and ManagePage.md for a full walkthrough.
+
+Create from stdin:
+```bash
+echo "# Hello World" | cfl page create -s DEV -t "My Page"
+```
+
+## Search
+
+| Command | Description |
+|---------|-------------|
+| `cfl search "query"` | Full-text search |
+| `cfl search "query" --space KEY` | Search within space |
+| `cfl search "query" --type page` | Search pages only |
+| `cfl search --label TAG` | Filter by label |
+| `cfl search --title "TEXT"` | Filter by title |
+| `cfl search --cql "CQL_QUERY"` | Raw CQL query |
+
+**Note:** When `--cql` is provided, it takes precedence over the positional `[query]` argument. Don't combine them.
+
+### Search Flags
+
+| Flag | Description |
+|------|-------------|
+| `--space KEY` / `-s` | Filter by space key |
+| `--type TYPE` / `-t` | Content type: `page`, `blogpost`, `attachment`, `comment` |
+| `--label TAG` | Filter by label |
+| `--title "TEXT"` | Filter by title (contains) |
+| `--cql "QUERY"` | Raw CQL query (advanced). Takes precedence over positional query. |
+| `--limit N` / `-l` | Max results (default 25) |
+
+### Common CQL Patterns
+
+| Intent | CQL |
+|--------|-----|
+| Recently modified pages | `type=page AND lastModified > now('-7d')` |
+| Pages in space | `type=page AND space=KEY` |
+| Pages by creator | `type=page AND creator=currentUser()` |
+| Pages with label | `type=page AND label="TAG"` |
+| Pages modified by me | `type=page AND contributor=currentUser()` |
+| Blog posts in space | `type=blogpost AND space=KEY` |
+| Ancestor (child pages) | `type=page AND ancestor=PAGE_ID` |
+| Title match | `type=page AND title~"search term"` |
+| Combined filters | `type=page AND space=DEV AND lastModified > now('-7d') AND label="api"` |
+
+## Spaces
+
+| Command | Description |
+|---------|-------------|
+| `cfl space list` | List all spaces |
+| `cfl space list --type global` | List only global spaces |
+| `cfl space list --type personal` | List only personal spaces |
+| `cfl space list --cursor CURSOR` | Paginate (use cursor from previous response) |
+| `cfl space view KEY` | View space details (alias: `get`) |
+| `cfl space create --key KEY --name "NAME"` | Create space |
+| `cfl space update KEY --name "NAME"` | Update space name |
+| `cfl space delete KEY` | Delete space |
+
+### Space List Flags
+
+| Flag | Description |
+|------|-------------|
+| `--type TYPE` / `-t` | Filter by space type: `global`, `personal` |
+| `--limit N` / `-l` | Max results (default 25) |
+| `--cursor CURSOR` | Pagination cursor for next page |
+
+### Space Create Flags
+
+| Flag | Description |
+|------|-------------|
+| `--key KEY` / `-k` | Space key (required) |
+| `--name "NAME"` / `-n` | Space name (required) |
+| `--description "TEXT"` / `-d` | Space description |
+| `--type TYPE` / `-t` | Space type: `global`, `personal` (default `global`) |
+
+## Attachments
+
+| Command | Description |
+|---------|-------------|
+| `cfl attachment list --page PAGE_ID` | List attachments on page |
+| `cfl attachment list --page PAGE_ID --limit 50` | List with custom limit (default 25) |
+| `cfl attachment list --page PAGE_ID --unused` | List orphaned attachments (not referenced in page content) |
+| `cfl attachment upload --page PAGE_ID --file PATH` | Upload attachment |
+| `cfl attachment upload --page PAGE_ID --file PATH -m "comment"` | Upload with comment |
+| `cfl attachment download ATT_ID` | Download (uses original filename) |
+| `cfl attachment download ATT_ID -O filename` | Download to specific filename |
+| `cfl attachment download ATT_ID --force` | Overwrite existing file without warning |
+| `cfl attachment delete ATT_ID` | Delete attachment (with confirmation) |
+| `cfl attachment delete ATT_ID --force` | Delete without confirmation |
+
+## Output
+
+- Default representation: `agent`; default format: `table`. See SKILL.md "Output Representation and Format" for the full model.
+- Use `-o json` for machine-readable output (useful for scripting — e.g. extracting IDs from search results or storage-format body from a page)
+- Use `-o plain` for plain text
+- Use `--no-color` to disable colored output
+- Data goes to stdout (pipeable)

--- a/skills/Confluence/SKILL.md
+++ b/skills/Confluence/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: Confluence
+description: Confluence wiki and knowledge base management via cfl CLI — search, create, view, edit pages, manage spaces, attachments. USE WHEN confluence, wiki, knowledge base, runbook, documentation, docs page, wiki search, confluence page, create page, edit page, move page, search confluence, confluence space, view page, page attachments, attach to page, CQL, confluence search.
+---
+
+## Customization
+
+**Before executing, check for user customizations at:**
+`~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Confluence/`
+
+If this directory exists, load and apply any PREFERENCES.md, configurations, or resources found there. These override default behavior. If the directory does not exist, proceed with skill defaults.
+
+If PREFERENCES.md exists but is malformed, unreadable, or missing referenced values, treat it the same as "no preferences" and proceed with skill defaults — do not abort the workflow on a broken preferences file.
+
+# Confluence
+
+Wiki and knowledge base management via the `cfl` CLI tool ([open-cli-collective/atlassian-cli](https://github.com/open-cli-collective/atlassian-cli)).
+
+## Prerequisites
+
+All workflows share these prerequisites. Workflows do not repeat them — check these before entering any workflow.
+
+1. **cfl installed** — verify with `cfl --version`
+2. **Auth configured** — config file at `~/.config/cfl/config.yml` (run `cfl init` to set up). Verify with `cfl config test` (reports connection + identity).
+3. **Personal space keys** — in Confluence, space keys that start with `~` are personal spaces (e.g., `~aaron`). The `~` is part of the key, not a shell home-directory shortcut. In shells that expand leading `~` (bash, zsh), quote the key: `cfl space view '~aaron'`.
+4. **Customization** (optional) — `~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Confluence/PREFERENCES.md` for defaults
+   - If no customization AND the request requires a space key not specified by the user: abort with a message explaining how to create PREFERENCES.md (see template in SearchPages.md)
+
+## Common Patterns
+
+### Output Representation and Format
+
+`cfl` distinguishes two independent output concerns (per the repo's [Artifact Contract](../../docs/ARTIFACT_CONTRACT.md)):
+
+- **Representation** — what content is shown:
+  - `agent` (default) — curated, action-oriented, LLM-optimized
+  - `full` (`--full`) — inspection-oriented, additional fields (dates, authors, versions)
+  - `raw` (`--raw`) — source-faithful content (e.g., XHTML instead of markdown). Command-specific; only supported where source transformation occurs (currently `page view`).
+- **Output format** — how it's rendered: `table` (default), `json` (`-o json`), `plain` (`-o plain`)
+
+They combine freely — e.g., `--full -o json` returns the inspection representation as JSON.
+
+### Extracting Page IDs from URLs
+
+Many workflows (ViewPage, ManagePage, ManageAttachments) and CQL filters (`ancestor=PAGE_ID`) take a numeric `PAGE_ID`. If the user provides a Confluence URL, the page ID is the path segment immediately after `/pages/`:
+
+```
+https://INSTANCE.atlassian.net/wiki/spaces/SPACEKEY/pages/PAGE_ID/Page-Title-Slug
+                                                        ^^^^^^^^
+```
+
+Use that numeric segment as the `PAGE_ID` in any command that takes one.
+
+## Common Errors
+
+| Symptom | Likely Cause | Remedy |
+|---------|--------------|--------|
+| `unauthorized` / `401` / "invalid credentials" | Missing or expired API token | Run `cfl init` to reconfigure; tokens from https://id.atlassian.com/manage-profile/security/api-tokens |
+| `cfl config test` fails after `cfl init` | URL typo, wrong instance, or token scoped to a different product | Re-run `cfl init` and double-check the URL and token |
+| `permission denied` on a specific page/space | Account lacks permission on that space | Verify space membership; ask a space admin to grant access |
+| `not found` on a valid-looking page ID | Wrong ID, page deleted/archived, or insufficient permission (Confluence may return 404 for unauthorized reads) | Try `cfl search --title "..." --space KEY` to re-locate |
+| Page body looks empty or missing structure | Macros stripped by default markdown rendering | Use `cfl page view ID --show-macros` to preserve macro placeholders, or `--raw` for full storage format |
+| Edit via markdown loses formatting | Markdown round-trip is lossy for macro-rich pages | Use the storage-format round-trip (fetch via `-o json`, modify the `content` field, send back with `--storage`) — see ManagePage.md |
+
+## Workflow Routing
+
+| Workflow | Trigger | File |
+|----------|---------|------|
+| **SearchPages** | "search confluence", "find pages", "CQL", "search wiki" | `Workflows/SearchPages.md` |
+| **ManagePage** | "create page", "edit page", "update page", "move page", "reparent page", "delete page", "copy page", "rename page" | `Workflows/ManagePage.md` |
+| **ViewPage** | "view page", "show page", "read page", "open page" | `Workflows/ViewPage.md` |
+| **ManageSpaces** | "list spaces", "create space", "space details", "update space" | `Workflows/ManageSpaces.md` |
+| **ManageAttachments** | "attach file", "list attachments", "download attachment", "upload to page" | `Workflows/ManageAttachments.md` |
+
+## Quick Reference
+
+| Operation | Command |
+|-----------|---------|
+| Search pages | `cfl search "query" --space KEY --type page` |
+| Search with CQL | `cfl search --cql "CQL_QUERY"` |
+| List pages in space | `cfl page list --space KEY` |
+| View page (truncated) | `cfl page view PAGE_ID` |
+| View full page content | `cfl page view PAGE_ID --no-truncate` |
+| View page content-only (pipe-friendly) | `cfl page view PAGE_ID --content-only` |
+| Create page | `cfl page create --space KEY --title "..." --file content.md` |
+| Edit page | `cfl page edit PAGE_ID --file content.md` |
+| List spaces | `cfl space list` |
+| Upload attachment | `cfl attachment upload --page PAGE_ID --file path` |
+
+**Full CLI reference:** load `CliReference.md`
+
+## Examples
+
+**Example 1: Search for documentation**
+```
+User: "Search confluence for deployment guide"
+-> Invokes SearchPages workflow
+-> Runs: cfl search "deployment guide" --type page
+-> Returns formatted results with page IDs, titles, spaces
+```
+
+**Example 2: Create a new page**
+```
+User: "Create a confluence page in DEV space titled 'API Reference'"
+-> Invokes ManagePage workflow
+-> Runs: cfl page create --space DEV --title "API Reference"
+-> Opens editor or accepts piped content
+-> Returns page ID and link
+```
+
+**Example 3: View a page**
+```
+User: "Show me confluence page 12345"
+-> Invokes ViewPage workflow
+-> Runs: cfl page view 12345
+-> Returns page content in markdown format (truncated at 5000 chars by default)
+```

--- a/skills/Confluence/SKILL.md
+++ b/skills/Confluence/SKILL.md
@@ -3,15 +3,6 @@ name: Confluence
 description: Confluence wiki and knowledge base management via cfl CLI — search, create, view, edit pages, manage spaces, attachments. USE WHEN confluence, wiki, knowledge base, runbook, documentation, docs page, wiki search, confluence page, create page, edit page, move page, search confluence, confluence space, view page, page attachments, attach to page, CQL, confluence search.
 ---
 
-## Customization
-
-**Before executing, check for user customizations at:**
-`~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Confluence/`
-
-If this directory exists, load and apply any PREFERENCES.md, configurations, or resources found there. These override default behavior. If the directory does not exist, proceed with skill defaults.
-
-If PREFERENCES.md exists but is malformed, unreadable, or missing referenced values, treat it the same as "no preferences" and proceed with skill defaults — do not abort the workflow on a broken preferences file.
-
 # Confluence
 
 Wiki and knowledge base management via the `cfl` CLI tool ([open-cli-collective/atlassian-cli](https://github.com/open-cli-collective/atlassian-cli)).
@@ -21,10 +12,29 @@ Wiki and knowledge base management via the `cfl` CLI tool ([open-cli-collective/
 All workflows share these prerequisites. Workflows do not repeat them — check these before entering any workflow.
 
 1. **cfl installed** — verify with `cfl --version`
-2. **Auth configured** — config file at `~/.config/cfl/config.yml` (run `cfl init` to set up). Verify with `cfl config test` (reports connection + identity).
-3. **Personal space keys** — in Confluence, space keys that start with `~` are personal spaces (e.g., `~aaron`). The `~` is part of the key, not a shell home-directory shortcut. In shells that expand leading `~` (bash, zsh), quote the key: `cfl space view '~aaron'`.
-4. **Customization** (optional) — `~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Confluence/PREFERENCES.md` for defaults
-   - If no customization AND the request requires a space key not specified by the user: abort with a message explaining how to create PREFERENCES.md (see template in SearchPages.md)
+2. **Auth configured** — run `cfl init` to set up interactively. Verify with `cfl config test` (reports connection + identity). Run `cfl config show` to see the resolved config file path on your system (typical location: `~/.config/cfl/config.yml` on Linux/macOS; `$XDG_CONFIG_HOME/cfl/config.yml` if set).
+3. **Environment-variable auth** (alternative to config file) — precedence: `CFL_*` env vars → `ATLASSIAN_*` env vars → config file. Use `ATLASSIAN_URL` / `ATLASSIAN_EMAIL` / `ATLASSIAN_API_TOKEN` for credentials shared with `jtk` (Jira CLI); use `CFL_*` to override per-tool. Bearer auth additionally requires `CFL_CLOUD_ID` (or `ATLASSIAN_CLOUD_ID`) — find the Cloud ID at `https://your-site.atlassian.net/_edge/tenant_info`.
+4. **Personal space keys** — in Confluence, space keys that start with `~` are personal spaces (e.g., `~aaron`). The `~` is part of the key, not a shell home-directory shortcut. In shells that expand leading `~` (bash, zsh), quote the key: `cfl space view '~aaron'`.
+5. **Defaults for missing inputs** — see the **Defaults & Missing Inputs** section below.
+
+## Defaults & Missing Inputs
+
+When the user's request doesn't specify a required input (space key, page ID, etc.), consult `cfl`'s own defaulting mechanisms before asking. If the input is still missing, ask the user — and suggest the one-time setup that would persist the default.
+
+### Space key
+
+Resolution order `cfl` uses: `--space` flag → `CFL_DEFAULT_SPACE` env var → `default_space` in config file.
+
+If still missing: ask the user. Then suggest they persist it:
+
+- **Env var (per-shell):** `export CFL_DEFAULT_SPACE=KEY` — add to `.bashrc` / `.zshrc` / equivalent to persist
+- **Config file:** edit the `default_space` field in the file shown by `cfl config show`
+
+Env var wins over config. Once set, space-scoped commands work without `--space`.
+
+### Page ID, attachment ID, etc.
+
+No defaults exist. Ask the user. Do not guess. If the user provides a Confluence URL, extract the page ID directly from the `/pages/` segment — see **Extracting Page IDs from URLs** below.
 
 ## Common Patterns
 

--- a/skills/Confluence/Workflows/ManageAttachments.md
+++ b/skills/Confluence/Workflows/ManageAttachments.md
@@ -1,0 +1,85 @@
+# ManageAttachments Workflow
+
+List, upload, download, and delete attachments on Confluence pages.
+
+## Intent-to-Flag Mapping
+
+### Action Selection
+
+| User Says | Command | Required |
+|-----------|---------|----------|
+| "list attachments", "show attachments" | `cfl attachment list --page PAGE_ID` | Page ID |
+| "orphaned attachments", "unused attachments" | `cfl attachment list --page PAGE_ID --unused` | Page ID |
+| "upload file", "attach file", "add attachment" | `cfl attachment upload --page PAGE_ID --file PATH` | Page ID + file path |
+| "download attachment", "get attachment" | `cfl attachment download ATT_ID` | Attachment ID |
+| "delete attachment", "remove attachment" | `cfl attachment delete ATT_ID` | Attachment ID |
+
+## Execute
+
+### List Attachments
+
+```bash
+cfl attachment list --page PAGE_ID
+
+# Increase result count (default 25)
+cfl attachment list --page PAGE_ID --limit 100
+
+# Show only unused/orphaned attachments
+cfl attachment list --page PAGE_ID --unused
+```
+
+### Upload Attachment
+
+```bash
+# Basic upload
+cfl attachment upload --page PAGE_ID --file /path/to/file
+
+# Upload with comment
+cfl attachment upload --page PAGE_ID --file /path/to/file -m "Description of attachment"
+```
+
+Verify the file exists before attempting upload. If the path doesn't exist, ask the user for the correct path.
+
+### Download Attachment
+
+```bash
+# Download with original filename into the current working directory
+cfl attachment download ATT_ID
+
+# Download to a specific file path
+cfl attachment download ATT_ID -O /path/to/output
+```
+
+- Without `-O`, the file is saved in the current working directory using the attachment's original filename.
+- `-O` expects a **file path** (not a directory path).
+- **Overwrite behavior:** if the target file already exists, the download fails with an error suggesting `--force`. To avoid relying on `--force`, choose a path that doesn't exist or remove the existing file first.
+
+If user specifies by filename rather than ID, list attachments first, match by name, then download by ID.
+
+### Delete Attachment
+
+**Always confirm with user before deleting.** This is a destructive action.
+
+```bash
+cfl attachment delete ATT_ID
+```
+
+## Output Format
+
+- **List:** Table with ID, Filename, Size, Created date
+- **Upload:** Confirm success with filename and page ID
+- **Download:** Confirm download location and filename
+- **Delete:** Confirm which attachment was deleted
+
+## Post-Action
+
+After any action:
+1. For list: state total attachment count
+2. For upload: confirm filename and page ID
+3. For download: confirm download path and filename
+4. For delete: confirm deletion
+
+## Notes
+
+- Attachment size limits depend on Confluence instance configuration
+- Use `--unused` flag to find orphaned attachments not referenced in page content

--- a/skills/Confluence/Workflows/ManagePage.md
+++ b/skills/Confluence/Workflows/ManagePage.md
@@ -1,0 +1,140 @@
+# ManagePage Workflow
+
+Create, edit, copy, move, and delete Confluence pages.
+
+## Intent-to-Flag Mapping
+
+### Action Selection
+
+| User Says | Action | Command |
+|-----------|--------|---------|
+| "create page", "new page", "add page" | Create | `cfl page create` |
+| "edit page", "update page", "change content" | Edit | `cfl page edit PAGE_ID` |
+| "rename page", "change title" | Rename | `cfl page edit PAGE_ID --title "New Title"` |
+| "move page", "reparent" | Move | `cfl page edit PAGE_ID --parent NEW_PARENT_ID` |
+| "copy page", "duplicate" | Copy | `cfl page copy PAGE_ID --title "Copy Title"` |
+| "delete page", "remove page" | Delete | `cfl page delete PAGE_ID` |
+
+### Content Source Mapping (for create/edit)
+
+| User Says | Flag | Notes |
+|-----------|------|-------|
+| "from file", "use this file" | `--file PATH` | Reads content from file |
+| provides content inline | Pipe via stdin | `echo "content" \| cfl page create ...` |
+| "open editor" | `--editor` | Opens interactive editor |
+| "legacy format" | `--legacy` | Uses legacy editor format |
+| "raw XHTML", "storage format" | `--storage` | Sends raw Confluence XHTML |
+
+## Execute
+
+### Create Page
+
+```bash
+# From file (most common)
+cfl page create --space KEY --title "Page Title" --file content.md
+
+# With parent page
+cfl page create --space KEY --title "Child Page" --parent PARENT_ID --file content.md
+
+# From stdin
+echo "# Page Content" | cfl page create --space KEY --title "Page Title"
+
+# From raw Confluence storage format (XHTML) — preserves macros exactly
+cfl page create --space KEY --title "Page Title" --storage --file content.xhtml
+```
+
+The `--storage` flag works on `page create` as well as `page edit`. Use it when the source content is already raw Confluence XHTML (e.g. copied from another page's storage format).
+
+If the user provides content as part of the request, write it to a temp file and use `--file`. Use `mktemp` to avoid collisions:
+```bash
+# Create a unique temp file
+TMPFILE=$(mktemp /tmp/confluence-content-XXXXXX.md)
+
+cat > "$TMPFILE" << 'CONTENT'
+# The content here
+CONTENT
+
+cfl page create --space KEY --title "Page Title" --file "$TMPFILE"
+rm -f "$TMPFILE"
+```
+
+### Edit Page
+
+```bash
+# Update content from file
+cfl page edit PAGE_ID --file content.md
+
+# Update title only
+cfl page edit PAGE_ID --title "New Title"
+
+# Move page to new parent
+cfl page edit PAGE_ID --parent NEW_PARENT_ID
+
+# Move and rename
+cfl page edit PAGE_ID --parent NEW_PARENT_ID --title "New Title"
+```
+
+For editing existing content: view first, modify, then update. Use `mktemp` so concurrent edits don't collide:
+```bash
+# Get current content into a unique temp file
+TMPFILE=$(mktemp /tmp/confluence-edit-XXXXXX.md)
+cfl page view PAGE_ID --content-only > "$TMPFILE"
+
+# (modify $TMPFILE)
+
+# Push updated content
+cfl page edit PAGE_ID --file "$TMPFILE"
+rm -f "$TMPFILE"
+```
+
+#### Lossless Edit (Storage-Format Round-Trip)
+
+The markdown round-trip above is convenient but **lossy** — macros (TOC, include, status, etc.) and some formatting are stripped. For edits that must preserve everything:
+
+- Fetch the page with `-o json` (see ViewPage.md for the JSON structure) — the `content` field holds the raw storage XHTML
+- Modify the XHTML as needed
+- Send the modified XHTML back via `cfl page edit PAGE_ID --storage` — reads from stdin, or pass via `--file`
+
+The `--storage` flag sends the input directly via the storage representation API, preserving all macros and formatting exactly. Use this whenever:
+- The page contains macros you need to keep (TOC, include, excerpt, status, etc.)
+- You're doing a find/replace that must not touch surrounding markup
+- You're scripting against pages with complex structure
+
+### Copy Page
+
+```bash
+# Copy within same space
+cfl page copy PAGE_ID --title "Copy of Page"
+
+# Copy to different space
+cfl page copy PAGE_ID --title "Page Title" --space OTHER_KEY
+
+# Copy without attachments or labels
+cfl page copy PAGE_ID --title "Light Copy" --no-attachments --no-labels
+```
+
+**Placement:** `cfl page copy` always places the new page at the root of the destination space — it does not inherit the source page's parent, and it does not accept `--parent`. To place the copy under a specific page, follow the copy with a reparent edit:
+
+```bash
+NEW_ID=$(cfl page copy SOURCE_ID --title "Copy of Page" -o json | ...)   # capture the new page ID from JSON
+cfl page edit $NEW_ID --parent DESIRED_PARENT_ID
+```
+
+Or do it as two explicit steps (capture ID from the table output, then edit).
+
+### Delete Page
+
+**Always confirm with user before deleting.** This is a destructive action.
+
+```bash
+cfl page delete PAGE_ID
+```
+
+## Post-Action
+
+After any action:
+1. For creates: show the new page ID and confirm title/space
+2. For edits: confirm what was changed (content, title, parent)
+3. For copies: show the new page ID and location
+4. For deletes: confirm which page was deleted
+5. For moves: confirm old and new parent

--- a/skills/Confluence/Workflows/ManageSpaces.md
+++ b/skills/Confluence/Workflows/ManageSpaces.md
@@ -1,0 +1,75 @@
+# ManageSpaces Workflow
+
+List, view, create, and update Confluence spaces.
+
+## Intent-to-Flag Mapping
+
+### Action Selection
+
+| User Says | Command | Required |
+|-----------|---------|----------|
+| "list spaces", "show spaces" | `cfl space list` | Nothing |
+| "global spaces only" | `cfl space list --type global` | Nothing |
+| "personal spaces" | `cfl space list --type personal` | Nothing |
+| "space details", "show space" | `cfl space view KEY` | Space key |
+| "create space", "new space" | `cfl space create --key KEY --name "NAME"` | Key + name |
+| "update space", "rename space" | `cfl space update KEY` | Space key + fields |
+
+## Execute
+
+### List Spaces
+
+```bash
+# All spaces
+cfl space list
+
+# Global spaces only
+cfl space list --type global
+
+# With higher limit
+cfl space list --limit 50
+```
+
+### View Space Details
+
+```bash
+cfl space view SPACE_KEY
+```
+
+### Create Space
+
+```bash
+# Basic creation
+cfl space create --key KEY --name "Space Name"
+
+# With description
+cfl space create --key KEY --name "Space Name" --description "Description text"
+```
+
+### Update Space
+
+```bash
+# Update name
+cfl space update KEY --name "New Name"
+
+# Update description
+cfl space update KEY --description "New description"
+
+# Update both
+cfl space update KEY --name "New Name" --description "New description"
+```
+
+## Output Format
+
+- **List:** Table with Key, Name, Type
+- **View:** Full space details including key, name, type, description
+- **Create:** Confirm creation with key and name
+- **Update:** Confirm what was changed
+
+## Post-Action
+
+After any action:
+1. For list: state total space count
+2. For create: confirm space key and name, note it's ready for pages
+3. For update: confirm what was changed
+4. For view: show space details and offer to list pages in the space

--- a/skills/Confluence/Workflows/SearchPages.md
+++ b/skills/Confluence/Workflows/SearchPages.md
@@ -1,0 +1,116 @@
+# SearchPages Workflow
+
+Search, find, and filter Confluence pages using full-text search, CQL, or space-based queries.
+
+## Intent-to-Flag Mapping
+
+### Search Method
+
+| User Says | Command | When to Use |
+|-----------|---------|-------------|
+| "search for", "find pages", custom query | `cfl search "query"` | Full-text search |
+| "search in SPACE" | `cfl search "query" --space KEY` | Space-scoped search |
+| "find pages with label" | `cfl search --label TAG` | Label-based search |
+| "search by title" | `cfl search --title "text"` | Title-based search |
+| "CQL", advanced query | `cfl search --cql "CQL"` | Raw CQL query (takes precedence over positional query) |
+| "list pages in SPACE" | `cfl page list --space KEY` | Simple space listing |
+
+**Note:** `--cql` takes precedence over the positional `[query]` argument. Don't combine them — use one or the other.
+
+### Common Filters (CQL Building Blocks)
+
+| User Says | CQL Fragment |
+|-----------|-------------|
+| "pages only" | `type=page` |
+| "blog posts" | `type=blogpost` |
+| "in SPACE" | `space=KEY` |
+| "with label TAG" | `label="TAG"` |
+| "updated recently", "updated this week" | `lastModified > now('-7d')` |
+| "created today" | `created > now('-1d')` |
+| "my pages", "pages I created" | `creator=currentUser()` |
+| "pages I edited" | `contributor=currentUser()` |
+| "descendant pages of PAGE_ID" (all nested levels) | `ancestor=PAGE_ID` |
+| "title contains" | `title~"search term"` |
+
+### Combining Filters
+
+Build CQL by combining fragments with `AND`:
+```
+User: "Find pages I created in DEV space with label 'api'"
+-> CQL: type=page AND space=DEV AND creator=currentUser() AND label="api"
+```
+
+## Execute
+
+Based on the user's request, construct and run the appropriate command:
+
+```bash
+# Full-text search
+cfl search "query text" --type page
+
+# Space-scoped search
+cfl search "query text" --space KEY --type page
+
+# CQL search
+cfl search --cql "type=page AND space=KEY AND lastModified > now('-7d')"
+
+# Simple space listing
+cfl page list --space KEY
+```
+
+Use `--limit N` to control result count (default 25).
+
+### Scripting / Parsing Output
+
+When the next step depends on extracting a page ID from the results, request JSON output. With `-o json`, the output has this structure:
+
+```json
+{
+  "results": [
+    { "id": "...", "title": "...", "type": "page", "spaceName": "...", "excerpt": "..." }
+  ],
+  "_meta": { "count": 0, "hasMore": false }
+}
+```
+
+The `--title` filter does substring matching, so multiple pages may be returned — narrow with `--space` when you need a single result.
+
+Avoid pattern-matching against default `table` output — it's human-oriented and layout may change. Always use `-o json` when a downstream step parses the response.
+
+## Output Format
+
+Present results clearly:
+- For search results: table with Page ID, Title, Space, Last Modified
+- For page listings: table with ID, Title, Status, Version
+- If no results: state clearly, suggest broadening the query or checking space key
+
+## Post-Action
+
+After returning results:
+1. State the result count
+2. If results are large, offer to narrow the query
+3. If no results, suggest broadening or adjusting filters
+4. Offer to view any specific page from the results
+
+## Missing Customization Template
+
+If a space key is needed but no customization exists, provide this template:
+
+```
+Create this file at: ~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Confluence/PREFERENCES.md
+
+---
+Content:
+
+# Confluence Skill Preferences
+
+## Defaults
+- **Default space:** SPACE_KEY
+- **Default content type:** page
+
+## Common Spaces
+| Key | Name | Notes |
+|-----|------|-------|
+| DEV | Development | Engineering docs |
+| TEAM | Team Space | Team wiki |
+```

--- a/skills/Confluence/Workflows/SearchPages.md
+++ b/skills/Confluence/Workflows/SearchPages.md
@@ -92,25 +92,11 @@ After returning results:
 3. If no results, suggest broadening or adjusting filters
 4. Offer to view any specific page from the results
 
-## Missing Customization Template
+## Missing Space Key
 
-If a space key is needed but no customization exists, provide this template:
+If a space key is needed but not specified in the request, consult `cfl`'s defaulting order (`--space` flag → `CFL_DEFAULT_SPACE` env var → `default_space` in config file). If still missing, ask the user and suggest persisting it:
 
-```
-Create this file at: ~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Confluence/PREFERENCES.md
+- **Env var (per-shell):** `export CFL_DEFAULT_SPACE=KEY` — add to `.bashrc` / `.zshrc` / equivalent to persist
+- **Config file:** edit the `default_space` field in the file shown by `cfl config show`
 
----
-Content:
-
-# Confluence Skill Preferences
-
-## Defaults
-- **Default space:** SPACE_KEY
-- **Default content type:** page
-
-## Common Spaces
-| Key | Name | Notes |
-|-----|------|-------|
-| DEV | Development | Engineering docs |
-| TEAM | Team Space | Team wiki |
-```
+Env var wins over config. See the **Defaults & Missing Inputs** section in `SKILL.md` for the full rationale.

--- a/skills/Confluence/Workflows/ViewPage.md
+++ b/skills/Confluence/Workflows/ViewPage.md
@@ -1,0 +1,97 @@
+# ViewPage Workflow
+
+View Confluence page content and metadata.
+
+## Intent-to-Flag Mapping
+
+### Truncation Rule
+
+See SKILL.md "Output Representation and Format" for the global representation (`agent`/`full`/`raw`) and format (`table`/`json`/`plain`) concepts.
+
+The default markdown body is truncated at 5000 chars. This applies to the default view, `--raw`, and `--show-macros`. To get the full body, combine any of these with `--no-truncate`, or use `--content-only` (which implies `--no-truncate`). `-o json` is always full — no truncation, regardless of representation or flags.
+
+`--content-only` already implies `--no-truncate`; don't combine them.
+
+### View Mode
+
+| User Says | Command | When to Use |
+|-----------|---------|-------------|
+| "view page", "show page", "read page" | `cfl page view PAGE_ID` | Default markdown view (subject to truncation) |
+| "show full page", "all content", "no truncation" | `cfl page view PAGE_ID --no-truncate` | Full content without truncation |
+| "just the content", "content only" | `cfl page view PAGE_ID --content-only` | Content without metadata headers (implies `--no-truncate`) |
+| "raw format", "XHTML", "storage format" | `cfl page view PAGE_ID --raw` | Raw Confluence storage format (subject to truncation) |
+| "show macros" | `cfl page view PAGE_ID --show-macros` | Preserve macro placeholders like `[TOC]` (subject to truncation) |
+| "open in browser", "open page" | `cfl page view PAGE_ID --web` | Opens in default browser |
+| "page as JSON" | `cfl page view PAGE_ID -o json` | Full JSON output (body always included in full — no truncation) |
+
+### Finding Page IDs
+
+If the user provides a page title instead of ID, search first:
+```bash
+cfl search --title "Page Title" --type page --space KEY
+```
+
+Then use the page ID from the results. For scripted extraction, add `-o json` — see SearchPages.md for the output structure.
+
+If the user provides a Confluence URL instead of a page ID, see "Extracting Page IDs from URLs" in SKILL.md.
+
+## Execute
+
+```bash
+# Standard view (markdown, truncated at 5000 chars)
+cfl page view PAGE_ID
+
+# Full content (no truncation)
+cfl page view PAGE_ID --no-truncate
+
+# Content only (for piping or clean reading; implies --no-truncate)
+cfl page view PAGE_ID --content-only
+
+# Preserve macros that would otherwise be stripped
+cfl page view PAGE_ID --show-macros
+
+# Raw storage format (XHTML) — also subject to default truncation
+cfl page view PAGE_ID --raw
+
+# Full raw storage format (no truncation)
+cfl page view PAGE_ID --raw --no-truncate
+
+# Open in browser
+cfl page view PAGE_ID --web
+```
+
+### Macro Handling
+
+By default, Confluence macros (TOC, include, status, etc.) are stripped from the markdown output. If the page structure depends on macros, use `--show-macros` to preserve their placeholders (e.g. `[TOC]`) so the structure remains visible.
+
+## JSON Output Structure
+
+With `-o json`, the output has this structure:
+
+```json
+{
+  "id": "...",
+  "title": "...",
+  "spaceId": "...",
+  "spaceKey": "...",
+  "parentId": "...",
+  "content": "..."
+}
+```
+
+The `content` field holds the full storage-format XHTML with no truncation, regardless of `--no-truncate`. Version and timestamp fields are not included in this output — use the default table view if you need those.
+
+## Output Format
+
+Present page content clearly:
+- Show page title, space, last modified date, and version at the top
+- Show the page body in markdown format
+- If truncated, note that and offer `--no-truncate` or `--content-only`
+- For raw format, note it's XHTML storage format
+
+## Post-Action
+
+After viewing:
+1. If content was truncated, mention it and offer `--no-truncate` for full content
+2. If the user might want to edit, mention the page ID for reference
+3. If page has child pages, note their existence

--- a/skills/Jira/CliReference.md
+++ b/skills/Jira/CliReference.md
@@ -1,0 +1,226 @@
+# jtk CLI Reference
+
+Reference for the `jtk` command line tool from [open-cli-collective/atlassian-cli](https://github.com/open-cli-collective/atlassian-cli).
+
+## Authentication
+
+**Config file** (recommended): typical paths — `~/.config/jira-ticket-cli/config.json` (Linux), `~/Library/Application Support/jira-ticket-cli/config.json` (macOS). Run `jtk config show` for the resolved path on your system.
+
+Set up interactively:
+```bash
+jtk init
+```
+
+Verify:
+```bash
+jtk config test    # reports connection + identity
+jtk config show    # shows config path + current values (credentials masked)
+```
+
+Prompts for: Atlassian instance URL, email, API token (from https://id.atlassian.com/manage-profile/security/api-tokens).
+
+**Env-var auth** (alternative / overrides): precedence `JIRA_*` → `ATLASSIAN_*` → config. Primary vars: `*_URL`, `*_EMAIL`, `*_API_TOKEN`, `*_AUTH_METHOD` (`basic` or `bearer`), `*_CLOUD_ID` (bearer only). Use `ATLASSIAN_*` for credentials shared with `cfl` (Confluence CLI). `JIRA_DEFAULT_PROJECT` sets a default project key.
+
+**Bearer auth** (scoped service account tokens): Does NOT support Agile operations (boards, sprints, automation, dashboards) due to Atlassian platform limitations. Requires a Cloud ID — find it at `https://your-site.atlassian.net/_edge/tenant_info`. Use classic API token auth for full functionality.
+
+## Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `--extended` | Include admin/schema/audit fields in output |
+| `--fulltext` | Disable truncation of descriptions and comments (`--no-truncate` is a deprecated alias kept during migration) |
+| `--id` | Emit only the primary identifier (useful for scripting). Takes precedence over `--extended` and `--fulltext` |
+| `--no-color` | Disable colored output |
+| `-v, --verbose` | Enable verbose output |
+
+> `-o table|json|plain` (`--output` / `-o`) is retained for backward compatibility but hidden from `--help`. Prefer `--id` over format-parsing. JSON output is still first-class for scripting needs that require structured data.
+
+## Command Structure
+
+```
+jtk [resource] [action] [KEY/ID] [flags]
+```
+
+## Current User
+
+| Command | Description |
+|---------|-------------|
+| `jtk me` | Show current authenticated user |
+| `jtk me --id` | Print just the account ID (script-friendly) |
+
+## Issues
+
+| Command | Description |
+|---------|-------------|
+| `jtk issues list --project KEY` | List issues in project |
+| `jtk issues list --project KEY --sprint current` | List issues in current sprint |
+| `jtk issues get PROJ-123` | Get issue details |
+| `jtk issues create --project KEY --type TYPE --summary "TEXT"` | Create issue |
+| `jtk issues update PROJ-123 --field FIELD=VALUE` | Update issue fields |
+| `jtk issues search --jql "JQL"` | Search with JQL query (flag is **required**) |
+| `jtk issues update PROJ-123 --assignee VALUE` | Assign issue. Resolver accepts `me`, email, display name, or raw account ID |
+| `jtk issues update PROJ-123 --assignee none` | Unassign via update |
+| `jtk issues assign PROJ-123 VALUE` | Dedicated assign command; same resolver inputs as `--assignee` (user is a positional arg, not a flag) |
+| `jtk issues assign PROJ-123 --unassign` | Unassign via dedicated command (equivalent to `--assignee none` on update) |
+| `jtk issues move PROJ-1 [PROJ-2 ...] --to-project NEWPROJ` | Move one or more issues to another project (Jira Cloud only). By default synchronous — waits for completion. Max 1000 issues per request. See move flags below |
+| `jtk issues move-status TASK_ID` | Check status of an async move operation (used with `--no-wait`) |
+| `jtk issues delete PROJ-123` | Permanently delete an issue. Interactive `y/N` prompt by default (prompt goes to stderr, reads from stdin); pass `--force` to skip. Destructive and irreversible |
+| `jtk issues types --project KEY` | List valid issue types for a project (output includes the `SUBTASK` column; use values from this list as `--type` on create) |
+| `jtk issues fields [PROJ-123]` | List available fields (all fields, or editable fields for a specific issue) |
+| `jtk issues field-options FIELD_NAME_OR_ID [--issue PROJ-123]` | List allowed values for a field (e.g. priority, custom selects) |
+
+### Create Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--project KEY` / `-p` | Yes | Project key |
+| `--type TYPE` / `-t` | No | Issue type (default Task). Task, Bug, Story, Epic, Sub-task |
+| `--summary "TEXT"` / `-s` | Yes | Issue title |
+| `--description "TEXT"` / `-d` | No | Issue description |
+| `--assignee VALUE` / `-a` | No | Assignee (resolver accepts `me`, email, display name, or raw account ID) |
+| `--parent KEY` | No | Parent issue key (epic or parent) |
+| `--field NAME=VALUE` / `-f` | No | Set custom field (repeatable) |
+
+### Update Flags
+
+| Flag | Description |
+|------|-------------|
+| `--summary "TEXT"` / `-s` | New summary |
+| `--description "TEXT"` / `-d` | New description |
+| `--assignee VALUE` / `-a` | Reassign (resolver accepts `me`, email, display name, or raw account ID; use `none` to unassign). Note: `jtk issues update --help` flag text underclaims the resolver (omits display name) — the resolver implementation accepts all four, same as `issues create` and `issues assign` |
+| `--type TYPE` / `-t` | Change issue type (uses bulk move API) |
+| `--parent KEY` | Change parent/epic |
+| `--field NAME=VALUE` / `-f` | Update custom field (repeatable; repeating the same key accumulates values for multi-select fields) |
+
+**Notes:**
+- `jtk issues update` does **not** change workflow status. Use `jtk transitions do` for status changes (see Transitions below).
+- `--type` on update uses the Jira Cloud bulk-move API (different path than a plain edit) — safe, but behaves asynchronously.
+- `--description` and other text flags support `\n`, `\t`, `\\` escape sequences.
+
+### Move Flags (`jtk issues move`)
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--to-project KEY_OR_NAME` | Yes | Target project (accepts key or name) |
+| `--to-type TYPE` | No | Target issue type name. If omitted, uses the same type as the source issue (resolved via cache; may need `jtk refresh issuetypes` on a cold cache) |
+| `--wait` / `--no-wait` | No | `--wait` (default) polls the move task to completion; `--no-wait` returns the task ID immediately. Use `jtk issues move-status TASK_ID` to check an async move later |
+| `--notify` / `--no-notify` | No | `--notify` (default) sends Jira notifications for the move; `--no-notify` suppresses them |
+
+Positional: one or more `<issue-key>` (up to 1000 per request). Jira Cloud only — not available on Server or Data Center.
+
+### Search & List Flags (shared by `jtk issues search` and `jtk issues list`)
+
+| Flag | Description |
+|------|-------------|
+| `--jql "QUERY"` | JQL query string (required for `search`) |
+| `--project KEY` / `-p` | Filter by project key (for `list`) |
+| `--sprint current` / `-s current` | Filter by current sprint (for `list`) |
+| `--max N` / `-m N` | Maximum results (default 25; auto-paginates) |
+| `--next-page-token TOKEN` | Resume from previous page token |
+| `--all-fields` | Include all fields (e.g. description) |
+| `--fields summary,status,customfield_10005` | Comma-separated list of specific fields |
+
+### Common Issue Types
+
+Task, Bug, Story, Epic, Sub-task (instance-dependent)
+
+## Transitions (Workflow Status Changes)
+
+Status changes happen via `jtk transitions do`, **not** `jtk issues update`.
+
+| Command | Description |
+|---------|-------------|
+| `jtk transitions list PROJ-123` | List available transitions for issue |
+| `jtk transitions list PROJ-123 --fields` | Show required fields for each transition |
+| `jtk transitions do PROJ-123 "Transition Name"` | Apply transition by name |
+| `jtk transitions do PROJ-123 21` | Apply transition by numeric ID |
+| `jtk transitions do PROJ-123 "Done" --field NAME=VALUE` | Apply with required fields (only when `transitions list --fields` shows a required field) |
+
+Common transition names: "To Do", "In Progress", "In Review", "Done" (instance-dependent — always run `transitions list` first).
+
+> **Do not speculatively pass `--field resolution=Done` (or any other field) unless `jtk transitions list --fields PROJ-123` explicitly shows it is required for the transition you're applying.** Many Jira workflows set resolution via post-function or hide it from the transition screen — speculatively providing `--field resolution=Done` will fail with "Field 'resolution' cannot be set. It is not on the appropriate screen, or unknown." In that case, re-run the transition without the `--field` flag.
+
+## Projects
+
+| Command | Description |
+|---------|-------------|
+| `jtk projects list` | List all projects |
+| `jtk projects get KEY` | Get project details |
+
+## Sprints
+
+| Command | Description |
+|---------|-------------|
+| `jtk sprints list --board ID` | List sprints for board |
+| `jtk sprints current --board ID` | Get active sprint |
+| `jtk sprints issues SPRINT_ID` | List issues in sprint |
+| `jtk sprints add SPRINT_ID PROJ-1 PROJ-2 ...` | Add issues to sprint (issues are positional) |
+
+## Boards
+
+| Command | Description |
+|---------|-------------|
+| `jtk boards list` | List all boards |
+| `jtk boards get ID` | Get board details |
+
+## Comments
+
+| Command | Description |
+|---------|-------------|
+| `jtk comments list PROJ-123` | List comments on issue |
+| `jtk comments add PROJ-123 --body "TEXT"` | Add comment (`--body` / `-b` is **required**; supports `\n`, `\t`, `\\` escapes) |
+| `jtk comments delete PROJ-123 COMMENT_ID` | Delete a comment |
+
+## Attachments
+
+| Command | Description |
+|---------|-------------|
+| `jtk attachments list PROJ-123` | List attachments on issue |
+| `jtk attachments add PROJ-123 --file PATH` | Upload attachment (`--file` / `-f` repeatable for multiple) |
+| `jtk attachments get ATTACHMENT_ID` | Download attachment (alias: `download`) |
+| `jtk attachments get ATTACHMENT_ID --output ./dir/` | Download to specific directory |
+| `jtk attachments get ATTACHMENT_ID --output ./renamed.pdf` | Download with custom filename |
+| `jtk attachments delete ATTACHMENT_ID` | Delete attachment |
+
+## Users
+
+| Command | Description |
+|---------|-------------|
+| `jtk users search "QUERY"` | Search for users (matches display name, email, etc.) |
+| `jtk users search "QUERY" --max 1 --id` | Resolve a query to a single account ID (script-friendly) |
+| `jtk users get ACCOUNT_ID` | Get user details by account ID |
+| `jtk users get ACCOUNT_ID --id` | Echo just the account ID (useful in pipelines) |
+| `jtk me` | Show current authenticated user (see Current User section above) |
+
+## Common JQL Patterns
+
+| Intent | JQL |
+|--------|-----|
+| My open issues | `assignee = currentUser() AND status != Done` |
+| My in-progress | `assignee = currentUser() AND status = "In Progress"` |
+| Project bugs | `project = KEY AND type = Bug` |
+| High priority | `project = KEY AND priority = High` |
+| Updated this week | `project = KEY AND updated >= -7d` |
+| Created today | `project = KEY AND created >= startOfDay()` |
+| Unassigned | `project = KEY AND assignee is EMPTY` |
+| Sprint issues | `sprint in openSprints() AND project = KEY` |
+| Overdue | `project = KEY AND duedate < now() AND status != Done` |
+
+## Output
+
+- Data goes to stdout (pipeable)
+- Diagnostics/logs go to stderr
+- **Pagination continuation notices (`More results available ...`) go to STDOUT, not stderr** — this is intentional per `jtk`'s output contract, and applies even with `--id`. When using `--id` in command substitution or piping to a tool that reads line-by-line, size `--max` to match your expectation, or post-filter with `grep -oE '[A-Z]+-[0-9]+' | head -1` (or equivalent) to isolate just the identifier from any trailing notice.
+- Use `--id` global flag for just the primary identifier (useful when piping to another command; note the pagination caveat above)
+- Use `--fulltext` global flag to disable truncation of descriptions/comments
+- Use standard shell tools for filtering: `jtk issues list --project KEY | grep "Bug"`
+
+## Scope of This Reference
+
+This reference covers `jtk`'s daily-use operator surface — issues, transitions, sprints, boards, comments, attachments, projects, users. It intentionally does **not** cover administrative surfaces, which are out of scope for the workflows in this skill:
+
+- `jtk fields` — custom field management (create, delete, restore, contexts, options)
+- `jtk dashboards` — dashboard and gadget management
+- `jtk automation` — automation rule management (list, export, create, update, enable/disable)
+
+These subcommands exist and work — run `jtk <subcommand> --help` for discovery, or see the [upstream README](https://github.com/open-cli-collective/atlassian-cli/blob/main/tools/jtk/README.md) for the full command reference.

--- a/skills/Jira/SKILL.md
+++ b/skills/Jira/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: Jira
+description: Jira issue tracking and project management via jtk CLI — search, create (single or bulk), update, assign, transition issues, manage sprints and boards, comments, attachments, cross-issue links, parent/sub-task hierarchies. USE WHEN jira, issues, tickets, sprint, standup, backlog, board, jira board, JQL, create issue, create tickets, bulk create, multiple tickets, sub-tasks, parent with children, epic with stories, decompose spec into tickets, turn PRD into tickets, link issues, my tickets, assign issue, move ticket, transition issue, move to done, add comment, attach to issue, jira attachment, jira status, what am I working on.
+---
+
+# Jira
+
+Issue tracking and project management via the `jtk` CLI tool ([open-cli-collective/atlassian-cli](https://github.com/open-cli-collective/atlassian-cli)).
+
+## Prerequisites
+
+All workflows share these prerequisites. Workflows do not repeat them — check these before entering any workflow.
+
+1. **jtk installed** — verify with `jtk --version`
+2. **Auth configured** — run `jtk init` to set up interactively. Verify with `jtk config test` (reports connection + identity). Run `jtk config show` to see the resolved config file path on your system (typical locations: `~/.config/jira-ticket-cli/config.json` on Linux, `~/Library/Application Support/jira-ticket-cli/config.json` on macOS).
+3. **Environment-variable auth** (alternative to config file) — precedence: `JIRA_*` env vars → `ATLASSIAN_*` env vars → config file. Use `ATLASSIAN_URL` / `ATLASSIAN_EMAIL` / `ATLASSIAN_API_TOKEN` for credentials shared with `cfl` (Confluence CLI); use `JIRA_*` to override per-tool. Bearer auth additionally requires `JIRA_CLOUD_ID` (or `ATLASSIAN_CLOUD_ID`) — find the Cloud ID at `https://your-site.atlassian.net/_edge/tenant_info`.
+4. **Defaults for missing inputs** — see the **Defaults & Missing Inputs** section below.
+
+## Defaults & Missing Inputs
+
+When the user's request doesn't specify a required input (project key, board ID, etc.), consult `jtk`'s own defaulting mechanisms before asking. If the input is still missing, ask the user — and suggest the one-time setup that would persist the default.
+
+### Project key
+
+Resolution order `jtk` uses: `--project` flag → `JIRA_DEFAULT_PROJECT` env var → `default_project` in config file.
+
+If still missing: ask the user. Then suggest they persist it:
+
+- **Env var (per-shell):** `export JIRA_DEFAULT_PROJECT=PROJ` — add to `.bashrc` / `.zshrc` / equivalent to persist
+- **Config file:** edit the `default_project` field in the file shown by `jtk config show`
+
+Env var wins over config. Once set, `jtk issues list` (and other project-scoped commands) work without `--project`.
+
+### Board ID
+
+`jtk` has no default-board mechanism — there's no env var or config key for a default board. If a board ID is needed and the user hasn't provided one, ask which board. Suggest `jtk boards list` or `jtk boards list --project KEY` to discover IDs.
+
+### Sprint, issue key, attachment ID, comment ID, etc.
+
+No defaults exist. Ask the user. Do not guess.
+
+### Assignee / user identity shortcut
+
+For assignment and self-scoped queries, `--assignee me` resolves to the authenticated user — no account ID lookup needed. `jtk me --id` returns the current user's account ID when a raw ID is specifically needed (e.g., embedding in a script or passing to an API-boundary tool that can't consume an email or display name). For regular assign/unassign, just use `--assignee me` — both `jtk issues update` and `jtk issues assign` accept it directly via their resolver.
+
+## Cache Warming (first use per session)
+
+`jtk` caches instance metadata locally — fields, projects, users, issue types, statuses, priorities, resolutions, boards, and link types — to avoid repeated API calls on every invocation. When a session first exercises a workflow that depends on a cold cache (creating issues, creating links, moving issues between projects, resolving user identities for assignment, etc.), the command will fail with an actionable error like `cannot resolve link type "X" from cache — run 'jtk refresh linktypes'` or `cannot resolve issue type ID for "Task" in project KEY from cache — run 'jtk refresh issuetypes'`.
+
+To avoid hitting this mid-workflow, warm the caches once near the start of any session that will do significant write work or user lookups:
+
+```bash
+jtk refresh          # refresh everything (recommended)
+```
+
+Or refresh just the resources you expect to touch:
+
+```bash
+jtk refresh linktypes issuetypes users
+```
+
+Both forms are idempotent and fast. Bare `jtk refresh` is the simplest — it fetches every cacheable resource and auto-resolves dependencies; on a warm cache it's cheap. Repeated refreshes within a session are fine. If a command fails mid-run with `run jtk refresh <resource>`, run the suggested refresh (or bare `jtk refresh`) and retry.
+
+Use `jtk refresh --status` to inspect cache freshness without fetching anything.
+
+## Common Errors
+
+| Symptom | Likely Cause | Remedy |
+|---------|--------------|--------|
+| `unauthorized` / `401` / "invalid credentials" | Missing or expired API token | Run `jtk init` to reconfigure; tokens from https://id.atlassian.com/manage-profile/security/api-tokens |
+| `permission denied` on a specific issue/project | Account lacks permission on that project | Verify project membership; ask a project admin to grant access |
+| `forbidden: insufficient permissions` on a delete operation (`jtk issues delete`, `jtk links delete`, `jtk comments delete`, `jtk attachments delete`) | Account lacks the specific Delete permission in this project — most Jira Cloud projects restrict Delete Issue permission to admins; other delete permissions (links, comments, attachments) are also separately granted | Inform the user the delete failed due to insufficient permissions. Stop and wait for user direction — do not attempt alternative cleanup paths (transitions, status changes, workarounds) unless the user explicitly asks |
+| `not found` on a valid-looking issue key | Wrong project key, or issue deleted, or insufficient permission (Jira returns 404 instead of 403 for unauthorized reads) | Double-check the key; try `jtk projects list` to confirm project visibility |
+| Agile operations fail (boards, sprints, automation, dashboards) with auth errors | Using bearer/scoped API token — scoped tokens lack Agile/Automation/Dashboard scopes (Atlassian platform limitation) | Reconfigure with a classic API token via `jtk init` |
+| Bearer auth fails to connect or gateway URL is wrong | Missing or wrong Cloud ID | Set `JIRA_CLOUD_ID` (or `ATLASSIAN_CLOUD_ID`), or re-run `jtk init --auth-method bearer` with `--cloud-id`. Find the Cloud ID at `https://your-site.atlassian.net/_edge/tenant_info` |
+| `Unbounded JQL queries are not allowed here` from `jtk issues list` | `jtk issues list` ran without `--project` and without a default project set | Pass `--project KEY` or set `JIRA_DEFAULT_PROJECT` / config `default_project` (see Defaults & Missing Inputs) |
+| `required flag(s) "jql" not set` | Passing a bare positional query to `jtk issues search` | Use `--jql "QUERY"` — the flag is required |
+| `required flag(s) "body" not set` on comment add | Passing comment text positionally | Use `--body "TEXT"` |
+| Status change silently does nothing | Trying `jtk issues update --status` (no such flag) | Use `jtk transitions do KEY "Target"` instead |
+
+## Common Patterns
+
+### Output Contract
+
+`jtk` commands follow a text-first output model (per the repo's [Output Artifact Contract](https://github.com/open-cli-collective/atlassian-cli/blob/main/docs/ARTIFACT_CONTRACT.md)). Three global flags shape what gets emitted:
+
+- **`--extended`** — includes admin/schema/audit fields on top of the default output. Use when the user asks for "more detail," "all fields," or similar.
+- **`--fulltext`** — disables truncation of descriptions and comments. Use when the user needs full body content (e.g., "show the full description"). `--no-truncate` is a deprecated alias kept during the migration; prefer `--fulltext`.
+- **`--id`** — emits only the primary identifier (issue key, account ID, etc.). Takes precedence over `--extended` and `--fulltext`. Use whenever a downstream step will parse the output — no decoration to strip, formatting is stable. **Caveat for scripts:** when a list command's result is truncated (multi-page), the pagination continuation notice (`More results available ...`) is still appended to STDOUT even with `--id`. For command substitution or line-by-line piping, either size `--max` so all results fit on one page, or post-filter with `grep -oE '[A-Z]+-[0-9]+' | head -1` to isolate just the identifier.
+
+`-o table|json|plain` is retained for backward compatibility but hidden from `--help`; prefer `--id` over format-parsing. JSON output is still first-class for scripting needs that require structured data.
+
+### Pagination & Result Sizing
+
+Most list-type commands (`jtk issues list`, `jtk issues search`, `jtk projects list`, `jtk comments list`, `jtk attachments list`, `jtk sprints list`, `jtk boards list`, `jtk users search`, `jtk dashboards list`, etc.) accept `--max N` to cap results. Defaults vary by command (typically 25–50). Commands that paginate also accept `--next-page-token TOKEN` to resume. When a listing is truncated, `jtk` prints a "More results available" notice **on stdout** (not stderr — and this holds even with `--id`; see the `--id` bullet above for the scripting caveat) — honor it or raise `--max` if the user expects more.
+
+### Extracting Issue Keys from URLs
+
+Many commands take an issue key (`PROJ-123`). If the user provides a browse URL, the key is the segment after `/browse/`:
+
+```
+https://INSTANCE.atlassian.net/browse/PROJ-123
+                                       ^^^^^^^^
+```
+
+Use that key directly — no API lookup needed.
+
+## Workflow Routing
+
+| Workflow | Trigger | File |
+|----------|---------|------|
+| **SearchIssues** | "search jira", "find issues", "JQL", "list issues", "filter issues" | `Workflows/SearchIssues.md` |
+| **ManageIssue** | "create issue" (single), "update issue", "assign", "transition", "move to done", "change status" — **single issue only** | `Workflows/ManageIssue.md` |
+| **ManageIssueSet** | "create N tickets", "create these tickets", "file three bugs", "bulk update", "update these issues", "parent with sub-tasks", "epic with stories", "link these together", "create and link", "link issue A to B", "add blocks/relates link between two issues", "remove a link" — **any multi-issue operation where the user specifies tickets directly, including link operations between two existing issues (links always involve two endpoints)** | `Workflows/ManageIssueSet.md` |
+| **SpecToTickets** | "decompose this spec into tickets", "turn this PRD into tickets", "break this design doc into tasks", "file tickets for this plan" — **any case where the agent is making the ticket-breakdown judgment from a spec/PRD/plan**. Hands off to ManageIssueSet for execution. | `Workflows/SpecToTickets.md` |
+| **SprintBoard** | "current sprint", "sprint issues", "boards", "add to sprint", "list sprints" | `Workflows/SprintBoard.md` |
+| **QuickStatus** | "my jira", "what am I working on", "jira status", "my tickets", "my issues" | `Workflows/QuickStatus.md` |
+| **ManageComments** | "add comment", "view comments", "comment on issue", "list comments" | `Workflows/ManageComments.md` |
+| **ManageAttachments** | "attach file", "list attachments", "download attachment", "upload attachment" | `Workflows/ManageAttachments.md` |
+
+## Quick Reference
+
+| Operation | Command |
+|-----------|---------|
+| Search by JQL | `jtk issues search --jql "JQL_QUERY"` |
+| List project issues | `jtk issues list --project KEY` |
+| List current sprint issues | `jtk issues list --project KEY --sprint current` |
+| Get issue details | `jtk issues get PROJ-123` |
+| Create issue | `jtk issues create --project KEY --type Task --summary "..."` |
+| Assign (me / email / display name / account ID) | `jtk issues update PROJ-123 --assignee VALUE` (or equivalently `jtk issues assign PROJ-123 VALUE`) |
+| Unassign | `jtk issues update PROJ-123 --assignee none` (or equivalently `jtk issues assign PROJ-123 --unassign`) |
+| Transition issue | `jtk transitions list PROJ-123` then `jtk transitions do PROJ-123 "Done"` |
+| Current user | `jtk me` (or `jtk me --id` for just the account ID) |
+| Current sprint | `jtk sprints current --board ID` |
+| Add comment | `jtk comments add PROJ-123 --body "..."` |
+
+**Full CLI reference:** load `CliReference.md`
+
+## Examples
+
+**Example 1: Quick status check**
+```
+User: "What am I working on in Jira?"
+→ Invokes QuickStatus workflow
+→ Searches for issues assigned to current user in active statuses
+→ Returns grouped list by status
+```
+
+**Example 2: Create and assign a bug**
+```
+User: "Create a bug in PROJ for broken login page, assign to me"
+→ Invokes ManageIssue workflow
+→ Creates issue with --type Bug --summary "Broken login page" --assignee me
+→ Returns issue key and link
+```
+
+**Example 3: Search with JQL**
+```
+User: "Find all high priority issues in PROJ updated this week"
+→ Invokes SearchIssues workflow
+→ Runs: jtk issues search --jql "project = PROJ AND priority = High AND updated >= -7d"
+→ Returns formatted results
+```

--- a/skills/Jira/Workflows/ManageAttachments.md
+++ b/skills/Jira/Workflows/ManageAttachments.md
@@ -1,0 +1,84 @@
+# ManageAttachments Workflow
+
+List, upload, download, and delete attachments on Jira issues.
+
+## Intent-to-Flag Mapping
+
+### Action Selection
+
+| User Says | Command | Required |
+|-----------|---------|----------|
+| "list attachments", "show attachments" | `jtk attachments list PROJ-123` | Issue key |
+| "attach file", "upload file", "add attachment" | `jtk attachments add PROJ-123 --file PATH` | Issue key + file path |
+| "download attachment", "get attachment" | `jtk attachments get ATTACHMENT_ID` | Attachment ID |
+| "delete attachment" | `jtk attachments delete ATTACHMENT_ID` | Attachment ID |
+
+The `get` command has an alias `download` — both work identically.
+
+## Execute
+
+### List Attachments
+
+```bash
+jtk attachments list PROJ-123
+```
+
+### Upload Attachment
+
+Single file:
+```bash
+jtk attachments add PROJ-123 --file /path/to/file
+```
+
+Multiple files (the `--file` / `-f` flag is repeatable):
+```bash
+jtk attachments add PROJ-123 --file doc.pdf --file image.png
+```
+
+Verify files exist before attempting upload. If a path doesn't exist, ask the user for the correct path.
+
+### Download Attachment
+
+```bash
+# First list to get attachment IDs
+jtk attachments list PROJ-123
+
+# Download to current directory (uses original filename)
+jtk attachments get ATTACHMENT_ID
+
+# Download to a specific directory
+jtk attachments get ATTACHMENT_ID --output ./downloads/
+
+# Download with a custom filename
+jtk attachments get ATTACHMENT_ID --output ./downloads/renamed.pdf
+```
+
+If the user specifies by filename rather than ID: list attachments first, match by name, then download by ID.
+
+### Delete Attachment
+
+**Agent must confirm with user before calling this command.** `jtk attachments delete` executes immediately with no interactive CLI-level prompt — there is no safety net in the tool itself. This is a destructive action; the agent is responsible for the pre-call confirmation.
+
+```bash
+jtk attachments delete ATTACHMENT_ID
+```
+
+## Output Format
+
+- **List:** Table with ID, Filename, Size, Author, Created date
+- **Upload:** Confirm success with filename(s) and issue key
+- **Download:** Confirm download location and filename
+- **Delete:** Confirm which attachment was deleted
+
+## Post-Action
+
+After any action:
+1. For list: state total attachment count
+2. For upload: confirm filename(s), size, and issue key
+3. For download: confirm download path and filename
+
+## Notes
+
+- **Attachment IDs are numeric** (long integers) and come from the output of `jtk attachments list PROJ-123` — there's no "friendly" path to a specific attachment. Always list first if the user refers to an attachment by filename.
+- Large file uploads may take time — inform user if file is substantial
+- Attachment size limits depend on Jira instance configuration (default 10MB for Cloud)

--- a/skills/Jira/Workflows/ManageComments.md
+++ b/skills/Jira/Workflows/ManageComments.md
@@ -1,0 +1,71 @@
+# ManageComments Workflow
+
+View and add comments on Jira issues.
+
+## Intent-to-Flag Mapping
+
+### Action Selection
+
+| User Says | Command | Required |
+|-----------|---------|----------|
+| "view comments", "list comments", "show comments" | `jtk comments list PROJ-123` | Issue key |
+| "add comment", "comment on", "post comment" | `jtk comments add PROJ-123 --body "TEXT"` | Issue key + `--body` text |
+| "delete comment", "remove comment" | `jtk comments delete PROJ-123 COMMENT_ID` | Issue key + comment ID |
+
+## Execute
+
+### List Comments
+
+```bash
+jtk comments list PROJ-123
+```
+
+Optional: `--max N` to control result count (default 50). Use `--fulltext` global flag to disable truncation of long comment bodies.
+
+### Add Comment
+
+The comment text goes through the **required** `--body` flag (or `-b`):
+
+```bash
+jtk comments add PROJ-123 --body "Comment text here"
+```
+
+Do **not** pass the comment as a positional argument — it will be rejected with "required flag(s) \"body\" not set".
+
+For multi-line comments, either pass the literal newline in the quoted string, or use the `\n` escape sequence (`--body` supports `\n`, `\t`, `\\`):
+```bash
+# Literal newlines (works in most shells)
+jtk comments add PROJ-123 --body "Line 1
+Line 2
+Line 3"
+
+# Escape sequences (works everywhere)
+jtk comments add PROJ-123 --body "Line 1\nLine 2\nLine 3"
+```
+
+### Delete Comment
+
+**Agent must confirm with user before calling this command.** `jtk comments delete` executes immediately with no interactive CLI-level prompt. The operation is destructive and cannot be undone; the agent is responsible for the pre-call confirmation.
+
+```bash
+jtk comments delete PROJ-123 COMMENT_ID
+```
+
+The `COMMENT_ID` is a numeric ID (e.g., `12345`). If the user refers to the comment by content or author, list comments first (`jtk comments list PROJ-123`) to recover the ID, then delete by ID.
+
+## Output Format
+
+- **List comments:** Show each comment with author, timestamp, and body
+- **Add comment:** Confirm comment was added with issue key and a snippet of the comment text
+
+## Post-Action
+
+After any action:
+1. For list: state total comment count
+2. For add: confirm the comment was posted with issue key and author
+3. When adding comments, remind user it will be posted as the authenticated user
+
+## Notes
+
+- Comments support Jira wiki markup / markdown depending on instance configuration
+- Comment bodies are truncated by default in list output — pass `--fulltext` to see full text

--- a/skills/Jira/Workflows/ManageIssue.md
+++ b/skills/Jira/Workflows/ManageIssue.md
@@ -1,0 +1,163 @@
+# ManageIssue Workflow
+
+Create, update, assign, and transition **a single** Jira issue.
+
+> **For multi-issue operations** — creating more than one issue, parent+sub-task hierarchies, bulk updates across multiple issues, mixing creates with updates, or decomposing a spec into tickets — use `Workflows/ManageIssueSet.md` instead. That workflow handles discovery, plan confirmation, ordering, and partial-failure recovery for coordinated multi-issue work.
+
+## Intent-to-Flag Mapping
+
+### Action Selection
+
+| User Says | Action | Command |
+|-----------|--------|---------|
+| "create issue", "new ticket", "file a bug" | Create | `jtk issues create` |
+| "update issue", "change field", "set priority" | Update | `jtk issues update PROJ-123 --field FIELD=VALUE` |
+| "assign to X" (any form: `me`, email, display name, account ID) | Assign | `jtk issues update PROJ-123 --assignee VALUE` |
+| "unassign" | Unassign | `jtk issues update PROJ-123 --assignee none` |
+| "move to done", "close", "transition", "change status" | Transition | `jtk transitions do PROJ-123 "Target Status"` |
+
+### Choosing an Issue Type (for create)
+
+Issue types are **project-configurable** — each project has its own set, and names vary. A project might have `Support Request` instead of `Bug`, or `Feature` instead of `Story`, or entirely custom types like `Capability`, `Initiative`, `PRD`, `Tech Design`, `UAT`, etc. Some types are *sub-task types* (Jira's `subtask: true` flag), which **require `--parent KEY`** pointing at a non-subtask parent issue.
+
+Common Jira type names you may encounter: `Bug`, `Story`, `Task`, `Epic`, and one or more sub-task types (typically but not always named `Sub-task`). Many projects add custom types.
+
+**Before creating, run `jtk issues types --project KEY`** to list the project's actual types. Output includes a `SUBTASK` column — rows with `SUBTASK: yes` are sub-task types. Match the user's phrasing (e.g., "bug," "user story," "design task") to the discovered list.
+
+If `jtk issues create --type X` fails with an invalid-type error, the project's scheme doesn't include `X`. Re-run `jtk issues types --project KEY` and present the available options to the user.
+
+### Confirming ambiguous or multi-ticket type choices
+
+After discovering the project's types, confirm with the user — don't silently pick — when any of these apply:
+
+- **Multiple types could match the intent.** If the user says "file a design task" and the project has `Tech Design`, `UX Design`, and `Development`, ask which. If the user says "create a release ticket" and the project has `UAT`, `Pilot Release`, and `Full Release`, ask.
+- **Nothing matches cleanly.** If no discovered type fits the user's phrasing, list the available types and ask which one they want.
+- **Hierarchy / sub-task creation.** When the user wants a parent + sub-task, confirm (a) the parent's type, and (b) the sub-task type specifically — some projects have more than one sub-task type (e.g., `Technical Sub-task`, `Bug Sub-task`). Ask which one.
+- **Creating multiple tickets in one request.** If the user asks for more than one issue in a single request, you've likely landed in this workflow by mistake — route to **ManageIssueSet** instead.
+
+Use the user's confirmed choice — don't fall back to guessing a "close enough" type once you've surfaced an ambiguity.
+
+### Choosing a Priority (for create/update)
+
+Priority values are **project-scoped**, not universal. A fresh Jira Cloud project ships with something like `Highest / High / Medium / Low / Lowest`, but many instances replace or extend that with schemes like `Blocker / Critical / Major / Minor / Trivial` or ten-level custom priorities. The skill does not assume any priority value is valid on any project.
+
+**Before setting priority, run `jtk issues field-options priority --issue PROJ-123`** to list the valid values for the issue's project. `--issue PROJ-123` is strongly recommended — priority schemes are usually project-scoped, and without a project-scoped issue reference the CLI falls back to whatever global scheme data is available, which may be incomplete or empty. For a create where the issue doesn't exist yet, run the call against an existing issue in the target project to learn the scheme. If an `--issue`-less call returns empty or missing values, retry with `--issue PROJ-123`.
+
+Match the user's phrasing (e.g., "urgent," "critical," "low priority") to the discovered values. If the user's wording is ambiguous (e.g., "high" in a scheme that has both `High` and `Highest`), ask.
+
+If `jtk issues update --field priority=X` or `jtk issues create ... --field priority=X` fails with a "not found" or "invalid option" error, re-run the `field-options` command and present the available values to the user.
+
+## Execute
+
+### Create Issue
+
+```bash
+jtk issues create \
+  --project KEY \
+  --type TYPE \
+  --summary "Summary text" \
+  --description "Description text"
+```
+
+Optional flags:
+```bash
+  --assignee me                 # or an email, display name, or raw account ID
+  --parent PROJ-100              # attach to epic/parent
+  --field priority=High \
+  --field labels=label1,label2
+```
+
+### Update Issue (fields)
+
+```bash
+jtk issues update PROJ-123 \
+  --field FIELD=VALUE
+```
+
+Common direct flags instead of `--field`: `--summary`, `--description`, `--assignee`, `--type`, `--parent`.
+
+**Multi-value fields** (multi-select customfields, labels, etc.): repeat `--field` with the same key to accumulate values, e.g. `--field customfield_10050=Option1 --field customfield_10050=Option2`.
+
+**Text escapes:** `--summary`, `--description`, and `--body`-style flags support `\n` (newline), `\t` (tab), and `\\` (literal backslash) escape sequences. Use these for multi-line content passed on the command line.
+
+**Discovering editable fields and valid values:** `jtk issues fields PROJ-123` lists the fields you can edit on a specific issue. `jtk issues field-options FIELD --issue PROJ-123` lists the allowed values for enum-type fields (priority, status categories, select customfields). Many fields — including `priority` on most instances — have project-scoped or issue-scoped schemes, so `--issue PROJ-123` is effectively required. You can omit `--issue` for truly global fields, but if the call fails with "Field key '...' is not valid" or similar, add `--issue` and retry.
+
+**Changing issue type (`--type`):** uses the Jira Cloud bulk-move API rather than a direct edit, so the operation is asynchronous and behaves slightly differently from a plain field update. Safe, but expect a brief delay before the change is visible.
+
+### Assign Issue
+
+Use `jtk issues update KEY --assignee VALUE`. The resolver accepts four forms: `me`, email address, display name, or raw account ID. All four flow through the same User resolver and produce the same result — pick whichever the user provided verbatim.
+
+```bash
+jtk issues update PROJ-123 --assignee me
+jtk issues update PROJ-123 --assignee user@example.com
+jtk issues update PROJ-123 --assignee "Alice Cooper"             # display name
+jtk issues update PROJ-123 --assignee 5b10ac8d82e05b22cc7d4ef5   # raw accountId
+jtk issues update PROJ-123 --assignee none                       # unassign
+```
+
+Note: `jtk issues assign KEY VALUE` (positional user arg) and `jtk issues assign KEY --unassign` are equivalent alternatives — same resolver, same accepted forms. This workflow standardizes on `--assignee` for uniformity across the assign/unassign/update surface. `jtk me --id` returns your own account ID if you need it for scripting.
+
+#### Fallback when the resolver fails
+
+If `--assignee VALUE` returns an error ("user not found", "ambiguous match", "multiple users matched", or similar), the resolver couldn't map the input to a single account. Fall back to explicit search:
+
+```bash
+jtk users search "QUERY" --max 10
+```
+
+Then apply match-count logic — mirror the pattern used in SpecToTickets stage 2 step 4:
+
+| Match count | Action |
+|-------------|--------|
+| **0** | Surface to the user: "No matches for `QUERY` — did you mean someone else, or should I leave unassigned?" Wait for user direction. Do not silently substitute. |
+| **1, with clear fit** (exact display name, exact email, or the single result is the obvious intended user) | Use that account ID — retry with `--assignee <ACCOUNT_ID>`. |
+| **1, with possible doubt** (common first name, loose partial match, single result but weak fit) | Surface the single match to the user for confirmation before using. |
+| **2–9** | Surface the full candidate list (display name + email for each). Ask the user which account is correct. Do NOT auto-pick. |
+| **10 (the cap)** | The intended user may be past the cap. Surface as ambiguous, ask the user to refine the search (fuller name, specific email domain, exact email address). |
+
+Never silently commit to an account ID without evidence of correctness. When any doubt remains, error back to the user for disambiguation rather than guessing.
+
+### Transition Issue (workflow status)
+
+Status changes happen through `jtk transitions do`, **not** through `jtk issues update`.
+
+```bash
+# Step 1: List available transitions (names are instance-dependent)
+jtk transitions list PROJ-123
+
+# Step 1b (optional but useful): show which transitions require fields
+jtk transitions list PROJ-123 --fields
+
+# Step 2: Apply the transition by name
+jtk transitions do PROJ-123 "In Progress"
+
+# Or by numeric ID (stable even if names change)
+jtk transitions do PROJ-123 21
+
+# If `transitions list --fields` showed a required field, pass it. Only
+# pass --field values that the list-fields output explicitly flagged as
+# required — many workflows set resolution via post-function or hide it
+# from the transition screen, and a speculative --field resolution=Done
+# will fail with "Field 'resolution' cannot be set. It is not on the
+# appropriate screen, or unknown." If that happens, retry without --field.
+jtk transitions do PROJ-123 "Done" --field NAME=VALUE
+```
+
+Common transition names (instance-dependent — always `list` first):
+
+| User Says | Typical Target |
+|-----------|----------------|
+| "start working", "in progress" | `In Progress` |
+| "ready for review", "in review" | `In Review` |
+| "done", "close", "complete", "resolve" | `Done` |
+| "reopen" | `To Do` |
+| "block", "blocked" | `Blocked` (if configured) |
+
+## Post-Action
+
+After any action:
+1. Confirm success with the issue key
+2. For creates: show the new issue key. **Note: the `--id` global flag is currently ignored by `jtk issues create` — the command emits its full `Created issue PROJ-123 (https://...)` message regardless. For scripting, parse the key out of the decorated output (e.g., `grep -oE '[A-Z]+-[0-9]+' | head -1`) rather than relying on `--id`.**
+3. For transitions: show old status → new status
+4. For assignments: confirm assignee display name

--- a/skills/Jira/Workflows/ManageIssueSet.md
+++ b/skills/Jira/Workflows/ManageIssueSet.md
@@ -1,0 +1,204 @@
+# ManageIssueSet Workflow
+
+Create, update, link, or organize **multiple** related Jira issues as a coordinated set. Covers bulk operations, parent+sub-task hierarchies, and mixed create/update/link flows.
+
+For single-issue operations, use `Workflows/ManageIssue.md` instead.
+
+## When to Use This Workflow
+
+Route here instead of ManageIssue when the request involves:
+
+- Creating more than one issue in a single request
+- Creating a parent issue plus one or more sub-tasks under it
+- Updating multiple existing issues with the same or related changes
+- Mixing creates and updates (e.g., "create a PRD, update these 3 to point at it")
+- Establishing links between multiple issues as a planned set
+- Any creation request where ordering or partial-failure matters
+
+For spec decomposition — "turn this PRD into tickets," "decompose this design doc," etc. — route to `Workflows/SpecToTickets.md` first. That workflow handles the judgment call of proposing a ticket breakdown, composes full ticket content to a workfile, and hands off to this workflow's Execute stage once the user has confirmed the breakdown. If you arrive at this workflow from SpecToTickets with a confirmed and validated workfile, skip the Discovery & Confirmation stages below and proceed directly to Execute — SpecToTickets has already accomplished all of that.
+
+## Four Patterns
+
+Every multi-issue operation fits one of these shapes. Identify which up front — it shapes what you need to discover and confirm.
+
+### Pattern A — Bulk Create
+
+User lists multiple new issues to create. Examples:
+
+- "Create a bug for X and a task for Y"
+- "File three stories: A, B, C"
+- "Create these 5 tickets in PROJ: ..."
+
+### Pattern B — Hierarchy Create
+
+User wants a parent issue plus sub-tasks (and possibly nested children). Examples:
+
+- "Create a PRD with sub-tasks for design and implementation"
+- "File an epic with three stories under it"
+- "Make a tech design task and break it into sub-tasks for schema, API, and frontend"
+
+### Pattern C — Bulk Update
+
+User wants the same or related changes across multiple existing issues. Examples:
+
+- "Set priority=High on PROJ-100, PROJ-101, PROJ-102"
+- "Reassign all my open tickets in PROJ to Alice"
+- "Add label `q2-goal` to these four issues"
+
+### Pattern D — Mixed Create / Update / Link
+
+User wants a combination — creating some issues, updating others, establishing links across the set. Examples:
+
+- "Create a tracking issue and link these 3 existing bugs to it as 'blocks'"
+- "Create a PRD, update these tickets to reference it, link them as sub-tasks"
+- "File a new epic, move these existing stories under it, and add them all to the current sprint"
+
+## Discovery & Confirmation (before any writes)
+
+Regardless of pattern, work through every applicable step below before writing anything. Every multi-issue operation must get a plan-and-confirm step before execution — the friction is small, the cost of wrong tickets appearing in a live project is not.
+
+1. **Project types** (once per project touched — most sets are in a single project):
+
+   ```bash
+   jtk issues types --project KEY
+   ```
+
+   Remember which types have `SUBTASK: yes` — those require `--parent KEY` on create.
+
+2. **Per-ticket type confirmation.** Do not apply a uniform type unless the user explicitly said so ("three bugs" is uniform; "some tickets," "these work items," "the tasks from the spec" are not). For ambiguous matches — e.g., user said "design task" and the project has `Tech Design`, `UX Design`, and `Development` — ask which one for each ticket.
+
+3. **Sub-task types specifically.** If the project has more than one type with `SUBTASK: yes` (e.g., `Technical Sub-task` + `Bug Sub-task`), ask which one for each sub-task. If there's only one sub-task type, use it but state it explicitly in the plan.
+
+4. **Priority discovery** (if the user wants priorities set). Run `jtk issues field-options priority --issue EXISTING_KEY` against any existing issue in the target project to learn the scheme. Match the user's phrasing to the discovered values. Ask when ambiguous.
+
+5. **Per-ticket fields.** Don't assume uniform assignee, priority, or labels unless the user said so. Confirm per ticket when in doubt. For a spec-decomposition flow, default individual tickets to unassigned unless the spec or user names a specific owner.
+
+   **Assignee resolution.** `--assignee VALUE` accepts `me`, email, display name, or raw account ID — the resolver handles all four. When a user name is ambiguous ("Alice" on a project with multiple Alices) or the resolver fails ("user not found", "multiple users matched"), fall back to `jtk users search "QUERY" --max 10` and apply the match-count logic (0 / 1-clear / 1-doubt / 2-9 / 10-cap). For the full disambiguation pattern, see `Workflows/ManageIssue.md` → **Assign Issue → Fallback when the resolver fails**. Apply the same logic here — never silently commit to an account ID without evidence.
+
+6. **For updates (Patterns C and D):** Confirm the exact issue keys being touched. Don't let "all my tickets" or "these" stay ambiguous — translate it to a concrete JQL query, run `jtk issues search --jql "..."` to fetch matches, **show the user the list of matched keys**, and get explicit confirmation before any updates. The user should see exactly which issues you'll modify.
+
+7. **For links (Patterns B and D):** Confirm link direction and type. `A blocks B` and `B blocks A` are very different. Confirm the relationship semantics before creating links. Run `jtk links types` if unsure which link-type name matches the user's wording.
+
+8. **Present the plan.** List every intended operation in execution order. Use a structured format (table or numbered list) that makes the agent's inferences visible to the user. For example:
+
+   ```
+   Plan (8 operations in PROJ):
+
+   Creates:
+     1. Create PRD                  summary="[Title]"             assignee=me
+     2. Create Tech Design          summary="Design schema"       parent=#1
+     3. Create Development          summary="Build API endpoint"  parent=#1
+     4. Create Development          summary="Wire frontend"       parent=#1
+
+   Updates:
+     5. Update PROJ-489              priority=High
+
+   Links:
+     6. Link #2 blocks #3
+     7. Link #3 blocks #4
+
+   Sprint:
+     8. Add #1, #2, #3, #4 to sprint 597 (Sprint 42)
+   ```
+
+   Then ask for explicit go/no-go. Do not proceed until the user confirms. If the user corrects the plan (types, hierarchy, fields, assignees, anything), revise the plan and re-confirm before any writes.
+
+## Execute
+
+**If arriving from SpecToTickets with a workfile:** the workfile is the authoritative plan. Execute in three phases, all reading from the workfile:
+
+**Phase 1 — Ticket creation pass.** Walk the workfile in order. For each ticket section, pull metadata from the bullet fields (`type`, `summary`, `priority`, `assignee`, `labels`, `parent`) and pull the full description body verbatim from between the `<!-- SPECTOTICKETS_DESCRIPTION_START -->` and `<!-- SPECTOTICKETS_DESCRIPTION_END -->` markers (use this as the Jira `description` field). Resolve `parent`: if it matches `SpecToTicketWorkflowTemp-\d+`, that ticket was created earlier in this phase — look up its current `jira_key` in the workfile (which now holds the real Jira key); if `parent` is already a real Jira key, use it directly. Call `jtk issues create`. **Do not call `jtk links create` during this phase** — preserve each ticket's `links[]` metadata unchanged. After each successful create, do a file-wide find-and-replace of that ticket's `SpecToTicketWorkflowTemp-N` with the new real key throughout the workfile — bullet field values and description body prose alike — so subsequent tickets' references resolve correctly.
+
+**Phase 2 — Link creation pass.** Walk the workfile a second time. By this point, every `links[].target` is a real Jira key (either from the start for existing-issue references, or via Phase 1 find-and-replace for in-batch references). For each ticket's `links[]` entries, call `jtk links create SOURCE_KEY TARGET_KEY --type NAME` where SOURCE_KEY is the ticket's current `jira_key` (the source of the link), TARGET_KEY is the link's `target` (the INWARD endpoint), and NAME is the canonical link-type NAME from the workfile's `type:` field (e.g., `Blocks`, `Relates`) — which is what `jtk links create --type` accepts. Jira stores one link per pair; do not call `jtk links create` twice per link.
+
+**Phase 3 — Sprint assignment.** If the workfile's top section has `target_sprint` set to a sprint ID (not `none`), call `jtk sprints add SPRINT_ID PROJ-1 PROJ-2 ...` with all ticket keys from this batch as positional arguments — a single call at the end.
+
+Sequential, not parallel. Ordering rules — do not deviate without user direction:
+
+1. **Parents first.** Epics, PRDs, top-level tasks, standalone new issues created before any child that references them with `--parent`.
+2. **Children second.** Sub-tasks and any issue that needs a `--parent` flag, using keys tracked from step 1.
+3. **Existing-issue updates third.** Bulk field/assignee/label changes on pre-existing tickets.
+4. **Cross-issue links fourth.** `jtk links create` — after all link endpoints exist (whether from this batch or from existing tickets).
+5. **Sprint membership last.** `jtk sprints add SPRINT_ID PROJ-1 PROJ-2 ...` — at the end, once all target issues exist. Note: `jtk` has no "remove from sprint" command; sprint membership is implicitly cleaned up when an issue is deleted.
+
+Track every ID as you go — created issue keys, comment IDs, attachment IDs, link IDs. You'll need them for:
+
+- `--parent` on children (parent key)
+- `jtk links create` (both endpoint keys) — **does not return a link ID.** The Atlassian REST API responds to `POST /rest/api/3/issueLink` with a 201 and empty body, so the CLI has no ID to emit. To capture the link ID for later `jtk links delete`, immediately follow each `jtk links create SOURCE TARGET --type NAME` with `jtk links list SOURCE` and match the new entry by `(type, target)` to extract its ID. Record that ID in your tracking log.
+- `jtk sprints add` (sprint ID + issue keys)
+- Partial-failure reporting
+- Delete-newly-created recovery if requested
+
+### Failure Handling
+
+**Stop on failure.** If operation N fails partway through, do not continue without user direction.
+
+Produce a status report structured exactly like the Post-Action summary — the user sees the same shape whether the batch succeeded fully or partially:
+
+1. **Succeeded** (same format as a fully-successful batch):
+   - Summary table of issues created (keys, types, summaries, hierarchy relationships)
+   - Summary of issues updated (keys, what changed)
+   - Summary of links created
+   - Summary of sprint memberships added
+   - Browse URLs for each created issue so the user can click through and inspect
+
+2. **Failed:**
+   - Which operation (by plan-step number and description)
+   - Exact error message from `jtk`
+   - Likely cause if apparent (permission denied, bad type name, missing required field, etc.)
+
+3. **Not attempted:**
+   - Remaining plan-steps that never ran, in order
+
+4. **Ask the user how to proceed.** Offer three options with clear consequences:
+
+   - **Abort and leave as-is.** No further operations run; succeeded items stay in place. Choose this if the partial state is actually useful, or if the user wants to investigate before deciding anything further.
+
+   - **Resume from failure point.** If the user fixes the underlying cause (grants permission, clarifies the type name, provides a missing field), retry from operation N and continue through the remaining plan-steps.
+
+   - **Delete the newly-created issues and links from this batch.** Destructive; requires explicit user confirmation before running. Important caveats to state when offering this option:
+     - Only issues and links created in THIS batch will be deleted, in reverse order (links → sub-tasks → parents).
+     - **Updates applied to pre-existing issues (field changes, reassignments, label additions, comments) cannot be automatically reverted.** The agent does not have a safe way to undo updates. If the user wants those undone, they will need to run inverse updates manually, or use Jira's History view on each affected issue.
+     - Confirm by stating exactly: "I'll delete these N created issues and M created links. These X updates to existing issues will NOT be reverted — [list them]." Wait for explicit yes.
+
+Do not proceed past a failure without explicit user direction. Do not assume "abort" is the default.
+
+## Post-Action
+
+Produce a structured summary regardless of whether the batch fully succeeded or partially failed (the Failure Handling section uses this same summary format for the succeeded portion).
+
+1. **Summary table.** List what was created, updated, and linked, with keys and relationships. Example:
+
+   ```
+   Created:
+     PROJ-500 (PRD)           "[Title]"                  → parent
+     PROJ-501 (Tech Design)   "Design schema"            → child of PROJ-500
+     PROJ-502 (Development)   "Build API endpoint"       → child of PROJ-500
+     PROJ-503 (Development)   "Wire frontend"            → child of PROJ-500
+
+   Updated:
+     PROJ-489  priority → High
+
+   Linked:
+     PROJ-501 blocks PROJ-502
+     PROJ-502 blocks PROJ-503
+
+   Sprint:
+     PROJ-500, PROJ-501, PROJ-502, PROJ-503 → sprint 597 (Sprint 42)
+   ```
+
+2. **Offer direct links.** For each created issue, include the browse URL (e.g., `https://INSTANCE.atlassian.net/browse/PROJ-500`) so the user can click through.
+
+3. **Flag anything the workflow couldn't do.** If the user asked for sprint addition but the auth is bearer/scoped (Agile operations unavailable), note that the sprint add was skipped. Same for any other skipped operation.
+
+## Anti-patterns (avoid these)
+
+- Applying uniform type, assignee, priority, or labels to a multi-issue set without explicit user confirmation — the user said "some tickets," not "these specific tickets with this specific uniform config"
+- Skipping the plan-and-confirm step for a "small" or "simple" multi-issue request — always present the plan
+- Creating sub-tasks before their parent exists (ordering violation)
+- Creating links before both endpoints exist
+- Silently guessing link direction or link type when the user's intent was ambiguous ("link these" — ask which relationship)
+- Running a bulk update (Pattern C or D) without first showing the user the exact list of target issue keys
+- Running `jtk` calls in parallel within a single batch — stay sequential, keeps causality clear in logs and in the failure report
+- Proceeding past a mid-batch failure without user direction
+- Offering "rollback" as if Jira had transactions — it doesn't. Use "delete newly-created issues and links" wording, and explicitly note that updates to existing issues can't be auto-reverted

--- a/skills/Jira/Workflows/QuickStatus.md
+++ b/skills/Jira/Workflows/QuickStatus.md
@@ -1,0 +1,60 @@
+# QuickStatus Workflow
+
+Fast "what am I working on?" overview — shows current user's active Jira issues.
+
+## Intent-to-Flag Mapping
+
+| User Says | JQL Query |
+|-----------|-----------|
+| "my jira", "my tickets", "my issues" | `assignee = currentUser() AND status != Done ORDER BY updated DESC` |
+| "what am I working on" | `assignee = currentUser() AND status = "In Progress" ORDER BY updated DESC` |
+| "my open issues" | `assignee = currentUser() AND status != Done ORDER BY priority DESC` |
+| "anything overdue" | `assignee = currentUser() AND duedate < now() AND status != Done ORDER BY duedate ASC` |
+| "my recent" | `assignee = currentUser() ORDER BY updated DESC` |
+| "jira status" (with project from prefs) | `assignee = currentUser() AND project = KEY AND status != Done ORDER BY updated DESC` |
+
+## Execute
+
+```bash
+jtk issues search --jql "SELECTED_JQL_QUERY"
+```
+
+If customization provides a default project, scope the query:
+```bash
+jtk issues search --jql "assignee = currentUser() AND project = KEY AND status != Done ORDER BY updated DESC"
+```
+
+Add `--max N` if the user has many issues and wants a larger result set (default is 25):
+```bash
+jtk issues search --jql "assignee = currentUser() AND status != Done" --max 100
+```
+
+## Output Format
+
+Present as a concise status dashboard. The CLI returns a table by default; the skill post-processes it into a grouped view:
+
+```
+## My Jira Status
+
+### In Progress (3)
+- PROJ-123: Fix login validation — High
+- PROJ-456: Update API docs — Medium
+- PROJ-789: Refactor auth module — Medium
+
+### To Do (2)
+- PROJ-101: Add rate limiting — High
+- PROJ-102: Update dependencies — Low
+
+### In Review (1)
+- PROJ-200: New dashboard widget — Medium
+```
+
+Group by status, show key + summary + priority. Keep it scannable.
+
+If no results: "No open issues assigned to you." and suggest checking project scope.
+
+## Post-Action
+
+1. State total issue count across all statuses
+2. If any issues are overdue, flag them explicitly
+3. If results span multiple projects, note which projects are represented

--- a/skills/Jira/Workflows/SearchIssues.md
+++ b/skills/Jira/Workflows/SearchIssues.md
@@ -1,0 +1,123 @@
+# SearchIssues Workflow
+
+Search, list, and filter Jira issues using JQL or project-based queries.
+
+## Intent-to-Flag Mapping
+
+### Search Method
+
+| User Says | Command | When to Use |
+|-----------|---------|-------------|
+| "search for", "find", "JQL", custom query | `jtk issues search --jql "JQL"` | Flexible JQL-based search |
+| "list issues in PROJECT" | `jtk issues list --project KEY` | Simple project listing |
+| "in current sprint" | `jtk issues list --project KEY --sprint current` | Current-sprint shortcut |
+| "get ISSUE-123", "show me ISSUE-123" | `jtk issues get PROJ-123` | Single issue details |
+
+**Note:** `jtk issues search` **requires** the `--jql` flag — a bare positional query is not accepted.
+
+### Common Filters (JQL Building Blocks)
+
+| User Says | JQL Fragment |
+|-----------|-------------|
+| "my issues", "assigned to me" | `assignee = currentUser()` |
+| "unassigned" | `assignee is EMPTY` |
+| "bugs", "bug type" | `type = Bug` |
+| "stories" | `type = Story` |
+| "tasks" | `type = Task` |
+| "high priority" | `priority = High` |
+| "critical" | `priority = Critical` |
+| "open", "not done" | `status != Done` |
+| "in progress" | `status = "In Progress"` |
+| "updated recently", "updated this week" | `updated >= -7d` |
+| "created today" | `created >= startOfDay()` |
+| "overdue" | `duedate < now() AND status != Done` |
+| "in current sprint" | `sprint in openSprints()` |
+
+### Combining Filters
+
+Build JQL by combining fragments with `AND`:
+```
+User: "Find my open bugs in PROJ"
+→ JQL: project = PROJ AND assignee = currentUser() AND type = Bug AND status != Done
+```
+
+## Execute
+
+Based on the user's request, construct and run the appropriate command:
+
+```bash
+# JQL search
+jtk issues search --jql "PROJECT_AND_FILTER_JQL"
+
+# Project listing
+jtk issues list --project KEY
+
+# Current sprint listing
+jtk issues list --project KEY --sprint current
+
+# Single issue
+jtk issues get PROJ-123
+```
+
+### Result Sizing & Field Control
+
+Both `search` and `list` support the same paging/field flags:
+
+| Flag | Description |
+|------|-------------|
+| `--max N` / `-m N` | Maximum results (default 25; auto-paginates) |
+| `--next-page-token TOKEN` | Resume from previous page token |
+| `--all-fields` | Include all fields (descriptions, etc.) |
+| `--fields summary,status,customfield_10005` | Comma-separated list of specific fields |
+
+Examples:
+```bash
+# Get up to 200 results
+jtk issues search --jql "project = PROJ" --max 200
+
+# Get specific custom fields (e.g. Story Points)
+jtk issues search --jql "project = PROJ" --fields summary,status,customfield_10005
+
+# Include full descriptions
+jtk issues search --jql "project = PROJ" --all-fields
+```
+
+## Output Format
+
+Present results clearly:
+- For lists: table format with Key, Summary, Status, Assignee, Priority
+- For single issues: full detail view
+- If no results: state clearly, suggest broadening the query
+
+### Scripting / Parsing Output
+
+When the next step depends on extracting an identifier from the result (e.g. feeding an issue key into another command), use the global `--id` flag so the CLI emits only the primary identifier — no decoration to strip:
+
+```bash
+# Get all keys in a project as a flat list
+jtk issues list --project KEY --id
+
+# Get the single issue key this search would match
+jtk issues search --jql "summary ~ \"login bug\"" --max 1 --id
+
+# Feed keys into another command
+jtk issues list --project KEY --sprint current --id | xargs -I{} jtk issues get {}
+```
+
+Use `--id` whenever a downstream step parses the output. Avoid trying to pattern-match against the default table/plain output — it's human-oriented and may change formatting.
+
+## Post-Action
+
+After returning results:
+1. State the result count
+2. If results are large, offer to narrow the query
+3. If no results, suggest broadening or adjusting filters
+
+## Setting a Default Project
+
+If the user routinely works in the same project and hasn't told you which one, ask — then suggest they make the default stick:
+
+- **Env var:** `export JIRA_DEFAULT_PROJECT=PROJ` (per-shell; add to `.bashrc` / `.zshrc` / etc. to persist)
+- **Config file:** edit the `default_project` field in the file shown by `jtk config show` (typical paths: `~/.config/jira-ticket-cli/config.json` on Linux, `~/Library/Application Support/jira-ticket-cli/config.json` on macOS)
+
+Env var wins over config file. Once set, `jtk issues list` without `--project` will use the default.

--- a/skills/Jira/Workflows/SpecToTickets.md
+++ b/skills/Jira/Workflows/SpecToTickets.md
@@ -473,7 +473,9 @@ Show the user a compact overview generated from the workfile. For each ticket, d
 - Source reference (spec section)
 - A note that the full description is available for review on request
 
-Example proposal row (full temp IDs used throughout for consistency with the workfile's reference format):
+**Always use the full `SpecToTicketWorkflowTemp-N` identifiers in the proposal view — never abbreviate to short forms like "Temp-N" or "#N".** The proposal must use the same identifiers as the workfile so the user can cross-reference without ambiguity.
+
+Example proposal row:
 
 ```
 SpecToTicketWorkflowTemp-3 [child of SpecToTicketWorkflowTemp-1]   type=Development
@@ -679,4 +681,5 @@ In all failure-recovery variants, the workfile persists and remains an accurate 
 - **Presenting the compact proposal as if it's the full ticket content** — the proposal is a review artifact; the actual ticket descriptions should be substantial and live inside the `<!-- SPECTOTICKETS_DESCRIPTION_START -->` / `<!-- SPECTOTICKETS_DESCRIPTION_END -->` markers in the workfile
 - **Holding proposed changes in conversation context** rather than persisting them to the workfile immediately. The workfile is the source of truth
 - **Skipping the validation step in stage 4a** — validation catches real problems that would otherwise surface mid-execution in ManageIssueSet
+- **Abbreviating temp IDs in the proposal view** — never shorten `SpecToTicketWorkflowTemp-N` to "Temp-N", "#N", or any other abbreviated form. The proposal must use the same identifiers as the workfile so the user can cross-reference without ambiguity. This applies to ticket headers, relationship descriptions, dependency diagrams, and all other user-facing text in stage 3b.
 - **Broken description markers.** The `<!-- SPECTOTICKETS_DESCRIPTION_START -->` and `<!-- SPECTOTICKETS_DESCRIPTION_END -->` markers must always come in matched pairs — every start gets exactly one end, every end belongs to exactly one start, in the order they appear. Never nest them (no start-start-end-end, no overlap). Never omit the closing marker. Never misspell either marker. Parsers depend on the markers being well-formed; a broken pair corrupts every ticket section after it until the next correctly-paired section recovers. The validation pass at stage 4a catches unpaired markers, but getting them right the first time avoids needing to re-validate.

--- a/skills/Jira/Workflows/SpecToTickets.md
+++ b/skills/Jira/Workflows/SpecToTickets.md
@@ -1,0 +1,682 @@
+# SpecToTickets Workflow
+
+Decompose a specification, PRD, design doc, plan, or other structured content into a proposed set of Jira tickets. This workflow produces a structured breakdown for user review and composes the full content that will be written to Jira. It does **not** create tickets itself — once the user approves the breakdown, continue into ManageIssueSet for execution.
+
+For multi-issue operations where the user already specifies the tickets directly ("create these 3 issues"), skip this workflow and go straight to ManageIssueSet.
+
+## When to Use This Workflow
+
+Route here when:
+
+- User provides a specification, PRD, design doc, plan, or similar structured content AND asks to turn it into tickets
+- User says "decompose this into tickets," "turn this into a ticket set," "break this spec into tasks," "file tickets for this," or similar
+- User provides a long/structured document with an implicit or explicit "what tickets should I file?"
+
+If the user directly provides a concrete list of tickets to create (no spec — just "create these 3 issues"), route straight to ManageIssueSet. This workflow is for cases where the breakdown itself is a judgment call the agent is making on behalf of the user.
+
+## Terminology
+
+Consistent word choices used throughout this workflow:
+
+- **Ticket** — one Jira issue. Used interchangeably with "issue" when referring to the external Jira object. A **ticket section** is one `## Ticket: <jira_key>` block inside the workfile.
+- **Breakdown** — the overall set of proposed tickets derived from the spec. The thing this workflow produces.
+- **Proposal** — the compact user-facing view of the breakdown shown in stage 3b for review. A read-only projection of the workfile.
+- **Workfile** — the authoritative persistent document at the agent's working/scratch path. Holds the full breakdown with complete ticket content.
+- **Description** — the full multi-paragraph Jira description body, written into the workfile between `<!-- SPECTOTICKETS_DESCRIPTION_START -->` and `<!-- SPECTOTICKETS_DESCRIPTION_END -->` markers, later written to Jira as the issue's `description` field.
+- **short_description** — a distinct workfile field (1-3 sentence brief) used in the proposal view. Not the full Description.
+- **Temp ID** — a `SpecToTicketWorkflowTemp-N` placeholder for a ticket that has not yet been created in Jira. Replaced with the real Jira key during execution.
+
+## Stages
+
+### 1. Read & Understand the Spec
+
+Read the provided content carefully. Treat its structure — headings, sections, bullets, numbered lists, emphasis — as a hint about natural work units, but don't mechanically map structure to tickets.
+
+Identify:
+
+- **Top-level deliverable.** Often maps to a parent (Epic, Initiative, PRD, or similar — project-dependent).
+
+- **Units of work, and the right granularity for each.** A single conceptual unit from the spec might be any of:
+  - A standalone ticket
+  - A parent ticket that needs sub-tasks (because the work is too large for one ticket, or because different people will own different parts)
+  - Multiple sibling tickets at the same level (when the work has parallel, independent threads of a similar shape)
+  - A parent with both sub-tasks AND sibling-level tickets linked by blocks/relates-to
+
+  Choose the granularity deliberately. When in doubt, err on fewer, larger tickets — and explicitly call out where you think splitting might be useful so the user can weigh in during confirmation.
+
+- **Relationships between tickets.** Jira's link-type model stores one link per pair with a canonical NAME and two directional phrasings (OUTWARD from the source, INWARD from the target). For example, the `Blocks` link type has NAME `Blocks`, OUTWARD phrase `blocks`, INWARD phrase `is blocked by`. When composing a link in the workfile, the agent encodes the source-side perspective: the link entry lives in the source ticket's section, and the `type:` value is the canonical NAME. Common link types (by NAME / OUTWARD / INWARD):
+  - **Parent/child hierarchy** (sub-tasks, epic-to-story) — this is NOT a link type; it's created via `--parent KEY` on the child at ticket creation, not via `jtk links create`
+  - **Blocks** — OUTWARD `blocks`, INWARD `is blocked by`; A must complete before B can start; most common dependency type
+  - **Relates** — OUTWARD and INWARD both `relates to`; informal association, no ordering
+  - **Duplicate** — OUTWARD `duplicates`, INWARD `is duplicated by`; same work captured twice
+  - **Problem/Incident** — OUTWARD `causes`, INWARD `is caused by`; bug-causation links
+  - **Cloners** — OUTWARD `clones`, INWARD `is cloned by`; template relationship
+  - Project-specific custom link types may also exist.
+
+  **Discover the exact set** and verify NAME values for your instance by running `jtk links types`. The command output shows four columns: ID, NAME, OUTWARD, INWARD. Use the NAME column value for the workfile `type:` field. Use the OUTWARD phrasing when rendering the link to the user in the proposal view.
+
+  Spec language to watch for: "depends on," "requires," "after," "in parallel with," "related to," "caused by," "implements," "fixes," "supersedes," etc. These often map to link types — but **ask the user when direction or type is ambiguous** ("A blocks B" and "B blocks A" are opposite encodings; pick wrong and Jira shows the opposite relationship). Be explicit in the confirmation prompt about which ticket is the source and which is the target.
+
+- **Sequential vs parallel work.** If the spec describes a sequence ("first design, then build, then test"), that's likely a chain of `Blocks` links between siblings — each earlier ticket blocks the next. If it describes parallel threads, they might be siblings with no links, or siblings all linked back to a coordination parent.
+
+- **Implicit fields.** Priorities signaled by words like "urgent," "critical," "must-have," "nice-to-have"; owners mentioned by name; rough sizing hints ("small," "big effort").
+
+- **A flat set of peer siblings with no shared top-level parent.** When a spec is a grab-bag of loosely-related work items that don't need a coordinating parent, a flat set of top-level tickets is fine. Each ticket's `parent` is `none` — the Project itself is the effective parent. Don't invent a coordinator ticket just to satisfy a mental model of hierarchy.
+
+- **Ambiguities.** Things that could map to multiple ticket shapes, where the spec is unclear about work boundaries, or where the relationship between units isn't explicit. Identify them during this stage. They'll be written to the workfile's `ambiguities` field when you compose the workfile in stage 3a (the workfile is the source of truth — don't rely on conversation context to hold them). They're surfaced to the user in stage 3b's proposal and resolved during stage 4 confirmation.
+
+### 2. Discovery (Up-Front and On-Demand)
+
+#### Step 1 — Establish the target project
+
+Every subsequent step in this workflow requires a known target project — type discovery, priority discovery, ticket composition, and ticket creation all depend on it.
+
+If the user has clearly specified a project (by key or by name) in their request, use it.
+
+**If the project is not specified, or is ambiguous, ask the user before proceeding.** Do not guess from spec content — spec titles and section content don't reliably map to Jira project keys, and decomposing against a wrong project wastes effort at every subsequent stage.
+
+Use `jtk projects list` if the user wants to see which projects they have access to.
+
+Once the project is established, it will be recorded in the workfile's batch-metadata `project:` field during stage 3a composition. From here through the rest of Stage 2, "the project" refers to this established key.
+
+#### Step 2 — Issue types (up-front)
+
+Run:
+
+```
+jtk issues types --project KEY
+```
+
+The breakdown proposal must use types that actually exist in the target project. The `SUBTASK` column identifies sub-task types (which require `--parent KEY` at creation time). Record these values in the workfile's batch-metadata `discovered_types:` field during stage 3a composition (including the `SUBTASK: yes` annotation where applicable).
+
+#### Step 3 — Priority scheme (conditionally up-front)
+
+If the user intends to set priorities on any ticket in the batch, run priority discovery now. If priorities aren't needed (every ticket will have `priority: none`), skip this step and set `discovered_priorities: none` in the workfile header during stage 3a.
+
+**Two-step command pattern:**
+
+1. Find any existing issue in the target project to use as the `--issue` reference:
+
+   ```
+   jtk issues list --project KEY --max 1 --id
+   ```
+
+   This returns a single issue key (e.g., `ANP-100`). Any existing issue works as the reference.
+
+2. Use that key for the priority discovery:
+
+   ```
+   jtk issues field-options priority --issue ANP-100
+   ```
+
+   The output lists the valid priority values for this project's priority scheme. Record these in the workfile's batch-metadata `discovered_priorities:` field during stage 3a composition.
+
+**If step 1 returns no results** (the project has no existing issues at all), `jtk issues field-options priority --issue` cannot run. Inform the user: "This project has no existing issues — priority discovery needs at least one issue to run against. Options: (a) create a bootstrap issue in Jira first (any trivial placeholder), (b) skip priorities entirely for this batch (set `discovered_priorities: none` and every ticket's `priority: none`), or (c) cancel and come back after issues exist." Wait for the user's choice before proceeding. Do not silently fabricate priority values or skip the discovery step without user approval.
+
+**Known limitation — project-scoped assumption.** This workflow treats the priority scheme as project-scoped based on a single `jtk issues field-options priority --issue` query against one existing issue in the project. Most Jira instances have one priority scheme per project, so this is correct. Some instances configure per-type priority schemes (different priority lists for Bug vs Task vs Epic, etc.). Stage 4a validation cannot detect this mismatch — it only verifies each ticket's `priority` is in the single `discovered_priorities` list. If a priority is valid for the reference issue's type but not for another ticket's type, the mismatch surfaces at Phase 1 execution, not at validation. See Stage 5's priority-mismatch handling for what happens then.
+
+#### Step 4 — On-demand discovery (during ticket composition)
+
+The following discoveries are declared here but run during stage 3a composition — when the specific value is needed, not up front. Declaring them here keeps all project-discovery guidance in one section.
+
+- **Users / assignees** — when the spec names a specific person or the user wants one assigned, run `jtk users search "NAME" --max 10` (explicit cap so the result-count check below is predictable; don't rely on CLI defaults). Inspect the result count:
+  - **No matches:** set `assignee: none` in the workfile and surface the name as an ambiguity for stage 3b's proposal — ask the user whether they meant someone else or want to leave unassigned.
+  - **Multiple matches (2-9):** set `assignee: none`, surface the candidate list during stage 4 confirmation, let the user pick which account ID is correct.
+  - **Exactly 10 matches:** this is the cap — the intended user may well be past it. Treat as ambiguous: set `assignee: none`, surface to the user during stage 4, and ask them either to refine the search (fuller name, email domain, exact email) or to pick from the 10 returned.
+  - **Single match with clear fit** (full name exact match, email match, etc.): use that account ID. If the match is plausible but you have doubt (common name, loose match against a first name only), treat it as ambiguous and surface for user confirmation rather than silently committing.
+
+  Never use `jtk users search --max 1 --id` in this workflow — it suppresses the ambiguity signal and commits to the first match without evidence of whether there were others.
+
+- **Sprint IDs** — if the user wants tickets added to a sprint, run `jtk sprints current --board BOARD_ID` for the active sprint, or `jtk sprints list --board BOARD_ID` to list all sprints for that board. The user may provide the sprint ID directly; ask if neither the board ID nor the sprint ID is clear.
+
+- **Link types** — if the spec implies a link type beyond the common canonical NAMEs (`Blocks`, `Relates`, `Duplicate`, `Problem/Incident`, `Cloners`), or if the instance may use custom link types, run `jtk links types` to confirm the exact NAME column value for your instance. Use that NAME verbatim in the workfile `type:` field. Ask the user if the match is ambiguous.
+
+### 3. Compose Full Ticket Content, Then Present a Proposal
+
+This stage has two parts: composing the authoritative ticket content to a workfile, and presenting a compact summary to the user for review.
+
+#### 3a. Compose full ticket content to a workfile
+
+Before presenting anything to the user, write the full breakdown to a structured workfile. This file is the source of truth for the proposed tickets — the agent's conversation context may get compacted or truncated, but the file persists.
+
+**Workfile location:** the agent's working/scratch directory. If your harness provides a dedicated scratch area for operational artifacts that persists across conversation turns, use it. Otherwise, before falling back to the system temp directory (`$TMPDIR` or `/tmp` on Unix-like systems, `%TEMP%` on Windows), **warn the user and ask them to choose a location.** Use wording like: "I'd like to write the breakdown workfile to the system temp directory (`/tmp` or equivalent). Many systems auto-clean temp directories (systemd-tmpfiles, macOS periodic cleanup). If this workflow spans multiple sessions or days — e.g., you want to come back later to finish the breakdown or review before execution — the workfile may be deleted before the process completes. Options: (a) proceed with system temp and accept the risk, (b) use a more durable path such as `~/.cache/jira-spec-to-tickets/` or a project directory you specify. Which would you prefer?" Only compose the workfile once the path is agreed. An example filename: `breakdown-YYYYMMDD-HHMMSS-<short-name>.md`. The file must persist across conversation turns and be editable by the agent throughout the workflow.
+
+**File format:** pure Markdown. The file opens with a top section containing batch-level metadata, followed by one `## Ticket: <jira_key>` section per proposed ticket — the heading literally contains that ticket's `jira_key` field value (e.g., `## Ticket: SpecToTicketWorkflowTemp-7` pre-execution, `## Ticket: ANP-501` post-execution). All metadata fields — at the batch level and the ticket level — use bold-labeled bullet lines (`- **field_name:** value`). The `links` field uses nested Markdown bullets (not YAML) with a fixed shape: the `- **links:**` bullet is followed by one entry per link, where each entry is a two-space-indented `  - type: <type>` bullet with a four-space-indented `    target: <target>` continuation line on the next line. The nested-bullet form is structural, not a YAML subset. See Example 2 below for the concrete layout.
+
+Each ticket section contains metadata bullets followed by a `### Description` heading, then the full ticket body enclosed in distinctive HTML-comment marker pairs:
+
+```
+### Description
+
+<!-- SPECTOTICKETS_DESCRIPTION_START -->
+
+[the full description body goes here, verbatim — any Markdown is allowed
+inside: code blocks, nested headings (## Context, ## Schema, etc.),
+tables, horizontal rules, bullet lists, whatever the ticket needs]
+
+<!-- SPECTOTICKETS_DESCRIPTION_END -->
+```
+
+The comment markers delimit the description body unambiguously, even if the body contains `##`/`###` headings, horizontal rules, or other Markdown constructs that would otherwise confuse section-boundary parsing. Agents reading the workfile extract everything between `<!-- SPECTOTICKETS_DESCRIPTION_START -->` and `<!-- SPECTOTICKETS_DESCRIPTION_END -->` verbatim as the ticket's `description` field.
+
+Ticket sections are separated by a `---` horizontal rule on its own line between the previous ticket's `<!-- SPECTOTICKETS_DESCRIPTION_END -->` and the next ticket's `## Ticket: <jira_key>` heading. The seam between two tickets looks like this:
+
+```
+<!-- SPECTOTICKETS_DESCRIPTION_END -->
+
+---
+
+## Ticket: SpecToTicketWorkflowTemp-N
+```
+
+The `---` sits outside description bodies (which are protected by the comment markers), so it can't collide with description content.
+
+**Batch metadata at file top:**
+
+```
+# Breakdown — <spec title>
+
+- **spec_title:** Auth Rework PRD
+- **spec_source:** Confluence page 12345 (https://...)
+- **project:** ANP
+- **created:** 2026-04-20T15:30:00-07:00
+- **updated:** 2026-04-20T15:45:00-07:00
+- **status:** proposed
+- **target_sprint:** 597
+- **discovered_types:**
+  - Task
+  - Bug
+  - Story
+  - Epic
+  - Sub-task (SUBTASK: yes, requires --parent)
+- **discovered_priorities:**
+  - Highest
+  - High
+  - Medium
+  - Low
+  - Lowest
+- **ambiguities:**
+  - Should §2.1 be one ticket or split into schema + lifecycle?
+  - "Alice" mentioned as owner — which Alice? (Multiple users named Alice matched `jtk users search`)
+  - Unclear if §3.4 implies a dependency on §2.1 — "after" could mean sequential or independent
+```
+
+Field notes:
+
+- **`status`** starts as `proposed`, becomes `revised` when the user requests changes during confirmation, and becomes `confirmed` once the user gives final go-ahead. The `updated` timestamp is refreshed on every edit.
+- **`target_sprint`** is `none` if no sprint is requested.
+- **`discovered_types`** is populated at the end of stage 2 from `jtk issues types --project KEY`. Mark sub-task types explicitly (e.g., "Sub-task (SUBTASK: yes, requires --parent)") so validation and composition can distinguish them. Stage 4a's type-related validation checks reference this list — it's the authoritative record of what types are valid for this batch, independent of conversation context.
+- **`discovered_priorities`** is populated at the end of stage 2 from `jtk issues field-options priority --issue EXISTING_KEY`, or `none` if the user doesn't plan to set priorities. Stage 4a's priority validation check references this list.
+- **`ambiguities`** is a list of open questions identified during stage 1 that the user needs to resolve. Empty (`none`) if none were found. The agent writes these here during stage 3a composition; stage 3b surfaces them to the user; stage 4 confirmation resolves them (and the agent clears or updates the list as each is resolved). If a revision during stage 4 introduces a new ambiguity, add it here and re-surface.
+
+**Temp IDs:** each ticket has a `jira_key` field initially set to `SpecToTicketWorkflowTemp-N` where N is a batch-local integer. References to other tickets in this batch — in `parent`, in `links[].target`, in description body prose, or in `short_description` — use the same temp ID. During execution (stage 5, inside ManageIssueSet), each temp ID gets replaced file-wide with the real Jira key as that ticket is created.
+
+**Temp ID numbering:** temp IDs are unique integers but do not need to be sequential or gap-free. Initial numbering typically goes 1, 2, 3, ... monotonically as tickets are proposed. When a ticket is removed or merged during revision (stage 4), leave its temp ID retired — do not reuse the number, do not renumber the remaining tickets. Gaps are fine.
+
+**Heading-and-`jira_key` coupling:** the section heading `## Ticket: <jira_key>` literally contains the full `jira_key` value. There is no separate "numeric suffix" concept — the heading and the `jira_key` field always match by construction. If the `jira_key` changes (during Phase 1's find-and-replace when a temp ID becomes a real Jira key, or during manual edits), the heading must change in lockstep. Phase 1's file-wide find-and-replace handles this naturally: replacing `SpecToTicketWorkflowTemp-7` with `ANP-501` rewrites both the `jira_key` field and the heading `## Ticket: SpecToTicketWorkflowTemp-7` → `## Ticket: ANP-501` in one pass. For manual edits (stage 4 revisions), remember to update both. Validation check #17 enforces the coupling.
+
+**Ticket ordering within the workfile:** what matters is file position, not temp ID numbering. Tickets whose `parent` is a temp ID (referring to another ticket in this batch) must appear later in the file than the ticket they reference. Phase 1 execution reads the file top-to-bottom and creates tickets as it encounters them — a parent must already have been created by the time its child is processed. Numbering is independent: `SpecToTicketWorkflowTemp-5` may appear before `SpecToTicketWorkflowTemp-3` in the file — the numeric suffix is just an identifier, not an ordering signal. Tickets whose `parent` is `none` or a real Jira key (existing issue) have no in-batch dependency and can appear anywhere in the file relative to other tickets.
+
+**All fields are listed on every ticket**, even when empty. Use `none` for empty values. This keeps parsing uniform and avoids ambiguity about whether a field was intentionally left blank or forgotten.
+
+**Single-project scope:** a workfile represents a single-project batch. The top-level `project:` field applies to every ticket in the file. If the user's intent spans multiple projects, work with them to either run SpecToTickets separately per project, or adapt this workflow's handling for that specific case (e.g., per-ticket `project:` overrides, coordinated temp-ID namespaces, etc.). Do not silently widen scope within a single workfile.
+
+**Required fields per ticket** (always present; the order shown is recommended for readability but not enforced by the validation pass):
+
+- `jira_key` — `SpecToTicketWorkflowTemp-N` pre-execution, replaced with real Jira key during execution
+- `type` — from the discovered types list (stage 2)
+- `summary` — concise, under ~150 characters, what will be the Jira summary field verbatim
+- `priority` — from the discovered priority scheme, or `none`
+- `assignee` — `none`, `me`, an email address, or a discovered account ID. The literal string `me` is supported natively by `jtk issues create` and `jtk issues update` per the CLI's own help text (`Assignee (account ID, email, or "me")`); `jtk` resolves it to the authenticated user's account ID at execution time, so the workflow doesn't need to substitute anything
+- `parent` — `none`, a temp ID (another ticket in this batch), or an existing Jira key
+- `labels` — comma-space-separated list (e.g., `auth-rework, q2-goal, backend`) or `none`. Individual labels should not contain spaces; use hyphens or underscores per project convention.
+- `links` — a structured list of `type` + `target` pairs, or `none`. The `type:` value is the canonical NAME from Jira's link-type model (e.g., `Blocks`, `Relates`, `Cloners`, `Duplicate`) — matches what `jtk links create --type` accepts. Run `jtk links types` to see the NAME column for your instance. The link entry lives in the SOURCE ticket's section; `target:` is the link's INWARD endpoint. A single link is stored once (in the source's section only), not twice: Jira represents the relationship from both sides automatically, rendering the OUTWARD phrase on the source side and the INWARD phrase on the target side. Example: if `SpecToTicketWorkflowTemp-2` blocks `SpecToTicketWorkflowTemp-3`, the entry lives in **#2's** section as `type: Blocks`, `target: SpecToTicketWorkflowTemp-3`. Do NOT add an inverse `is blocked by` entry in #3's section — that would double-count the relationship in Jira.
+- `source` — where in the spec this ticket was derived from (section heading, page, URL if applicable)
+- `short_description` — 1-3 sentence brief for the proposal view, NOT the ticket description
+
+Plus a `### Description` body enclosed in marker comments — the full multi-paragraph ticket description that will be written to Jira. This is the meat of the ticket and should be substantial enough that someone picking up the ticket cold can act on it without reading the spec. Include:
+
+- **Context** — why this work exists, what problem it solves
+- **The work to be done** — detailed, with the specificity necessary to execute. Include requirements, acceptance criteria, expected behavior, API signatures, schema definitions
+- **Pulled-forward material** — if the ticket's primary spec section references diagrams, pseudocode, tables, type definitions, or constants that live elsewhere in the spec, pull that material into the description. A ticket must not say "implement the flow shown in §1.4" without the §1.4 content being present in the ticket itself
+- **Dependencies and relationships in prose** — state relationships in natural language (e.g., "This ticket blocks `SpecToTicketWorkflowTemp-4` because the frontend wiring depends on this API") in addition to the structured `links` metadata
+- **Source attribution** — at the top or bottom of the description, note the spec origin: title, section heading, page, URL if available
+
+Descriptions should be as long as the work requires — multiple paragraphs, headings, code blocks, tables are all fine. Err toward over-inclusion of context.
+
+**Jira markdown support:** Jira Cloud accepts a substantial subset of standard Markdown in the `description` field: headings, bold/italic/strikethrough, inline code and fenced code blocks, ordered/unordered lists, tables, task-list checkboxes, blockquotes, links, and horizontal rules. For the authoritative list of supported syntax, see [Atlassian's Markdown docs](https://support.atlassian.com/jira-software-cloud/docs/markdown-and-keyboard-shortcuts/#Edit-and-create-with-markdown). Most spec content ports directly; exotic extensions (e.g., footnotes, definition lists) may not render.
+
+#### Canonical workfile template
+
+The following is a minimal but complete workfile showing all required structural pieces — the batch-metadata header, one fully-formed ticket section with every required field, the marker-delimited description body, and the `---` seam leading into the next ticket. Agents composing a workfile from scratch should use this as the structural template; the three detailed examples below fill out the variety of ticket shapes (standalone, sub-task with links, sub-task under existing issue):
+
+```
+# Breakdown — <spec title>
+
+- **spec_title:** <spec title>
+- **spec_source:** <where the spec lives (URL, page ref, inline)>
+- **project:** <PROJECT_KEY>
+- **created:** <ISO 8601 timestamp>
+- **updated:** <ISO 8601 timestamp>
+- **status:** proposed
+- **target_sprint:** <sprint ID or none>
+- **discovered_types:**
+  - <Type1>
+  - <Type2> (SUBTASK: yes, requires --parent)
+- **discovered_priorities:**
+  - <Priority1>
+  - <Priority2>
+- **ambiguities:**
+  - <open question 1>
+  - <open question 2>
+
+## Ticket: SpecToTicketWorkflowTemp-1
+
+- **jira_key:** SpecToTicketWorkflowTemp-1
+- **type:** <Type1>
+- **summary:** <concise one-line summary>
+- **priority:** <Priority1>
+- **assignee:** none
+- **parent:** none
+- **labels:** none
+- **links:** none
+- **source:** <spec section reference>
+- **short_description:** <1-3 sentence brief for the proposal view>
+
+### Description
+
+<!-- SPECTOTICKETS_DESCRIPTION_START -->
+
+<full multi-paragraph description — context, work to be done, acceptance criteria, pulled-forward material, source attribution>
+
+<!-- SPECTOTICKETS_DESCRIPTION_END -->
+
+---
+
+## Ticket: SpecToTicketWorkflowTemp-2
+...
+```
+
+#### Example ticket sections
+
+Each example below is a standalone illustration of a common ticket shape. In a real workfile, ticket sections would be separated by `---` per the seam pattern shown above. The examples below use temp IDs 1, 2, and 4 — the gap at 3 is intentional to demonstrate that numbering can have gaps (e.g., after a ticket was removed during revision), as described in the temp-ID numbering rules above.
+
+**Example 1 — Standalone top-level ticket, no parent, no links, no assignee:**
+
+```
+## Ticket: SpecToTicketWorkflowTemp-1
+
+- **jira_key:** SpecToTicketWorkflowTemp-1
+- **type:** PRD
+- **summary:** Auth rework — tracking PRD
+- **priority:** High
+- **assignee:** none
+- **parent:** none
+- **labels:** none
+- **links:** none
+- **source:** PRD §0 (title + overview)
+- **short_description:** Parent tracking ticket for the auth rework rollout across Q2.
+
+### Description
+
+<!-- SPECTOTICKETS_DESCRIPTION_START -->
+
+## Context
+
+The auth system rework is a Q2 priority driven by two forces: the compliance requirements raised by legal in Q1 (see §0.3) and the engineering team's need to remove the Postgres-based session store in favor of Redis (see §2.1).
+
+## Scope
+
+This PRD coordinates four distinct workstreams: session token storage redesign (tracked as a Tech Design child), API endpoint rebuild (Development child), frontend integration (Development child), and end-to-end validation (UAT child). Each has its own child ticket linked to this parent.
+
+## Rollout target
+
+Feature flag behind `auth_v2` starting sprint 2604.6 (post-2604.5 freeze), full rollout sprint 2604.8.
+
+## Source
+
+Derived from [PRD Title / Link] §0 (title + overview), §0.3 (compliance), §2.1 (session storage), §3 (API rebuild), §4 (rollout plan).
+
+<!-- SPECTOTICKETS_DESCRIPTION_END -->
+```
+
+**Example 2 — Sub-task under another proposed ticket, with links to a sibling-in-batch and an existing issue, has assignee:**
+
+```
+## Ticket: SpecToTicketWorkflowTemp-2
+
+- **jira_key:** SpecToTicketWorkflowTemp-2
+- **type:** Tech Design
+- **summary:** Design session token storage schema and lifecycle
+- **priority:** High
+- **assignee:** me
+- **parent:** SpecToTicketWorkflowTemp-1
+- **labels:** auth-rework
+- **links:**
+  - type: Blocks
+    target: SpecToTicketWorkflowTemp-3
+  - type: Relates
+    target: ANP-489
+  - type: Relates
+    target: SpecToTicketWorkflowTemp-5
+- **source:** PRD §2.1 (Session Token Storage)
+- **short_description:** Schema and lifecycle design for Redis-backed session tokens per PRD §2.1. Pulled-forward auth flow from §1.4 and compliance constraints from §0.3. Peer-level relationship with the monitoring sub-task for operational observability of the new store.
+
+### Description
+
+<!-- SPECTOTICKETS_DESCRIPTION_START -->
+
+## Context
+
+The current session storage keeps tokens in a Postgres table indexed by user ID with a 24-hour sliding-window refresh. Per the compliance flags raised in Q1 (§0.3), this approach doesn't meet the new retention requirements.
+
+## Proposed design
+
+Move session tokens to a Redis keyed store with explicit TTL, per the auth flow in PRD §1.4 (pulled forward below):
+
+[auth flow diagram / pseudocode from §1.4 goes here, in a fenced code block]
+
+## Schema
+
+| Field      | Type   | Notes |
+|------------|--------|-------|
+| token_id   | UUID   | Primary key, client-opaque |
+| user_id    | bigint | FK to users table |
+| scope      | enum   | `full`, `readonly`, `refresh` |
+| expires_at | ts     | Enforced by Redis TTL, stored for audit |
+
+## Acceptance criteria
+
+- [ ] Sessions persist to Redis with TTL set via SETEX
+- [ ] Expired sessions are not retrievable (sleep+read test)
+- [ ] Audit log in Postgres captures `{user_id, token_id, scope, issued_at, expires_at}`
+- [ ] Load-test: 10k concurrent logins produce zero session-lookup failures
+
+## Related existing work
+
+ANP-489 is the middleware layer this design reuses for token validation. No changes required there, but link added as a reference for developers onboarding to this ticket.
+
+## Peer-level related work (no hierarchy)
+
+This ticket has an informal "relates to" relationship with `SpecToTicketWorkflowTemp-5` (the monitoring/observability sub-task), which is a peer sibling under the same PRD parent. Neither blocks the other and there is no ordering dependency — they are flagged as related because the monitoring design needs to reference the schema defined here, and decisions made in either can usefully inform the other. Pure "peer context" link, not a dependency.
+
+## Blocks downstream
+
+This ticket blocks `SpecToTicketWorkflowTemp-3` (API endpoint implementation), which consumes the schema defined here.
+
+## Source
+
+Derived from PRD §2.1 "Session Token Storage". Flow diagram pulled forward from §1.4. Compliance context from §0.3.
+
+<!-- SPECTOTICKETS_DESCRIPTION_END -->
+```
+
+**Example 3 — Sub-task under an existing Jira issue (not created in this batch), no links, unassigned:**
+
+```
+## Ticket: SpecToTicketWorkflowTemp-4
+
+- **jira_key:** SpecToTicketWorkflowTemp-4
+- **type:** Sub-task
+- **summary:** Add session-token audit log schema to users-db
+- **priority:** Medium
+- **assignee:** none
+- **parent:** ANP-200
+- **labels:** none
+- **links:** none
+- **source:** PRD §2.1 (Acceptance criteria #3)
+- **short_description:** Schema change to the users-db to capture session-token audit fields. Sub-task under the existing quarterly DB infrastructure epic ANP-200.
+
+### Description
+
+<!-- SPECTOTICKETS_DESCRIPTION_START -->
+
+## Context
+
+The session storage redesign in PRD §2.1 introduces an audit log requirement: every session issuance writes a row capturing `{user_id, token_id, scope, issued_at, expires_at}` to Postgres. This sub-task covers the schema change to the users-db to add that audit table.
+
+This work slots under the existing quarterly DB infrastructure epic ANP-200, which already tracks DDL changes for Q2.
+
+## Schema addition
+
+[DDL pulled from spec §2.1 goes here, in a fenced code block]
+
+## Migration plan
+
+1. Add the `session_audit` table via standard migration tooling in the users-db repo
+2. Deploy to staging first; validate no impact on existing queries
+3. Deploy to prod during the rollout window defined in PRD §4
+
+## Acceptance criteria
+
+- [ ] Migration applied cleanly in staging
+- [ ] Existing users-db queries unaffected (regression test pass)
+- [ ] Migration applied to prod during rollout window
+
+## Source
+
+Derived from PRD §2.1 acceptance criterion #3. Parent epic ANP-200 tracks infrastructure DB changes for Q2.
+
+<!-- SPECTOTICKETS_DESCRIPTION_END -->
+```
+
+#### 3b. Present a compact proposal derived from the workfile
+
+Show the user a compact overview generated from the workfile. For each ticket, display:
+
+- Position in hierarchy / relationships to other tickets
+- Type
+- Summary (the actual summary from 3a, verbatim)
+- `short_description` (from the bullet field — 1-3 sentence brief)
+- Priority / assignee if set
+- Relationships to other tickets or existing issues
+- Source reference (spec section)
+- A note that the full description is available for review on request
+
+Example proposal row (full temp IDs used throughout for consistency with the workfile's reference format):
+
+```
+SpecToTicketWorkflowTemp-3 [child of SpecToTicketWorkflowTemp-1]   type=Development
+   Summary:     "Build API endpoint for X"
+   Source:      PRD §3.2 "API Schema Design"
+   Brief:       Implements POST /api/x per the auth flow in §1.4.
+                Includes schema validation and error-case handling.
+   Priority:    Medium
+   Relationships:
+     - blocks SpecToTicketWorkflowTemp-4 (frontend wiring needs this API)
+     - relates to ANP-123 (reuses auth middleware)
+   [Full description available on request]
+```
+
+Surface any ambiguities from stage 1 as open questions for the user to resolve.
+
+Offer the user the option to review the full description body for any specific ticket. If they ask to see ticket #3's full description, show the content between its `<!-- SPECTOTICKETS_DESCRIPTION_START -->` and `<!-- SPECTOTICKETS_DESCRIPTION_END -->` markers verbatim — do not summarize or paraphrase.
+
+### 4. Confirm with User, Persist Changes to Workfile
+
+Ask the user to confirm, and wait for a concrete answer before proceeding:
+
+- Is this the right breakdown? (Scope correct? Granularity — too fine? Too coarse? Any tickets to merge or split?)
+- Are the proposed types correct per ticket?
+- Is the hierarchy and relationship structure correct?
+- Any priorities, assignees, or fields to adjust?
+- Any tickets to add or remove?
+- Want to review the full description of any specific ticket before approving?
+
+**If the user requests any changes, update the workfile immediately** before responding. Do not hold changes in conversation context and defer the file update — the workfile is the source of truth and must reflect every confirmed edit.
+
+When updating:
+
+1. Edit the relevant section(s) of the workfile in place
+2. Update the top section's `updated` field with the current timestamp
+3. Set the top section's `status` field to `revised` (from `proposed`)
+4. Present the revised view back to the user from the updated file
+
+Iterate until the user gives explicit go-ahead. If the user substantially revises the breakdown (adds/removes/merges/splits tickets), regenerate the full proposal from the updated workfile and re-confirm — don't partial-apply changes and proceed.
+
+**When a ticket is removed or merged during revision, scan the workfile for any remaining references to that ticket's temp ID.** Check every location a reference could live: `parent` fields on other tickets, `links[].target` entries on other tickets, prose inside description bodies (between the `<!-- SPECTOTICKETS_DESCRIPTION_START -->` / `<!-- SPECTOTICKETS_DESCRIPTION_END -->` markers), prose inside `short_description`, prose inside `source`, and prose inside the batch-level `ambiguities` field. For each remaining reference, present it to the user with its specific location and ask them to choose:
+
+- **(a) Update the reference to point at a different ticket** — user specifies which. Agent edits the reference in place.
+- **(b) Remove the reference entirely** — agent deletes the reference from whichever field it's in.
+- **(c) Defer — keep the reference in place for now but note it explicitly as unresolved.** The agent is responsible for tracking deferred references within the current session and raising them to the user again before marking `status: confirmed`. If the session ends or context is lost before resolution, stage 4a validation will catch the dangling reference (check #5) and force the user to resolve it at that point. Choosing (c) is a valid "I'll think about it later" path — it is NOT a way to proceed to execution with unresolved references; validation will block.
+
+Do not silently drop references or leave them dangling without user direction.
+
+On confirmation:
+
+1. Set the top section's `status` field to `confirmed`
+2. Update the top section's `updated` field
+3. Proceed to stage 4a (validation)
+
+### 4a. Pre-execution Validation
+
+Before proceeding to ManageIssueSet's Execute stage, validate the workfile. Do not proceed to stage 5 if any hard-failure check fails.
+
+**Validation is a mandatory gate before every invocation of ManageIssueSet's Execute stage, not just the first time.** If the user hand-edits the workfile after confirmation, if a Phase 1 failure sends them back to revise and retry, if any non-trivial time elapses between confirmation and execution — re-run stage 4a before proceeding. The workfile is the authoritative input to execution, and anything that could have changed it (user edits, filesystem corruption, manual cleanup) must re-pass validation. Never invoke ManageIssueSet on a workfile that hasn't just passed validation.
+
+**Hard failures vs soft warnings.** Most checks below are hard-failure: if any produce errors, validation fails and the user must fix before proceeding. A few checks (currently only the >150 character summary rule in check #13) are soft warnings: they surface in the validation report shown to the user for awareness but do not block execution. The user can choose to revise the ticket or proceed as-is on soft warnings. Treat everything as hard-failure unless the check text explicitly marks it as soft-warn.
+
+**Checks:**
+
+1. **Every ticket section has all required fields and a description body.** Required bullet-field metadata: `jira_key`, `type`, `summary`, `priority`, `assignee`, `parent`, `labels`, `links`, `source`, `short_description`. The order shown in stage 3a is recommended for readability but is NOT enforced here — validation only checks that every required field is present, not that it appears in a specific position. Plus a `### Description` heading followed by content enclosed in `<!-- SPECTOTICKETS_DESCRIPTION_START -->` and `<!-- SPECTOTICKETS_DESCRIPTION_END -->` markers. The file's top section has the batch fields: `spec_title`, `spec_source`, `project`, `created`, `updated`, `status`, `target_sprint`, `discovered_types`, `discovered_priorities`, `ambiguities`.
+
+2. **Description markers are well-formed.** For every ticket section, exactly one `<!-- SPECTOTICKETS_DESCRIPTION_START -->` marker followed by exactly one `<!-- SPECTOTICKETS_DESCRIPTION_END -->` marker, in that order. No nesting. No overlapping pairs. No start without a matching end. No end without a preceding start. File-wide count of start markers equals file-wide count of end markers equals the number of ticket sections.
+
+3. **`jira_key` values are unique within the workfile.** No two tickets share the same temp ID.
+
+4. **`jira_key` values match either the temp-ID pattern or a real Jira key pattern.** Each `jira_key` must be either `SpecToTicketWorkflowTemp-\d+` (with a non-empty digit suffix) OR a real Jira key matching `[A-Z]+-\d+`.
+   - A workfile where **every** `jira_key` is a temp ID is a fresh breakdown — the normal pre-execution state.
+   - A workfile where **some** `jira_key` values are real Jira keys and others are temp IDs is mid-execution state, indicating Phase 1 partially completed during a prior run (see Stage 5's resume handling). This is valid when the workfile is being re-validated before a resume.
+   - A workfile where **every** `jira_key` is a real Jira key is post-execution — Phase 1 completed. Re-running validation on a fully-executed workfile serves only audit purposes; the workflow has nothing further to do.
+
+   Reject values matching neither pattern.
+
+5. **Every temp-ID reference resolves to a declared ticket.** Scan the workfile for occurrences of `SpecToTicketWorkflowTemp-\d+` that appear in a reference context — specifically:
+   - `parent` field values
+   - `links[].target` values
+   - Prose inside description bodies (between the `<!-- SPECTOTICKETS_DESCRIPTION_START -->` and `<!-- SPECTOTICKETS_DESCRIPTION_END -->` markers)
+   - Prose inside `short_description`
+   - Prose inside `source`
+   - Prose inside the batch-level `ambiguities` field
+
+   Each hit must match the `jira_key` value of exactly one ticket section. A reference that doesn't resolve is flagged with its specific location (which ticket section or batch field, and which line).
+
+   **A declared `jira_key` does not need to be referenced anywhere else** — a ticket with no incoming references is a valid standalone ticket in the batch.
+
+6. **Every `parent` value is `none`, a temp ID (resolved per check #5), or a real Jira key** matching the `[A-Z]+-\d+` pattern.
+
+7. **Every `links[].target` value is a temp ID (resolved per check #5) or a real Jira key.**
+
+8. **If `type` is a sub-task type** (per the batch metadata `discovered_types` field — rows annotated with `SUBTASK: yes`), **`parent` must be non-`none`.** Jira requires sub-tasks to have a parent.
+
+9. **`type` is in the workfile's `discovered_types` list** (recorded in batch metadata at the end of stage 2).
+
+10. **`priority` is in the workfile's `discovered_priorities` list** (recorded in batch metadata at the end of stage 2) when set; `none` is valid if the batch isn't setting priorities. If `discovered_priorities` is `none`, every ticket's `priority` must be `none`.
+
+11. **`assignee` is `none`, `me`, an email address (`user@example.com` format), or a discovered Atlassian account ID.** Atlassian Cloud account IDs are typically alphanumeric strings (either a long hex-looking form like `5b10ac8d82e05b22cc7d4ef5` or a prefixed form like `712020:abc123-def456-...`). If the value doesn't match any of these shapes, flag it.
+
+12. **No circular parent chains** within the batch (if A's parent is B, then B's parent can't transitively be A).
+
+13. **`summary` length is within Jira's limit.** Hard-fail if `summary` is empty or exceeds 255 characters (Jira Cloud's maximum). Soft-warn if `summary` exceeds ~150 characters — this workflow prefers concise summaries for readability in the proposal view, but tickets with longer summaries still pass validation.
+
+14. **`labels` is well-formed.** The field is either `none` or a comma-space-separated list. Individual labels must not contain whitespace (Jira Cloud does not allow spaces in labels; the CLI will reject them). Example of valid: `auth-rework, q2-goal, backend`. Example of invalid: `q2 goal` (contains a space), `auth-rework,q2-goal` (missing space after comma).
+
+15. **`source` is non-empty.** Every ticket must attribute where in the spec its content was derived from. `source` must not be `none` or an empty string — at minimum, a section heading or page reference. Tickets with no clear spec origin indicate the agent is padding the breakdown; ask the user to confirm the ticket belongs here rather than silently committing.
+
+16. **Parents-before-children in file position.** For every ticket whose `parent` is a temp ID, the referenced ticket must appear earlier in the file (by section position, not by numeric suffix). If ticket X has `parent: SpecToTicketWorkflowTemp-Y`, then the `## Ticket` section whose `jira_key` is `SpecToTicketWorkflowTemp-Y` must come before X's section in the workfile. This check does not apply when `parent` is `none` or a real Jira key (existing issue) — those have no in-batch position dependency. Rationale: Phase 1 execution iterates tickets in file order and creates each one as it reads it; a parent must already exist as a real Jira key before its child is created.
+
+17. **Section heading matches `jira_key` exactly.** The section heading `## Ticket: <value>` must literally equal `## Ticket: ` followed by that section's `jira_key` field value. Heading `## Ticket: SpecToTicketWorkflowTemp-7` requires `jira_key: SpecToTicketWorkflowTemp-7`; heading `## Ticket: ANP-501` requires `jira_key: ANP-501`. Divergence is a hard failure — the workfile contains two disagreeing claims about the ticket's identifier, and execution logic reads one or the other depending on context. If this check fails, surface the exact mismatch to the user (both values, which section) and ask whether the heading or the `jira_key` is authoritative before fixing.
+
+18. **`links[]` entries are well-formed.** Each link entry in a `- **links:**` block must have a `type:` line and a `target:` line. Standard shape: `  - type: <value>` followed on the next line by `    target: <value>` (two-space indent for the `- type:` continuation bullet, four-space indent for the `target:` sub-line). Malformed or missing `type`/`target` lines within a link entry will silently break Phase 2 link creation — flag them here. Skip this check when the ticket's `links:` field is `none`.
+
+19. **Batch `status` is `confirmed` before execution.** The batch-metadata `status:` field must be `confirmed` when validation runs pre-execution (stage 5 entry). A `status` of `proposed` or `revised` indicates the user hasn't finished approving the breakdown — execution would bypass the confirmation contract. Any value other than `confirmed` is a hard failure. Rationale: this guards against hand-edits or process errors where someone attempts to invoke execution on an unapproved workfile.
+
+**If validation surfaces any issues:**
+
+1. Present every error to the user with specific locations (ticket section number, field name, or line number in a description body for prose-level errors).
+2. Ask the user how to fix each issue.
+3. Update the workfile to incorporate the fixes.
+4. Re-run validation.
+5. Loop until validation passes, or the user asks to cancel.
+
+Common causes of validation failures:
+
+- The agent composed a description that references a ticket that was later merged or removed during revision — stale prose reference
+- The user renumbered or restructured tickets and references weren't updated
+- A sub-task type was picked but no parent was assigned
+- A priority was set that doesn't match the discovered scheme
+- A circular parent chain emerged through a multi-step revision
+- A description marker was omitted or misspelled during an edit
+
+### 5. Proceed to ManageIssueSet for Execution
+
+Once the user has confirmed the breakdown and validation has passed, proceed to ManageIssueSet for execution. This is the same agent continuing into another workflow's instructions, using the workfile you produced in stage 3a as the authoritative input — not a formal handoff to a different actor. Follow ManageIssueSet's Execute section, reading the workfile for every ticket, field, and relationship. Execution semantics (Phase 1 ticket creation, Phase 2 link creation, Phase 3 sprint assignment) are defined canonically in ManageIssueSet's Execute section.
+
+**Entry precondition: stage 4a must have just passed.** If the workfile could have been modified since the last validation run (user hand-edits, time elapsed, filesystem activity), re-run stage 4a before entering Phase 1. ManageIssueSet's Execute assumes it's reading a freshly-validated workfile.
+
+**Resume from partial execution.** If Phase 1 previously ran and failed partway (some tickets created, others not), the workfile will have real Jira keys in the `jira_key` fields of already-created tickets and `SpecToTicketWorkflowTemp-N` placeholders in the rest. This is the "mid-execution state" covered by check #4 — validation passes on this mixed state. When Phase 1 re-enters: **skip any ticket whose `jira_key` already matches the real-Jira-key pattern** (`[A-Z]+-\d+`) — it was already created in the prior run. Phase 1 only re-attempts tickets where `jira_key` is still a `SpecToTicketWorkflowTemp-N` placeholder. The same find-and-replace semantics apply after each new successful create. If the user wants to re-create a ticket that already succeeded (unusual — typically means they changed their mind about its content), they should revert that section's `jira_key` back to its original temp ID in the workfile before resuming, and delete the real Jira ticket manually.
+
+**Detecting a crashed-mid-create scenario.** There's a narrow failure window where `jtk issues create` succeeded (a real Jira ticket exists) but the subsequent file-wide find-and-replace didn't complete — e.g., the agent crashed, the session died, or the file write was interrupted before the workfile was updated. On resume, the workfile would still show that ticket as "not yet created" (still holding its `SpecToTicketWorkflowTemp-N` value), and Phase 1 would attempt to create it again — producing a duplicate in Jira. This is unlikely but real. **Mitigation: on entry to Phase 1 against a workfile that shows any real Jira keys in its `jira_key` fields (i.e., any mid-execution state)**, ask the user: "This workfile shows partial execution progress from a prior run. Did the previous run crash or get interrupted mid-create? If so, any ticket whose workfile entry still shows a temp ID might already exist in Jira — resuming as-is could produce duplicates. Options: (a) proceed as-is (safe if the prior run ended cleanly, e.g., the user chose `abort-and-leave-as-is` after a `jtk issues create` failure), or (b) verify against Jira first — I'll run `jtk issues search --jql "project = KEY AND summary = \"<summary text>\""` for each remaining temp-ID ticket and check whether a match already exists before creating. Use **exact-equality JQL** (`summary = "..."`, not `summary ~ "..."`) to avoid fuzzy-match false positives; JQL's `~` is a contains-operator that would match unrelated tickets sharing words with the summary and silently treat the wrong ticket as 'already-created.' After running the exact-match search, additionally **verify the result's summary equals the workfile ticket's summary character-for-character** before claiming a match — Jira's `summary = "..."` is case-insensitive and treats some punctuation loosely, so a post-query exact-string check closes any residual gap. On a verified exact match, treat the ticket as already-created, update the workfile's `jira_key` to the matched real key (using the same `\b`-anchored find-and-replace as Phase 1), and skip the `jtk issues create` call for that ticket." Wait for the user's choice. If the user selects (b), run the exact-match pre-create search for each remaining temp-ID ticket with the post-query verification described above.
+
+**Phase 1 priority-mismatch failure.** If `jtk issues create` rejects a ticket because its `priority` value isn't valid for its type (typical error wording: "Field 'priority' cannot be set" or similar indicating an invalid option for the issue type in that project), treat this as a hard stop. Do not retry with a different priority automatically. Surface the exact `jtk` error to the user and ask how to proceed. Offer three options:
+
+- **Re-discover priorities for this specific type and pick a valid value.** Two-step: `jtk issues search --jql "project = KEY AND type = TYPENAME" --max 1 --id` to find an existing issue of that type, then `jtk issues field-options priority --issue <that-key>` to see the priorities valid for that type. The user picks a value; update the ticket's `priority` in the workfile; re-run stage 4a; re-enter Phase 1 to retry.
+- **Set this ticket's `priority` to `none`** and retry the create (skip the priority field entirely for this ticket).
+- **Abort execution** and revise the breakdown — user returns to stage 4 to restructure.
+
+Do not silently choose a replacement priority or pattern-match "something close." The per-type scheme mismatch is a real configuration detail the user needs to see and decide on, not something to paper over. This handling applies equally to the initial Phase 1 run and to any resume-from-failure retry.
+
+**How temp IDs resolve during execution:** this workflow's `SpecToTicketWorkflowTemp-N` convention is specific to the SpecToTickets → ManageIssueSet transition. During ManageIssueSet's Phase 1, each successful `jtk issues create` is followed by a file-wide find-and-replace in the workfile that swaps the ticket's `SpecToTicketWorkflowTemp-N` placeholder with the newly-issued real Jira key. Subsequent tickets that reference that temp ID (in `parent`, `links[].target`, or description prose) will see the real key by the time they're processed. The mechanic is owned by this workflow but executed by ManageIssueSet, so the same semantics are described in ManageIssueSet's "If arriving from SpecToTickets with a workfile" preamble.
+
+**Find-and-replace must use exact token matching, not substring matching.** A naive substring replacement of `SpecToTicketWorkflowTemp-1` would corrupt `SpecToTicketWorkflowTemp-10`, `SpecToTicketWorkflowTemp-11`, `SpecToTicketWorkflowTemp-100`, etc. Use a regex with word boundaries around the temp ID: `\bSpecToTicketWorkflowTemp-<N>\b` where `<N>` is the specific integer being replaced. The `\b` anchor treats digits as word characters, so `SpecToTicketWorkflowTemp-1` and `SpecToTicketWorkflowTemp-10` are distinct tokens and won't cross-contaminate.
+
+Tested regex that works for this pattern across common tools (all three produce identical, correct output on mixed workfiles — they correctly replace the target while leaving other temp IDs that share its prefix untouched):
+
+- **GNU sed:** `sed -i -E 's/\bSpecToTicketWorkflowTemp-1\b/ANP-500/g' workfile.md`
+- **perl:** `perl -pi -e 's/\bSpecToTicketWorkflowTemp-1\b/ANP-500/g' workfile.md`
+- **Python:** `re.sub(r'\bSpecToTicketWorkflowTemp-1\b', 'ANP-500', content)`
+
+Replacement order does not matter: replacing `-3` first then `-30`, or `-30` first then `-3`, both produce the same correct result because the word boundary prevents any cross-matching.
+
+If using a tool that doesn't support `\b` (e.g., BSD sed without `-E`, basic string-replace functions), either switch to a tool that does, or manually ensure the pattern is **both preceded AND followed by** a non-word character (whitespace, punctuation, end-of-line, or end-of-file) — word boundaries are symmetric, so both sides must be non-word for the match to be safe. Apply this everywhere in the workfile where temp IDs appear: metadata field values, description body prose, `short_description`, `source`, the batch-level `ambiguities` field, and the `## Ticket: <jira_key>` section headings.
+
+**Skip these ManageIssueSet sections** — they have already been accomplished here:
+
+- Pattern classification
+- Project discovery (types, priorities)
+- Per-ticket type / priority / field confirmation
+- Link-direction confirmation
+- Plan presentation
+
+Pick up at ManageIssueSet's **Execute** section and follow its ordering rules (parents → children → links → sprint) and failure-handling semantics from there. Do not re-implement execution logic in this workflow.
+
+### Post-ManageIssueSet steps
+
+After ManageIssueSet's Execute completes all applicable phases and presents its post-action summary to the user, control returns to this workflow. SpecToTickets then owns:
+
+1. **Ask about workfile persistence.** The workfile has served its purpose as the execution payload but is also a useful audit artifact. Ask the user: "Keep the workfile at `<path>` for audit/reference, or remove it?" Default to keeping if the user is non-committal.
+2. **Handle the user's answer.** Remove the workfile only on explicit user confirmation. Otherwise leave it in place.
+
+**Failure-recovery variants** (when Execute didn't complete cleanly):
+
+- **Abort / leave as-is** — Execute halted at a failure and the user chose to leave partially-completed work. Return here, but skip the workfile cleanup question entirely. The user may want to inspect or retry; let them decide when they've figured out next steps.
+- **Resume from failure point** — ManageIssueSet handles the retry itself; control only returns here if the retry eventually succeeds (run the workfile-persistence prompt then) or the user aborts (skip the prompt).
+- **Delete newly-created** — ManageIssueSet handles the destructive cleanup of created tickets and links; the workfile is NOT deleted by that recovery. Return here with the workfile intact (real keys mixed with temp IDs for uncreated tickets). Do not prompt for workfile cleanup automatically in this state — the user is in mid-recovery and will decide when to clean up.
+
+In all failure-recovery variants, the workfile persists and remains an accurate record of what was attempted, what succeeded (rows with real Jira keys in `jira_key`), and what never got created (rows still holding `SpecToTicketWorkflowTemp-N` values).
+
+## Anti-patterns (avoid these)
+
+- **Creating tickets from the spec without presenting the breakdown first** — this is not ManageIssueSet, it's SpecToTickets, and the breakdown proposal is the whole point of the workflow
+- **Mechanically mapping spec section structure to ticket hierarchy** without considering whether a section should become sub-tasks, siblings with links, or a single larger ticket. Use judgment; surface the choice to the user in the proposal
+- **Guessing issue types without running `jtk issues types` first**
+- **Inferring assignees from vague language** like "someone should do X" or "the team needs to" — leave unassigned unless the spec explicitly names a specific person
+- **Padding the proposal with speculative sub-tasks** to look thorough. Err on fewer, larger tickets; let the user split further if they want
+- **Applying uniform type/priority/assignee across the whole breakdown** without confirming per-ticket
+- **Skipping the confirmation step to save time** — the confirmation is the value this workflow provides
+- **Silently falling back to guessing** when the user's feedback on the breakdown is ambiguous — ask for clarification
+- **Composing thin descriptions that just say "do the work described in §X"** without pulling the §X content into the ticket. Tickets must be self-contained
+- **Presenting the compact proposal as if it's the full ticket content** — the proposal is a review artifact; the actual ticket descriptions should be substantial and live inside the `<!-- SPECTOTICKETS_DESCRIPTION_START -->` / `<!-- SPECTOTICKETS_DESCRIPTION_END -->` markers in the workfile
+- **Holding proposed changes in conversation context** rather than persisting them to the workfile immediately. The workfile is the source of truth
+- **Skipping the validation step in stage 4a** — validation catches real problems that would otherwise surface mid-execution in ManageIssueSet
+- **Broken description markers.** The `<!-- SPECTOTICKETS_DESCRIPTION_START -->` and `<!-- SPECTOTICKETS_DESCRIPTION_END -->` markers must always come in matched pairs — every start gets exactly one end, every end belongs to exactly one start, in the order they appear. Never nest them (no start-start-end-end, no overlap). Never omit the closing marker. Never misspell either marker. Parsers depend on the markers being well-formed; a broken pair corrupts every ticket section after it until the next correctly-paired section recovers. The validation pass at stage 4a catches unpaired markers, but getting them right the first time avoids needing to re-validate.

--- a/skills/Jira/Workflows/SprintBoard.md
+++ b/skills/Jira/Workflows/SprintBoard.md
@@ -1,0 +1,82 @@
+# SprintBoard Workflow
+
+Manage sprints and boards — view active sprint, list sprint issues, add issues to sprints.
+
+**Note:** Sprint and board operations require classic API token auth (not bearer/scoped tokens). If operations fail with auth errors, inform user of this Atlassian limitation.
+
+## Intent-to-Flag Mapping
+
+### Action Selection
+
+| User Says | Command | Required |
+|-----------|---------|----------|
+| "list boards", "show boards" | `jtk boards list` (optionally `--project KEY` to scope) | Nothing |
+| "board details" | `jtk boards get ID` | Board ID |
+| "current sprint", "active sprint" | `jtk sprints current --board ID` | Board ID |
+| "list sprints" | `jtk sprints list --board ID` | Board ID |
+| "sprint issues", "what's in the sprint" | `jtk sprints issues SPRINT_ID` | Sprint ID |
+| "what's in our current sprint" (shortcut) | `jtk issues list --project KEY --sprint current` | Project key |
+| "add to sprint" | `jtk sprints add SPRINT_ID PROJ-1 PROJ-2 ...` | Sprint ID + issue keys |
+
+## Execute
+
+### List Boards
+
+```bash
+# All boards (can be long on large instances)
+jtk boards list
+
+# Scope to a project — recommended when you already know the project
+jtk boards list --project KEY
+```
+
+### Get Active Sprint
+
+```bash
+# Get board ID from customization or ask user
+jtk sprints current --board BOARD_ID
+```
+
+### List Sprint Issues
+
+Two paths — pick based on what's known:
+
+**Path A: Board-based (when you have a board ID)**
+```bash
+# Get current sprint first
+jtk sprints current --board BOARD_ID
+
+# Then list issues in that sprint
+jtk sprints issues SPRINT_ID
+```
+
+**Path B: Project shortcut (when you only have a project key)**
+```bash
+jtk issues list --project KEY --sprint current
+```
+
+Path B is faster when you already know the project key and don't need the sprint metadata (name, start/end dates).
+
+### Add Issues to Sprint
+
+Issues are **positional arguments**, not a flag:
+
+```bash
+# Single issue
+jtk sprints add SPRINT_ID PROJ-123
+
+# Multiple issues
+jtk sprints add SPRINT_ID PROJ-123 PROJ-456 PROJ-789
+```
+
+## Output Format
+
+- **Boards:** table with ID, Name, Type (Scrum/Kanban)
+- **Sprint info:** Name, State (active/future/closed), Start/End dates
+- **Sprint issues:** table with Key, Summary, Status, Assignee — grouped by status if possible
+
+## Post-Action
+
+After any action:
+1. For sprint listings: state total issue count and breakdown by status
+2. For add-to-sprint: confirm which issues were added and to which sprint by name


### PR DESCRIPTION
## Summary

Adds two skills that teach LLM agents how to use the CLIs in this repo through documented workflows:

- **`skills/Confluence/`** — Confluence page, space, and attachment management via `cfl`
- **`skills/Jira/`** — Jira issue, sprint, link, comment, and attachment management via `jtk`

Both skills share the same structure and patterns: a top-level `SKILL.md` for routing and shared context, a `CliReference.md` with full command coverage, and a `Workflows/` directory where each workflow has intent-to-flag 
mapping and execute blocks.

## Structure

### Confluence (`skills/Confluence/`)

- **`SKILL.md`** — routing, prerequisites (including personal-space `~` quoting), env-var auth (`CFL_*` → `ATLASSIAN_*` → config precedence), defaults & missing inputs (`--space` → `CFL_DEFAULT_SPACE` → `default_space`),
output representation and format model, URL-to-page-ID extraction, common errors.
- **`CliReference.md`** — flag reference for `search`, `page`, `space`, `attachment`, with cross-links back to SKILL.md concepts.
- **`Workflows/`** — `SearchPages`, `ViewPage`, `ManagePage`, `ManageSpaces`, `ManageAttachments`.

### Jira (`skills/Jira/`)

- **`SKILL.md`** — routing, prerequisites, env-var auth (`JIRA_*` → `ATLASSIAN_*` → config), defaults & missing inputs (`--project` → `JIRA_DEFAULT_PROJECT` → `default_project`), cache warming (`jtk refresh`), output
contract (`--extended` / `--fulltext` / `--id`), pagination semantics (notices on stdout, scripting caveat), common errors.
- **`CliReference.md`** — full command reference covering issues (create/update/assign/transition/move/delete/types/fields/field-options), transitions, sprints, boards, comments, attachments, projects, users. Explicit flag
tables for create/update/move, the Jira Cloud bulk-move behavior for `issues move` (synchronous by default, `--no-wait` for async), and the transition-field anti-pattern (don't speculatively pass `--field
resolution=Done`).
- **`Workflows/`** — eight workflow files:
- `ManageIssue.md` — single-issue create/update/assign/transition. The `--assignee` resolver accepts `me` / email / display name / account ID, with a match-count fallback table (0 / 1-clear / 1-doubt / 2–9 / 10-cap) for 
resolver failures.
- `ManageIssueSet.md` — coordinated multi-issue operations with four patterns (Bulk Create / Hierarchy Create / Bulk Update / Mixed), plan-and-confirm step, three-phase Execute (tickets → links → sprint), and structured 
failure handling with three recovery options (abort / resume / delete newly-created).
- `SpecToTickets.md` — spec decomposition into a structured workfile (`SpecToTicketWorkflowTemp-N` placeholders, HTML-comment description markers, batch-level metadata) that hands off to ManageIssueSet's Execute phase.
Covers validation (19 checks), partial-execution resume, crashed-mid-create detection, and `\b`-anchored find-and-replace.
- `SearchIssues.md`, `SprintBoard.md`, `ManageComments.md`, `ManageAttachments.md`, `QuickStatus.md` — focused workflows.

## Shared patterns (both skills)

- **No host-specific customization scaffolding** — skills rely on the CLIs' own defaulting mechanisms (env vars, config files, flags) rather than external preference files. If a required input is missing, the skill asks
the user and suggests how to persist the default via env var or config.
- **Output contract documented against the CLI's actual behavior** — representation and format are orthogonal, output streams (stdout vs stderr) are stated, pagination-on-stdout caveats captured where `--id` scripting
intersects paginated listings.
- **Common errors mapped to specific remedies** — auth failures, permission denials, missing required flags, platform-limitation surfaces (bearer auth → no Agile).
- **Generic placeholders throughout** — `PROJ-123`, `KEY`, `INSTANCE.atlassian.net`, etc., matching the example style used in the repo's own Go source.

### Known upstream issue surfaced during Jira validation

The global `--id` flag is silently ignored by `jtk issues create`, `jtk links create`, and `jtk attachments add` even though it's honored by read commands and the Output Artifact Contract positions `--id` as the
agent-friendly identifier-only mode. The Jira skill documents the current behavior (agents must parse decorated output with `grep -oE '[A-Z]+-[0-9]+' | head -1` on writes). A separate issue will be filed for the upstream
fix — not blocking this PR.

## Scope

Both skills cover each CLI's daily-use operator surface. For Jira, administrative surfaces (`jtk fields` for custom field management, `jtk dashboards`, `jtk automation`) are documented as out-of-scope — discoverable via 
`jtk <subcommand> --help` and the upstream README. `cfl`'s full surface is covered because it doesn't split admin from daily-use surfaces the same way.

## Files

skills/Confluence/SKILL.md
skills/Confluence/CliReference.md
skills/Confluence/Workflows/SearchPages.md
skills/Confluence/Workflows/ViewPage.md
skills/Confluence/Workflows/ManagePage.md
skills/Confluence/Workflows/ManageSpaces.md
skills/Confluence/Workflows/ManageAttachments.md

skills/Jira/SKILL.md
skills/Jira/CliReference.md
skills/Jira/Workflows/ManageIssue.md
skills/Jira/Workflows/ManageIssueSet.md
skills/Jira/Workflows/SpecToTickets.md
skills/Jira/Workflows/SearchIssues.md
skills/Jira/Workflows/SprintBoard.md
skills/Jira/Workflows/ManageComments.md
skills/Jira/Workflows/ManageAttachments.md
skills/Jira/Workflows/QuickStatus.md