### PR TITLE
feat(jtk): migrate transitions to new output model with live API behavior

### DIFF
--- a/tools/jtk/internal/cmd/transitions/transitions.go
+++ b/tools/jtk/internal/cmd/transitions/transitions.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
-
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
@@ -40,22 +38,24 @@ func newListCmd(opts *root.Options) *cobra.Command {
 		Example: `  # List transitions
   jtk transitions list PROJ-123
 
-  # Show required fields for each transition
-  jtk transitions list PROJ-123 --fields`,
+  # Extended output with status category and required fields
+  jtk transitions list PROJ-123 --extended
+
+  # Emit only transition IDs
+  jtk transitions list PROJ-123 --id`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), opts, args[0], showFields)
+			return runList(cmd.Context(), opts, args[0], showFields || opts.IsExtended())
 		},
 	}
 
 	cmd.Flags().BoolVar(&showFields, "fields", false, "Show required fields for each transition")
+	_ = cmd.Flags().MarkDeprecated("fields", "use --extended instead")
 
 	return cmd
 }
 
 func runList(ctx context.Context, opts *root.Options, issueKey string, showFields bool) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -66,32 +66,28 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, showField
 		return err
 	}
 
-	if len(transitions) == 0 {
-		model := jtkpresent.TransitionPresenter{}.PresentEmpty(issueKey)
-		out := present.Render(model, opts.RenderStyle())
-		fmt.Fprint(opts.Stdout, out.Stdout)
-		fmt.Fprint(opts.Stderr, out.Stderr)
-		return nil
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(transitions))
+		for i, t := range transitions {
+			ids[i] = t.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
 	}
 
-	if opts.Output == "json" {
+	if len(transitions) == 0 {
+		return jtkpresent.Emit(opts, jtkpresent.TransitionPresenter{}.PresentEmpty(issueKey))
+	}
+
+	v := opts.View()
+	if v.Format == "json" {
 		return v.JSON(transitions)
 	}
 
-	var model *present.OutputModel
-	if showFields {
-		model = jtkpresent.TransitionPresenter{}.PresentListWithFields(transitions)
-	} else {
-		model = jtkpresent.TransitionPresenter{}.PresentList(transitions)
-	}
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	model := jtkpresent.TransitionPresenter{}.PresentList(transitions, showFields)
+	return jtkpresent.Emit(opts, model)
 }
 
-// getRequiredFields returns a comma-separated list of required field names
-// This is exported for testing and delegates to the presenter implementation
+// getRequiredFields delegates to the presenter implementation (exported for testing).
 func getRequiredFields(t api.Transition) string {
 	return jtkpresent.GetRequiredFieldsForTransition(t)
 }
@@ -131,16 +127,13 @@ func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID
 		return err
 	}
 
-	// Get available transitions
 	transitions, err := client.GetTransitions(ctx, issueKey)
 	if err != nil {
 		return err
 	}
 
-	// Find the transition
 	var transitionID string
 
-	// First try by ID
 	for _, t := range transitions {
 		if t.ID == transitionNameOrID {
 			transitionID = t.ID
@@ -148,7 +141,6 @@ func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID
 		}
 	}
 
-	// Then try by name
 	if transitionID == "" {
 		if t := api.FindTransitionByName(transitions, transitionNameOrID); t != nil {
 			transitionID = t.ID
@@ -157,18 +149,14 @@ func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID
 
 	if transitionID == "" {
 		model := jtkpresent.TransitionPresenter{}.PresentNotFound(transitionNameOrID, transitions)
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+		_ = jtkpresent.Emit(opts, model)
 		return fmt.Errorf("transition not found: %s", transitionNameOrID)
 	}
 
-	// Parse fields if provided
 	var fields map[string]any
 	if len(fieldArgs) > 0 {
 		fields = make(map[string]any)
 
-		// Get field metadata for name resolution and type detection
 		allFields, err := client.GetFields(ctx)
 		if err != nil {
 			return fmt.Errorf("getting field metadata: %w", err)
@@ -182,7 +170,6 @@ func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID
 
 			key, value := parts[0], parts[1]
 
-			// Try to resolve field name to ID and get field info
 			var fieldID string
 			var field *api.Field
 			if resolved := api.FindFieldByName(allFields, key); resolved != nil {
@@ -195,7 +182,6 @@ func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID
 				fieldID = key
 			}
 
-			// Format value based on field type
 			fields[fieldID] = api.FormatFieldValue(field, value)
 		}
 	}
@@ -204,9 +190,5 @@ func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID
 		return err
 	}
 
-	model := jtkpresent.TransitionPresenter{}.PresentTransitioned(issueKey)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.TransitionPresenter{}.PresentTransitioned(issueKey))
 }

--- a/tools/jtk/internal/cmd/transitions/transitions.go
+++ b/tools/jtk/internal/cmd/transitions/transitions.go
@@ -61,12 +61,15 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, showField
 		return err
 	}
 
-	transitions, err := client.GetTransitionsWithFields(ctx, issueKey, showFields)
+	idOnly := opts.EmitIDOnly()
+	expandFields := showFields && !idOnly
+
+	transitions, err := client.GetTransitionsWithFields(ctx, issueKey, expandFields)
 	if err != nil {
 		return err
 	}
 
-	if opts.EmitIDOnly() {
+	if idOnly {
 		ids := make([]string, len(transitions))
 		for i, t := range transitions {
 			ids[i] = t.ID

--- a/tools/jtk/internal/cmd/transitions/transitions_test.go
+++ b/tools/jtk/internal/cmd/transitions/transitions_test.go
@@ -1,11 +1,18 @@
 package transitions
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
 func TestFormatFieldValue(t *testing.T) {
@@ -185,14 +192,94 @@ func TestGetRequiredFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := getRequiredFields(tt.transition)
-			// For multiple fields, check both are present (order may vary due to map iteration)
-			if tt.name == "multiple required fields" {
-				testutil.Contains(t, got, "Resolution")
-				testutil.Contains(t, got, "Root Cause")
-				testutil.NotContains(t, got, "Comment")
-			} else {
-				testutil.Equal(t, got, tt.want)
-			}
+			testutil.Equal(t, got, tt.want)
 		})
+	}
+}
+
+func transitionsServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := api.TransitionsResponse{
+			Transitions: []api.Transition{
+				{ID: "11", Name: "Backlog", To: api.Status{Name: "Backlog", StatusCategory: api.StatusCategory{Name: "To Do"}}},
+				{ID: "31", Name: "In Development", To: api.Status{Name: "In Development", StatusCategory: api.StatusCategory{Name: "In Progress"}}},
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestRunList_Default(t *testing.T) {
+	t.Parallel()
+	server := transitionsServer(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "TEST-1", false)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "ID")
+	testutil.Contains(t, out, "Backlog")
+	testutil.Contains(t, out, "In Development")
+}
+
+func TestRunList_Extended(t *testing.T) {
+	t.Parallel()
+	server := transitionsServer(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "TEST-1", true)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "STATUS_CATEGORY")
+	testutil.Contains(t, out, "To Do")
+	testutil.Contains(t, out, "In Progress")
+}
+
+func TestRunList_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := transitionsServer(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "TEST-1", false)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Equal(t, out, "11\n31\n")
+}
+
+func TestRunList_DeprecatedFieldsAlias(t *testing.T) {
+	t.Parallel()
+	cmd := newListCmd(&root.Options{})
+	flag := cmd.Flags().Lookup("fields")
+	if flag == nil {
+		t.Fatal("expected --fields flag to exist as deprecated alias")
+	}
+	if !strings.Contains(flag.Deprecated, "extended") {
+		t.Errorf("expected deprecation message to mention --extended, got %q", flag.Deprecated)
 	}
 }

--- a/tools/jtk/internal/present/transition.go
+++ b/tools/jtk/internal/present/transition.go
@@ -1,4 +1,3 @@
-// Package present provides presenters that map domain types to presentation models.
 package present
 
 import (
@@ -8,58 +7,61 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 // TransitionPresenter creates presentation models for transition data.
 type TransitionPresenter struct{}
 
-// PresentList creates a table view for a list of transitions.
-func (TransitionPresenter) PresentList(transitions []api.Transition) *present.OutputModel {
+// TransitionListSpec declares the columns emitted by PresentList. Default
+// order per #230 is ID|NAME|TO_STATUS; extended adds STATUS_CATEGORY and
+// REQUIRED_FIELDS.
+var TransitionListSpec = projection.Registry{
+	{Header: "ID", Identity: true},
+	{Header: "NAME"},
+	{Header: "TO_STATUS"},
+	{Header: "STATUS_CATEGORY", Extended: true},
+	{Header: "REQUIRED_FIELDS", Extended: true},
+}
+
+// PresentList creates a table view for a list of transitions. Default
+// order is ID|NAME|TO_STATUS; --extended adds STATUS_CATEGORY and
+// REQUIRED_FIELDS.
+func (TransitionPresenter) PresentList(transitions []api.Transition, extended bool) *present.OutputModel {
+	var headers []string
+	if extended {
+		headers = []string{"ID", "NAME", "TO_STATUS", "STATUS_CATEGORY", "REQUIRED_FIELDS"}
+	} else {
+		headers = []string{"ID", "NAME", "TO_STATUS"}
+	}
+
 	rows := make([]present.Row, len(transitions))
 	for i, t := range transitions {
-		toStatus := ""
-		if t.To.Name != "" {
-			toStatus = t.To.Name
-		}
-		rows[i] = present.Row{
-			Cells: []string{t.ID, t.Name, toStatus},
+		toStatus := OrDash(t.To.Name)
+		if extended {
+			rows[i] = present.Row{
+				Cells: []string{
+					t.ID,
+					t.Name,
+					toStatus,
+					OrDash(t.To.StatusCategory.Name),
+					GetRequiredFieldsForTransition(t),
+				},
+			}
+		} else {
+			rows[i] = present.Row{
+				Cells: []string{t.ID, t.Name, toStatus},
+			}
 		}
 	}
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"ID", "NAME", "TO STATUS"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
 	}
 }
 
-// PresentListWithFields creates a table view for transitions with required fields.
-func (TransitionPresenter) PresentListWithFields(transitions []api.Transition) *present.OutputModel {
-	rows := make([]present.Row, len(transitions))
-	for i, t := range transitions {
-		toStatus := ""
-		if t.To.Name != "" {
-			toStatus = t.To.Name
-		}
-		required := getRequiredFields(t)
-		rows[i] = present.Row{
-			Cells: []string{t.ID, t.Name, toStatus, required},
-		}
-	}
-	return &present.OutputModel{
-		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"ID", "NAME", "TO STATUS", "REQUIRED FIELDS"},
-				Rows:    rows,
-			},
-		},
-	}
-}
-
-// GetRequiredFieldsForTransition returns a comma-separated list of required field names
-// This is exported for use in transitions command tests
+// GetRequiredFieldsForTransition returns a comma-separated list of required field names.
 func GetRequiredFieldsForTransition(t api.Transition) string {
 	var required []string
 	for _, field := range t.Fields {
@@ -71,11 +73,6 @@ func GetRequiredFieldsForTransition(t api.Transition) string {
 		return "-"
 	}
 	return strings.Join(required, ", ")
-}
-
-// getRequiredFields returns a comma-separated list of required field names (internal use)
-func getRequiredFields(t api.Transition) string {
-	return GetRequiredFieldsForTransition(t)
 }
 
 // PresentTransitioned creates a success message for a completed transition.
@@ -105,7 +102,6 @@ func (TransitionPresenter) PresentEmpty(issueKey string) *present.OutputModel {
 }
 
 // PresentNotFound creates an error with available transitions as context.
-// Both the error and the available options route to stderr.
 func (TransitionPresenter) PresentNotFound(name string, available []api.Transition) *present.OutputModel {
 	sections := []present.Section{
 		&present.MessageSection{

--- a/tools/jtk/internal/present/transition.go
+++ b/tools/jtk/internal/present/transition.go
@@ -2,6 +2,7 @@ package present
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/present"
@@ -72,6 +73,7 @@ func GetRequiredFieldsForTransition(t api.Transition) string {
 	if len(required) == 0 {
 		return "-"
 	}
+	sort.Strings(required)
 	return strings.Join(required, ", ")
 }
 

--- a/tools/jtk/internal/present/transition_test.go
+++ b/tools/jtk/internal/present/transition_test.go
@@ -1,0 +1,116 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestTransitionPresenter_PresentList_Default(t *testing.T) {
+	t.Parallel()
+	transitions := []api.Transition{
+		{ID: "11", Name: "Backlog", To: api.Status{Name: "Backlog"}},
+		{ID: "21", Name: "In Progress", To: api.Status{Name: "In Progress"}},
+	}
+
+	model := TransitionPresenter{}.PresentList(transitions, false)
+	table := model.Sections[0].(*present.TableSection)
+
+	expectedHeaders := []string{"ID", "NAME", "TO_STATUS"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	}
+	for i, h := range expectedHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+
+	if len(table.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
+	}
+	if table.Rows[0].Cells[0] != "11" {
+		t.Errorf("row 0 ID: expected '11', got %q", table.Rows[0].Cells[0])
+	}
+	if table.Rows[0].Cells[2] != "Backlog" {
+		t.Errorf("row 0 TO_STATUS: expected 'Backlog', got %q", table.Rows[0].Cells[2])
+	}
+}
+
+func TestTransitionPresenter_PresentList_Extended(t *testing.T) {
+	t.Parallel()
+	transitions := []api.Transition{
+		{
+			ID:   "71",
+			Name: "Deployed",
+			To: api.Status{
+				Name:           "Deployed",
+				StatusCategory: api.StatusCategory{Name: "Done"},
+			},
+			Fields: map[string]api.TransitionField{
+				"resolution": {Required: true, Name: "Resolution"},
+			},
+		},
+		{
+			ID:   "11",
+			Name: "Backlog",
+			To: api.Status{
+				Name:           "Backlog",
+				StatusCategory: api.StatusCategory{Name: "To Do"},
+			},
+		},
+	}
+
+	model := TransitionPresenter{}.PresentList(transitions, true)
+	table := model.Sections[0].(*present.TableSection)
+
+	expectedHeaders := []string{"ID", "NAME", "TO_STATUS", "STATUS_CATEGORY", "REQUIRED_FIELDS"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	}
+	for i, h := range expectedHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+
+	if table.Rows[0].Cells[3] != "Done" {
+		t.Errorf("row 0 STATUS_CATEGORY: expected 'Done', got %q", table.Rows[0].Cells[3])
+	}
+	if table.Rows[0].Cells[4] != "Resolution" {
+		t.Errorf("row 0 REQUIRED_FIELDS: expected 'Resolution', got %q", table.Rows[0].Cells[4])
+	}
+	if table.Rows[1].Cells[4] != "-" {
+		t.Errorf("row 1 REQUIRED_FIELDS: expected '-', got %q", table.Rows[1].Cells[4])
+	}
+}
+
+// TestTransitionListSpec_MatchesPresentListHeaders locks the spec against
+// PresentList headers for both default and extended modes.
+func TestTransitionListSpec_MatchesPresentListHeaders(t *testing.T) {
+	t.Parallel()
+	transitions := []api.Transition{{ID: "1", Name: "x", To: api.Status{Name: "y"}}}
+
+	for _, extended := range []bool{false, true} {
+		name := "default"
+		if extended {
+			name = "extended"
+		}
+		t.Run(name, func(t *testing.T) {
+			specs := TransitionListSpec.ForMode(extended)
+			model := TransitionPresenter{}.PresentList(transitions, extended)
+			table := model.Sections[0].(*present.TableSection)
+
+			if len(table.Headers) != len(specs) {
+				t.Fatalf("header count mismatch: spec has %d, table has %d", len(specs), len(table.Headers))
+			}
+			for i, spec := range specs {
+				if table.Headers[i] != spec.Header {
+					t.Errorf("index %d: spec Header=%q, table header=%q", i, spec.Header, table.Headers[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Migrate `transitions list` to the output model (Emit path, --id, --extended) while preserving live per-issue API behavior
- Extended mode adds STATUS_CATEGORY and REQUIRED_FIELDS columns (--fields retained as deprecated alias)
- `transitions do` migrated to Emit path for consistent output handling
- Add spec/header parity tests

Closes #240

## Test plan

- [x] `make build` passes
- [x] `make test` passes (1357 tests)
- [x] `make lint` clean
- [ ] Manual: `jtk transitions list MON-4810` — ID|NAME|TO_STATUS
- [ ] Manual: `jtk transitions list MON-4810 --extended` — adds STATUS_CATEGORY, REQUIRED_FIELDS
- [ ] Manual: `jtk transitions list MON-4810 --id` — transition IDs only
- [ ] Manual: `jtk transitions list MON-4810 --fields` — deprecated alias works