### PR TITLE
feat(jtk): migrate boards and sprints reads to new output model

### DIFF
--- a/tools/jtk/api/boards.go
+++ b/tools/jtk/api/boards.go
@@ -35,6 +35,22 @@ func (c *Client) ListBoards(ctx context.Context, projectKeyOrID string, startAt,
 	return &result, nil
 }
 
+// GetBoardConfiguration retrieves the configuration (filter, columns) for a board.
+func (c *Client) GetBoardConfiguration(ctx context.Context, boardID int) (*BoardConfiguration, error) {
+	urlStr := fmt.Sprintf("%s/board/%d/configuration", c.AgileURL, boardID)
+	body, err := c.Get(ctx, urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("getting board %d configuration: %w", boardID, err)
+	}
+
+	var config BoardConfiguration
+	if err := json.Unmarshal(body, &config); err != nil {
+		return nil, fmt.Errorf("parsing board configuration: %w", err)
+	}
+
+	return &config, nil
+}
+
 // GetBoard retrieves a board by ID
 func (c *Client) GetBoard(ctx context.Context, boardID int) (*Board, error) {
 	urlStr := fmt.Sprintf("%s/board/%d", c.AgileURL, boardID)

--- a/tools/jtk/api/types.go
+++ b/tools/jtk/api/types.go
@@ -292,6 +292,31 @@ type BoardLocation struct {
 	ProjectName string `json:"projectName"`
 }
 
+// BoardConfiguration represents the configuration of an agile board,
+// including its filter and column layout.
+type BoardConfiguration struct {
+	ID           int               `json:"id"`
+	Name         string            `json:"name"`
+	Filter       BoardFilter       `json:"filter"`
+	ColumnConfig BoardColumnConfig `json:"columnConfig"`
+}
+
+// BoardFilter identifies the JQL filter backing a board.
+type BoardFilter struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// BoardColumnConfig holds the column layout for a board.
+type BoardColumnConfig struct {
+	Columns []BoardColumn `json:"columns"`
+}
+
+// BoardColumn represents a single column in a board's layout.
+type BoardColumn struct {
+	Name string `json:"name"`
+}
+
 // Transition represents a workflow transition
 type Transition struct {
 	ID     string                     `json:"id"`

--- a/tools/jtk/internal/cmd/boards/boards.go
+++ b/tools/jtk/internal/cmd/boards/boards.go
@@ -229,8 +229,13 @@ func runGet(ctx context.Context, opts *root.Options, client *api.Client, resolve
 	}
 
 	var config *api.BoardConfiguration
-	if opts.IsExtended() {
-		config, _ = client.GetBoardConfiguration(ctx, board.ID)
+	needsConfig := opts.IsExtended() || projection.HasExtendedFields(selected, jtkpresent.BoardDetailSpec)
+	if needsConfig {
+		var configErr error
+		config, configErr = client.GetBoardConfiguration(ctx, board.ID)
+		if configErr != nil {
+			_, _ = fmt.Fprintf(opts.Stderr, "warning: could not fetch board configuration: %v\n", configErr)
+		}
 	}
 
 	if v.Format == view.FormatJSON {

--- a/tools/jtk/internal/cmd/boards/boards.go
+++ b/tools/jtk/internal/cmd/boards/boards.go
@@ -85,12 +85,6 @@ func newListCmd(opts *root.Options) *cobra.Command {
 
 func runList(ctx context.Context, opts *root.Options, project string, maxResults int, nextPageToken, fieldsFlag string) error {
 	v := opts.View()
-
-	client, err := opts.APIClient()
-	if err != nil {
-		return err
-	}
-
 	idOnly := opts.EmitIDOnly()
 
 	startAt, err := jtkpresent.ParseStartAtToken(nextPageToken)
@@ -100,6 +94,11 @@ func runList(ctx context.Context, opts *root.Options, project string, maxResults
 
 	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
 		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
 	}
 
 	var selected []projection.ColumnSpec

--- a/tools/jtk/internal/cmd/boards/boards.go
+++ b/tools/jtk/internal/cmd/boards/boards.go
@@ -4,19 +4,22 @@ package boards
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 )
+
+func noFieldFetch(_ context.Context) ([]api.Field, error) { return nil, nil }
 
 // Register registers the boards commands
 func Register(parent *cobra.Command, opts *root.Options) {
@@ -48,6 +51,8 @@ func Register(parent *cobra.Command, opts *root.Options) {
 func newListCmd(opts *root.Options) *cobra.Command {
 	var project string
 	var maxResults int
+	var nextPageToken string
+	var fieldsFlag string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -58,99 +63,187 @@ func newListCmd(opts *root.Options) *cobra.Command {
 
   # List boards for a project (accepts key or name)
   jtk boards list --project MYPROJECT
-  jtk boards list --project "Platform Development"`,
+  jtk boards list --project "Platform Development"
+
+  # Extended output with project names
+  jtk boards list --extended
+
+  # Emit only board IDs
+  jtk boards list --id`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runList(cmd.Context(), opts, project, maxResults)
+			return runList(cmd.Context(), opts, project, maxResults, nextPageToken, fieldsFlag)
 		},
 	}
 
 	cmd.Flags().StringVarP(&project, "project", "p", "", "Filter by project key or name")
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of results")
+	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Decimal startAt for the next page")
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns")
 
 	return cmd
 }
 
-func runList(ctx context.Context, opts *root.Options, project string, maxResults int) error {
+func runList(ctx context.Context, opts *root.Options, project string, maxResults int, nextPageToken, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
+	}
+
+	idOnly := opts.EmitIDOnly()
+
+	startAt, err := jtkpresent.ParseStartAtToken(nextPageToken)
+	if err != nil {
+		return err
+	}
+
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
+		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.BoardListSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			noFieldFetch,
+			"boards list",
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	projectFilter := project
 	if project != "" {
-		resolvedProject, err := resolve.New(client).Project(ctx, project)
-		if err != nil {
-			return err
+		resolvedProject, resolveErr := resolve.New(client).Project(ctx, project)
+		if resolveErr != nil {
+			return resolveErr
 		}
 		projectFilter = resolvedProject.Key
 	}
 
-	result, err := client.ListBoards(ctx, projectFilter, 0, maxResults)
+	result, err := client.ListBoards(ctx, projectFilter, startAt, maxResults)
 	if err != nil {
 		return err
 	}
 
+	hasMore := !result.IsLast
+	if hasMore && len(result.Values) == 0 {
+		return fmt.Errorf("unexpected paginated response: IsLast=false with empty values (startAt=%d)", startAt)
+	}
+	nextToken := ""
+	if hasMore {
+		nextToken = strconv.Itoa(startAt + len(result.Values))
+	}
+
+	if idOnly {
+		ids := make([]string, len(result.Values))
+		for i, b := range result.Values {
+			ids[i] = strconv.Itoa(b.ID)
+		}
+		return jtkpresent.EmitIDsWithPaginationToken(opts, ids, hasMore, nextToken)
+	}
+
 	if len(result.Values) == 0 {
-		model := jtkpresent.BoardPresenter{}.PresentEmpty()
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.BoardPresenter{}.PresentEmpty())
 	}
 
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectBoards(result.Values, opts.ArtifactMode())
-		hasMore := !result.IsLast
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.BoardPresenter{}.PresentList(result.Values)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	presenter := jtkpresent.BoardPresenter{}
+	model := presenter.PresentList(result.Values, opts.IsExtended())
+	if projected {
+		projection.ApplyToTableInModel(model, selected)
+	}
+	model.Sections = jtkpresent.AppendPaginationHintWithToken(model.Sections, hasMore, nextToken)
+	return jtkpresent.Emit(opts, model)
 }
 
 func newGetCmd(opts *root.Options) *cobra.Command {
-	return &cobra.Command{
-		Use:     "get <board-id>",
-		Short:   "Get board details",
-		Long:    "Get details for a specific board.",
-		Example: `  jtk boards get 123`,
-		Args:    cobra.ExactArgs(1),
+	var fieldsFlag string
+
+	cmd := &cobra.Command{
+		Use:   "get <board>",
+		Short: "Get board details",
+		Long:  "Get details for a specific board. Accepts a board ID or name (resolved via cache).",
+		Example: `  jtk boards get 123
+  jtk boards get "MON board"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var boardID int
-			if _, err := fmt.Sscanf(args[0], "%d", &boardID); err != nil {
-				return fmt.Errorf("invalid board ID: %s", args[0])
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
 			}
-			return runGet(cmd.Context(), opts, boardID)
+			resolvedBoard, err := resolve.New(client).Board(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return runGet(cmd.Context(), opts, client, &resolvedBoard, fieldsFlag)
 		},
 	}
+
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display fields")
+
+	return cmd
 }
 
-func runGet(ctx context.Context, opts *root.Options, boardID int) error {
+func runGet(ctx context.Context, opts *root.Options, client *api.Client, resolvedBoard *api.Board, fieldsFlag string) error {
 	v := opts.View()
 
-	client, err := opts.APIClient()
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{strconv.Itoa(resolvedBoard.ID)})
+	}
+
+	if fieldsFlag != "" && v.Format == view.FormatJSON {
+		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	selected, projected, err := projection.Resolve(
+		ctx,
+		jtkpresent.BoardDetailSpec,
+		opts.IsExtended(),
+		fieldsFlag,
+		noFieldFetch,
+		"boards get",
+	)
 	if err != nil {
 		return err
 	}
 
-	board, err := client.GetBoard(ctx, boardID)
+	board, err := client.GetBoard(ctx, resolvedBoard.ID)
 	if err != nil {
 		return err
+	}
+
+	// Preserve the resolved name if the API response lacks it
+	if board.Name == "" && resolvedBoard.Name != "" {
+		board.Name = resolvedBoard.Name
+	}
+
+	var config *api.BoardConfiguration
+	if opts.IsExtended() {
+		config, _ = client.GetBoardConfiguration(ctx, board.ID)
 	}
 
 	if v.Format == view.FormatJSON {
 		return v.RenderArtifact(jtkartifact.ProjectBoard(board, opts.ArtifactMode()))
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.BoardPresenter{}.PresentDetail(board)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	presenter := jtkpresent.BoardPresenter{}
+	if projected {
+		model := presenter.PresentDetailProjection(board, config)
+		projection.ApplyToDetailInModel(model, selected)
+		return jtkpresent.Emit(opts, model)
+	}
+
+	model := presenter.PresentDetail(board, config, opts.IsExtended())
+	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/boards/boards_test.go
+++ b/tools/jtk/internal/cmd/boards/boards_test.go
@@ -395,8 +395,8 @@ func TestRunGet_Extended(t *testing.T) {
 		requestPaths = append(requestPaths, r.URL.Path)
 		if strings.Contains(r.URL.Path, "/configuration") {
 			_ = json.NewEncoder(w).Encode(api.BoardConfiguration{
-				ID:   42,
-				Name: "Sprint Board",
+				ID:     42,
+				Name:   "Sprint Board",
 				Filter: api.BoardFilter{ID: "100", Name: "my filter"},
 				ColumnConfig: api.BoardColumnConfig{
 					Columns: []api.BoardColumn{{Name: "Backlog"}, {Name: "Done"}},

--- a/tools/jtk/internal/cmd/boards/boards_test.go
+++ b/tools/jtk/internal/cmd/boards/boards_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -300,11 +301,21 @@ func TestRunGet_Table(t *testing.T) {
 
 func TestRunGet_IDOnly(t *testing.T) {
 	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("API should not be called in --id mode")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
 	var stdout bytes.Buffer
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
 
 	resolvedBoard := &api.Board{ID: 42, Name: "Sprint Board"}
-	err := runGet(context.Background(), opts, nil, resolvedBoard, "")
+	err = runGet(context.Background(), opts, client, resolvedBoard, "")
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "42\n")
 }
@@ -390,9 +401,12 @@ func TestRunList_Pagination(t *testing.T) {
 
 func TestRunGet_Extended(t *testing.T) {
 	t.Parallel()
+	var mu sync.Mutex
 	requestPaths := make([]string, 0, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		requestPaths = append(requestPaths, r.URL.Path)
+		mu.Unlock()
 		if strings.Contains(r.URL.Path, "/configuration") {
 			_ = json.NewEncoder(w).Encode(api.BoardConfiguration{
 				ID:     42,
@@ -426,8 +440,11 @@ func TestRunGet_Extended(t *testing.T) {
 	testutil.Contains(t, output, "Filter: my filter (id: 100)")
 	testutil.Contains(t, output, "Column config: Backlog, Done")
 	// Verify both board and configuration endpoints were hit
-	if len(requestPaths) < 2 {
-		t.Errorf("expected 2 API calls (board + config), got %d", len(requestPaths))
+	mu.Lock()
+	pathCount := len(requestPaths)
+	mu.Unlock()
+	if pathCount < 2 {
+		t.Errorf("expected 2 API calls (board + config), got %d", pathCount)
 	}
 }
 
@@ -509,7 +526,7 @@ func TestRunGet_ResolvesBoardByName(t *testing.T) {
 	testutil.Equal(t, capturedPath, "/rest/agile/1.0/board/42")
 }
 
-func TestRunGet_InvalidID(t *testing.T) {
+func TestRunGet_MissingArg(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/tools/jtk/internal/cmd/boards/boards_test.go
+++ b/tools/jtk/internal/cmd/boards/boards_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -336,6 +337,143 @@ func TestRunGet_JSON(t *testing.T) {
 	output := stdout.String()
 	testutil.Contains(t, output, `"name"`)
 	testutil.Contains(t, output, "Sprint Board")
+}
+
+func TestRunList_FieldsWithJSONError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.BoardsResponse{IsLast: true, Values: []api.Board{{ID: 1}}})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	opts := &root.Options{Output: "json", Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50, "", "ID,NAME")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--fields is not supported")
+}
+
+func TestRunList_InvalidNextPageToken(t *testing.T) {
+	t.Parallel()
+	opts := &root.Options{Output: "table", Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+
+	err := runList(context.Background(), opts, "", 50, "abc", "")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--next-page-token")
+}
+
+func TestRunList_Pagination(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.BoardsResponse{
+			Values: []api.Board{{ID: 1, Name: "Board A", Type: "scrum"}},
+			IsLast: false,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 1, "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "More results available (next: 1)")
+}
+
+func TestRunGet_Extended(t *testing.T) {
+	t.Parallel()
+	requestPaths := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPaths = append(requestPaths, r.URL.Path)
+		if strings.Contains(r.URL.Path, "/configuration") {
+			_ = json.NewEncoder(w).Encode(api.BoardConfiguration{
+				ID:   42,
+				Name: "Sprint Board",
+				Filter: api.BoardFilter{ID: "100", Name: "my filter"},
+				ColumnConfig: api.BoardColumnConfig{
+					Columns: []api.BoardColumn{{Name: "Backlog"}, {Name: "Done"}},
+				},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode(api.Board{
+				ID: 42, Name: "Sprint Board", Type: "scrum",
+				Location: api.BoardLocation{ProjectKey: "PROJ", ProjectName: "My Project"},
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	resolvedBoard := &api.Board{ID: 42, Name: "Sprint Board"}
+	err = runGet(context.Background(), opts, client, resolvedBoard, "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Filter: my filter (id: 100)")
+	testutil.Contains(t, output, "Column config: Backlog, Done")
+	// Verify both board and configuration endpoints were hit
+	if len(requestPaths) < 2 {
+		t.Errorf("expected 2 API calls (board + config), got %d", len(requestPaths))
+	}
+}
+
+func TestRunGet_NameFallback(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// API returns board without name
+		_ = json.NewEncoder(w).Encode(api.Board{
+			ID: 42, Type: "scrum",
+			Location: api.BoardLocation{ProjectKey: "PROJ"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	// Resolved board has name from cache, but API response lacks it
+	resolvedBoard := &api.Board{ID: 42, Name: "Cached Name"}
+	err = runGet(context.Background(), opts, client, resolvedBoard, "")
+	testutil.RequireNoError(t, err)
+
+	testutil.Contains(t, stdout.String(), "Cached Name")
+}
+
+func TestRunGet_FieldsWithJSONError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.Board{ID: 42, Name: "B", Type: "scrum"})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	opts := &root.Options{Output: "json", Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	resolvedBoard := &api.Board{ID: 42}
+	err = runGet(context.Background(), opts, client, resolvedBoard, "ID,NAME")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--fields is not supported")
 }
 
 func TestRunGet_ResolvesBoardByName(t *testing.T) {

--- a/tools/jtk/internal/cmd/boards/boards_test.go
+++ b/tools/jtk/internal/cmd/boards/boards_test.go
@@ -30,6 +30,12 @@ func TestNewListCmd(t *testing.T) {
 	maxFlag := cmd.Flags().Lookup("max")
 	testutil.NotNil(t, maxFlag)
 	testutil.Equal(t, maxFlag.DefValue, "50")
+
+	nextPageTokenFlag := cmd.Flags().Lookup("next-page-token")
+	testutil.NotNil(t, nextPageTokenFlag)
+
+	fieldsFlag := cmd.Flags().Lookup("fields")
+	testutil.NotNil(t, fieldsFlag)
 }
 
 func TestRunList_Table(t *testing.T) {
@@ -69,7 +75,7 @@ func TestRunList_Table(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "", 50)
+	err = runList(context.Background(), opts, "", 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -79,6 +85,70 @@ func TestRunList_Table(t *testing.T) {
 	testutil.Contains(t, output, "BETA")
 	testutil.Contains(t, output, "scrum")
 	testutil.Contains(t, output, "kanban")
+}
+
+func TestRunList_Extended(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.BoardsResponse{
+			Values: []api.Board{
+				{
+					ID:   23,
+					Name: "MON board",
+					Type: "scrum",
+					Location: api.BoardLocation{
+						ProjectKey:  "MON",
+						ProjectName: "Platform Development",
+					},
+				},
+			},
+			Total:  1,
+			IsLast: true,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "PROJECT_NAME")
+	testutil.Contains(t, output, "Platform Development")
+}
+
+func TestRunList_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.BoardsResponse{
+			Values: []api.Board{
+				{ID: 1, Name: "Board A"},
+				{ID: 2, Name: "Board B"},
+			},
+			Total:  2,
+			IsLast: true,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Equal(t, output, "1\n2\n")
 }
 
 func TestRunList_JSON(t *testing.T) {
@@ -108,7 +178,7 @@ func TestRunList_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "", 50)
+	err = runList(context.Background(), opts, "", 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -134,7 +204,7 @@ func TestRunList_Empty(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &stderr}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "", 50)
+	err = runList(context.Background(), opts, "", 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	combined := stdout.String() + stderr.String()
@@ -143,13 +213,7 @@ func TestRunList_Empty(t *testing.T) {
 
 func TestRunList_ResolvesProjectByName(t *testing.T) {
 	// NOT t.Parallel(): SetRootForTest / SetInstanceKeyForTest mutate package
-	// globals in the cache package. Running in parallel with the other
-	// TestRunList_* tests in this file that also touch the cache root would
-	// allow one test's cache isolation to bleed into another.
-	//
-	// --project "Platform" must resolve to its cached key before hitting
-	// the boards endpoint; the URL query string should carry the key, not
-	// the display name.
+	// globals in the cache package.
 	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 	testutil.RequireNoError(t, cache.WriteResource("projects", "24h", []api.Project{
@@ -172,15 +236,13 @@ func TestRunList_ResolvesProjectByName(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "Platform", 50)
+	err = runList(context.Background(), opts, "Platform", 50, "", "")
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, capturedProject, "PLAT")
 }
 
 func TestRunList_ProjectKeyShapePassesThrough(t *testing.T) {
 	// NOT t.Parallel(): see the comment on TestRunList_ResolvesProjectByName.
-	// Project-key-shape input that isn't cached should still reach the API
-	// (cold-start / out-of-cache-horizon projects).
 	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 
@@ -197,7 +259,7 @@ func TestRunList_ProjectKeyShapePassesThrough(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "UNCACHED", 50)
+	err = runList(context.Background(), opts, "UNCACHED", 50, "", "")
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, capturedProject, "UNCACHED")
 }
@@ -210,7 +272,8 @@ func TestRunGet_Table(t *testing.T) {
 			Name: "Sprint Board",
 			Type: "scrum",
 			Location: api.BoardLocation{
-				ProjectKey: "PROJ",
+				ProjectKey:  "PROJ",
+				ProjectName: "My Project",
 			},
 		})
 	}))
@@ -223,7 +286,8 @@ func TestRunGet_Table(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, 42)
+	resolvedBoard := &api.Board{ID: 42, Name: "Sprint Board"}
+	err = runGet(context.Background(), opts, client, resolvedBoard, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -231,6 +295,17 @@ func TestRunGet_Table(t *testing.T) {
 	testutil.Contains(t, output, "Sprint Board")
 	testutil.Contains(t, output, "scrum")
 	testutil.Contains(t, output, "PROJ")
+}
+
+func TestRunGet_IDOnly(t *testing.T) {
+	t.Parallel()
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+
+	resolvedBoard := &api.Board{ID: 42, Name: "Sprint Board"}
+	err := runGet(context.Background(), opts, nil, resolvedBoard, "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "42\n")
 }
 
 func TestRunGet_JSON(t *testing.T) {
@@ -254,12 +329,46 @@ func TestRunGet_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, 42)
+	resolvedBoard := &api.Board{ID: 42, Name: "Sprint Board"}
+	err = runGet(context.Background(), opts, client, resolvedBoard, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
 	testutil.Contains(t, output, `"name"`)
 	testutil.Contains(t, output, "Sprint Board")
+}
+
+func TestRunGet_ResolvesBoardByName(t *testing.T) {
+	// NOT t.Parallel(): cache globals
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
+	testutil.RequireNoError(t, cache.WriteResource("boards", "24h", []api.Board{
+		{ID: 42, Name: "MON board", Type: "scrum"},
+	}))
+
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(api.Board{
+			ID: 42, Name: "MON board", Type: "scrum",
+			Location: api.BoardLocation{ProjectKey: "MON", ProjectName: "Platform Development"},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	rootCmd, opts := root.NewCmd()
+	opts.SetAPIClient(client)
+	opts.Stdout = &bytes.Buffer{}
+	opts.Stderr = &bytes.Buffer{}
+	Register(rootCmd, opts)
+
+	rootCmd.SetArgs([]string{"boards", "get", "MON board"})
+	err = rootCmd.Execute()
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, capturedPath, "/rest/agile/1.0/board/42")
 }
 
 func TestRunGet_InvalidID(t *testing.T) {
@@ -276,8 +385,7 @@ func TestRunGet_InvalidID(t *testing.T) {
 	opts.SetAPIClient(client)
 	Register(rootCmd, opts)
 
-	rootCmd.SetArgs([]string{"boards", "get", "abc"})
+	rootCmd.SetArgs([]string{"boards", "get"})
 	err = rootCmd.Execute()
 	testutil.NotNil(t, err)
-	testutil.Contains(t, err.Error(), "invalid board ID")
 }

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -218,6 +218,27 @@ func newCurrentCmd(opts *root.Options) *cobra.Command {
 func runCurrent(ctx context.Context, opts *root.Options, client *api.Client, board *api.Board, fieldsFlag string) error {
 	v := opts.View()
 
+	if !opts.EmitIDOnly() && fieldsFlag != "" && v.Format == view.FormatJSON {
+		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !opts.EmitIDOnly() {
+		var err error
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.SprintDetailSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			noFieldFetch,
+			"sprints current",
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	sprint, err := client.GetCurrentSprint(ctx, board.ID)
 	if err != nil {
 		return err
@@ -225,22 +246,6 @@ func runCurrent(ctx context.Context, opts *root.Options, client *api.Client, boa
 
 	if opts.EmitIDOnly() {
 		return jtkpresent.EmitIDs(opts, []string{strconv.Itoa(sprint.ID)})
-	}
-
-	if fieldsFlag != "" && v.Format == view.FormatJSON {
-		return jtkpresent.ErrFieldsWithJSON
-	}
-
-	selected, projected, err := projection.Resolve(
-		ctx,
-		jtkpresent.SprintDetailSpec,
-		opts.IsExtended(),
-		fieldsFlag,
-		noFieldFetch,
-		"sprints current",
-	)
-	if err != nil {
-		return err
 	}
 
 	if v.Format == view.FormatJSON {

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -9,15 +9,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 )
+
+func noFieldFetch(_ context.Context) ([]api.Field, error) { return nil, nil }
 
 // validateBoardRef rejects inputs that would parse as numeric but produce a
 // synthetic Board{ID: n} with n <= 0, which the downstream Agile endpoints
@@ -66,6 +68,8 @@ func newListCmd(opts *root.Options) *cobra.Command {
 	var board string
 	var state string
 	var maxResults int
+	var nextPageToken string
+	var fieldsFlag string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -76,7 +80,13 @@ func newListCmd(opts *root.Options) *cobra.Command {
   jtk sprints list --board "MON board"
 
   # List only active sprints
-  jtk sprints list --board 123 --state active`,
+  jtk sprints list --board 123 --state active
+
+  # Extended output with completion dates, board, goal
+  jtk sprints list --board 123 --extended
+
+  # Emit only sprint IDs
+  jtk sprints list --board 123 --id`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := validateBoardRef(board); err != nil {
 				return err
@@ -89,55 +99,100 @@ func newListCmd(opts *root.Options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runList(cmd.Context(), opts, client, resolvedBoard.ID, state, maxResults)
+			return runList(cmd.Context(), opts, client, resolvedBoard.ID, state, maxResults, nextPageToken, fieldsFlag)
 		},
 	}
 
 	cmd.Flags().StringVarP(&board, "board", "b", "", "Board ID or name (required)")
 	cmd.Flags().StringVarP(&state, "state", "s", "", "Filter by state (active, closed, future)")
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of results")
+	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Decimal startAt for the next page")
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns")
 
 	return cmd
 }
 
-func runList(ctx context.Context, opts *root.Options, client *api.Client, boardID int, state string, maxResults int) error {
+func runList(ctx context.Context, opts *root.Options, client *api.Client, boardID int, state string, maxResults int, nextPageToken, fieldsFlag string) error {
 	v := opts.View()
 
-	result, err := client.ListSprints(ctx, boardID, state, 0, maxResults)
+	idOnly := opts.EmitIDOnly()
+
+	startAt, err := jtkpresent.ParseStartAtToken(nextPageToken)
 	if err != nil {
 		return err
 	}
 
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
+		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.SprintListSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			noFieldFetch,
+			"sprints list",
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	result, err := client.ListSprints(ctx, boardID, state, startAt, maxResults)
+	if err != nil {
+		return err
+	}
+
+	hasMore := !result.IsLast
+	if hasMore && len(result.Values) == 0 {
+		return fmt.Errorf("unexpected paginated response: IsLast=false with empty values (startAt=%d)", startAt)
+	}
+	nextToken := ""
+	if hasMore {
+		nextToken = strconv.Itoa(startAt + len(result.Values))
+	}
+
+	if idOnly {
+		ids := make([]string, len(result.Values))
+		for i, s := range result.Values {
+			ids[i] = strconv.Itoa(s.ID)
+		}
+		return jtkpresent.EmitIDsWithPaginationToken(opts, ids, hasMore, nextToken)
+	}
+
 	if len(result.Values) == 0 {
-		model := jtkpresent.SprintPresenter{}.PresentEmpty()
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.SprintPresenter{}.PresentEmpty())
 	}
 
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectSprints(result.Values, opts.ArtifactMode())
-		hasMore := !result.IsLast
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.SprintPresenter{}.PresentList(result.Values)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	presenter := jtkpresent.SprintPresenter{}
+	model := presenter.PresentList(result.Values, opts.IsExtended())
+	if projected {
+		projection.ApplyToTableInModel(model, selected)
+	}
+	model.Sections = jtkpresent.AppendPaginationHintWithToken(model.Sections, hasMore, nextToken)
+	return jtkpresent.Emit(opts, model)
 }
 
 func newCurrentCmd(opts *root.Options) *cobra.Command {
 	var board string
+	var fieldsFlag string
 
 	cmd := &cobra.Command{
 		Use:   "current",
 		Short: "Show current sprint",
 		Long:  "Show the current active sprint for a board. --board accepts a board ID or name.",
 		Example: `  jtk sprints current --board 123
-  jtk sprints current --board "MON board"`,
+  jtk sprints current --board "MON board"
+  jtk sprints current --board 123 --extended`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := validateBoardRef(board); err != nil {
 				return err
@@ -150,19 +205,40 @@ func newCurrentCmd(opts *root.Options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runCurrent(cmd.Context(), opts, client, resolvedBoard.ID)
+			return runCurrent(cmd.Context(), opts, client, &resolvedBoard, fieldsFlag)
 		},
 	}
 
 	cmd.Flags().StringVarP(&board, "board", "b", "", "Board ID or name (required)")
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display fields")
 
 	return cmd
 }
 
-func runCurrent(ctx context.Context, opts *root.Options, client *api.Client, boardID int) error {
+func runCurrent(ctx context.Context, opts *root.Options, client *api.Client, board *api.Board, fieldsFlag string) error {
 	v := opts.View()
 
-	sprint, err := client.GetCurrentSprint(ctx, boardID)
+	sprint, err := client.GetCurrentSprint(ctx, board.ID)
+	if err != nil {
+		return err
+	}
+
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{strconv.Itoa(sprint.ID)})
+	}
+
+	if fieldsFlag != "" && v.Format == view.FormatJSON {
+		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	selected, projected, err := projection.Resolve(
+		ctx,
+		jtkpresent.SprintDetailSpec,
+		opts.IsExtended(),
+		fieldsFlag,
+		noFieldFetch,
+		"sprints current",
+	)
 	if err != nil {
 		return err
 	}
@@ -171,38 +247,48 @@ func runCurrent(ctx context.Context, opts *root.Options, client *api.Client, boa
 		return v.RenderArtifact(jtkartifact.ProjectSprint(sprint, opts.ArtifactMode()))
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.SprintPresenter{}.PresentDetail(sprint)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	presenter := jtkpresent.SprintPresenter{}
+	if projected {
+		model := presenter.PresentDetailProjection(sprint, board)
+		projection.ApplyToDetailInModel(model, selected)
+		return jtkpresent.Emit(opts, model)
+	}
+
+	model := presenter.PresentDetail(sprint, board, opts.IsExtended())
+	return jtkpresent.Emit(opts, model)
 }
 
 func newIssuesCmd(opts *root.Options) *cobra.Command {
 	var maxResults int
+	var nextPageToken string
 
 	cmd := &cobra.Command{
-		Use:     "issues <sprint-id>",
-		Short:   "List issues in a sprint",
-		Long:    "List all issues in a specific sprint.",
-		Example: `  jtk sprints issues 456`,
-		Args:    cobra.ExactArgs(1),
+		Use:   "issues <sprint>",
+		Short: "List issues in a sprint",
+		Long:  "List all issues in a specific sprint. Accepts a sprint ID or name (resolved via cache).",
+		Example: `  jtk sprints issues 456
+  jtk sprints issues "MON Sprint 70"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var sprintID int
-			if _, err := fmt.Sscanf(args[0], "%d", &sprintID); err != nil {
-				return fmt.Errorf("invalid sprint ID: %s", args[0])
+			client, err := opts.APIClient()
+			if err != nil {
+				return err
 			}
-			return runIssues(cmd.Context(), opts, sprintID, maxResults)
+			resolvedSprint, err := resolve.New(client).Sprint(cmd.Context(), args[0], 0)
+			if err != nil {
+				return err
+			}
+			return runIssues(cmd.Context(), opts, resolvedSprint.ID, maxResults, nextPageToken)
 		},
 	}
 
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of results")
+	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Decimal startAt for the next page")
 
 	return cmd
 }
 
-func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults int) error {
+func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults int, nextPageToken string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -210,37 +296,47 @@ func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults
 		return err
 	}
 
-	result, err := client.GetSprintIssues(ctx, sprintID, 0, maxResults)
+	startAt, err := jtkpresent.ParseStartAtToken(nextPageToken)
 	if err != nil {
 		return err
 	}
 
+	result, err := client.GetSprintIssues(ctx, sprintID, startAt, maxResults)
+	if err != nil {
+		return err
+	}
+
+	var hasMore bool
+	if result.Total < 0 {
+		hasMore = len(result.Issues) == maxResults
+	} else {
+		hasMore = result.StartAt+len(result.Issues) < result.Total
+	}
+	nextToken := ""
+	if hasMore {
+		nextToken = strconv.Itoa(startAt + len(result.Issues))
+	}
+
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(result.Issues))
+		for i, issue := range result.Issues {
+			ids[i] = issue.Key
+		}
+		return jtkpresent.EmitIDsWithPaginationToken(opts, ids, hasMore, nextToken)
+	}
+
 	if len(result.Issues) == 0 {
-		model := jtkpresent.SprintPresenter{}.PresentNoIssues()
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.SprintPresenter{}.PresentNoIssues())
 	}
 
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectIssues(result.Issues, opts.ArtifactMode())
-		// Guard against Total < 0 (Jira returns -1 when count is unknown).
-		// When Total is unknown, assume more results if we got a full page.
-		var hasMore bool
-		if result.Total < 0 {
-			hasMore = len(result.Issues) == maxResults
-		} else {
-			hasMore = result.StartAt+len(result.Issues) < result.Total
-		}
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	// Text path: presenter → render → write
 	model := jtkpresent.IssuePresenter{}.PresentList(result.Issues)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	model.Sections = jtkpresent.AppendPaginationHintWithToken(model.Sections, hasMore, nextToken)
+	return jtkpresent.Emit(opts, model)
 }
 
 func newAddCmd(opts *root.Options) *cobra.Command {
@@ -279,8 +375,5 @@ func runAdd(ctx context.Context, opts *root.Options, client *api.Client, sprintI
 	}
 
 	model := jtkpresent.SprintPresenter{}.PresentMoved(issueKeys, sprintID)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -33,9 +33,7 @@ func seedBoardsAndSprints(t *testing.T, boards []api.Board, byBoard map[int][]ap
 
 // newAgileClient builds an api.Client pointed at the given server with a
 // URL that triggers SupportsAgile() so the boards/sprints PersistentPreRunE
-// guard passes. The default httptest URL works because SupportsAgile checks
-// for AgileURL being non-empty — AgileURL is populated whenever BaseURL is
-// a non-api.atlassian.com host.
+// guard passes.
 func newAgileClient(t *testing.T, server *httptest.Server) *api.Client {
 	t.Helper()
 	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
@@ -64,6 +62,12 @@ func TestNewListCmd(t *testing.T) {
 	maxFlag := cmd.Flags().Lookup("max")
 	testutil.NotNil(t, maxFlag)
 	testutil.Equal(t, maxFlag.DefValue, "50")
+
+	nextPageTokenFlag := cmd.Flags().Lookup("next-page-token")
+	testutil.NotNil(t, nextPageTokenFlag)
+
+	fieldsFlag := cmd.Flags().Lookup("fields")
+	testutil.NotNil(t, fieldsFlag)
 }
 
 func newTestSprintsServer(_ *testing.T, sprints []api.Sprint) *httptest.Server {
@@ -98,7 +102,7 @@ func TestRunList_Table(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, client, 123, "", 50)
+	err = runList(context.Background(), opts, client, 123, "", 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -110,6 +114,29 @@ func TestRunList_Table(t *testing.T) {
 	testutil.Contains(t, output, "11")
 	testutil.Contains(t, output, "Sprint 2")
 	testutil.Contains(t, output, "future")
+}
+
+func TestRunList_IDOnly(t *testing.T) {
+	t.Parallel()
+	sprints := []api.Sprint{
+		{ID: 10, Name: "Sprint 1", State: "active"},
+		{ID: 11, Name: "Sprint 2", State: "future"},
+	}
+
+	server := newTestSprintsServer(t, sprints)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 123, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+
+	testutil.Equal(t, stdout.String(), "10\n11\n")
 }
 
 func TestRunList_JSON(t *testing.T) {
@@ -128,7 +155,7 @@ func TestRunList_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, client, 123, "", 50)
+	err = runList(context.Background(), opts, client, 123, "", 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -148,7 +175,7 @@ func TestRunList_Empty(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, client, 123, "", 50)
+	err = runList(context.Background(), opts, client, 123, "", 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	testutil.Contains(t, stdout.String(), "No sprints found")
@@ -169,12 +196,11 @@ func TestRunList_NullDates(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, client, 123, "", 50)
+	err = runList(context.Background(), opts, client, 123, "", 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
 	testutil.Contains(t, output, "Sprint Future")
-	// Dates should be empty strings (not "N/A") when nil
 	testutil.NotContains(t, output, "0001-01-01")
 }
 
@@ -190,6 +216,9 @@ func TestNewCurrentCmd(t *testing.T) {
 	boardFlag := cmd.Flags().Lookup("board")
 	testutil.NotNil(t, boardFlag)
 	testutil.Equal(t, boardFlag.DefValue, "")
+
+	fieldsFlag := cmd.Flags().Lookup("fields")
+	testutil.NotNil(t, fieldsFlag)
 }
 
 func TestRunCurrent_Table(t *testing.T) {
@@ -209,7 +238,8 @@ func TestRunCurrent_Table(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runCurrent(context.Background(), opts, client, 123)
+	board := &api.Board{ID: 123, Name: "Test Board"}
+	err = runCurrent(context.Background(), opts, client, board, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -218,6 +248,29 @@ func TestRunCurrent_Table(t *testing.T) {
 	testutil.Contains(t, output, "active")
 	testutil.Contains(t, output, "2025-02-01")
 	testutil.Contains(t, output, "2025-02-14")
+	testutil.Contains(t, output, "Board: 123 (Test Board)")
+}
+
+func TestRunCurrent_IDOnly(t *testing.T) {
+	sprints := []api.Sprint{
+		{ID: 42, Name: "Sprint Active", State: "active"},
+	}
+
+	server := newTestSprintsServer(t, sprints)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	board := &api.Board{ID: 123}
+	err = runCurrent(context.Background(), opts, client, board, "")
+	testutil.RequireNoError(t, err)
+
+	testutil.Equal(t, stdout.String(), "42\n")
 }
 
 func TestRunCurrent_JSON(t *testing.T) {
@@ -236,7 +289,8 @@ func TestRunCurrent_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runCurrent(context.Background(), opts, client, 123)
+	board := &api.Board{ID: 123}
+	err = runCurrent(context.Background(), opts, client, board, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -258,10 +312,11 @@ func TestRunCurrent_WithGoal(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
 	opts.SetAPIClient(client)
 
-	err = runCurrent(context.Background(), opts, client, 123)
+	board := &api.Board{ID: 123, Name: "Test Board"}
+	err = runCurrent(context.Background(), opts, client, board, "")
 	testutil.RequireNoError(t, err)
 
 	testutil.Contains(t, stdout.String(), "Ship feature X")
@@ -278,9 +333,35 @@ func TestRunCurrent_NotFound(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runCurrent(context.Background(), opts, client, 123)
+	board := &api.Board{ID: 123}
+	err = runCurrent(context.Background(), opts, client, board, "")
 	testutil.NotNil(t, err)
 	testutil.Contains(t, err.Error(), "no active sprint")
+}
+
+func TestRunCurrent_SyntheticBoard(t *testing.T) {
+	sprints := []api.Sprint{
+		{ID: 42, Name: "Sprint Active", State: "active"},
+	}
+
+	server := newTestSprintsServer(t, sprints)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	// Synthetic board with no name (cold cache / numeric pass-through)
+	board := &api.Board{ID: 123}
+	err = runCurrent(context.Background(), opts, client, board, "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Board: 123")
+	testutil.NotContains(t, output, "Board: 123 (")
 }
 
 // --- issues subcommand ---
@@ -289,12 +370,15 @@ func TestNewIssuesCmd(t *testing.T) {
 	opts := &root.Options{}
 	cmd := newIssuesCmd(opts)
 
-	testutil.Equal(t, cmd.Use, "issues <sprint-id>")
+	testutil.Equal(t, cmd.Use, "issues <sprint>")
 	testutil.NotEmpty(t, cmd.Short)
 
 	maxFlag := cmd.Flags().Lookup("max")
 	testutil.NotNil(t, maxFlag)
 	testutil.Equal(t, maxFlag.DefValue, "50")
+
+	nextPageTokenFlag := cmd.Flags().Lookup("next-page-token")
+	testutil.NotNil(t, nextPageTokenFlag)
 }
 
 func newTestSprintIssuesServer(_ *testing.T, issues []api.Issue) *httptest.Server {
@@ -341,7 +425,7 @@ func TestRunIssues_Table(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runIssues(context.Background(), opts, 456, 50)
+	err = runIssues(context.Background(), opts, 456, 50, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -353,6 +437,28 @@ func TestRunIssues_Table(t *testing.T) {
 	testutil.Contains(t, output, "PROJ-102")
 	testutil.Contains(t, output, "Add search feature")
 	testutil.Contains(t, output, "Story")
+}
+
+func TestRunIssues_IDOnly(t *testing.T) {
+	issues := []api.Issue{
+		{Key: "PROJ-101", Fields: api.IssueFields{Summary: "Fix login bug"}},
+		{Key: "PROJ-102", Fields: api.IssueFields{Summary: "Add search"}},
+	}
+
+	server := newTestSprintIssuesServer(t, issues)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runIssues(context.Background(), opts, 456, 50, "")
+	testutil.RequireNoError(t, err)
+
+	testutil.Equal(t, stdout.String(), "PROJ-101\nPROJ-102\n")
 }
 
 func TestRunIssues_JSON(t *testing.T) {
@@ -376,7 +482,7 @@ func TestRunIssues_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runIssues(context.Background(), opts, 456, 50)
+	err = runIssues(context.Background(), opts, 456, 50, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -395,7 +501,7 @@ func TestRunIssues_Empty(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runIssues(context.Background(), opts, 456, 50)
+	err = runIssues(context.Background(), opts, 456, 50, "")
 	testutil.RequireNoError(t, err)
 
 	testutil.Contains(t, stdout.String(), "No issues in sprint")
@@ -462,8 +568,6 @@ func TestRunAdd_SingleIssue(t *testing.T) {
 // --- Cobra entry-point tests that exercise the resolver ---
 
 func TestListCmd_ResolvesBoardByName(t *testing.T) {
-	// --board "MON board" must resolve via the cached boards to ID 23
-	// before hitting the sprints endpoint.
 	seedBoardsAndSprints(t,
 		[]api.Board{{ID: 23, Name: "MON board", Type: "scrum"}},
 		nil,
@@ -520,9 +624,39 @@ func TestCurrentCmd_ResolvesBoardByName(t *testing.T) {
 	testutil.Equal(t, capturedPath, "/rest/agile/1.0/board/23/sprint")
 }
 
+func TestIssuesCmd_ResolvesSprintByName(t *testing.T) {
+	seedBoardsAndSprints(t,
+		[]api.Board{{ID: 23, Name: "MON board"}},
+		map[int][]api.Sprint{
+			23: {{ID: 125, Name: "MON Sprint 70", State: "active"}},
+		},
+	)
+
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(api.SearchResult{
+			Total:  0,
+			Issues: []api.Issue{},
+		})
+	}))
+	defer server.Close()
+
+	client := newAgileClient(t, server)
+
+	rootCmd, opts := root.NewCmd()
+	opts.SetAPIClient(client)
+	opts.Stdout = &bytes.Buffer{}
+	opts.Stderr = &bytes.Buffer{}
+	Register(rootCmd, opts)
+
+	rootCmd.SetArgs([]string{"sprints", "issues", "MON Sprint 70"})
+	err := rootCmd.Execute()
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, capturedPath, "/rest/agile/1.0/sprint/125/issue")
+}
+
 func TestAddCmd_ResolvesSprintByName(t *testing.T) {
-	// `jtk sprints add "MON Sprint 70" PROJ-1` must resolve the name via
-	// cache to sprint ID 125, then POST to /sprint/125/issue.
 	seedBoardsAndSprints(t,
 		[]api.Board{{ID: 23, Name: "MON board"}},
 		map[int][]api.Sprint{
@@ -560,9 +694,6 @@ func TestAddCmd_ResolvesSprintByName(t *testing.T) {
 }
 
 func TestAddCmd_AmbiguousSprintAcrossBoardsErrors(t *testing.T) {
-	// Two boards with a sprint of the same name — `sprints add "Sprint 1"`
-	// with no --board scope must surface AmbiguousMatchError, not silently
-	// pick one.
 	seedBoardsAndSprints(t,
 		[]api.Board{
 			{ID: 23, Name: "MON board"},
@@ -597,14 +728,12 @@ func TestAddCmd_AmbiguousSprintAcrossBoardsErrors(t *testing.T) {
 	if !strings.Contains(err.Error(), "Ambiguous sprint") {
 		t.Fatalf("expected 'Ambiguous sprint' in error, got: %v", err)
 	}
-	// Error should list both candidate boards so the user can disambiguate.
 	if !strings.Contains(err.Error(), "MON board") || !strings.Contains(err.Error(), "ON board") {
 		t.Fatalf("expected both board names in error, got: %v", err)
 	}
 }
 
 func TestAddCmd_NumericSprintPassThrough(t *testing.T) {
-	// Numeric sprint arg bypasses cache lookup and targets the given ID.
 	seedBoardsAndSprints(t,
 		[]api.Board{{ID: 23, Name: "MON"}},
 		map[int][]api.Sprint{23: {{ID: 1, Name: "Other"}}},
@@ -649,12 +778,10 @@ func TestRunAdd_AgentOutput(t *testing.T) {
 	err = runAdd(context.Background(), opts, client, 456, []string{"MON-123"})
 	testutil.RequireNoError(t, err)
 
-	// Agent policy: plain text, no checkmark
 	want := "Moved MON-123 to sprint 456\n"
 	if stdout.String() != want {
 		t.Errorf("mutation output:\ngot: %q\nwant: %q", stdout.String(), want)
 	}
-	// Verify no checkmark
 	if strings.Contains(stdout.String(), "✓") {
 		t.Error("agent policy should not have checkmark")
 	}

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -303,6 +303,7 @@ func TestRunCurrent_Table(t *testing.T) {
 }
 
 func TestRunCurrent_IDOnly(t *testing.T) {
+	t.Parallel()
 	sprints := []api.Sprint{
 		{ID: 42, Name: "Sprint Active", State: "active"},
 	}
@@ -391,6 +392,7 @@ func TestRunCurrent_NotFound(t *testing.T) {
 }
 
 func TestRunCurrent_SyntheticBoard(t *testing.T) {
+	t.Parallel()
 	sprints := []api.Sprint{
 		{ID: 42, Name: "Sprint Active", State: "active"},
 	}

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -204,6 +204,57 @@ func TestRunList_NullDates(t *testing.T) {
 	testutil.NotContains(t, output, "0001-01-01")
 }
 
+func TestRunList_FieldsWithJSONError(t *testing.T) {
+	t.Parallel()
+	server := newTestSprintsServer(t, []api.Sprint{{ID: 1}})
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	opts := &root.Options{Output: "json", Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 123, "", 50, "", "ID,NAME")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--fields is not supported")
+}
+
+func TestRunList_InvalidNextPageToken(t *testing.T) {
+	t.Parallel()
+	client, err := api.New(api.ClientConfig{URL: "http://localhost", Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	opts := &root.Options{Output: "table", Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 123, "", 50, "abc", "")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--next-page-token")
+}
+
+func TestRunList_Pagination(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.SprintsResponse{
+			Values: []api.Sprint{{ID: 10, Name: "S1", State: "active"}},
+			IsLast: false,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 123, "", 1, "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "More results available (next: 1)")
+}
+
 // --- current subcommand ---
 
 func TestNewCurrentCmd(t *testing.T) {

--- a/tools/jtk/internal/present/board.go
+++ b/tools/jtk/internal/present/board.go
@@ -87,15 +87,19 @@ func (BoardPresenter) PresentDetail(board *api.Board, config *api.BoardConfigura
 		msg(fmt.Sprintf("Type: %s   Project: %s", OrDash(board.Type), projectRef)),
 	}
 
-	if extended && config != nil {
-		filterLine := fmt.Sprintf("Filter: %s (id: %s)", config.Filter.Name, config.Filter.ID)
-		sections = append(sections, msg(filterLine))
-
-		colNames := make([]string, len(config.ColumnConfig.Columns))
-		for i, c := range config.ColumnConfig.Columns {
-			colNames[i] = c.Name
+	if extended {
+		filterVal := "-"
+		columnVal := "-"
+		if config != nil {
+			filterVal = fmt.Sprintf("%s (id: %s)", config.Filter.Name, config.Filter.ID)
+			colNames := make([]string, len(config.ColumnConfig.Columns))
+			for i, c := range config.ColumnConfig.Columns {
+				colNames[i] = c.Name
+			}
+			columnVal = OrDash(strings.Join(colNames, ", "))
 		}
-		sections = append(sections, msg("Column config: "+OrDash(strings.Join(colNames, ", "))))
+		sections = append(sections, msg("Filter: "+filterVal))
+		sections = append(sections, msg("Column config: "+columnVal))
 	}
 
 	return &present.OutputModel{Sections: sections}

--- a/tools/jtk/internal/present/board.go
+++ b/tools/jtk/internal/present/board.go
@@ -1,49 +1,130 @@
 package present
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 // BoardPresenter creates presentation models for board data.
 type BoardPresenter struct{}
 
-// PresentDetail creates a detail view for a single board.
-func (BoardPresenter) PresentDetail(board *api.Board) *present.OutputModel {
-	fields := []present.Field{
-		{Label: "ID", Value: FormatInt(board.ID)},
-		{Label: "Name", Value: board.Name},
-		{Label: "Type", Value: board.Type},
-		{Label: "Project", Value: board.Location.ProjectKey},
-	}
-
-	return &present.OutputModel{
-		Sections: []present.Section{&present.DetailSection{Fields: fields}},
-	}
+// BoardListSpec declares the columns emitted by PresentList. Default order
+// per #230 is ID|TYPE|PROJECT|NAME; extended adds PROJECT_NAME between
+// PROJECT and NAME.
+var BoardListSpec = projection.Registry{
+	{Header: "ID", Identity: true},
+	{Header: "TYPE"},
+	{Header: "PROJECT"},
+	{Header: "PROJECT_NAME", Extended: true},
+	{Header: "NAME"},
 }
 
-// PresentList creates a table view for a list of boards.
-func (BoardPresenter) PresentList(boards []api.Board) *present.OutputModel {
+// BoardDetailSpec declares the fields emitted by PresentDetailProjection.
+var BoardDetailSpec = projection.Registry{
+	{Header: "ID", Identity: true},
+	{Header: "NAME"},
+	{Header: "TYPE"},
+	{Header: "PROJECT"},
+	{Header: "PROJECT_NAME"},
+	{Header: "FILTER", Extended: true},
+	{Header: "COLUMN_CONFIG", Extended: true},
+}
+
+// PresentList renders `boards list` output as a table. Default order is
+// ID|TYPE|PROJECT|NAME; --extended adds PROJECT_NAME.
+func (BoardPresenter) PresentList(boards []api.Board, extended bool) *present.OutputModel {
+	var headers []string
+	if extended {
+		headers = []string{"ID", "TYPE", "PROJECT", "PROJECT_NAME", "NAME"}
+	} else {
+		headers = []string{"ID", "TYPE", "PROJECT", "NAME"}
+	}
+
 	rows := make([]present.Row, len(boards))
 	for i, b := range boards {
-		rows[i] = present.Row{
-			Cells: []string{
+		var cells []string
+		if extended {
+			cells = []string{
 				FormatInt(b.ID),
+				OrDash(b.Type),
+				OrDash(b.Location.ProjectKey),
+				OrDash(b.Location.ProjectName),
 				b.Name,
-				b.Type,
-				b.Location.ProjectKey,
-			},
+			}
+		} else {
+			cells = []string{
+				FormatInt(b.ID),
+				OrDash(b.Type),
+				OrDash(b.Location.ProjectKey),
+				b.Name,
+			}
 		}
+		rows[i] = present.Row{Cells: cells}
 	}
 
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"ID", "NAME", "TYPE", "PROJECT"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
+	}
+}
+
+// PresentDetail builds the spec-shaped output for `boards get`. Default:
+// title line + Type/Project row. Extended adds Filter and Column config.
+func (BoardPresenter) PresentDetail(board *api.Board, config *api.BoardConfiguration, extended bool) *present.OutputModel {
+	projectRef := OrDash(board.Location.ProjectKey)
+	if board.Location.ProjectName != "" {
+		projectRef = fmt.Sprintf("%s (%s)", board.Location.ProjectKey, board.Location.ProjectName)
+	}
+
+	sections := []present.Section{
+		msg(fmt.Sprintf("%d  %s", board.ID, board.Name)),
+		msg(fmt.Sprintf("Type: %s   Project: %s", OrDash(board.Type), projectRef)),
+	}
+
+	if extended && config != nil {
+		filterLine := fmt.Sprintf("Filter: %s (id: %s)", config.Filter.Name, config.Filter.ID)
+		sections = append(sections, msg(filterLine))
+
+		colNames := make([]string, len(config.ColumnConfig.Columns))
+		for i, c := range config.ColumnConfig.Columns {
+			colNames[i] = c.Name
+		}
+		sections = append(sections, msg("Column config: "+OrDash(strings.Join(colNames, ", "))))
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// PresentDetailProjection builds a DetailSection view for `boards get --fields`.
+func (BoardPresenter) PresentDetailProjection(board *api.Board, config *api.BoardConfiguration) *present.OutputModel {
+	filterName := "-"
+	columnConfig := "-"
+	if config != nil {
+		filterName = fmt.Sprintf("%s (id: %s)", config.Filter.Name, config.Filter.ID)
+		colNames := make([]string, len(config.ColumnConfig.Columns))
+		for i, c := range config.ColumnConfig.Columns {
+			colNames[i] = c.Name
+		}
+		columnConfig = OrDash(strings.Join(colNames, ", "))
+	}
+
+	fields := []present.Field{
+		{Label: "ID", Value: FormatInt(board.ID)},
+		{Label: "NAME", Value: board.Name},
+		{Label: "TYPE", Value: OrDash(board.Type)},
+		{Label: "PROJECT", Value: OrDash(board.Location.ProjectKey)},
+		{Label: "PROJECT_NAME", Value: OrDash(board.Location.ProjectName)},
+		{Label: "FILTER", Value: filterName},
+		{Label: "COLUMN_CONFIG", Value: columnConfig},
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{&present.DetailSection{Fields: fields}},
 	}
 }
 

--- a/tools/jtk/internal/present/board_test.go
+++ b/tools/jtk/internal/present/board_test.go
@@ -1,0 +1,182 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestBoardListSpec_HeaderParityWithPresenter(t *testing.T) {
+	t.Parallel()
+	for _, extended := range []bool{false, true} {
+		model := BoardPresenter{}.PresentList(nil, extended)
+		table := sectionTable(t, model, 0)
+		want := registryHeadersFor(BoardListSpec, extended)
+		if !equalStringSlices(table.Headers, want) {
+			t.Errorf("extended=%v headers mismatch: presenter %v vs registry %v",
+				extended, table.Headers, want)
+		}
+	}
+}
+
+func TestPresentBoardList_DefaultShape(t *testing.T) {
+	t.Parallel()
+	boards := []api.Board{
+		{ID: 23, Name: "MON board", Type: "scrum", Location: api.BoardLocation{ProjectKey: "MON"}},
+		{ID: 24, Name: "ON board", Type: "kanban", Location: api.BoardLocation{ProjectKey: "ON"}},
+	}
+	model := BoardPresenter{}.PresentList(boards, false)
+	table := sectionTable(t, model, 0)
+
+	wantHeaders := []string{"ID", "TYPE", "PROJECT", "NAME"}
+	if !equalStringSlices(table.Headers, wantHeaders) {
+		t.Errorf("headers = %v, want %v", table.Headers, wantHeaders)
+	}
+	if len(table.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
+	}
+	if table.Rows[0].Cells[0] != "23" {
+		t.Errorf("row 0 ID: got %q", table.Rows[0].Cells[0])
+	}
+}
+
+func TestPresentBoardList_ExtendedShape(t *testing.T) {
+	t.Parallel()
+	boards := []api.Board{
+		{ID: 23, Name: "MON board", Type: "scrum", Location: api.BoardLocation{
+			ProjectKey: "MON", ProjectName: "Platform Development",
+		}},
+	}
+	model := BoardPresenter{}.PresentList(boards, true)
+	table := sectionTable(t, model, 0)
+
+	wantHeaders := []string{"ID", "TYPE", "PROJECT", "PROJECT_NAME", "NAME"}
+	if !equalStringSlices(table.Headers, wantHeaders) {
+		t.Errorf("extended headers = %v, want %v", table.Headers, wantHeaders)
+	}
+	if table.Rows[0].Cells[3] != "Platform Development" {
+		t.Errorf("PROJECT_NAME: got %q", table.Rows[0].Cells[3])
+	}
+}
+
+func TestPresentBoardDetail_Default(t *testing.T) {
+	t.Parallel()
+	board := &api.Board{
+		ID: 23, Name: "MON board", Type: "scrum",
+		Location: api.BoardLocation{ProjectKey: "MON", ProjectName: "Platform Development"},
+	}
+	model := BoardPresenter{}.PresentDetail(board, nil, false)
+
+	if len(model.Sections) != 2 {
+		t.Fatalf("expected 2 sections, got %d", len(model.Sections))
+	}
+	title := model.Sections[0].(*present.MessageSection)
+	if title.Message != "23  MON board" {
+		t.Errorf("title: got %q", title.Message)
+	}
+	typeLine := model.Sections[1].(*present.MessageSection)
+	if typeLine.Message != "Type: scrum   Project: MON (Platform Development)" {
+		t.Errorf("type line: got %q", typeLine.Message)
+	}
+}
+
+func TestPresentBoardDetail_Extended(t *testing.T) {
+	t.Parallel()
+	board := &api.Board{
+		ID: 23, Name: "MON board", Type: "scrum",
+		Location: api.BoardLocation{ProjectKey: "MON", ProjectName: "Platform Development"},
+	}
+	config := &api.BoardConfiguration{
+		Filter: api.BoardFilter{ID: "10084", Name: "board filter for MON board"},
+		ColumnConfig: api.BoardColumnConfig{
+			Columns: []api.BoardColumn{
+				{Name: "Backlog"},
+				{Name: "In Development"},
+				{Name: "Deployed"},
+			},
+		},
+	}
+	model := BoardPresenter{}.PresentDetail(board, config, true)
+
+	// title + type + filter + column config = 4 sections
+	if len(model.Sections) != 4 {
+		t.Fatalf("expected 4 sections, got %d", len(model.Sections))
+	}
+	filterLine := model.Sections[2].(*present.MessageSection)
+	if filterLine.Message != "Filter: board filter for MON board (id: 10084)" {
+		t.Errorf("filter: got %q", filterLine.Message)
+	}
+	colLine := model.Sections[3].(*present.MessageSection)
+	if colLine.Message != "Column config: Backlog, In Development, Deployed" {
+		t.Errorf("columns: got %q", colLine.Message)
+	}
+}
+
+func TestPresentBoardDetailProjection_ContainsAllSpecHeaders(t *testing.T) {
+	t.Parallel()
+	board := &api.Board{
+		ID: 23, Name: "MON board", Type: "scrum",
+		Location: api.BoardLocation{ProjectKey: "MON", ProjectName: "Platform Development"},
+	}
+	config := &api.BoardConfiguration{
+		Filter: api.BoardFilter{ID: "10084", Name: "test filter"},
+		ColumnConfig: api.BoardColumnConfig{
+			Columns: []api.BoardColumn{{Name: "Col1"}},
+		},
+	}
+	model := BoardPresenter{}.PresentDetailProjection(board, config)
+	detail := model.Sections[0].(*present.DetailSection)
+
+	specHeaders := make(map[string]bool)
+	for _, c := range BoardDetailSpec {
+		specHeaders[c.Header] = false
+	}
+	for _, f := range detail.Fields {
+		if _, ok := specHeaders[f.Label]; ok {
+			specHeaders[f.Label] = true
+		}
+	}
+	for h, found := range specHeaders {
+		if !found {
+			t.Errorf("spec header %q not found in projection detail fields", h)
+		}
+	}
+}
+
+func TestSprintListSpec_HeaderParityWithPresenter(t *testing.T) {
+	t.Parallel()
+	for _, extended := range []bool{false, true} {
+		model := SprintPresenter{}.PresentList(nil, extended)
+		table := sectionTable(t, model, 0)
+		want := registryHeadersFor(SprintListSpec, extended)
+		if !equalStringSlices(table.Headers, want) {
+			t.Errorf("extended=%v headers mismatch: presenter %v vs registry %v",
+				extended, table.Headers, want)
+		}
+	}
+}
+
+func TestSprintDetailSpec_ContainsAllProjectionHeaders(t *testing.T) {
+	t.Parallel()
+	sprint := &api.Sprint{ID: 1, Name: "Test", State: "active", OriginBoardID: 23}
+	board := &api.Board{ID: 23, Name: "Test Board"}
+	model := SprintPresenter{}.PresentDetailProjection(sprint, board)
+	detail := model.Sections[0].(*present.DetailSection)
+
+	specHeaders := make(map[string]bool)
+	for _, c := range SprintDetailSpec {
+		specHeaders[c.Header] = false
+	}
+	for _, f := range detail.Fields {
+		if _, ok := specHeaders[f.Label]; ok {
+			specHeaders[f.Label] = true
+		}
+	}
+	for h, found := range specHeaders {
+		if !found {
+			t.Errorf("spec header %q not found in projection detail fields", h)
+		}
+	}
+}

--- a/tools/jtk/internal/present/board_test.go
+++ b/tools/jtk/internal/present/board_test.go
@@ -114,6 +114,29 @@ func TestPresentBoardDetail_Extended(t *testing.T) {
 	}
 }
 
+func TestPresentBoardDetail_ExtendedStableRows_NilConfig(t *testing.T) {
+	t.Parallel()
+	board := &api.Board{
+		ID: 23, Name: "MON board", Type: "scrum",
+		Location: api.BoardLocation{ProjectKey: "MON", ProjectName: "Platform Development"},
+	}
+	// Extended with nil config should still show Filter and Column config rows with "-"
+	model := BoardPresenter{}.PresentDetail(board, nil, true)
+
+	// title + type + filter + column config = 4 sections
+	if len(model.Sections) != 4 {
+		t.Fatalf("expected 4 sections even with nil config, got %d", len(model.Sections))
+	}
+	filterLine := model.Sections[2].(*present.MessageSection)
+	if filterLine.Message != "Filter: -" {
+		t.Errorf("nil config filter: got %q", filterLine.Message)
+	}
+	colLine := model.Sections[3].(*present.MessageSection)
+	if colLine.Message != "Column config: -" {
+		t.Errorf("nil config columns: got %q", colLine.Message)
+	}
+}
+
 func TestPresentBoardDetailProjection_ContainsAllSpecHeaders(t *testing.T) {
 	t.Parallel()
 	board := &api.Board{

--- a/tools/jtk/internal/present/helpers.go
+++ b/tools/jtk/internal/present/helpers.go
@@ -16,6 +16,22 @@ func FormatDate(t *time.Time) string {
 	return t.Format("2006-01-02")
 }
 
+// FormatDateOrDash formats a time.Time as YYYY-MM-DD, returning "-" for nil/zero.
+func FormatDateOrDash(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return "-"
+	}
+	return t.Format("2006-01-02")
+}
+
+// FormatTimestampOrDash formats a time.Time as RFC3339, returning "-" for nil/zero.
+func FormatTimestampOrDash(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return "-"
+	}
+	return t.Format(time.RFC3339)
+}
+
 // FormatDateTime formats a time.Time with date and time.
 // Returns empty string for nil or zero time.
 func FormatDateTime(t *time.Time) string {

--- a/tools/jtk/internal/present/projection/project.go
+++ b/tools/jtk/internal/present/projection/project.go
@@ -102,6 +102,25 @@ func ApplyToDetailInModel(model *present.OutputModel, selected []ColumnSpec) {
 	}
 }
 
+// HasExtendedFields returns true if any of the selected specs correspond to
+// Extended-only fields in the registry. This lets commands gate expensive
+// fetches on whether the user explicitly requested extended fields via
+// --fields, not just whether --extended is active.
+func HasExtendedFields(selected []ColumnSpec, registry Registry) bool {
+	extendedHeaders := make(map[string]struct{})
+	for _, c := range registry {
+		if c.Extended {
+			extendedHeaders[c.Header] = struct{}{}
+		}
+	}
+	for _, c := range selected {
+		if _, ok := extendedHeaders[c.Header]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // DeriveFetchFields returns the minimum Jira field-ID set needed to render
 // the selected specs. Output is sorted and deduplicated so API requests are
 // stable across runs. Synthetic specs (empty FieldID, empty Fetch) are

--- a/tools/jtk/internal/present/sprint.go
+++ b/tools/jtk/internal/present/sprint.go
@@ -111,12 +111,12 @@ func (SprintPresenter) PresentDetail(sprint *api.Sprint, board *api.Board, exten
 	sections = append(sections, msg("Board: "+formatBoardRef(board)))
 
 	if extended {
-		if sprint.Goal != "" {
-			sections = append(sections, msg("Goal: "+sprint.Goal))
-		}
+		sections = append(sections, msg("Goal: "+OrDash(sprint.Goal)))
+		originBoard := "-"
 		if sprint.OriginBoardID != 0 {
-			sections = append(sections, msg(fmt.Sprintf("Origin Board: %d", sprint.OriginBoardID)))
+			originBoard = FormatInt(sprint.OriginBoardID)
 		}
+		sections = append(sections, msg("Origin Board: "+originBoard))
 	}
 
 	return &present.OutputModel{Sections: sections}

--- a/tools/jtk/internal/present/sprint.go
+++ b/tools/jtk/internal/present/sprint.go
@@ -6,59 +6,141 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 // SprintPresenter creates presentation models for sprint data.
 type SprintPresenter struct{}
 
-// PresentDetail creates a detail view for a single sprint.
-func (SprintPresenter) PresentDetail(sprint *api.Sprint) *present.OutputModel {
-	fields := []present.Field{
-		{Label: "ID", Value: FormatInt(sprint.ID)},
-		{Label: "Name", Value: sprint.Name},
-		{Label: "State", Value: sprint.State},
-	}
-
-	if sprint.Goal != "" {
-		fields = append(fields, present.Field{Label: "Goal", Value: sprint.Goal})
-	}
-	if sprint.StartDate != nil {
-		fields = append(fields, present.Field{Label: "Start Date", Value: FormatDate(sprint.StartDate)})
-	}
-	if sprint.EndDate != nil {
-		fields = append(fields, present.Field{Label: "End Date", Value: FormatDate(sprint.EndDate)})
-	}
-	if sprint.CompleteDate != nil {
-		fields = append(fields, present.Field{Label: "Complete Date", Value: FormatDate(sprint.CompleteDate)})
-	}
-
-	return &present.OutputModel{
-		Sections: []present.Section{&present.DetailSection{Fields: fields}},
-	}
+// SprintListSpec declares the columns emitted by PresentList. Default order
+// per #230 is ID|STATE|START|END|NAME; extended adds COMPLETED, BOARD, GOAL.
+var SprintListSpec = projection.Registry{
+	{Header: "ID", Identity: true},
+	{Header: "STATE"},
+	{Header: "START"},
+	{Header: "END"},
+	{Header: "COMPLETED", Extended: true},
+	{Header: "BOARD", Extended: true},
+	{Header: "GOAL", Extended: true},
+	{Header: "NAME"},
 }
 
-// PresentList creates a table view for a list of sprints.
-func (SprintPresenter) PresentList(sprints []api.Sprint) *present.OutputModel {
+// SprintDetailSpec declares the fields emitted by PresentDetailProjection.
+var SprintDetailSpec = projection.Registry{
+	{Header: "ID", Identity: true},
+	{Header: "NAME"},
+	{Header: "STATE"},
+	{Header: "START"},
+	{Header: "END"},
+	{Header: "BOARD"},
+	{Header: "GOAL", Extended: true},
+	{Header: "ORIGIN_BOARD", Extended: true},
+}
+
+// PresentList renders `sprints list` output as a table. BOARD column uses
+// each sprint's OriginBoardID (per-row), not the request boardID.
+func (SprintPresenter) PresentList(sprints []api.Sprint, extended bool) *present.OutputModel {
+	var headers []string
+	if extended {
+		headers = []string{"ID", "STATE", "START", "END", "COMPLETED", "BOARD", "GOAL", "NAME"}
+	} else {
+		headers = []string{"ID", "STATE", "START", "END", "NAME"}
+	}
+
 	rows := make([]present.Row, len(sprints))
-	for i, sprint := range sprints {
-		rows[i] = present.Row{
-			Cells: []string{
-				FormatInt(sprint.ID),
-				sprint.Name,
-				sprint.State,
-				FormatDate(sprint.StartDate),
-				FormatDate(sprint.EndDate),
-			},
+	for i, s := range sprints {
+		var cells []string
+		if extended {
+			boardVal := "-"
+			if s.OriginBoardID != 0 {
+				boardVal = FormatInt(s.OriginBoardID)
+			}
+			cells = []string{
+				FormatInt(s.ID),
+				OrDash(s.State),
+				FormatDateOrDash(s.StartDate),
+				FormatDateOrDash(s.EndDate),
+				FormatDateOrDash(s.CompleteDate),
+				boardVal,
+				OrDash(s.Goal),
+				s.Name,
+			}
+		} else {
+			cells = []string{
+				FormatInt(s.ID),
+				OrDash(s.State),
+				FormatDateOrDash(s.StartDate),
+				FormatDateOrDash(s.EndDate),
+				s.Name,
+			}
 		}
+		rows[i] = present.Row{Cells: cells}
 	}
 
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"ID", "NAME", "STATE", "START", "END"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
+	}
+}
+
+// PresentDetail builds the spec-shaped output for `sprints current`.
+// Board name degrades gracefully: "Board: 23 (MON board)" when known,
+// "Board: 23" when synthetic pass-through.
+func (SprintPresenter) PresentDetail(sprint *api.Sprint, board *api.Board, extended bool) *present.OutputModel {
+	sections := []present.Section{
+		msg(fmt.Sprintf("%d  %s", sprint.ID, sprint.Name)),
+	}
+
+	if extended {
+		sections = append(sections,
+			msg(fmt.Sprintf("State: %s   Start: %s   End: %s",
+				OrDash(sprint.State),
+				FormatTimestampOrDash(sprint.StartDate),
+				FormatTimestampOrDash(sprint.EndDate))),
+		)
+	} else {
+		sections = append(sections,
+			msg(fmt.Sprintf("State: %s   Start: %s   End: %s",
+				OrDash(sprint.State),
+				FormatDateOrDash(sprint.StartDate),
+				FormatDateOrDash(sprint.EndDate))),
+		)
+	}
+
+	sections = append(sections, msg("Board: "+formatBoardRef(board)))
+
+	if extended {
+		if sprint.Goal != "" {
+			sections = append(sections, msg("Goal: "+sprint.Goal))
+		}
+		if sprint.OriginBoardID != 0 {
+			sections = append(sections, msg(fmt.Sprintf("Origin Board: %d", sprint.OriginBoardID)))
+		}
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// PresentDetailProjection builds a DetailSection view for `sprints current --fields`.
+func (SprintPresenter) PresentDetailProjection(sprint *api.Sprint, board *api.Board) *present.OutputModel {
+	originBoard := "-"
+	if sprint.OriginBoardID != 0 {
+		originBoard = FormatInt(sprint.OriginBoardID)
+	}
+
+	fields := []present.Field{
+		{Label: "ID", Value: FormatInt(sprint.ID)},
+		{Label: "NAME", Value: sprint.Name},
+		{Label: "STATE", Value: OrDash(sprint.State)},
+		{Label: "START", Value: FormatDateOrDash(sprint.StartDate)},
+		{Label: "END", Value: FormatDateOrDash(sprint.EndDate)},
+		{Label: "BOARD", Value: formatBoardRef(board)},
+		{Label: "GOAL", Value: OrDash(sprint.Goal)},
+		{Label: "ORIGIN_BOARD", Value: originBoard},
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{&present.DetailSection{Fields: fields}},
 	}
 }
 
@@ -105,4 +187,16 @@ func (SprintPresenter) PresentNoIssues() *present.OutputModel {
 			},
 		},
 	}
+}
+
+// formatBoardRef renders a board reference: "23 (MON board)" when name is
+// known, "23" when synthetic pass-through (cold cache / numeric-only).
+func formatBoardRef(board *api.Board) string {
+	if board == nil {
+		return "-"
+	}
+	if board.Name != "" {
+		return fmt.Sprintf("%d (%s)", board.ID, board.Name)
+	}
+	return FormatInt(board.ID)
 }

--- a/tools/jtk/internal/present/sprint_test.go
+++ b/tools/jtk/internal/present/sprint_test.go
@@ -9,54 +9,89 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 )
 
-func TestSprintPresenter_PresentDetail(t *testing.T) {
+func TestSprintPresenter_PresentDetail_Default(t *testing.T) {
 	t.Parallel()
 	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2024, 1, 14, 0, 0, 0, 0, time.UTC)
 
 	sprint := &api.Sprint{
-		ID:        42,
-		Name:      "Sprint 1",
-		State:     "active",
-		Goal:      "Complete MVP",
-		StartDate: &startDate,
-		EndDate:   &endDate,
+		ID:            42,
+		Name:          "Sprint 1",
+		State:         "active",
+		Goal:          "Complete MVP",
+		StartDate:     &startDate,
+		EndDate:       &endDate,
+		OriginBoardID: 23,
 	}
+	board := &api.Board{ID: 23, Name: "MON board"}
 
 	p := SprintPresenter{}
-	model := p.PresentDetail(sprint)
+	model := p.PresentDetail(sprint, board, false)
 
-	if len(model.Sections) != 1 {
-		t.Fatalf("expected 1 section, got %d", len(model.Sections))
-	}
-
-	detail, ok := model.Sections[0].(*present.DetailSection)
-	if !ok {
-		t.Fatalf("expected DetailSection, got %T", model.Sections[0])
+	// Default: title + state/dates + board = 3 sections
+	if len(model.Sections) != 3 {
+		t.Fatalf("expected 3 sections, got %d", len(model.Sections))
 	}
 
-	fieldMap := make(map[string]string)
-	for _, f := range detail.Fields {
-		fieldMap[f.Label] = f.Value
+	// Title line
+	titleMsg := model.Sections[0].(*present.MessageSection)
+	if titleMsg.Message != "42  Sprint 1" {
+		t.Errorf("title: got %q", titleMsg.Message)
 	}
 
-	if fieldMap["ID"] != "42" {
-		t.Errorf("expected ID='42', got %q", fieldMap["ID"])
+	// State line with short dates
+	stateMsg := model.Sections[1].(*present.MessageSection)
+	if stateMsg.Message != "State: active   Start: 2024-01-01   End: 2024-01-14" {
+		t.Errorf("state line: got %q", stateMsg.Message)
 	}
-	if fieldMap["Name"] != "Sprint 1" {
-		t.Errorf("expected Name='Sprint 1', got %q", fieldMap["Name"])
+
+	// Board line
+	boardMsg := model.Sections[2].(*present.MessageSection)
+	if boardMsg.Message != "Board: 23 (MON board)" {
+		t.Errorf("board line: got %q", boardMsg.Message)
 	}
-	if fieldMap["State"] != "active" {
-		t.Errorf("expected State='active', got %q", fieldMap["State"])
+}
+
+func TestSprintPresenter_PresentDetail_Extended(t *testing.T) {
+	t.Parallel()
+	startDate := time.Date(2024, 1, 1, 0, 0, 45, 0, time.UTC)
+	endDate := time.Date(2024, 1, 14, 23, 30, 0, 0, time.UTC)
+
+	sprint := &api.Sprint{
+		ID:            42,
+		Name:          "Sprint 1",
+		State:         "active",
+		Goal:          "Complete MVP",
+		StartDate:     &startDate,
+		EndDate:       &endDate,
+		OriginBoardID: 23,
 	}
-	if fieldMap["Goal"] != "Complete MVP" {
-		t.Errorf("expected Goal='Complete MVP', got %q", fieldMap["Goal"])
+	board := &api.Board{ID: 23, Name: "MON board"}
+
+	p := SprintPresenter{}
+	model := p.PresentDetail(sprint, board, true)
+
+	// Extended: title + state/timestamps + board + goal + origin board = 5 sections
+	if len(model.Sections) != 5 {
+		t.Fatalf("expected 5 sections, got %d", len(model.Sections))
 	}
-	if fieldMap["Start Date"] != "2024-01-01" {
-		t.Errorf("expected Start Date='2024-01-01', got %q", fieldMap["Start Date"])
+
+	// State line with full timestamps
+	stateMsg := model.Sections[1].(*present.MessageSection)
+	if stateMsg.Message != "State: active   Start: 2024-01-01T00:00:45Z   End: 2024-01-14T23:30:00Z" {
+		t.Errorf("state line: got %q", stateMsg.Message)
 	}
-	if fieldMap["End Date"] != "2024-01-14" {
-		t.Errorf("expected End Date='2024-01-14', got %q", fieldMap["End Date"])
+
+	// Goal
+	goalMsg := model.Sections[3].(*present.MessageSection)
+	if goalMsg.Message != "Goal: Complete MVP" {
+		t.Errorf("goal: got %q", goalMsg.Message)
+	}
+
+	// Origin Board
+	originMsg := model.Sections[4].(*present.MessageSection)
+	if originMsg.Message != "Origin Board: 23" {
+		t.Errorf("origin board: got %q", originMsg.Message)
 	}
 }
 
@@ -66,21 +101,30 @@ func TestSprintPresenter_PresentDetail_MinimalFields(t *testing.T) {
 		ID:    1,
 		Name:  "Backlog",
 		State: "future",
-		// No goal, no dates
 	}
+	board := &api.Board{ID: 10}
 
 	p := SprintPresenter{}
-	model := p.PresentDetail(sprint)
+	model := p.PresentDetail(sprint, board, false)
 
-	detail := model.Sections[0].(*present.DetailSection)
+	// Title + state/dates + board = 3 sections
+	if len(model.Sections) != 3 {
+		t.Fatalf("expected 3 sections, got %d", len(model.Sections))
+	}
 
-	// Should only have ID, Name, State
-	if len(detail.Fields) != 3 {
-		t.Errorf("expected 3 fields for minimal sprint, got %d", len(detail.Fields))
+	stateMsg := model.Sections[1].(*present.MessageSection)
+	if stateMsg.Message != "State: future   Start: -   End: -" {
+		t.Errorf("state line: got %q", stateMsg.Message)
+	}
+
+	// Synthetic board with no name
+	boardMsg := model.Sections[2].(*present.MessageSection)
+	if boardMsg.Message != "Board: 10" {
+		t.Errorf("board line: got %q", boardMsg.Message)
 	}
 }
 
-func TestSprintPresenter_PresentList(t *testing.T) {
+func TestSprintPresenter_PresentList_Default(t *testing.T) {
 	t.Parallel()
 	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2024, 1, 14, 0, 0, 0, 0, time.UTC)
@@ -96,26 +140,28 @@ func TestSprintPresenter_PresentList(t *testing.T) {
 		{
 			ID:    2,
 			Name:  "Sprint 2",
-			State: "active",
-			// No dates yet
+			State: "future",
 		},
 	}
 
 	p := SprintPresenter{}
-	model := p.PresentList(sprints)
+	model := p.PresentList(sprints, false)
 
 	table, ok := model.Sections[0].(*present.TableSection)
 	if !ok {
 		t.Fatalf("expected TableSection, got %T", model.Sections[0])
 	}
 
-	// Verify headers
-	expectedHeaders := []string{"ID", "NAME", "STATE", "START", "END"}
+	expectedHeaders := []string{"ID", "STATE", "START", "END", "NAME"}
 	if len(table.Headers) != len(expectedHeaders) {
 		t.Errorf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
 	}
+	for i, h := range expectedHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header %d: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
 
-	// Verify rows
 	if len(table.Rows) != 2 {
 		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
 	}
@@ -124,12 +170,76 @@ func TestSprintPresenter_PresentList(t *testing.T) {
 	if table.Rows[0].Cells[0] != "1" {
 		t.Errorf("row 0 ID: expected '1', got %q", table.Rows[0].Cells[0])
 	}
-	if table.Rows[0].Cells[3] != "2024-01-01" {
-		t.Errorf("row 0 start: expected '2024-01-01', got %q", table.Rows[0].Cells[3])
+	if table.Rows[0].Cells[2] != "2024-01-01" {
+		t.Errorf("row 0 START: expected '2024-01-01', got %q", table.Rows[0].Cells[2])
 	}
 
-	// Row 2 - no dates
-	if table.Rows[1].Cells[3] != "" {
-		t.Errorf("row 1 start: expected empty for nil date, got %q", table.Rows[1].Cells[3])
+	// Row 2 - no dates → "-"
+	if table.Rows[1].Cells[2] != "-" {
+		t.Errorf("row 1 START: expected '-' for nil date, got %q", table.Rows[1].Cells[2])
+	}
+}
+
+func TestSprintPresenter_PresentList_Extended(t *testing.T) {
+	t.Parallel()
+	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2024, 1, 14, 0, 0, 0, 0, time.UTC)
+
+	sprints := []api.Sprint{
+		{
+			ID:            1,
+			Name:          "Sprint 1",
+			State:         "active",
+			StartDate:     &startDate,
+			EndDate:       &endDate,
+			OriginBoardID: 23,
+			Goal:          "Ship it",
+		},
+	}
+
+	p := SprintPresenter{}
+	model := p.PresentList(sprints, true)
+
+	table := model.Sections[0].(*present.TableSection)
+
+	expectedHeaders := []string{"ID", "STATE", "START", "END", "COMPLETED", "BOARD", "GOAL", "NAME"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Errorf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	}
+	for i, h := range expectedHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header %d: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+
+	// BOARD column should be OriginBoardID
+	if table.Rows[0].Cells[5] != "23" {
+		t.Errorf("BOARD: expected '23', got %q", table.Rows[0].Cells[5])
+	}
+	if table.Rows[0].Cells[6] != "Ship it" {
+		t.Errorf("GOAL: expected 'Ship it', got %q", table.Rows[0].Cells[6])
+	}
+}
+
+func TestFormatBoardRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		board *api.Board
+		want  string
+	}{
+		{"nil board", nil, "-"},
+		{"with name", &api.Board{ID: 23, Name: "MON board"}, "23 (MON board)"},
+		{"no name", &api.Board{ID: 23}, "23"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatBoardRef(tt.board)
+			if got != tt.want {
+				t.Errorf("formatBoardRef: got %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/tools/jtk/internal/present/sprint_test.go
+++ b/tools/jtk/internal/present/sprint_test.go
@@ -124,6 +124,33 @@ func TestSprintPresenter_PresentDetail_MinimalFields(t *testing.T) {
 	}
 }
 
+func TestSprintPresenter_PresentDetail_ExtendedStableRows(t *testing.T) {
+	t.Parallel()
+	// Extended output must always have the same row count regardless of data
+	sprint := &api.Sprint{
+		ID:    1,
+		Name:  "Backlog",
+		State: "future",
+	}
+	board := &api.Board{ID: 10}
+
+	p := SprintPresenter{}
+	model := p.PresentDetail(sprint, board, true)
+
+	// Extended: title + state/timestamps + board + goal + origin board = 5 sections
+	if len(model.Sections) != 5 {
+		t.Fatalf("expected 5 sections even with empty goal/origin, got %d", len(model.Sections))
+	}
+	goalMsg := model.Sections[3].(*present.MessageSection)
+	if goalMsg.Message != "Goal: -" {
+		t.Errorf("empty goal should show '-': got %q", goalMsg.Message)
+	}
+	originMsg := model.Sections[4].(*present.MessageSection)
+	if originMsg.Message != "Origin Board: -" {
+		t.Errorf("empty origin board should show '-': got %q", originMsg.Message)
+	}
+}
+
 func TestSprintPresenter_PresentList_Default(t *testing.T) {
 	t.Parallel()
 	startDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

- Migrate boards list/get and sprints list/current/issues to the output model from #257
- Add `--extended`, `--id`, `--fields`, and `--next-page-token` flags to all board/sprint read commands
- Board and sprint entry points now accept name or ID (resolved via cache), not just numeric IDs
- Add `GetBoardConfiguration` API method for `boards get --extended` (filter + column config)
- Add `BoardListSpec`, `BoardDetailSpec`, `SprintListSpec`, `SprintDetailSpec` projection registries
- Board name rendering degrades gracefully on cold cache (shows ID only instead of ID + name)
- JSON path retains artifact-based output to preserve flat shapes
- Sprint list BOARD column uses per-row `OriginBoardID`, not the request boardID

## Test plan

- [x] `make build` compiles cleanly
- [x] All 1333 jtk tests pass
- [x] No new lint issues
- [ ] Smoke test: `jtk boards list` / `--extended` / `--id`
- [ ] Smoke test: `jtk boards get 23` / `--extended` / `--id` / `"MON board"` (name)
- [ ] Smoke test: `jtk sprints list -b 23` / `--extended` / `--id`
- [ ] Smoke test: `jtk sprints current -b 23` / `--extended` / `--id`
- [ ] Smoke test: `jtk sprints issues 125` / `--id` / `"MON Sprint 70"` (name)
- [ ] Smoke test: `--fields ID,NAME` projection on list commands
- [ ] Pagination: `jtk boards list --max 2`, verify token, fetch next page

Closes #238