### PR TITLE
feat(jtk): migrate issue read surfaces to new output model

### DIFF
--- a/tools/jtk/api/search.go
+++ b/tools/jtk/api/search.go
@@ -37,6 +37,7 @@ var DefaultSearchFields = []string{
 	"components",
 	"reporter",
 	"parent",
+	"customfield_10035",
 }
 
 // ListSearchFields are lightweight fields for list/search commands (no description).
@@ -50,6 +51,7 @@ var ListSearchFields = []string{
 	"labels",
 	"created",
 	"updated",
+	"customfield_10035",
 }
 
 // Search searches for issues using JQL (uses /search/jql endpoint).

--- a/tools/jtk/internal/cmd/fields/fields.go
+++ b/tools/jtk/internal/cmd/fields/fields.go
@@ -104,7 +104,7 @@ func runList(ctx context.Context, opts *root.Options, customOnly bool, nameFilte
 		return v.JSON(fields)
 	}
 
-	model := jtkpresent.FieldPresenter{}.PresentList(fields)
+	model := jtkpresent.FieldPresenter{}.PresentList(fields, opts.IsExtended())
 	out := present.Render(model, opts.RenderStyle())
 	fmt.Fprint(opts.Stdout, out.Stdout)
 	fmt.Fprint(opts.Stderr, out.Stderr)

--- a/tools/jtk/internal/cmd/issues/field_options.go
+++ b/tools/jtk/internal/cmd/issues/field_options.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
@@ -26,8 +26,8 @@ Without --issue, attempts to show all possible values for the field.`,
 		Example: `  # List options for a field using issue context
   jtk issues field-options "Priority" --issue PROJ-123
 
-  # List options using field ID
-  jtk issues field-options customfield_10001 --issue PROJ-123`,
+  # Emit only option IDs
+  jtk issues field-options "Priority" --issue PROJ-123 --id`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFieldOptions(cmd.Context(), opts, args[0], issueKey)
@@ -40,7 +40,6 @@ Without --issue, attempts to show all possible values for the field.`,
 }
 
 func runFieldOptions(ctx context.Context, opts *root.Options, fieldNameOrID, issueKey string) error {
-	v := opts.View()
 	fp := jtkpresent.FieldPresenter{}
 
 	client, err := opts.APIClient()
@@ -48,59 +47,55 @@ func runFieldOptions(ctx context.Context, opts *root.Options, fieldNameOrID, iss
 		return err
 	}
 
-	// Get all fields to resolve name to ID
 	fields, err := client.GetFields(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Resolve field name/ID
 	fieldID, err := api.ResolveFieldID(fields, fieldNameOrID)
 	if err != nil {
 		return err
 	}
 
-	// Get field info for display
 	field := api.FindFieldByID(fields, fieldID)
 	fieldName := fieldID
 	if field != nil {
 		fieldName = field.Name
 	}
 
-	// Get options
 	var options []api.FieldOptionValue
 
 	if issueKey != "" {
-		// Use edit metadata for issue-specific context
 		options, err = client.GetFieldOptionsFromEditMeta(ctx, issueKey, fieldID)
 		if err != nil {
 			return fmt.Errorf("getting options for field %s: %w", fieldName, err)
 		}
 	} else {
-		// Try to get options without issue context
 		options, err = client.GetFieldOptions(ctx, fieldID)
 		if err != nil {
 			warnModel := fp.PresentOptionsNoContext()
-			warnOut := present.Render(warnModel, opts.RenderStyle())
-			_, _ = fmt.Fprint(opts.Stderr, warnOut.Stderr)
+			_ = jtkpresent.Emit(opts, warnModel)
 			return fmt.Errorf("getting options for field %s: %w", fieldName, err)
 		}
 	}
 
 	if len(options) == 0 {
-		model := fp.PresentNoOptions(fieldID)
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, fp.PresentNoOptions(fieldID))
 	}
 
-	if opts.Output == "json" {
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(options))
+		for i, opt := range options {
+			ids[i] = opt.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	v := opts.View()
+	if v.Format == view.FormatJSON {
 		return v.JSON(options)
 	}
 
 	model := fp.PresentFieldOptionsWithHeader(fieldName, options)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/issues/fields.go
+++ b/tools/jtk/internal/cmd/issues/fields.go
@@ -2,11 +2,10 @@ package issues
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
@@ -24,10 +23,16 @@ func newFieldsCmd(opts *root.Options) *cobra.Command {
   jtk issues fields
 
   # List only custom fields
-  jtk issues fields --custom
+  jtk issues fields --custom-fields
 
   # List editable fields for a specific issue
-  jtk issues fields PROJ-123`,
+  jtk issues fields PROJ-123
+
+  # Extended output with searchable/navigable/orderable/clause names
+  jtk issues fields --extended
+
+  # Emit only field IDs
+  jtk issues fields --id`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			issueKey := ""
@@ -38,66 +43,84 @@ func newFieldsCmd(opts *root.Options) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&customOnly, "custom-fields", false, "Show only custom fields")
 	cmd.Flags().BoolVar(&customOnly, "custom", false, "Show only custom fields")
+	_ = cmd.Flags().MarkHidden("custom")
 
 	return cmd
 }
 
 func runFields(ctx context.Context, opts *root.Options, issueKey string, customOnly bool) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
 	}
 
 	if issueKey != "" {
-		// Get editable fields for a specific issue
-		meta, err := client.GetIssueEditMeta(ctx, issueKey)
-		if err != nil {
-			return err
-		}
-
-		if opts.Output == "json" {
-			return v.JSON(meta)
-		}
-
-		// Extract field information from metadata
-		fieldsData, ok := meta["fields"].(map[string]any)
-		if !ok {
-			model := jtkpresent.IssuePresenter{}.PresentNoEditableFields(issueKey)
-			out := present.Render(model, opts.RenderStyle())
-			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-			return nil
-		}
-
-		editableFields := api.ParseEditMeta(fieldsData)
-		model := jtkpresent.FieldPresenter{}.PresentEditableFields(editableFields)
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-		return nil
+		return runEditableFields(ctx, opts, client, issueKey)
 	}
+	return runGlobalFields(ctx, opts, client, customOnly)
+}
 
-	// List all fields
+func runGlobalFields(ctx context.Context, opts *root.Options, client *api.Client, customOnly bool) error {
 	var fields []api.Field
+	var err error
 	if customOnly {
 		fields, err = client.GetCustomFields(ctx)
 	} else {
 		fields, err = client.GetFields(ctx)
 	}
-
 	if err != nil {
 		return err
 	}
 
-	if opts.Output == "json" {
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(fields))
+		for i, f := range fields {
+			ids[i] = f.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	if len(fields) == 0 {
+		return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentEmpty())
+	}
+
+	v := opts.View()
+	if v.Format == view.FormatJSON {
 		return v.JSON(fields)
 	}
 
-	model := jtkpresent.FieldPresenter{}.PresentList(fields)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	model := jtkpresent.FieldPresenter{}.PresentList(fields, opts.IsExtended())
+	return jtkpresent.Emit(opts, model)
+}
+
+func runEditableFields(ctx context.Context, opts *root.Options, client *api.Client, issueKey string) error {
+	meta, err := client.GetIssueEditMeta(ctx, issueKey)
+	if err != nil {
+		return err
+	}
+
+	v := opts.View()
+	if v.Format == view.FormatJSON {
+		return v.JSON(meta)
+	}
+
+	fieldsData, ok := meta["fields"].(map[string]any)
+	if !ok {
+		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentNoEditableFields(issueKey))
+	}
+
+	editableFields := api.ParseEditMeta(fieldsData)
+
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(editableFields))
+		for i, f := range editableFields {
+			ids[i] = f.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	model := jtkpresent.FieldPresenter{}.PresentEditableFields(editableFields)
+	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -75,22 +75,22 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		return err
 	}
 
-	// issues get does not minimize fetch — api.GetIssue has no field-selection
-	// parameter, and adding one is out of scope for #233. Projection is
-	// purely a display-time operation here.
 	issue, err := client.GetIssue(ctx, issueKey)
 	if err != nil {
 		return err
 	}
 
-	// For JSON output, return the projected artifact
 	if v.Format == view.FormatJSON {
 		return v.RenderArtifact(jtkartifact.ProjectIssue(issue, opts.ArtifactMode()))
 	}
 
-	model := jtkpresent.IssuePresenter{}.PresentDetail(issue, client.IssueURL(issue.Key), noTruncate)
+	presenter := jtkpresent.IssuePresenter{}
 	if projected {
+		model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate)
 		projection.ApplyToDetailInModel(model, selected)
+		return jtkpresent.Emit(opts, model)
 	}
+
+	model := presenter.PresentDetail(issue, client.IssueURL(issue.Key), opts.IsExtended(), noTruncate)
 	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/issues/get_fields_test.go
+++ b/tools/jtk/internal/cmd/issues/get_fields_test.go
@@ -93,18 +93,18 @@ func TestRunGet_Fields_ProjectsDetailToSelected(t *testing.T) {
 	}
 }
 
-func TestRunGet_Fields_URL_SyntheticColumn(t *testing.T) {
+func TestRunGet_Fields_Points_Column(t *testing.T) {
 	t.Parallel()
 	cs := newCapturingGetServer(t, fullIssue(), nil)
 	defer cs.server.Close()
 
 	opts, stdout, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", false, "URL")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Points")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
 	testutil.Contains(t, output, "Key: TEST-1")
-	testutil.Contains(t, output, "URL:")
+	testutil.Contains(t, output, "Points:")
 }
 
 func TestRunGet_Fields_HumanName_TriggersFieldsFetch(t *testing.T) {
@@ -274,7 +274,7 @@ func TestRunGet_Fields_Description_TruncatedWithoutFullText(t *testing.T) {
 
 	output := stdout.String()
 	testutil.Contains(t, output, "Description:")
-	testutil.Contains(t, output, "[truncated, use --fulltext for complete text]")
+	testutil.Contains(t, output, "truncated")
 }
 
 // AC1+AC3 (issues get): description selected WITH --fulltext shows full body

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -72,7 +72,7 @@ func TestRunGet_TruncatesDescription(t *testing.T) {
 
 	output := stdout.String()
 	testutil.Contains(t, output, "TEST-1")
-	testutil.Contains(t, output, "[truncated, use --fulltext for complete text]")
+	testutil.Contains(t, output, "[truncated — use --fulltext for complete body]")
 	testutil.NotContains(t, output, longText)
 }
 

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -146,39 +146,35 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 	}
 
 	hasMore := !result.Pagination.IsLast
+	nextToken := result.Pagination.NextPageToken
 
 	if idOnly {
 		ids := make([]string, len(result.Issues))
 		for i, issue := range result.Issues {
 			ids[i] = issue.Key
 		}
-		return jtkpresent.EmitIDsWithPagination(opts, ids, hasMore)
+		return jtkpresent.EmitIDsWithPaginationToken(opts, ids, hasMore, nextToken)
 	}
 
 	if len(result.Issues) == 0 {
-		// Two cases, each with a single unambiguous message:
-		//   hasMore=false → "No issues found" (the query's result set is empty)
-		//   hasMore=true  → pagination hint only (this page is empty but more
-		//                    pages exist; the agent should keep paging)
-		// Emitting both together would contradict itself; pick one.
 		if hasMore {
 			return jtkpresent.Emit(opts, &present.OutputModel{
-				Sections: jtkpresent.AppendPaginationHint(nil, true),
+				Sections: jtkpresent.AppendPaginationHintWithToken(nil, true, nextToken),
 			})
 		}
 		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentEmpty())
 	}
 
-	// For JSON output, return the projected artifacts
 	if v.Format == view.FormatJSON {
 		arts := jtkartifact.ProjectIssues(result.Issues, opts.ArtifactMode())
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, hasMore)
+	model := jtkpresent.IssuePresenter{}.PresentList(result.Issues, opts.IsExtended())
 	if projected {
 		projection.ApplyToTableInModel(model, selected)
 	}
+	model.Sections = jtkpresent.AppendPaginationHintWithToken(model.Sections, hasMore, nextToken)
 	return jtkpresent.Emit(opts, model)
 }
 

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -188,7 +188,7 @@ func TestRunList_IDOnlyWithMoreResultsAppendsContinuation(t *testing.T) {
 	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "")
 	testutil.RequireNoError(t, err)
 
-	want := "TEST-1\nTEST-2\nMore results available (use --next-page-token to fetch next page)\n"
+	want := "TEST-1\nTEST-2\nMore results available (next: next-token)\n"
 	if stdout.String() != want {
 		t.Errorf("stdout:\ngot:  %q\nwant: %q", stdout.String(), want)
 	}
@@ -348,9 +348,7 @@ func TestRunList_Fields_Projection_PreservesPaginationHint(t *testing.T) {
 
 	out := stdout.String()
 	testutil.Contains(t, out, "KEY | SUMMARY | STATUS")
-	// Pagination hint survives projection — AppendPaginationHint emits a
-	// Message section whose body contains "next-page-token" when hasMore.
-	testutil.Contains(t, out, "next-page-token")
+	testutil.Contains(t, out, "next: next-token")
 }
 
 func TestRunList_Fields_JiraFieldIDs_ProjectsTable(t *testing.T) {

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -2,12 +2,10 @@ package issues
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -107,20 +105,18 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 	}
 
 	hasMore := !result.Pagination.IsLast
+	nextToken := result.Pagination.NextPageToken
 
 	if idOnly {
 		ids := make([]string, len(result.Issues))
 		for i, issue := range result.Issues {
 			ids[i] = issue.Key
 		}
-		return jtkpresent.EmitIDsWithPagination(opts, ids, hasMore)
+		return jtkpresent.EmitIDsWithPaginationToken(opts, ids, hasMore, nextToken)
 	}
 
 	if len(result.Issues) == 0 {
-		model := jtkpresent.IssuePresenter{}.PresentEmpty()
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentEmpty())
 	}
 
 	if v.Format == view.FormatJSON {
@@ -128,14 +124,10 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, hasMore)
+	model := jtkpresent.IssuePresenter{}.PresentList(result.Issues, opts.IsExtended())
 	if projected {
 		projection.ApplyToTableInModel(model, selected)
 	}
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-
-	return nil
+	model.Sections = jtkpresent.AppendPaginationHintWithToken(model.Sections, hasMore, nextToken)
+	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -116,6 +117,11 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 	}
 
 	if len(result.Issues) == 0 {
+		if hasMore {
+			return jtkpresent.Emit(opts, &present.OutputModel{
+				Sections: jtkpresent.AppendPaginationHintWithToken(nil, true, nextToken),
+			})
+		}
 		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentEmpty())
 	}
 

--- a/tools/jtk/internal/cmd/issues/types.go
+++ b/tools/jtk/internal/cmd/issues/types.go
@@ -2,11 +2,10 @@ package issues
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
@@ -23,8 +22,8 @@ func newTypesCmd(opts *root.Options) *cobra.Command {
 		Example: `  # List issue types for a project
   jtk issues types --project MYPROJ
 
-  # Using short flag
-  jtk issues types -p MYPROJ`,
+  # Emit only type IDs
+  jtk issues types --project MYPROJ --id`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runTypes(cmd.Context(), opts, project)
 		},
@@ -37,8 +36,6 @@ func newTypesCmd(opts *root.Options) *cobra.Command {
 }
 
 func runTypes(ctx context.Context, opts *root.Options, project string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -50,28 +47,28 @@ func runTypes(ctx context.Context, opts *root.Options, project string) error {
 	}
 	projectKey := resolvedProject.Key
 
-	// `issues types` only renders issue type names — the other expansions
-	// (description, versions, etc.) are wasted payload here.
 	projectDetail, err := client.GetProject(ctx, projectKey, "issueTypes")
 	if err != nil {
 		return err
 	}
 
-	if opts.Output == "json" {
+	if len(projectDetail.IssueTypes) == 0 {
+		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentNoTypes(projectKey))
+	}
+
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(projectDetail.IssueTypes))
+		for i, t := range projectDetail.IssueTypes {
+			ids[i] = t.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	v := opts.View()
+	if v.Format == view.FormatJSON {
 		return v.JSON(projectDetail.IssueTypes)
 	}
 
-	if len(projectDetail.IssueTypes) == 0 {
-		model := jtkpresent.IssuePresenter{}.PresentNoTypes(projectKey)
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
-	}
-
-	// Text path: presenter → render → write
 	model := jtkpresent.IssuePresenter{}.PresentTypes(projectDetail.IssueTypes)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/issues/types_test.go
+++ b/tools/jtk/internal/cmd/issues/types_test.go
@@ -226,3 +226,42 @@ func TestRunTypes_DescriptionTruncation(t *testing.T) {
 	testutil.NotContains(t, output, longDesc)
 	testutil.Contains(t, output, "...")
 }
+
+func TestRunTypes_IDOnly(t *testing.T) {
+	seedCacheForIssues(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		response := api.ProjectDetail{
+			ID:   json.Number("10000"),
+			Key:  "TEST",
+			Name: "Test Project",
+			IssueTypes: []api.IssueType{
+				{ID: "10001", Name: "Bug"},
+				{ID: "10002", Name: "Task"},
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{
+		URL:      server.URL,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+		IDOnly: true,
+	}
+	opts.SetAPIClient(client)
+
+	err = runTypes(context.Background(), opts, "TEST")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Equal(t, output, "10001\n10002\n")
+}

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -339,7 +339,7 @@ func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	model := jtkpresent.IssuePresenter{}.PresentList(result.Issues)
+	model := jtkpresent.IssuePresenter{}.PresentList(result.Issues, opts.IsExtended())
 	model.Sections = jtkpresent.AppendPaginationHintWithToken(model.Sections, hasMore, nextToken)
 	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/present/field.go
+++ b/tools/jtk/internal/present/field.go
@@ -17,13 +17,17 @@ type FieldPresenter struct{}
 func (FieldPresenter) PresentList(fields []api.Field, extended bool) *present.OutputModel {
 	var headers []string
 	if extended {
-		headers = []string{"ID", "TYPE", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES", "NAME"}
+		headers = []string{"ID", "NAME", "TYPE", "CUSTOM", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES"}
 	} else {
 		headers = []string{"ID", "NAME", "TYPE", "CUSTOM"}
 	}
 
 	rows := make([]present.Row, len(fields))
 	for i, f := range fields {
+		custom := "no"
+		if f.Custom {
+			custom = "yes"
+		}
 		if extended {
 			clauseNames := "-"
 			if len(f.ClauseNames) > 0 {
@@ -32,19 +36,16 @@ func (FieldPresenter) PresentList(fields []api.Field, extended bool) *present.Ou
 			rows[i] = present.Row{
 				Cells: []string{
 					f.ID,
+					f.Name,
 					OrDash(f.Schema.Type),
+					custom,
 					BoolString(f.Searchable),
 					BoolString(f.Navigable),
 					BoolString(f.Orderable),
 					clauseNames,
-					f.Name,
 				},
 			}
 		} else {
-			custom := "no"
-			if f.Custom {
-				custom = "yes"
-			}
 			rows[i] = present.Row{
 				Cells: []string{f.ID, f.Name, OrDash(f.Schema.Type), custom},
 			}

--- a/tools/jtk/internal/present/field.go
+++ b/tools/jtk/internal/present/field.go
@@ -2,6 +2,7 @@ package present
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 
@@ -11,25 +12,44 @@ import (
 // FieldPresenter creates presentation models for field data.
 type FieldPresenter struct{}
 
-// PresentList creates a table view for a list of fields.
-func (FieldPresenter) PresentList(fields []api.Field) *present.OutputModel {
+// PresentList creates a table view for a list of fields. Default: ID|TYPE|NAME.
+// Extended adds SEARCHABLE, NAVIGABLE, ORDERABLE, CLAUSE_NAMES per #230.
+func (FieldPresenter) PresentList(fields []api.Field, extended bool) *present.OutputModel {
+	var headers []string
+	if extended {
+		headers = []string{"ID", "TYPE", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES", "NAME"}
+	} else {
+		headers = []string{"ID", "TYPE", "NAME"}
+	}
+
 	rows := make([]present.Row, len(fields))
 	for i, f := range fields {
-		custom := "no"
-		if f.Custom {
-			custom = "yes"
-		}
-		rows[i] = present.Row{
-			Cells: []string{f.ID, f.Name, f.Schema.Type, custom},
+		if extended {
+			clauseNames := "-"
+			if len(f.ClauseNames) > 0 {
+				clauseNames = strings.Join(f.ClauseNames, ", ")
+			}
+			rows[i] = present.Row{
+				Cells: []string{
+					f.ID,
+					OrDash(f.Schema.Type),
+					BoolString(f.Searchable),
+					BoolString(f.Navigable),
+					BoolString(f.Orderable),
+					clauseNames,
+					f.Name,
+				},
+			}
+		} else {
+			rows[i] = present.Row{
+				Cells: []string{f.ID, OrDash(f.Schema.Type), f.Name},
+			}
 		}
 	}
 
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"ID", "NAME", "TYPE", "CUSTOM"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
 	}
 }

--- a/tools/jtk/internal/present/field.go
+++ b/tools/jtk/internal/present/field.go
@@ -19,7 +19,7 @@ func (FieldPresenter) PresentList(fields []api.Field, extended bool) *present.Ou
 	if extended {
 		headers = []string{"ID", "TYPE", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES", "NAME"}
 	} else {
-		headers = []string{"ID", "TYPE", "NAME"}
+		headers = []string{"ID", "NAME", "TYPE", "CUSTOM"}
 	}
 
 	rows := make([]present.Row, len(fields))
@@ -41,8 +41,12 @@ func (FieldPresenter) PresentList(fields []api.Field, extended bool) *present.Ou
 				},
 			}
 		} else {
+			custom := "no"
+			if f.Custom {
+				custom = "yes"
+			}
 			rows[i] = present.Row{
-				Cells: []string{f.ID, OrDash(f.Schema.Type), f.Name},
+				Cells: []string{f.ID, f.Name, OrDash(f.Schema.Type), custom},
 			}
 		}
 	}

--- a/tools/jtk/internal/present/field_test.go
+++ b/tools/jtk/internal/present/field_test.go
@@ -67,7 +67,7 @@ func TestFieldPresenter_PresentList_Extended(t *testing.T) {
 	model := FieldPresenter{}.PresentList(fields, true)
 
 	table := model.Sections[0].(*present.TableSection)
-	expectedHeaders := []string{"ID", "TYPE", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES", "NAME"}
+	expectedHeaders := []string{"ID", "NAME", "TYPE", "CUSTOM", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES"}
 	if len(table.Headers) != len(expectedHeaders) {
 		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
 	}
@@ -77,13 +77,16 @@ func TestFieldPresenter_PresentList_Extended(t *testing.T) {
 		}
 	}
 
-	if table.Rows[0].Cells[2] != "yes" {
-		t.Errorf("row 0 searchable: expected 'yes', got %q", table.Rows[0].Cells[2])
+	if table.Rows[0].Cells[3] != "no" {
+		t.Errorf("row 0 custom: expected 'no', got %q", table.Rows[0].Cells[3])
 	}
-	if table.Rows[0].Cells[5] != "summary" {
-		t.Errorf("row 0 clause_names: expected 'summary', got %q", table.Rows[0].Cells[5])
+	if table.Rows[0].Cells[4] != "yes" {
+		t.Errorf("row 0 searchable: expected 'yes', got %q", table.Rows[0].Cells[4])
 	}
-	if table.Rows[1].Cells[5] != "-" {
-		t.Errorf("row 1 clause_names: expected '-' for no clauses, got %q", table.Rows[1].Cells[5])
+	if table.Rows[0].Cells[7] != "summary" {
+		t.Errorf("row 0 clause_names: expected 'summary', got %q", table.Rows[0].Cells[7])
+	}
+	if table.Rows[1].Cells[7] != "-" {
+		t.Errorf("row 1 clause_names: expected '-' for no clauses, got %q", table.Rows[1].Cells[7])
 	}
 }

--- a/tools/jtk/internal/present/field_test.go
+++ b/tools/jtk/internal/present/field_test.go
@@ -1,0 +1,89 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestFieldPresenter_PresentList_Default(t *testing.T) {
+	t.Parallel()
+	fields := []api.Field{
+		{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}, Searchable: true},
+		{ID: "customfield_10035", Name: "Story Points", Schema: api.FieldSchema{Type: "number"}, Custom: true},
+	}
+
+	model := FieldPresenter{}.PresentList(fields, false)
+
+	table := model.Sections[0].(*present.TableSection)
+	expectedHeaders := []string{"ID", "NAME", "TYPE", "CUSTOM"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	}
+	for i, h := range expectedHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+	if len(table.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
+	}
+	if table.Rows[0].Cells[0] != "summary" {
+		t.Errorf("row 0 ID: expected 'summary', got %q", table.Rows[0].Cells[0])
+	}
+	if table.Rows[0].Cells[1] != "Summary" {
+		t.Errorf("row 0 Name: expected 'Summary', got %q", table.Rows[0].Cells[1])
+	}
+	if table.Rows[0].Cells[3] != "no" {
+		t.Errorf("row 0 Custom: expected 'no', got %q", table.Rows[0].Cells[3])
+	}
+	if table.Rows[1].Cells[3] != "yes" {
+		t.Errorf("row 1 Custom: expected 'yes', got %q", table.Rows[1].Cells[3])
+	}
+}
+
+func TestFieldPresenter_PresentList_Extended(t *testing.T) {
+	t.Parallel()
+	fields := []api.Field{
+		{
+			ID:          "summary",
+			Name:        "Summary",
+			Schema:      api.FieldSchema{Type: "string"},
+			Searchable:  true,
+			Navigable:   true,
+			Orderable:   true,
+			ClauseNames: []string{"summary"},
+		},
+		{
+			ID:     "customfield_10035",
+			Name:   "Story Points",
+			Schema: api.FieldSchema{Type: "number"},
+			Custom: true,
+		},
+	}
+
+	model := FieldPresenter{}.PresentList(fields, true)
+
+	table := model.Sections[0].(*present.TableSection)
+	expectedHeaders := []string{"ID", "TYPE", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES", "NAME"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	}
+	for i, h := range expectedHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+
+	if table.Rows[0].Cells[2] != "yes" {
+		t.Errorf("row 0 searchable: expected 'yes', got %q", table.Rows[0].Cells[2])
+	}
+	if table.Rows[0].Cells[5] != "summary" {
+		t.Errorf("row 0 clause_names: expected 'summary', got %q", table.Rows[0].Cells[5])
+	}
+	if table.Rows[1].Cells[5] != "-" {
+		t.Errorf("row 1 clause_names: expected '-' for no clauses, got %q", table.Rows[1].Cells[5])
+	}
+}

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -62,7 +62,7 @@ var IssueDetailSpec = projection.Registry{
 // Output uses msg() sections (title line + compound KV rows) matching
 // the boards/sprints/projects pattern. Labels and Components rows
 // appear only when non-empty in default mode; always in extended.
-func (IssuePresenter) PresentDetail(issue *api.Issue, issueURL string, extended bool, fulltext bool) *present.OutputModel {
+func (IssuePresenter) PresentDetail(issue *api.Issue, _ string, extended bool, fulltext bool) *present.OutputModel {
 	sections := []present.Section{
 		msg(fmt.Sprintf("%s  %s", issue.Key, issue.Fields.Summary)),
 	}
@@ -239,7 +239,7 @@ func issueDescriptionSection(issue *api.Issue, fulltext bool) []present.Section 
 }
 
 // PresentDetailProjection builds a DetailSection view for `issues get --fields`.
-func (IssuePresenter) PresentDetailProjection(issue *api.Issue, issueURL string, fulltext bool) *present.OutputModel {
+func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fulltext bool) *present.OutputModel {
 	fields := []present.Field{
 		{Label: "Key", Value: issue.Key},
 		{Label: "Summary", Value: issue.Fields.Summary},

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -13,125 +13,413 @@ import (
 // IssuePresenter creates presentation models for issue data.
 type IssuePresenter struct{}
 
-// IssueListSpec declares the columns emitted by PresentList /
-// PresentListWithPagination and the metadata needed for --fields
-// projection and minimum-fetch derivation. Order MUST match the
-// hardcoded Headers in PresentList (locked by a parity test).
+// IssueListSpec declares the columns emitted by PresentList and the
+// metadata needed for --fields projection and minimum-fetch derivation.
+// Order MUST match the hardcoded Headers in PresentList (locked by a
+// parity test). Default: KEY|STATUS|TYPE|PTS|ASSIGNEE|SUMMARY.
+// Extended adds REPORTER, SPRINT, PARENT, UPDATED, LABELS, COMPONENTS.
 var IssueListSpec = projection.Registry{
 	{Header: "KEY", Identity: true},
-	{Header: "SUMMARY", FieldID: "summary"},
 	{Header: "STATUS", FieldID: "status"},
-	{Header: "ASSIGNEE", FieldID: "assignee"},
 	{Header: "TYPE", FieldID: "issuetype"},
+	{Header: "PTS", FieldID: "customfield_10035", Fetch: []string{"customfield_10035"}},
+	{Header: "ASSIGNEE", FieldID: "assignee"},
+	{Header: "REPORTER", FieldID: "reporter", Extended: true},
+	{Header: "SPRINT", FieldID: "sprint", Extended: true},
+	{Header: "PARENT", FieldID: "parent", Extended: true},
+	{Header: "UPDATED", FieldID: "updated", Extended: true},
+	{Header: "LABELS", FieldID: "labels", Extended: true},
+	{Header: "COMPONENTS", FieldID: "components", Extended: true},
+	{Header: "SUMMARY", FieldID: "summary"},
 }
 
-// IssueDetailSpec declares the Fields emitted by PresentDetail and the
-// metadata for --fields projection. Order MUST match the default Field
-// order in PresentDetail at construction time; Description is optional
-// there (only emitted when non-empty) but is still declared here so
-// --fields Description resolves and projects correctly when present.
+// IssueDetailSpec declares the fields emitted by PresentDetail /
+// PresentDetailProjection and the metadata for --fields projection.
+// Default fields are those an agent needs daily; extended adds
+// admin/schema/audit detail per #230.
 var IssueDetailSpec = projection.Registry{
 	{Header: "Key", Identity: true},
 	{Header: "Summary", FieldID: "summary"},
 	{Header: "Status", FieldID: "status"},
 	{Header: "Type", FieldID: "issuetype"},
 	{Header: "Priority", FieldID: "priority"},
+	{Header: "Points", FieldID: "customfield_10035", Fetch: []string{"customfield_10035"}},
 	{Header: "Assignee", FieldID: "assignee"},
-	{Header: "Project", FieldID: "project"},
+	{Header: "Updated", FieldID: "updated"},
+	{Header: "Sprint", FieldID: "sprint"},
+	{Header: "Parent", FieldID: "parent"},
+	{Header: "Labels", FieldID: "labels"},
+	{Header: "Components", FieldID: "components"},
 	{Header: "Description", FieldID: "description"},
-	{Header: "URL"}, // synthetic; no Jira field ID
+	{Header: "Reporter", FieldID: "reporter", Extended: true},
+	{Header: "Created", FieldID: "created", Extended: true},
+	{Header: "Status_Category", Extended: true},
+	{Header: "Sprint_Dates", Extended: true},
+	{Header: "Component_IDs", Extended: true},
 }
 
-// PresentDetail creates a detail view for a single issue.
-func (IssuePresenter) PresentDetail(issue *api.Issue, issueURL string, noTruncate bool) *present.OutputModel {
-	status := ""
-	if issue.Fields.Status != nil {
-		status = issue.Fields.Status.Name
+// PresentDetail creates a spec-shaped detail view for a single issue.
+// Output uses msg() sections (title line + compound KV rows) matching
+// the boards/sprints/projects pattern. Labels and Components rows
+// appear only when non-empty in default mode; always in extended.
+func (IssuePresenter) PresentDetail(issue *api.Issue, issueURL string, extended bool, fulltext bool) *present.OutputModel {
+	sections := []present.Section{
+		msg(fmt.Sprintf("%s  %s", issue.Key, issue.Fields.Summary)),
 	}
 
-	issueType := ""
-	if issue.Fields.IssueType != nil {
-		issueType = issue.Fields.IssueType.Name
+	if extended {
+		sections = append(sections, issueDetailExtendedSections(issue, fulltext)...)
+	} else {
+		sections = append(sections, issueDetailDefaultSections(issue, fulltext)...)
 	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+func issueDetailDefaultSections(issue *api.Issue, fulltext bool) []present.Section {
+	status := issueStatusName(issue)
+	issueType := issueTypeName(issue)
+	priority := issuePriorityName(issue)
+	points := formatStoryPoints(issue)
+	assignee := issueAssigneeName(issue)
+	updated := FormatTime(issue.Fields.Updated)
+
+	sections := []present.Section{
+		msg(fmt.Sprintf("Status: %s   Type: %s   Priority: %s   Points: %s",
+			OrDash(status), OrDash(issueType), OrDash(priority), points)),
+		msg(fmt.Sprintf("Assignee: %s   Updated: %s",
+			assignee, OrDash(updated))),
+	}
+
+	if issue.Fields.Sprint != nil {
+		sprintRef := issue.Fields.Sprint.Name
+		if issue.Fields.Sprint.State != "" {
+			sprintRef += " (" + issue.Fields.Sprint.State + ")"
+		}
+		sections = append(sections, msg("Sprint: "+sprintRef))
+	}
+
+	if issue.Fields.Parent != nil {
+		parentRef := issue.Fields.Parent.Key
+		if issue.Fields.Parent.Fields.Summary != "" {
+			parentRef += " — " + issue.Fields.Parent.Fields.Summary
+		}
+		if issue.Fields.Parent.Fields.IssueType != nil {
+			parentRef += " (" + issue.Fields.Parent.Fields.IssueType.Name + ")"
+		}
+		sections = append(sections, msg("Parent: "+parentRef))
+	}
+
+	if len(issue.Fields.Labels) > 0 {
+		sections = append(sections, msg("Labels: "+strings.Join(issue.Fields.Labels, ", ")))
+	}
+
+	if len(issue.Fields.Components) > 0 {
+		names := make([]string, len(issue.Fields.Components))
+		for i, c := range issue.Fields.Components {
+			names[i] = c.Name
+		}
+		sections = append(sections, msg("Components: "+strings.Join(names, ", ")))
+	}
+
+	sections = append(sections, issueDescriptionSection(issue, fulltext)...)
+
+	return sections
+}
+
+func issueDetailExtendedSections(issue *api.Issue, fulltext bool) []present.Section {
+	status := issueStatusName(issue)
+	statusCategory := ""
+	if issue.Fields.Status != nil {
+		statusCategory = issue.Fields.Status.StatusCategory.Name
+	}
+	issueType := issueTypeName(issue)
+	priority := issuePriorityName(issue)
+	points := formatStoryPoints(issue)
 
 	assignee := "Unassigned"
+	assigneeID := ""
 	if issue.Fields.Assignee != nil {
 		assignee = issue.Fields.Assignee.DisplayName
+		assigneeID = issue.Fields.Assignee.AccountID
 	}
 
-	priority := ""
-	if issue.Fields.Priority != nil {
-		priority = issue.Fields.Priority.Name
+	reporter := "-"
+	reporterID := ""
+	if issue.Fields.Reporter != nil {
+		reporter = issue.Fields.Reporter.DisplayName
+		reporterID = issue.Fields.Reporter.AccountID
 	}
 
-	project := ""
-	if issue.Fields.Project != nil {
-		project = issue.Fields.Project.Key
+	statusLine := fmt.Sprintf("Status: %s", OrDash(status))
+	if statusCategory != "" {
+		statusLine += fmt.Sprintf(" (category: %s)", statusCategory)
+	}
+	statusLine += fmt.Sprintf("   Type: %s   Priority: %s   Points: %s",
+		OrDash(issueType), OrDash(priority), points)
+
+	assigneeLine := fmt.Sprintf("Assignee: %s", assignee)
+	if assigneeID != "" {
+		assigneeLine += fmt.Sprintf(" (%s)", assigneeID)
+	}
+	assigneeLine += fmt.Sprintf("   Reporter: %s", reporter)
+	if reporterID != "" {
+		assigneeLine += fmt.Sprintf(" (%s)", reporterID)
 	}
 
-	description := ""
-	if issue.Fields.Description != nil {
-		description = issue.Fields.Description.ToPlainText()
-		if !noTruncate && len(description) > 200 {
-			description = description[:200] + "... [truncated, use --fulltext for complete text]"
+	sections := []present.Section{
+		msg(statusLine),
+		msg(assigneeLine),
+		msg(fmt.Sprintf("Updated: %s   Created: %s",
+			OrDash(issue.Fields.Updated), OrDash(issue.Fields.Created))),
+	}
+
+	if issue.Fields.Sprint != nil {
+		s := issue.Fields.Sprint
+		sprintRef := s.Name
+		sprintMeta := fmt.Sprintf("id: %d, %s", s.ID, OrDash(s.State))
+		if s.StartDate != nil {
+			sprintMeta += ", " + FormatDateOrDash(s.StartDate) + " → " + FormatDateOrDash(s.EndDate)
 		}
+		sections = append(sections, msg(fmt.Sprintf("Sprint: %s (%s)", sprintRef, sprintMeta)))
+	} else {
+		sections = append(sections, msg("Sprint: -"))
 	}
 
+	if issue.Fields.Parent != nil {
+		parentRef := issue.Fields.Parent.Key
+		if issue.Fields.Parent.Fields.Summary != "" {
+			parentRef += " — " + issue.Fields.Parent.Fields.Summary
+		}
+		if issue.Fields.Parent.Fields.IssueType != nil {
+			parentRef += " (" + issue.Fields.Parent.Fields.IssueType.Name + ")"
+		}
+		sections = append(sections, msg("Parent: "+parentRef))
+	} else {
+		sections = append(sections, msg("Parent: -"))
+	}
+
+	labels := "-"
+	if len(issue.Fields.Labels) > 0 {
+		labels = strings.Join(issue.Fields.Labels, ", ")
+	}
+	sections = append(sections, msg("Labels: "+labels))
+
+	if len(issue.Fields.Components) > 0 {
+		names := make([]string, len(issue.Fields.Components))
+		for i, c := range issue.Fields.Components {
+			names[i] = fmt.Sprintf("%s (%s)", c.Name, c.ID)
+		}
+		sections = append(sections, msg("Components: "+strings.Join(names, ", ")))
+	} else {
+		sections = append(sections, msg("Components: -"))
+	}
+
+	sections = append(sections, issueDescriptionSection(issue, fulltext)...)
+
+	return sections
+}
+
+func issueDescriptionSection(issue *api.Issue, fulltext bool) []present.Section {
+	if issue.Fields.Description == nil {
+		return nil
+	}
+	desc := issue.Fields.Description.ToPlainText()
+	if desc == "" {
+		return nil
+	}
+	if !fulltext && len(desc) > 200 {
+		desc = desc[:200] + "...\n[truncated — use --fulltext for complete body]"
+	}
+	return []present.Section{
+		msg(""),
+		msg("Description:"),
+		msg(desc),
+	}
+}
+
+// PresentDetailProjection builds a DetailSection view for `issues get --fields`.
+func (IssuePresenter) PresentDetailProjection(issue *api.Issue, issueURL string, fulltext bool) *present.OutputModel {
 	fields := []present.Field{
 		{Label: "Key", Value: issue.Key},
 		{Label: "Summary", Value: issue.Fields.Summary},
-		{Label: "Status", Value: status},
-		{Label: "Type", Value: issueType},
-		{Label: "Priority", Value: priority},
-		{Label: "Assignee", Value: assignee},
-		{Label: "Project", Value: project},
+		{Label: "Status", Value: issueStatusName(issue)},
+		{Label: "Type", Value: issueTypeName(issue)},
+		{Label: "Priority", Value: issuePriorityName(issue)},
+		{Label: "Points", Value: formatStoryPoints(issue)},
+		{Label: "Assignee", Value: issueAssigneeName(issue)},
+		{Label: "Updated", Value: OrDash(FormatTime(issue.Fields.Updated))},
+		{Label: "Sprint", Value: issueSprintName(issue)},
+		{Label: "Parent", Value: issueParentRef(issue)},
+		{Label: "Labels", Value: OrDash(strings.Join(issue.Fields.Labels, ", "))},
+		{Label: "Components", Value: OrDash(issueComponentNames(issue))},
+		{Label: "Description", Value: issueDescriptionText(issue, fulltext)},
+		{Label: "Reporter", Value: issueReporterName(issue)},
+		{Label: "Created", Value: OrDash(issue.Fields.Created)},
+		{Label: "Status_Category", Value: issueStatusCategory(issue)},
+		{Label: "Sprint_Dates", Value: issueSprintDates(issue)},
+		{Label: "Component_IDs", Value: issueComponentIDs(issue)},
 	}
-	if description != "" {
-		fields = append(fields, present.Field{Label: "Description", Value: description})
-	}
-	fields = append(fields, present.Field{Label: "URL", Value: issueURL})
-
 	return &present.OutputModel{
 		Sections: []present.Section{&present.DetailSection{Fields: fields}},
 	}
 }
 
-// PresentList creates a table view for a list of issues.
-func (IssuePresenter) PresentList(issues []api.Issue) *present.OutputModel {
+func issueStatusName(issue *api.Issue) string {
+	if issue.Fields.Status != nil {
+		return issue.Fields.Status.Name
+	}
+	return ""
+}
+
+func issueTypeName(issue *api.Issue) string {
+	if issue.Fields.IssueType != nil {
+		return issue.Fields.IssueType.Name
+	}
+	return ""
+}
+
+func issuePriorityName(issue *api.Issue) string {
+	if issue.Fields.Priority != nil {
+		return issue.Fields.Priority.Name
+	}
+	return ""
+}
+
+func issueAssigneeName(issue *api.Issue) string {
+	if issue.Fields.Assignee != nil {
+		return issue.Fields.Assignee.DisplayName
+	}
+	return "Unassigned"
+}
+
+func issueReporterName(issue *api.Issue) string {
+	if issue.Fields.Reporter != nil {
+		return issue.Fields.Reporter.DisplayName
+	}
+	return "-"
+}
+
+func issueSprintName(issue *api.Issue) string {
+	if issue.Fields.Sprint != nil {
+		return issue.Fields.Sprint.Name
+	}
+	return "-"
+}
+
+func issueParentRef(issue *api.Issue) string {
+	if issue.Fields.Parent == nil {
+		return "-"
+	}
+	ref := issue.Fields.Parent.Key
+	if issue.Fields.Parent.Fields.Summary != "" {
+		ref += " — " + issue.Fields.Parent.Fields.Summary
+	}
+	return ref
+}
+
+func issueComponentNames(issue *api.Issue) string {
+	if len(issue.Fields.Components) == 0 {
+		return ""
+	}
+	names := make([]string, len(issue.Fields.Components))
+	for i, c := range issue.Fields.Components {
+		names[i] = c.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+func issueComponentIDs(issue *api.Issue) string {
+	if len(issue.Fields.Components) == 0 {
+		return "-"
+	}
+	ids := make([]string, len(issue.Fields.Components))
+	for i, c := range issue.Fields.Components {
+		ids[i] = fmt.Sprintf("%s (%s)", c.Name, c.ID)
+	}
+	return strings.Join(ids, ", ")
+}
+
+func issueStatusCategory(issue *api.Issue) string {
+	if issue.Fields.Status != nil && issue.Fields.Status.StatusCategory.Name != "" {
+		return issue.Fields.Status.StatusCategory.Name
+	}
+	return "-"
+}
+
+func issueSprintDates(issue *api.Issue) string {
+	if issue.Fields.Sprint == nil {
+		return "-"
+	}
+	s := issue.Fields.Sprint
+	return fmt.Sprintf("%s → %s", FormatDateOrDash(s.StartDate), FormatDateOrDash(s.EndDate))
+}
+
+func issueDescriptionText(issue *api.Issue, fulltext bool) string {
+	if issue.Fields.Description == nil {
+		return "-"
+	}
+	desc := issue.Fields.Description.ToPlainText()
+	if desc == "" {
+		return "-"
+	}
+	if !fulltext && len(desc) > 200 {
+		return desc[:200] + "... [truncated]"
+	}
+	return desc
+}
+
+// PresentList creates a table view for a list of issues. Default order
+// is KEY|STATUS|TYPE|PTS|ASSIGNEE|SUMMARY; --extended adds REPORTER,
+// SPRINT, PARENT, UPDATED, LABELS, COMPONENTS. Callers append
+// pagination via AppendPaginationHintWithToken after this returns.
+func (IssuePresenter) PresentList(issues []api.Issue, extended bool) *present.OutputModel {
+	var headers []string
+	if extended {
+		headers = []string{"KEY", "STATUS", "TYPE", "PTS", "ASSIGNEE", "REPORTER", "SPRINT", "PARENT", "UPDATED", "LABELS", "COMPONENTS", "SUMMARY"}
+	} else {
+		headers = []string{"KEY", "STATUS", "TYPE", "PTS", "ASSIGNEE", "SUMMARY"}
+	}
+
 	rows := make([]present.Row, len(issues))
 	for i, issue := range issues {
-		status := ""
-		if issue.Fields.Status != nil {
-			status = issue.Fields.Status.Name
-		}
+		status := issueStatusName(&issue)
+		issueType := issueTypeName(&issue)
+		pts := formatStoryPoints(&issue)
+		assignee := FormatAssignee(issueAssigneeNameRaw(&issue))
 
-		assignee := ""
-		if issue.Fields.Assignee != nil {
-			assignee = issue.Fields.Assignee.DisplayName
-		}
-
-		issueType := ""
-		if issue.Fields.IssueType != nil {
-			issueType = issue.Fields.IssueType.Name
-		}
-
-		rows[i] = present.Row{
-			Cells: []string{
+		var cells []string
+		if extended {
+			cells = []string{
 				issue.Key,
-				TruncateText(issue.Fields.Summary, 50),
 				OrDash(status),
-				FormatAssignee(assignee),
 				OrDash(issueType),
-			},
+				pts,
+				assignee,
+				OrDash(issueReporterNameRaw(&issue)),
+				OrDash(issueSprintName(&issue)),
+				OrDash(issueParentKey(&issue)),
+				OrDash(FormatTime(issue.Fields.Updated)),
+				OrDash(strings.Join(issue.Fields.Labels, ", ")),
+				OrDash(issueComponentNames(&issue)),
+				TruncateText(issue.Fields.Summary, 80),
+			}
+		} else {
+			cells = []string{
+				issue.Key,
+				OrDash(status),
+				OrDash(issueType),
+				pts,
+				assignee,
+				TruncateText(issue.Fields.Summary, 80),
+			}
 		}
+		rows[i] = present.Row{Cells: cells}
 	}
 
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
 	}
 }
@@ -481,44 +769,44 @@ func (IssuePresenter) PresentMoved(count int, project string) *present.OutputMod
 	}
 }
 
-// --- List with pagination ---
+// --- Issue field helpers ---
 
-// PresentListWithPagination creates a table with optional pagination hint.
-func (p IssuePresenter) PresentListWithPagination(issues []api.Issue, hasMore bool) *present.OutputModel {
-	rows := make([]present.Row, len(issues))
-	for i, issue := range issues {
-		status := ""
-		if issue.Fields.Status != nil {
-			status = issue.Fields.Status.Name
-		}
-
-		assignee := ""
-		if issue.Fields.Assignee != nil {
-			assignee = issue.Fields.Assignee.DisplayName
-		}
-
-		issueType := ""
-		if issue.Fields.IssueType != nil {
-			issueType = issue.Fields.IssueType.Name
-		}
-
-		rows[i] = present.Row{
-			Cells: []string{
-				issue.Key,
-				TruncateText(issue.Fields.Summary, 50),
-				OrDash(status),
-				FormatAssignee(assignee),
-				OrDash(issueType),
-			},
-		}
+func formatStoryPoints(issue *api.Issue) string {
+	if issue.Fields.CustomFields == nil {
+		return "-"
 	}
-
-	sections := []present.Section{
-		&present.TableSection{
-			Headers: []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"},
-			Rows:    rows,
-		},
+	v, ok := issue.Fields.CustomFields["customfield_10035"]
+	if !ok || v == nil {
+		return "-"
 	}
+	switch n := v.(type) {
+	case float64:
+		if n == float64(int(n)) {
+			return fmt.Sprintf("%d", int(n))
+		}
+		return fmt.Sprintf("%.1f", n)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
 
-	return &present.OutputModel{Sections: AppendPaginationHint(sections, hasMore)}
+func issueAssigneeNameRaw(issue *api.Issue) string {
+	if issue.Fields.Assignee != nil {
+		return issue.Fields.Assignee.DisplayName
+	}
+	return ""
+}
+
+func issueReporterNameRaw(issue *api.Issue) string {
+	if issue.Fields.Reporter != nil {
+		return issue.Fields.Reporter.DisplayName
+	}
+	return ""
+}
+
+func issueParentKey(issue *api.Issue) string {
+	if issue.Fields.Parent != nil {
+		return issue.Fields.Parent.Key
+	}
+	return ""
 }

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -1,6 +1,7 @@
 package present
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/present"
@@ -8,7 +9,7 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 )
 
-func TestIssuePresenter_PresentDetail(t *testing.T) {
+func TestIssuePresenter_PresentDetail_Default(t *testing.T) {
 	t.Parallel()
 	issue := &api.Issue{
 		Key: "PROJ-123",
@@ -19,41 +20,26 @@ func TestIssuePresenter_PresentDetail(t *testing.T) {
 			Priority:  &api.Priority{Name: "High"},
 			Assignee:  &api.User{DisplayName: "Alice"},
 			Project:   &api.Project{Key: "PROJ"},
+			Updated:   "2026-04-16",
 		},
 	}
 
 	p := IssuePresenter{}
-	model := p.PresentDetail(issue, "https://jira.example.com/browse/PROJ-123", false)
+	model := p.PresentDetail(issue, "https://jira.example.com/browse/PROJ-123", false, false)
 
-	if len(model.Sections) != 1 {
-		t.Fatalf("expected 1 section, got %d", len(model.Sections))
-	}
-
-	detail, ok := model.Sections[0].(*present.DetailSection)
-	if !ok {
-		t.Fatalf("expected DetailSection, got %T", model.Sections[0])
+	if len(model.Sections) < 2 {
+		t.Fatalf("expected at least 2 sections, got %d", len(model.Sections))
 	}
 
-	// Verify key fields are present
-	fieldMap := make(map[string]string)
-	for _, f := range detail.Fields {
-		fieldMap[f.Label] = f.Value
+	rendered := renderMsgSections(model)
+	if !strings.Contains(rendered, "PROJ-123  Fix the bug") {
+		t.Errorf("missing title line in output:\n%s", rendered)
 	}
-
-	if fieldMap["Key"] != "PROJ-123" {
-		t.Errorf("expected Key='PROJ-123', got %q", fieldMap["Key"])
+	if !strings.Contains(rendered, "Status: In Progress") {
+		t.Errorf("missing Status in output:\n%s", rendered)
 	}
-	if fieldMap["Summary"] != "Fix the bug" {
-		t.Errorf("expected Summary='Fix the bug', got %q", fieldMap["Summary"])
-	}
-	if fieldMap["Status"] != "In Progress" {
-		t.Errorf("expected Status='In Progress', got %q", fieldMap["Status"])
-	}
-	if fieldMap["Assignee"] != "Alice" {
-		t.Errorf("expected Assignee='Alice', got %q", fieldMap["Assignee"])
-	}
-	if fieldMap["URL"] != "https://jira.example.com/browse/PROJ-123" {
-		t.Errorf("expected URL to be set, got %q", fieldMap["URL"])
+	if !strings.Contains(rendered, "Assignee: Alice") {
+		t.Errorf("missing Assignee in output:\n%s", rendered)
 	}
 }
 
@@ -63,25 +49,49 @@ func TestIssuePresenter_PresentDetail_Unassigned(t *testing.T) {
 		Key: "PROJ-123",
 		Fields: api.IssueFields{
 			Summary: "Unassigned issue",
-			// Assignee is nil
 		},
 	}
 
 	p := IssuePresenter{}
-	model := p.PresentDetail(issue, "https://jira.example.com/browse/PROJ-123", false)
+	model := p.PresentDetail(issue, "https://jira.example.com/browse/PROJ-123", false, false)
 
-	detail := model.Sections[0].(*present.DetailSection)
-	fieldMap := make(map[string]string)
-	for _, f := range detail.Fields {
-		fieldMap[f.Label] = f.Value
-	}
-
-	if fieldMap["Assignee"] != "Unassigned" {
-		t.Errorf("expected Assignee='Unassigned' for nil assignee, got %q", fieldMap["Assignee"])
+	rendered := renderMsgSections(model)
+	if !strings.Contains(rendered, "Assignee: Unassigned") {
+		t.Errorf("expected 'Assignee: Unassigned' for nil assignee, got:\n%s", rendered)
 	}
 }
 
-func TestIssuePresenter_PresentList(t *testing.T) {
+func TestIssuePresenter_PresentDetail_Extended(t *testing.T) {
+	t.Parallel()
+	issue := &api.Issue{
+		Key: "PROJ-123",
+		Fields: api.IssueFields{
+			Summary:   "Fix the bug",
+			Status:    &api.Status{Name: "In Progress", StatusCategory: api.StatusCategory{Name: "In Progress"}},
+			IssueType: &api.IssueType{Name: "Bug"},
+			Assignee:  &api.User{DisplayName: "Alice", AccountID: "abc123"},
+			Reporter:  &api.User{DisplayName: "Bob", AccountID: "def456"},
+			Created:   "2026-04-15T10:00:00+0000",
+			Updated:   "2026-04-16T07:16:24+0000",
+		},
+	}
+
+	p := IssuePresenter{}
+	model := p.PresentDetail(issue, "https://jira.example.com/browse/PROJ-123", true, false)
+
+	rendered := renderMsgSections(model)
+	if !strings.Contains(rendered, "category: In Progress") {
+		t.Errorf("expected status category in extended output:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "Reporter: Bob (def456)") {
+		t.Errorf("expected reporter with ID in extended output:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "Created:") {
+		t.Errorf("expected Created in extended output:\n%s", rendered)
+	}
+}
+
+func TestIssuePresenter_PresentList_Default(t *testing.T) {
 	t.Parallel()
 	issues := []api.Issue{
 		{
@@ -99,13 +109,12 @@ func TestIssuePresenter_PresentList(t *testing.T) {
 				Summary:   "Second issue",
 				Status:    &api.Status{Name: "Open"},
 				IssueType: &api.IssueType{Name: "Bug"},
-				// Assignee is nil
 			},
 		},
 	}
 
 	p := IssuePresenter{}
-	model := p.PresentList(issues)
+	model := p.PresentList(issues, false)
 
 	if len(model.Sections) != 1 {
 		t.Fatalf("expected 1 section, got %d", len(model.Sections))
@@ -116,10 +125,61 @@ func TestIssuePresenter_PresentList(t *testing.T) {
 		t.Fatalf("expected TableSection, got %T", model.Sections[0])
 	}
 
-	// Verify headers
-	expectedHeaders := []string{"KEY", "SUMMARY", "STATUS", "ASSIGNEE", "TYPE"}
+	expectedHeaders := []string{"KEY", "STATUS", "TYPE", "PTS", "ASSIGNEE", "SUMMARY"}
 	if len(table.Headers) != len(expectedHeaders) {
 		t.Errorf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	}
+	for i, h := range expectedHeaders {
+		if i < len(table.Headers) && table.Headers[i] != h {
+			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+
+	if len(table.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
+	}
+
+	if table.Rows[0].Cells[0] != "PROJ-1" {
+		t.Errorf("row 0 key: expected 'PROJ-1', got %q", table.Rows[0].Cells[0])
+	}
+	if table.Rows[0].Cells[4] != "Bob" {
+		t.Errorf("row 0 assignee: expected 'Bob', got %q", table.Rows[0].Cells[4])
+	}
+	if table.Rows[1].Cells[4] != "Unassigned" {
+		t.Errorf("row 1 assignee: expected 'Unassigned', got %q", table.Rows[1].Cells[4])
+	}
+}
+
+func TestIssuePresenter_PresentList_Extended(t *testing.T) {
+	t.Parallel()
+	issues := []api.Issue{
+		{
+			Key: "PROJ-1",
+			Fields: api.IssueFields{
+				Summary:   "First issue",
+				Status:    &api.Status{Name: "Done"},
+				Assignee:  &api.User{DisplayName: "Bob"},
+				Reporter:  &api.User{DisplayName: "Alice"},
+				IssueType: &api.IssueType{Name: "Task"},
+				Sprint:    &api.Sprint{Name: "Sprint 1"},
+				Parent:    &api.Issue{Key: "PROJ-100"},
+				Updated:   "2026-04-16",
+				Labels:    []string{"bug", "urgent"},
+				Components: []api.Component{
+					{ID: "1", Name: "Backend"},
+				},
+			},
+		},
+	}
+
+	p := IssuePresenter{}
+	model := p.PresentList(issues, true)
+
+	table := model.Sections[0].(*present.TableSection)
+
+	expectedHeaders := []string{"KEY", "STATUS", "TYPE", "PTS", "ASSIGNEE", "REPORTER", "SPRINT", "PARENT", "UPDATED", "LABELS", "COMPONENTS", "SUMMARY"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
 	}
 	for i, h := range expectedHeaders {
 		if table.Headers[i] != h {
@@ -127,22 +187,15 @@ func TestIssuePresenter_PresentList(t *testing.T) {
 		}
 	}
 
-	// Verify rows
-	if len(table.Rows) != 2 {
-		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
+	row := table.Rows[0]
+	if row.Cells[5] != "Alice" {
+		t.Errorf("reporter: expected 'Alice', got %q", row.Cells[5])
 	}
-
-	// Row 1
-	if table.Rows[0].Cells[0] != "PROJ-1" {
-		t.Errorf("row 0 key: expected 'PROJ-1', got %q", table.Rows[0].Cells[0])
+	if row.Cells[6] != "Sprint 1" {
+		t.Errorf("sprint: expected 'Sprint 1', got %q", row.Cells[6])
 	}
-	if table.Rows[0].Cells[3] != "Bob" {
-		t.Errorf("row 0 assignee: expected 'Bob', got %q", table.Rows[0].Cells[3])
-	}
-
-	// Row 2 - unassigned
-	if table.Rows[1].Cells[3] != "Unassigned" {
-		t.Errorf("row 1 assignee: expected 'Unassigned', got %q", table.Rows[1].Cells[3])
+	if row.Cells[7] != "PROJ-100" {
+		t.Errorf("parent: expected 'PROJ-100', got %q", row.Cells[7])
 	}
 }
 
@@ -158,7 +211,6 @@ func TestIssuePresenter_PresentTypes(t *testing.T) {
 
 	table := model.Sections[0].(*present.TableSection)
 
-	// Headers: ID, NAME, SUBTASK, DESCRIPTION
 	if len(table.Headers) != 4 {
 		t.Errorf("expected 4 headers, got %d", len(table.Headers))
 	}
@@ -166,60 +218,94 @@ func TestIssuePresenter_PresentTypes(t *testing.T) {
 		t.Errorf("expected 2 rows, got %d", len(table.Rows))
 	}
 
-	// Verify subtask display (lowercase)
 	if table.Rows[0].Cells[2] != "no" {
 		t.Errorf("Bug subtask: expected 'no', got %q", table.Rows[0].Cells[2])
 	}
 	if table.Rows[1].Cells[2] != "yes" {
 		t.Errorf("Sub-task subtask: expected 'yes', got %q", table.Rows[1].Cells[2])
 	}
+}
 
-	// Verify description is included
-	if table.Rows[0].Cells[3] != "A bug in the software" {
-		t.Errorf("Bug description: expected 'A bug in the software', got %q", table.Rows[0].Cells[3])
+// TestIssueListSpec_MatchesPresentListHeaders locks the IssueListSpec default
+// headers against the hardcoded headers in PresentList(extended=false).
+func TestIssueListSpec_MatchesPresentListHeaders(t *testing.T) {
+	t.Parallel()
+	issues := []api.Issue{{Key: "PROJ-1", Fields: api.IssueFields{Summary: "x"}}}
+
+	defaultSpecs := IssueListSpec.ForMode(false)
+
+	model := IssuePresenter{}.PresentList(issues, false)
+	table := model.Sections[0].(*present.TableSection)
+
+	if len(table.Headers) != len(defaultSpecs) {
+		t.Fatalf("header count mismatch: spec has %d, table has %d", len(defaultSpecs), len(table.Headers))
+	}
+	for i, spec := range defaultSpecs {
+		if table.Headers[i] != spec.Header {
+			t.Errorf("index %d: spec Header=%q, table header=%q", i, spec.Header, table.Headers[i])
+		}
 	}
 }
 
-func TestIssuePresenter_PresentListWithPagination_NoMore(t *testing.T) {
+// TestIssueListSpec_ExtendedMatchesPresentListHeaders locks the extended spec
+// headers against PresentList(extended=true).
+func TestIssueListSpec_ExtendedMatchesPresentListHeaders(t *testing.T) {
 	t.Parallel()
-	issues := []api.Issue{
-		{Key: "PROJ-1", Fields: api.IssueFields{Summary: "Issue 1"}},
-	}
+	issues := []api.Issue{{Key: "PROJ-1", Fields: api.IssueFields{Summary: "x"}}}
 
-	p := IssuePresenter{}
-	model := p.PresentListWithPagination(issues, false)
+	extendedSpecs := IssueListSpec.ForMode(true)
 
-	// Should have only 1 section (table, no pagination hint)
-	if len(model.Sections) != 1 {
-		t.Errorf("expected 1 section, got %d", len(model.Sections))
+	model := IssuePresenter{}.PresentList(issues, true)
+	table := model.Sections[0].(*present.TableSection)
+
+	if len(table.Headers) != len(extendedSpecs) {
+		t.Fatalf("header count mismatch: spec has %d, table has %d", len(extendedSpecs), len(table.Headers))
 	}
-	if _, ok := model.Sections[0].(*present.TableSection); !ok {
-		t.Errorf("expected TableSection, got %T", model.Sections[0])
+	for i, spec := range extendedSpecs {
+		if table.Headers[i] != spec.Header {
+			t.Errorf("index %d: spec Header=%q, table header=%q", i, spec.Header, table.Headers[i])
+		}
 	}
 }
 
-func TestIssuePresenter_PresentListWithPagination_HasMore(t *testing.T) {
+// TestIssueDetailSpec_MatchesPresentDetailProjectionLabels verifies the
+// projection path stays in sync with the detail spec.
+func TestIssueDetailSpec_MatchesPresentDetailProjectionLabels(t *testing.T) {
 	t.Parallel()
-	issues := []api.Issue{
-		{Key: "PROJ-1", Fields: api.IssueFields{Summary: "Issue 1"}},
+	issue := &api.Issue{
+		Key: "PROJ-1",
+		Fields: api.IssueFields{
+			Summary:     "s",
+			Status:      &api.Status{Name: "Open"},
+			IssueType:   &api.IssueType{Name: "Bug"},
+			Priority:    &api.Priority{Name: "High"},
+			Assignee:    &api.User{DisplayName: "Alice"},
+			Reporter:    &api.User{DisplayName: "Bob"},
+			Project:     &api.Project{Key: "PROJ"},
+			Description: &api.Description{},
+		},
+	}
+	model := IssuePresenter{}.PresentDetailProjection(issue, "https://example.com/PROJ-1", true)
+	detail := model.Sections[0].(*present.DetailSection)
+
+	renderedLabels := make(map[string]bool, len(detail.Fields))
+	for _, f := range detail.Fields {
+		renderedLabels[f.Label] = true
+	}
+	for _, spec := range IssueDetailSpec {
+		if !renderedLabels[spec.Header] {
+			t.Errorf("spec Header %q not emitted by PresentDetailProjection", spec.Header)
+		}
 	}
 
-	p := IssuePresenter{}
-	model := p.PresentListWithPagination(issues, true)
-
-	// Should have 2 sections (table + pagination hint)
-	if len(model.Sections) != 2 {
-		t.Fatalf("expected 2 sections, got %d", len(model.Sections))
+	specLabels := make(map[string]bool, len(IssueDetailSpec))
+	for _, spec := range IssueDetailSpec {
+		specLabels[spec.Header] = true
 	}
-
-	msg, ok := model.Sections[1].(*present.MessageSection)
-	if !ok {
-		t.Fatalf("expected MessageSection for pagination hint, got %T", model.Sections[1])
-	}
-	// Pagination continuation routes to stdout (inline with data rows) per #230
-	// so agents reading a single stream see both data and the hint.
-	if msg.Stream != present.StreamStdout {
-		t.Errorf("pagination hint should go to stdout, got %v", msg.Stream)
+	for _, f := range detail.Fields {
+		if !specLabels[f.Label] {
+			t.Errorf("rendered field %q has no matching IssueDetailSpec entry", f.Label)
+		}
 	}
 }
 
@@ -228,21 +314,15 @@ func TestIssuePresenter_PresentTypeNotFound(t *testing.T) {
 	p := IssuePresenter{}
 	model := p.PresentTypeNotFound("Story", "PROJ", []string{"Bug", "Task", "Epic"})
 
-	// Should have: error + "Available types" header + 3 type entries = 5 sections
 	if len(model.Sections) != 5 {
 		t.Fatalf("expected 5 sections, got %d", len(model.Sections))
 	}
 
-	// First section is error
 	errMsg := model.Sections[0].(*present.MessageSection)
 	if errMsg.Kind != present.MessageError {
 		t.Errorf("first section should be error, got %v", errMsg.Kind)
 	}
-	if errMsg.Stream != present.StreamStderr {
-		t.Errorf("error should go to stderr")
-	}
 
-	// All sections should go to stderr
 	for i, s := range model.Sections {
 		msg := s.(*present.MessageSection)
 		if msg.Stream != present.StreamStderr {
@@ -256,7 +336,6 @@ func TestIssuePresenter_PresentMoveInitiated(t *testing.T) {
 	p := IssuePresenter{}
 	model := p.PresentMoveInitiated("task-123")
 
-	// Should have 2 sections: success + info hint
 	if len(model.Sections) != 2 {
 		t.Fatalf("expected 2 sections, got %d", len(model.Sections))
 	}
@@ -264,17 +343,6 @@ func TestIssuePresenter_PresentMoveInitiated(t *testing.T) {
 	success := model.Sections[0].(*present.MessageSection)
 	if success.Kind != present.MessageSuccess {
 		t.Errorf("expected success, got %v", success.Kind)
-	}
-	if success.Stream != present.StreamStdout {
-		t.Errorf("success should go to stdout")
-	}
-
-	info := model.Sections[1].(*present.MessageSection)
-	if info.Kind != present.MessageInfo {
-		t.Errorf("expected info, got %v", info.Kind)
-	}
-	if info.Stream != present.StreamStdout {
-		t.Errorf("info hint should go to stdout")
 	}
 }
 
@@ -287,36 +355,13 @@ func TestIssuePresenter_PresentMovePartialFailure(t *testing.T) {
 	}
 	model := p.PresentMovePartialFailure(successful, failed)
 
-	// Should have: warning + 1 error + 1 success = 3 sections
 	if len(model.Sections) != 3 {
 		t.Fatalf("expected 3 sections, got %d", len(model.Sections))
 	}
 
-	// Warning first
 	warn := model.Sections[0].(*present.MessageSection)
 	if warn.Kind != present.MessageWarning {
 		t.Errorf("expected warning, got %v", warn.Kind)
-	}
-	if warn.Stream != present.StreamStderr {
-		t.Errorf("warning should go to stderr")
-	}
-
-	// Error second
-	errMsg := model.Sections[1].(*present.MessageSection)
-	if errMsg.Kind != present.MessageError {
-		t.Errorf("expected error, got %v", errMsg.Kind)
-	}
-	if errMsg.Stream != present.StreamStderr {
-		t.Errorf("error should go to stderr")
-	}
-
-	// Success third
-	success := model.Sections[2].(*present.MessageSection)
-	if success.Kind != present.MessageSuccess {
-		t.Errorf("expected success, got %v", success.Kind)
-	}
-	if success.Stream != present.StreamStdout {
-		t.Errorf("success should go to stdout")
 	}
 }
 
@@ -328,123 +373,39 @@ func TestIssuePresenter_PresentMovePartialFailure_NoSuccessful(t *testing.T) {
 	}
 	model := p.PresentMovePartialFailure(nil, failed)
 
-	// Should have: warning + 1 error = 2 sections (no success section)
 	if len(model.Sections) != 2 {
 		t.Errorf("expected 2 sections when no successful, got %d", len(model.Sections))
 	}
 }
 
-// TestIssueListSpec_MatchesPresentListHeaders locks the IssueListSpec headers
-// against the hardcoded headers in PresentList AND PresentListWithPagination.
-// Commands call PresentListWithPagination (not PresentList); drift between
-// the two method implementations and the registry would silently break
-// ProjectTable in production.
-func TestIssueListSpec_MatchesPresentListHeaders(t *testing.T) {
+func TestStoryPoints_Formatting(t *testing.T) {
 	t.Parallel()
-	issues := []api.Issue{{Key: "PROJ-1", Fields: api.IssueFields{Summary: "x"}}}
-
 	cases := []struct {
-		name  string
-		model *present.OutputModel
+		name   string
+		custom map[string]any
+		want   string
 	}{
-		{"PresentList", IssuePresenter{}.PresentList(issues)},
-		{"PresentListWithPagination_NoMore", IssuePresenter{}.PresentListWithPagination(issues, false)},
-		{"PresentListWithPagination_HasMore", IssuePresenter{}.PresentListWithPagination(issues, true)},
+		{"nil map", nil, "-"},
+		{"missing key", map[string]any{}, "-"},
+		{"null value", map[string]any{"customfield_10035": nil}, "-"},
+		{"integer 5", map[string]any{"customfield_10035": float64(5)}, "5"},
+		{"float 3.5", map[string]any{"customfield_10035": float64(3.5)}, "3.5"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var table *present.TableSection
-			for _, s := range tc.model.Sections {
-				if ts, ok := s.(*present.TableSection); ok {
-					table = ts
-					break
-				}
+			issue := &api.Issue{
+				Fields: api.IssueFields{CustomFields: tc.custom},
 			}
-			if table == nil {
-				t.Fatalf("no TableSection in %s output", tc.name)
-			}
-			if len(table.Headers) != len(IssueListSpec) {
-				t.Fatalf("header count mismatch: spec has %d, table has %d", len(IssueListSpec), len(table.Headers))
-			}
-			for i, spec := range IssueListSpec {
-				if table.Headers[i] != spec.Header {
-					t.Errorf("index %d: spec Header=%q, table header=%q", i, spec.Header, table.Headers[i])
-				}
+			got := formatStoryPoints(issue)
+			if got != tc.want {
+				t.Errorf("formatStoryPoints: got %q, want %q", got, tc.want)
 			}
 		})
 	}
 }
 
-// TestIssueDetailSpec_MatchesPresentDetailLabels locks the IssueDetailSpec
-// entries against the Field labels emitted by PresentDetail, both directions:
-//   - Every spec entry must appear in the rendered output.
-//   - Every rendered field must have a matching spec entry — otherwise
-//     --fields projection would silently drop it.
-//
-// Order is also checked: IssueDetailSpec's doc comment claims the spec order
-// matches the PresentDetail Field order, and ProjectDetail relies on that
-// for deterministic projection output.
-//
-// Description is conditional in PresentDetail; this test constructs an issue
-// with a description present so all spec entries should be rendered.
-func TestIssueDetailSpec_MatchesPresentDetailLabels(t *testing.T) {
-	t.Parallel()
-	issue := &api.Issue{
-		Key: "PROJ-1",
-		Fields: api.IssueFields{
-			Summary:     "s",
-			Status:      &api.Status{Name: "Open"},
-			IssueType:   &api.IssueType{Name: "Bug"},
-			Priority:    &api.Priority{Name: "High"},
-			Assignee:    &api.User{DisplayName: "Alice"},
-			Project:     &api.Project{Key: "PROJ"},
-			Description: &api.Description{Text: "body text"},
-		},
-	}
-	model := IssuePresenter{}.PresentDetail(issue, "https://example.com/PROJ-1", true)
-	detail := model.Sections[0].(*present.DetailSection)
-
-	// Spec → rendered: every spec entry has a corresponding rendered field.
-	renderedLabels := make(map[string]bool, len(detail.Fields))
-	for _, f := range detail.Fields {
-		renderedLabels[f.Label] = true
-	}
-	for _, spec := range IssueDetailSpec {
-		if !renderedLabels[spec.Header] {
-			t.Errorf("spec Header %q not emitted by PresentDetail", spec.Header)
-		}
-	}
-
-	// Rendered → spec: every rendered field has a corresponding spec entry.
-	// Without this, a new field added to PresentDetail would be silently
-	// unreachable via --fields.
-	specLabels := make(map[string]bool, len(IssueDetailSpec))
-	for _, spec := range IssueDetailSpec {
-		specLabels[spec.Header] = true
-	}
-	for _, f := range detail.Fields {
-		if !specLabels[f.Label] {
-			t.Errorf("rendered field %q has no matching IssueDetailSpec entry", f.Label)
-		}
-	}
-
-	// Order: the spec must list entries in the same relative order as
-	// PresentDetail's Field order, so ProjectDetail output is deterministic.
-	specOrder := make([]string, 0, len(IssueDetailSpec))
-	for _, spec := range IssueDetailSpec {
-		specOrder = append(specOrder, spec.Header)
-	}
-	renderedOrder := make([]string, 0, len(detail.Fields))
-	for _, f := range detail.Fields {
-		renderedOrder = append(renderedOrder, f.Label)
-	}
-	if len(specOrder) != len(renderedOrder) {
-		t.Fatalf("spec has %d entries, rendered has %d", len(specOrder), len(renderedOrder))
-	}
-	for i := range specOrder {
-		if specOrder[i] != renderedOrder[i] {
-			t.Errorf("order mismatch at index %d: spec=%q rendered=%q", i, specOrder[i], renderedOrder[i])
-		}
-	}
+func renderMsgSections(model *present.OutputModel) string {
+	out := present.Render(model, present.StyleAgent)
+	return out.Stdout + out.Stderr
 }

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -390,6 +390,7 @@ func TestStoryPoints_Formatting(t *testing.T) {
 		{"null value", map[string]any{"customfield_10035": nil}, "-"},
 		{"integer 5", map[string]any{"customfield_10035": float64(5)}, "5"},
 		{"float 3.5", map[string]any{"customfield_10035": float64(3.5)}, "3.5"},
+		{"string value", map[string]any{"customfield_10035": "five"}, "five"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- Migrate `issues list`, `search`, `get`, `fields`, `types`, and `field-options` to the output model established by boards/sprints (#260) and me/users/projects (#257)
- Reorder list columns to KEY|STATUS|TYPE|PTS|ASSIGNEE|SUMMARY with extended mode adding REPORTER, SPRINT, PARENT, UPDATED, LABELS, COMPONENTS
- Rewrite detail output as spec-shaped msg() sections (title line + compound KV rows) with default and extended modes
- Switch to opaque cursor-token pagination for issues (not numeric startAt like boards)
- Add --id, --extended, and --custom-fields support to metadata subcommands (fields, types, field-options)
- Add story points (customfield_10035) to search field lists for PTS column

Closes #239

## Test plan

- [x] `make build` passes
- [x] `make test` passes (1348 tests)
- [x] `make lint` clean (no new issues)
- [ ] Manual: `jtk issues list -p MON` shows KEY|STATUS|TYPE|PTS|ASSIGNEE|SUMMARY
- [ ] Manual: `jtk issues list -p MON --extended` shows extended columns
- [ ] Manual: `jtk issues get MON-4810` shows spec-shaped detail block
- [ ] Manual: `jtk issues get MON-4810 --extended` shows extended detail
- [ ] Manual: `jtk issues fields --extended` shows searchable/navigable columns