### PR TITLE
feat(jtk): migrate comments, links, and attachments reads to new output model

### DIFF
--- a/tools/jtk/internal/cmd/attachments/attachments.go
+++ b/tools/jtk/internal/cmd/attachments/attachments.go
@@ -9,13 +9,15 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
+
+func noFieldFetch(_ context.Context) ([]api.Field, error) { return nil, nil }
 
 // Register registers the attachments commands
 func Register(parent *cobra.Command, opts *root.Options) {
@@ -35,24 +37,52 @@ func Register(parent *cobra.Command, opts *root.Options) {
 }
 
 func newListCmd(opts *root.Options) *cobra.Command {
+	var fieldsFlag string
+
 	cmd := &cobra.Command{
 		Use:     "list <issue-key>",
 		Aliases: []string{"ls"},
 		Short:   "List attachments on an issue",
 		Long:    "List all attachments on a Jira issue.",
 		Example: `  # List attachments
-  jtk attachments list PROJ-123`,
+  jtk attachments list PROJ-123
+  jtk attachments list PROJ-123 --extended
+  jtk attachments list PROJ-123 --id`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), opts, args[0])
+			return runList(cmd.Context(), opts, args[0], fieldsFlag)
 		},
 	}
+
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns")
 
 	return cmd
 }
 
-func runList(ctx context.Context, opts *root.Options, issueKey string) error {
+func runList(ctx context.Context, opts *root.Options, issueKey, fieldsFlag string) error {
 	v := opts.View()
+	idOnly := opts.EmitIDOnly()
+
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
+		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		var err error
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.AttachmentListSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			noFieldFetch,
+			"attachments list",
+		)
+		if err != nil {
+			return err
+		}
+	}
 
 	client, err := opts.APIClient()
 	if err != nil {
@@ -64,36 +94,27 @@ func runList(ctx context.Context, opts *root.Options, issueKey string) error {
 		return err
 	}
 
+	if idOnly {
+		ids := make([]string, len(attachments))
+		for i, a := range attachments {
+			ids[i] = a.ID.String()
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
 	if len(attachments) == 0 {
-		model := jtkpresent.AttachmentPresenter{}.PresentEmpty(issueKey)
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.AttachmentPresenter{}.PresentEmpty(issueKey))
 	}
 
 	if v.Format == view.FormatJSON {
-		data := make([]map[string]any, 0, len(attachments))
-		for _, att := range attachments {
-			data = append(data, map[string]any{
-				"id":       att.ID.String(),
-				"filename": att.Filename,
-				"size":     att.Size,
-				"mimeType": att.MimeType,
-				"created":  att.Created,
-				"author":   att.Author.DisplayName,
-				"content":  att.Content,
-			})
-		}
-
-		return v.JSON(data)
+		return v.JSON(attachments)
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.AttachmentPresenter{}.PresentList(attachments)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	model := jtkpresent.AttachmentPresenter{}.PresentList(attachments, opts.IsExtended())
+	if projected {
+		projection.ApplyToTableInModel(model, selected)
+	}
+	return jtkpresent.Emit(opts, model)
 }
 
 func newAddCmd(opts *root.Options) *cobra.Command {
@@ -144,9 +165,7 @@ func runAdd(ctx context.Context, opts *root.Options, issueKey string, files []st
 		}
 
 		for _, att := range attachments {
-			model := jtkpresent.AttachmentPresenter{}.PresentUploaded(att.Filename, att.ID.String(), api.FormatFileSize(att.Size))
-			out := present.Render(model, opts.RenderStyle())
-			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+			_ = jtkpresent.Emit(opts, jtkpresent.AttachmentPresenter{}.PresentUploaded(att.Filename, att.ID.String(), api.FormatFileSize(att.Size)))
 		}
 	}
 
@@ -203,10 +222,7 @@ func runGet(ctx context.Context, opts *root.Options, attachmentID, outputPath st
 		actualPath = filepath.Join(outputPath, attachment.Filename)
 	}
 
-	model := jtkpresent.AttachmentPresenter{}.PresentDownloaded(actualPath, api.FormatFileSize(attachment.Size))
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.AttachmentPresenter{}.PresentDownloaded(actualPath, api.FormatFileSize(attachment.Size)))
 }
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {
@@ -236,8 +252,5 @@ func runDelete(ctx context.Context, opts *root.Options, attachmentID string) err
 		return fmt.Errorf("deleting attachment: %w", err)
 	}
 
-	model := jtkpresent.AttachmentPresenter{}.PresentDeleted(attachmentID)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.AttachmentPresenter{}.PresentDeleted(attachmentID))
 }

--- a/tools/jtk/internal/cmd/attachments/attachments.go
+++ b/tools/jtk/internal/cmd/attachments/attachments.go
@@ -107,7 +107,19 @@ func runList(ctx context.Context, opts *root.Options, issueKey, fieldsFlag strin
 	}
 
 	if v.Format == view.FormatJSON {
-		return v.JSON(attachments)
+		data := make([]map[string]any, 0, len(attachments))
+		for _, att := range attachments {
+			data = append(data, map[string]any{
+				"id":       att.ID.String(),
+				"filename": att.Filename,
+				"size":     att.Size,
+				"mimeType": att.MimeType,
+				"created":  att.Created,
+				"author":   att.Author.DisplayName,
+				"content":  att.Content,
+			})
+		}
+		return v.JSON(data)
 	}
 
 	model := jtkpresent.AttachmentPresenter{}.PresentList(attachments, opts.IsExtended())

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -68,7 +68,7 @@ func TestRunList_Table(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "TEST-1")
+	err = runList(context.Background(), opts, "TEST-1", "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -111,7 +111,7 @@ func TestRunList_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "TEST-1")
+	err = runList(context.Background(), opts, "TEST-1", "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -140,7 +140,7 @@ func TestRunList_Empty(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, "TEST-1")
+	err = runList(context.Background(), opts, "TEST-1", "")
 	testutil.RequireNoError(t, err)
 
 	testutil.Contains(t, stdout.String(), "No attachments found")

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -3,7 +3,6 @@ package comments
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -130,14 +129,15 @@ func runList(ctx context.Context, opts *root.Options, issueKey string, maxResult
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
+	extended := opts.IsExtended()
 	var model *present.OutputModel
 	if noTruncate {
-		model = jtkpresent.CommentPresenter{}.PresentListFullWithPagination(result.Comments, hasMore)
+		model = jtkpresent.CommentPresenter{}.PresentListFullWithPagination(result.Comments, extended, hasMore)
 		if projected {
 			projectAllDetailSectionsInModel(model, selected)
 		}
 	} else {
-		model = jtkpresent.CommentPresenter{}.PresentListWithPagination(result.Comments, hasMore)
+		model = jtkpresent.CommentPresenter{}.PresentListWithPagination(result.Comments, extended, hasMore)
 		if projected {
 			projection.ApplyToTableInModel(model, selected)
 		}
@@ -210,11 +210,7 @@ func runAdd(ctx context.Context, opts *root.Options, issueKey, body string) erro
 		return v.JSON(comment)
 	}
 
-	model := jtkpresent.CommentPresenter{}.PresentAdded(comment.ID, issueKey)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.CommentPresenter{}.PresentAdded(comment.ID, issueKey))
 }
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {
@@ -248,9 +244,5 @@ func runDelete(ctx context.Context, opts *root.Options, issueKey, commentID stri
 		return v.JSON(map[string]string{"status": "deleted", "commentId": commentID})
 	}
 
-	model := jtkpresent.CommentPresenter{}.PresentDeleted(commentID, issueKey)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.CommentPresenter{}.PresentDeleted(commentID, issueKey))
 }

--- a/tools/jtk/internal/cmd/comments/comments_fields_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_fields_test.go
@@ -61,7 +61,7 @@ func TestRunList_Fields_TableMode_BodyTruncatedWithoutFullText(t *testing.T) {
 
 	output := stdout.String()
 	testutil.Contains(t, output, "BODY")
-	testutil.Contains(t, output, "[truncated, use --fulltext for complete text]")
+	testutil.Contains(t, output, "...")
 	testutil.NotContains(t, output, longBodyText)
 }
 

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -97,7 +97,7 @@ func TestRunList_TruncatesCommentBody(t *testing.T) {
 
 	output := stdout.String()
 	testutil.Contains(t, output, "Alice")
-	testutil.Contains(t, output, "[truncated, use --fulltext for complete text]")
+	testutil.Contains(t, output, "...")
 	testutil.NotContains(t, output, longText)
 }
 

--- a/tools/jtk/internal/cmd/links/links.go
+++ b/tools/jtk/internal/cmd/links/links.go
@@ -8,14 +8,16 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 )
+
+func noFieldFetch(_ context.Context) ([]api.Field, error) { return nil, nil }
 
 // Register registers the links commands
 func Register(parent *cobra.Command, opts *root.Options) {
@@ -35,22 +37,51 @@ func Register(parent *cobra.Command, opts *root.Options) {
 }
 
 func newListCmd(opts *root.Options) *cobra.Command {
+	var fieldsFlag string
+
 	cmd := &cobra.Command{
-		Use:     "list <issue-key>",
-		Short:   "List links on an issue",
-		Long:    "List all links on a specific issue.",
-		Example: `  jtk links list PROJ-123`,
-		Args:    cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			return runList(opts, args[0])
+		Use:   "list <issue-key>",
+		Short: "List links on an issue",
+		Long:  "List all links on a specific issue.",
+		Example: `  jtk links list PROJ-123
+  jtk links list PROJ-123 --extended
+  jtk links list PROJ-123 --id
+  jtk links list PROJ-123 --fields TYPE,ISSUE`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(cmd.Context(), opts, args[0], fieldsFlag)
 		},
 	}
+
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns")
 
 	return cmd
 }
 
-func runList(opts *root.Options, issueKey string) error {
+func runList(ctx context.Context, opts *root.Options, issueKey, fieldsFlag string) error {
 	v := opts.View()
+	idOnly := opts.EmitIDOnly()
+
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
+		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		var err error
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.LinkListSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			noFieldFetch,
+			"links list",
+		)
+		if err != nil {
+			return err
+		}
+	}
 
 	client, err := opts.APIClient()
 	if err != nil {
@@ -62,23 +93,27 @@ func runList(opts *root.Options, issueKey string) error {
 		return err
 	}
 
+	if idOnly {
+		ids := make([]string, len(links))
+		for i, l := range links {
+			ids[i] = l.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
 	if len(links) == 0 {
-		model := jtkpresent.LinkPresenter{}.PresentEmpty(issueKey)
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.LinkPresenter{}.PresentEmpty(issueKey))
 	}
 
 	if v.Format == view.FormatJSON {
 		return v.JSON(links)
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.LinkPresenter{}.PresentList(links)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	model := jtkpresent.LinkPresenter{}.PresentList(links, opts.IsExtended())
+	if projected {
+		projection.ApplyToTableInModel(model, selected)
+	}
+	return jtkpresent.Emit(opts, model)
 }
 
 func newCreateCmd(opts *root.Options) *cobra.Command {
@@ -165,10 +200,7 @@ func runCreate(ctx context.Context, opts *root.Options, outwardKey, inwardKey, l
 		})
 	}
 
-	model := jtkpresent.LinkPresenter{}.PresentCreated(linkType, outwardKey, inwardKey)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.LinkPresenter{}.PresentCreated(linkType, outwardKey, inwardKey))
 }
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {
@@ -203,28 +235,52 @@ func runDelete(opts *root.Options, linkID string) error {
 		return v.JSON(map[string]string{"status": "deleted", "linkId": linkID})
 	}
 
-	model := jtkpresent.LinkPresenter{}.PresentDeleted(linkID)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.LinkPresenter{}.PresentDeleted(linkID))
 }
 
 func newTypesCmd(opts *root.Options) *cobra.Command {
+	var fieldsFlag string
+
 	cmd := &cobra.Command{
-		Use:     "types",
-		Short:   "List available link types",
-		Long:    "List all available issue link types in the Jira instance.",
-		Example: `  jtk links types`,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return runTypes(opts)
+		Use:   "types",
+		Short: "List available link types",
+		Long:  "List all available issue link types in the Jira instance.",
+		Example: `  jtk links types
+  jtk links types --id`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTypes(cmd.Context(), opts, fieldsFlag)
 		},
 	}
+
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns")
 
 	return cmd
 }
 
-func runTypes(opts *root.Options) error {
+func runTypes(ctx context.Context, opts *root.Options, fieldsFlag string) error {
 	v := opts.View()
+	idOnly := opts.EmitIDOnly()
+
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
+		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		var err error
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.LinkTypesSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			noFieldFetch,
+			"links types",
+		)
+		if err != nil {
+			return err
+		}
+	}
 
 	client, err := opts.APIClient()
 	if err != nil {
@@ -237,22 +293,26 @@ func runTypes(opts *root.Options) error {
 	}
 
 	if len(linkTypes) == 0 {
-		model := jtkpresent.LinkPresenter{}.PresentNoTypes()
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.LinkPresenter{}.PresentNoTypes())
+	}
+
+	if idOnly {
+		ids := make([]string, len(linkTypes))
+		for i, t := range linkTypes {
+			ids[i] = t.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
 	}
 
 	if v.Format == view.FormatJSON {
 		return v.JSON(linkTypes)
 	}
 
-	// Text path: presenter → render → write
 	model := jtkpresent.LinkPresenter{}.PresentTypes(linkTypes)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	if projected {
+		projection.ApplyToTableInModel(model, selected)
+	}
+	return jtkpresent.Emit(opts, model)
 }
 
 // GetIssueLinkTypes returns all link types (exported for use by other commands)

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -89,6 +89,39 @@ func TestRunList_NoLinks(t *testing.T) {
 	testutil.RequireNoError(t, err)
 }
 
+func TestRunList_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"fields": map[string]any{
+				"issuelinks": []any{
+					map[string]any{
+						"id":   "17844",
+						"type": map[string]any{"id": "10", "name": "Blocker", "inward": "is blocked by", "outward": "blocks"},
+						"outwardIssue": map[string]any{
+							"key":    "PROJ-2",
+							"fields": map[string]any{"summary": "Target"},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "PROJ-123", "")
+	testutil.RequireNoError(t, err)
+
+	testutil.Equal(t, stdout.String(), "17844\n")
+}
+
 func TestRunCreate(t *testing.T) {
 	var capturedBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -60,7 +60,7 @@ func TestRunList(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runList(opts, "PROJ-123")
+	err = runList(context.Background(), opts, "PROJ-123", "")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "PROJ-456")
 	testutil.Contains(t, stdout.String(), "Blocks")
@@ -85,7 +85,7 @@ func TestRunList_NoLinks(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &stderr}
 	opts.SetAPIClient(client)
 
-	err = runList(opts, "PROJ-123")
+	err = runList(context.Background(), opts, "PROJ-123", "")
 	testutil.RequireNoError(t, err)
 }
 
@@ -307,7 +307,7 @@ func TestRunTypes(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runTypes(opts)
+	err = runTypes(context.Background(), opts, "")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Blocks")
 	testutil.Contains(t, stdout.String(), "Relates")

--- a/tools/jtk/internal/present/attachment.go
+++ b/tools/jtk/internal/present/attachment.go
@@ -7,25 +7,57 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 // AttachmentPresenter creates presentation models for issue attachments.
 type AttachmentPresenter struct{}
 
-// PresentList creates a table presentation of attachments.
-func (AttachmentPresenter) PresentList(attachments []api.Attachment) *present.OutputModel {
+// AttachmentListSpec declares the columns emitted by PresentList. Default:
+// ID|FILENAME|SIZE|AUTHOR|CREATED. Extended adds BYTES and MIME_TYPE.
+var AttachmentListSpec = projection.Registry{
+	{Header: "ID", Identity: true},
+	{Header: "FILENAME"},
+	{Header: "SIZE"},
+	{Header: "AUTHOR"},
+	{Header: "CREATED"},
+	{Header: "BYTES", Extended: true},
+	{Header: "MIME_TYPE", Extended: true},
+}
+
+// PresentList creates a table presentation of attachments. Extended
+// adds BYTES (raw size) and MIME_TYPE columns, uses full timestamps.
+func (AttachmentPresenter) PresentList(attachments []api.Attachment, extended bool) *present.OutputModel {
+	var headers []string
+	if extended {
+		headers = []string{"ID", "FILENAME", "SIZE", "AUTHOR", "CREATED", "BYTES", "MIME_TYPE"}
+	} else {
+		headers = []string{"ID", "FILENAME", "SIZE", "AUTHOR", "CREATED"}
+	}
+
 	rows := make([]present.Row, len(attachments))
 	for i, a := range attachments {
-		rows[i] = present.Row{
-			Cells: []string{a.ID.String(), a.Filename, FormatSize(a.Size), FormatTime(a.Created), a.Author.DisplayName},
+		if extended {
+			rows[i] = present.Row{
+				Cells: []string{
+					a.ID.String(),
+					a.Filename,
+					FormatSize(a.Size),
+					a.Author.DisplayName,
+					OrDash(a.Created),
+					FormatInt(int(a.Size)),
+					OrDash(a.MimeType),
+				},
+			}
+		} else {
+			rows[i] = present.Row{
+				Cells: []string{a.ID.String(), a.Filename, FormatSize(a.Size), a.Author.DisplayName, FormatTime(a.Created)},
+			}
 		}
 	}
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"ID", "FILENAME", "SIZE", "CREATED", "AUTHOR"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
 	}
 }

--- a/tools/jtk/internal/present/attachment_test.go
+++ b/tools/jtk/internal/present/attachment_test.go
@@ -1,0 +1,64 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestAttachmentListSpec_MatchesPresentListHeaders(t *testing.T) {
+	t.Parallel()
+	attachments := []api.Attachment{{
+		ID:       "10234",
+		Filename: "test.md",
+		Size:     4301,
+		MimeType: "text/markdown",
+		Created:  "2026-04-16",
+		Author:   api.User{DisplayName: "Alice"},
+	}}
+
+	for _, extended := range []bool{false, true} {
+		name := "default"
+		if extended {
+			name = "extended"
+		}
+		t.Run(name, func(t *testing.T) {
+			specs := AttachmentListSpec.ForMode(extended)
+			model := AttachmentPresenter{}.PresentList(attachments, extended)
+			table := model.Sections[0].(*present.TableSection)
+
+			if len(table.Headers) != len(specs) {
+				t.Fatalf("header count mismatch: spec has %d, table has %d", len(specs), len(table.Headers))
+			}
+			for i, spec := range specs {
+				if table.Headers[i] != spec.Header {
+					t.Errorf("index %d: spec=%q, table=%q", i, spec.Header, table.Headers[i])
+				}
+			}
+		})
+	}
+}
+
+func TestAttachmentPresenter_PresentList_Extended(t *testing.T) {
+	t.Parallel()
+	attachments := []api.Attachment{{
+		ID:       "10234",
+		Filename: "audit-notes.md",
+		Size:     4301,
+		MimeType: "text/markdown",
+		Created:  "2026-04-16T09:00:00+0000",
+		Author:   api.User{DisplayName: "Alice"},
+	}}
+
+	model := AttachmentPresenter{}.PresentList(attachments, true)
+	table := model.Sections[0].(*present.TableSection)
+
+	if table.Rows[0].Cells[5] != "4301" {
+		t.Errorf("BYTES: expected '4301', got %q", table.Rows[0].Cells[5])
+	}
+	if table.Rows[0].Cells[6] != "text/markdown" {
+		t.Errorf("MIME_TYPE: expected 'text/markdown', got %q", table.Rows[0].Cells[6])
+	}
+}

--- a/tools/jtk/internal/present/comment.go
+++ b/tools/jtk/internal/present/comment.go
@@ -23,6 +23,7 @@ var CommentListSpec = projection.Registry{
 	{Header: "ID", Identity: true},
 	{Header: "AUTHOR"},
 	{Header: "CREATED"},
+	{Header: "UPDATED", Extended: true},
 	{Header: "BODY"},
 }
 
@@ -33,42 +34,53 @@ var CommentDetailSpec = projection.Registry{
 	{Header: "ID", Identity: true},
 	{Header: "Author"},
 	{Header: "Created"},
+	{Header: "Updated", Extended: true},
 	{Header: "Body"},
 }
 
-// PresentList creates a table view for a list of comments.
-func (CommentPresenter) PresentList(comments []api.Comment) *present.OutputModel {
+// PresentList creates a table view for a list of comments. Extended
+// adds UPDATED column with full timestamp.
+func (CommentPresenter) PresentList(comments []api.Comment, extended bool) *present.OutputModel {
+	var headers []string
+	if extended {
+		headers = []string{"ID", "AUTHOR", "CREATED", "UPDATED", "BODY"}
+	} else {
+		headers = []string{"ID", "AUTHOR", "CREATED", "BODY"}
+	}
+
 	rows := make([]present.Row, len(comments))
 	for i, c := range comments {
 		author := "Unknown"
 		if c.Author.DisplayName != "" {
 			author = c.Author.DisplayName
 		}
-		// Truncate body for table display
 		body := ""
 		if c.Body != nil {
 			body = c.Body.ToPlainText()
 			if len(body) > 100 {
-				body = body[:100] + "... [truncated, use --fulltext for complete text]"
+				body = body[:100] + "..."
 			}
 		}
-		rows[i] = present.Row{
-			Cells: []string{c.ID, author, FormatTime(c.Created), body},
+		if extended {
+			rows[i] = present.Row{
+				Cells: []string{c.ID, author, OrDash(c.Created), OrDash(c.Updated), body},
+			}
+		} else {
+			rows[i] = present.Row{
+				Cells: []string{c.ID, author, FormatTime(c.Created), body},
+			}
 		}
 	}
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"ID", "AUTHOR", "CREATED", "BODY"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
 	}
 }
 
 // PresentListFull creates detail views for comments without truncation.
-// Each comment becomes a DetailSection; the renderer owns spacing between sections.
-func (CommentPresenter) PresentListFull(comments []api.Comment) *present.OutputModel {
+// Each comment becomes a DetailSection. Extended adds Updated field.
+func (CommentPresenter) PresentListFull(comments []api.Comment, extended bool) *present.OutputModel {
 	sections := make([]present.Section, len(comments))
 	for i, c := range comments {
 		author := "Unknown"
@@ -77,35 +89,34 @@ func (CommentPresenter) PresentListFull(comments []api.Comment) *present.OutputM
 		}
 		body := ""
 		if c.Body != nil {
-			// ADF rendering can append a trailing newline; trim it so each
-			// block has consistent termination and the renderer's block
-			// separator produces exactly one blank line between comments.
 			body = strings.TrimRight(c.Body.ToPlainText(), "\n")
 		}
-		sections[i] = &present.DetailSection{
-			Fields: []present.Field{
-				{Label: "ID", Value: c.ID},
-				{Label: "Author", Value: author},
-				{Label: "Created", Value: FormatTime(c.Created)},
-				{Label: "Body", Value: body},
-			},
+		fields := []present.Field{
+			{Label: "ID", Value: c.ID},
+			{Label: "Author", Value: author},
+			{Label: "Created", Value: FormatTime(c.Created)},
 		}
+		if extended {
+			fields = append(fields, present.Field{Label: "Updated", Value: OrDash(c.Updated)})
+		}
+		fields = append(fields, present.Field{Label: "Body", Value: body})
+		sections[i] = &present.DetailSection{Fields: fields}
 	}
 	return &present.OutputModel{Sections: sections}
 }
 
 // PresentListWithPagination wraps PresentList and appends a stdout-bound
 // pagination hint when hasMore is true.
-func (p CommentPresenter) PresentListWithPagination(comments []api.Comment, hasMore bool) *present.OutputModel {
-	model := p.PresentList(comments)
+func (p CommentPresenter) PresentListWithPagination(comments []api.Comment, extended bool, hasMore bool) *present.OutputModel {
+	model := p.PresentList(comments, extended)
 	model.Sections = AppendPaginationHint(model.Sections, hasMore)
 	return model
 }
 
 // PresentListFullWithPagination wraps PresentListFull and appends a
 // stdout-bound pagination hint when hasMore is true.
-func (p CommentPresenter) PresentListFullWithPagination(comments []api.Comment, hasMore bool) *present.OutputModel {
-	model := p.PresentListFull(comments)
+func (p CommentPresenter) PresentListFullWithPagination(comments []api.Comment, extended bool, hasMore bool) *present.OutputModel {
+	model := p.PresentListFull(comments, extended)
 	model.Sections = AppendPaginationHint(model.Sections, hasMore)
 	return model
 }

--- a/tools/jtk/internal/present/comment_test.go
+++ b/tools/jtk/internal/present/comment_test.go
@@ -38,9 +38,9 @@ func TestCommentListSpec_MatchesPresentListHeaders(t *testing.T) {
 		name  string
 		model *present.OutputModel
 	}{
-		{"PresentList", CommentPresenter{}.PresentList(comments)},
-		{"PresentListWithPagination_NoMore", CommentPresenter{}.PresentListWithPagination(comments, false)},
-		{"PresentListWithPagination_HasMore", CommentPresenter{}.PresentListWithPagination(comments, true)},
+		{"PresentList", CommentPresenter{}.PresentList(comments, false)},
+		{"PresentListWithPagination_NoMore", CommentPresenter{}.PresentListWithPagination(comments, false, false)},
+		{"PresentListWithPagination_HasMore", CommentPresenter{}.PresentListWithPagination(comments, false, true)},
 	}
 
 	for _, tc := range cases {
@@ -55,10 +55,11 @@ func TestCommentListSpec_MatchesPresentListHeaders(t *testing.T) {
 			if table == nil {
 				t.Fatalf("no TableSection in %s output", tc.name)
 			}
-			if len(table.Headers) != len(CommentListSpec) {
-				t.Fatalf("header count mismatch: spec has %d, table has %d", len(CommentListSpec), len(table.Headers))
+			defaultSpec := CommentListSpec.ForMode(false)
+			if len(table.Headers) != len(defaultSpec) {
+				t.Fatalf("header count mismatch: spec has %d, table has %d", len(defaultSpec), len(table.Headers))
 			}
-			for i, spec := range CommentListSpec {
+			for i, spec := range defaultSpec {
 				if table.Headers[i] != spec.Header {
 					t.Errorf("index %d: spec Header=%q, table header=%q", i, spec.Header, table.Headers[i])
 				}
@@ -83,9 +84,9 @@ func TestCommentDetailSpec_MatchesPresentDetailLabels(t *testing.T) {
 		name  string
 		model *present.OutputModel
 	}{
-		{"PresentListFull", CommentPresenter{}.PresentListFull(comments)},
-		{"PresentListFullWithPagination_NoMore", CommentPresenter{}.PresentListFullWithPagination(comments, false)},
-		{"PresentListFullWithPagination_HasMore", CommentPresenter{}.PresentListFullWithPagination(comments, true)},
+		{"PresentListFull", CommentPresenter{}.PresentListFull(comments, false)},
+		{"PresentListFullWithPagination_NoMore", CommentPresenter{}.PresentListFullWithPagination(comments, false, false)},
+		{"PresentListFullWithPagination_HasMore", CommentPresenter{}.PresentListFullWithPagination(comments, false, true)},
 	}
 
 	for _, tc := range cases {
@@ -101,20 +102,20 @@ func TestCommentDetailSpec_MatchesPresentDetailLabels(t *testing.T) {
 				t.Fatalf("no DetailSection in %s output", tc.name)
 			}
 
-			// Spec → rendered: every spec entry has a rendered field.
+			activeSpec := CommentDetailSpec.ForMode(false)
+
 			renderedLabels := make(map[string]bool, len(detail.Fields))
 			for _, f := range detail.Fields {
 				renderedLabels[f.Label] = true
 			}
-			for _, spec := range CommentDetailSpec {
+			for _, spec := range activeSpec {
 				if !renderedLabels[spec.Header] {
 					t.Errorf("spec Header %q not emitted by %s", spec.Header, tc.name)
 				}
 			}
 
-			// Rendered → spec: every rendered field has a spec entry.
-			specLabels := make(map[string]bool, len(CommentDetailSpec))
-			for _, spec := range CommentDetailSpec {
+			specLabels := make(map[string]bool, len(activeSpec))
+			for _, spec := range activeSpec {
 				specLabels[spec.Header] = true
 			}
 			for _, f := range detail.Fields {
@@ -123,9 +124,8 @@ func TestCommentDetailSpec_MatchesPresentDetailLabels(t *testing.T) {
 				}
 			}
 
-			// Order: spec order must match presenter Field order.
-			specOrder := make([]string, 0, len(CommentDetailSpec))
-			for _, spec := range CommentDetailSpec {
+			specOrder := make([]string, 0, len(activeSpec))
+			for _, spec := range activeSpec {
 				specOrder = append(specOrder, spec.Header)
 			}
 			renderedOrder := make([]string, 0, len(detail.Fields))

--- a/tools/jtk/internal/present/link.go
+++ b/tools/jtk/internal/present/link.go
@@ -7,39 +7,75 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
 // LinkPresenter creates presentation models for issue links.
 type LinkPresenter struct{}
 
-// PresentList creates a table presentation of issue links.
-func (LinkPresenter) PresentList(links []api.IssueLink) *present.OutputModel {
+// LinkListSpec declares the columns emitted by PresentList. Default:
+// LINK_ID|TYPE|DIRECTION|ISSUE|SUMMARY. Extended adds TYPE_ID and STATUS.
+var LinkListSpec = projection.Registry{
+	{Header: "LINK_ID", Identity: true},
+	{Header: "TYPE"},
+	{Header: "DIRECTION"},
+	{Header: "ISSUE"},
+	{Header: "SUMMARY"},
+	{Header: "TYPE_ID", Extended: true},
+	{Header: "STATUS", Extended: true},
+}
+
+// LinkTypesSpec declares the columns for link types. All default.
+var LinkTypesSpec = projection.Registry{
+	{Header: "ID", Identity: true},
+	{Header: "NAME"},
+	{Header: "INWARD"},
+	{Header: "OUTWARD"},
+}
+
+// PresentList creates a table presentation of issue links. Extended
+// adds TYPE_ID and the linked issue's current STATUS.
+func (LinkPresenter) PresentList(links []api.IssueLink, extended bool) *present.OutputModel {
+	var headers []string
+	if extended {
+		headers = []string{"LINK_ID", "TYPE", "DIRECTION", "ISSUE", "SUMMARY", "TYPE_ID", "STATUS"}
+	} else {
+		headers = []string{"LINK_ID", "TYPE", "DIRECTION", "ISSUE", "SUMMARY"}
+	}
+
 	rows := make([]present.Row, len(links))
 	for i, l := range links {
-		var direction, key, summary string
+		var direction, key, summary, status string
 
 		if l.OutwardIssue != nil {
-			// OutwardIssue is set → current issue is the inward side
 			direction = l.Type.Inward
 			key = l.OutwardIssue.Key
 			summary = l.OutwardIssue.Fields.Summary
+			if l.OutwardIssue.Fields.Status != nil {
+				status = l.OutwardIssue.Fields.Status.Name
+			}
 		} else if l.InwardIssue != nil {
-			// InwardIssue is set → current issue is the outward side
 			direction = l.Type.Outward
 			key = l.InwardIssue.Key
 			summary = l.InwardIssue.Fields.Summary
+			if l.InwardIssue.Fields.Status != nil {
+				status = l.InwardIssue.Fields.Status.Name
+			}
 		}
 
-		rows[i] = present.Row{
-			Cells: []string{l.ID, l.Type.Name, direction, key, summary},
+		if extended {
+			rows[i] = present.Row{
+				Cells: []string{l.ID, l.Type.Name, direction, key, summary, OrDash(l.Type.ID), OrDash(status)},
+			}
+		} else {
+			rows[i] = present.Row{
+				Cells: []string{l.ID, l.Type.Name, direction, key, summary},
+			}
 		}
 	}
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.TableSection{
-				Headers: []string{"ID", "TYPE", "DIRECTION", "ISSUE", "SUMMARY"},
-				Rows:    rows,
-			},
+			&present.TableSection{Headers: headers, Rows: rows},
 		},
 	}
 }
@@ -49,13 +85,13 @@ func (LinkPresenter) PresentTypes(types []api.IssueLinkType) *present.OutputMode
 	rows := make([]present.Row, len(types))
 	for i, t := range types {
 		rows[i] = present.Row{
-			Cells: []string{t.ID, t.Name, t.Outward, t.Inward},
+			Cells: []string{t.ID, t.Name, t.Inward, t.Outward},
 		}
 	}
 	return &present.OutputModel{
 		Sections: []present.Section{
 			&present.TableSection{
-				Headers: []string{"ID", "NAME", "OUTWARD", "INWARD"},
+				Headers: []string{"ID", "NAME", "INWARD", "OUTWARD"},
 				Rows:    rows,
 			},
 		},

--- a/tools/jtk/internal/present/link_test.go
+++ b/tools/jtk/internal/present/link_test.go
@@ -1,0 +1,90 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestLinkListSpec_MatchesPresentListHeaders(t *testing.T) {
+	t.Parallel()
+	links := []api.IssueLink{{
+		ID:   "1",
+		Type: api.IssueLinkType{ID: "10", Name: "Blocker", Inward: "is blocked by", Outward: "blocks"},
+		OutwardIssue: &api.LinkedIssue{
+			Key:    "PROJ-2",
+			Fields: struct {
+				Summary   string      `json:"summary"`
+				Status    *api.Status `json:"status,omitempty"`
+				IssueType *api.IssueType `json:"issuetype,omitempty"`
+			}{Summary: "Target", Status: &api.Status{Name: "Open"}},
+		},
+	}}
+
+	for _, extended := range []bool{false, true} {
+		name := "default"
+		if extended {
+			name = "extended"
+		}
+		t.Run(name, func(t *testing.T) {
+			specs := LinkListSpec.ForMode(extended)
+			model := LinkPresenter{}.PresentList(links, extended)
+			table := model.Sections[0].(*present.TableSection)
+
+			if len(table.Headers) != len(specs) {
+				t.Fatalf("header count mismatch: spec has %d, table has %d", len(specs), len(table.Headers))
+			}
+			for i, spec := range specs {
+				if table.Headers[i] != spec.Header {
+					t.Errorf("index %d: spec=%q, table=%q", i, spec.Header, table.Headers[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLinkTypesSpec_MatchesPresentTypesHeaders(t *testing.T) {
+	t.Parallel()
+	types := []api.IssueLinkType{{ID: "1", Name: "Blocker", Inward: "is blocked by", Outward: "blocks"}}
+
+	specs := LinkTypesSpec.ForMode(false)
+	model := LinkPresenter{}.PresentTypes(types)
+	table := model.Sections[0].(*present.TableSection)
+
+	if len(table.Headers) != len(specs) {
+		t.Fatalf("header count mismatch: spec has %d, table has %d", len(specs), len(table.Headers))
+	}
+	for i, spec := range specs {
+		if table.Headers[i] != spec.Header {
+			t.Errorf("index %d: spec=%q, table=%q", i, spec.Header, table.Headers[i])
+		}
+	}
+}
+
+func TestLinkPresenter_PresentList_Extended(t *testing.T) {
+	t.Parallel()
+	links := []api.IssueLink{{
+		ID:   "17844",
+		Type: api.IssueLinkType{ID: "10100", Name: "Blocker", Inward: "is blocked by", Outward: "blocks"},
+		OutwardIssue: &api.LinkedIssue{
+			Key: "MON-4819",
+			Fields: struct {
+				Summary   string      `json:"summary"`
+				Status    *api.Status `json:"status,omitempty"`
+				IssueType *api.IssueType `json:"issuetype,omitempty"`
+			}{Summary: "Linked issue B", Status: &api.Status{Name: "Backlog"}},
+		},
+	}}
+
+	model := LinkPresenter{}.PresentList(links, true)
+	table := model.Sections[0].(*present.TableSection)
+
+	if table.Rows[0].Cells[5] != "10100" {
+		t.Errorf("TYPE_ID: expected '10100', got %q", table.Rows[0].Cells[5])
+	}
+	if table.Rows[0].Cells[6] != "Backlog" {
+		t.Errorf("STATUS: expected 'Backlog', got %q", table.Rows[0].Cells[6])
+	}
+}

--- a/tools/jtk/internal/present/link_test.go
+++ b/tools/jtk/internal/present/link_test.go
@@ -14,10 +14,10 @@ func TestLinkListSpec_MatchesPresentListHeaders(t *testing.T) {
 		ID:   "1",
 		Type: api.IssueLinkType{ID: "10", Name: "Blocker", Inward: "is blocked by", Outward: "blocks"},
 		OutwardIssue: &api.LinkedIssue{
-			Key:    "PROJ-2",
+			Key: "PROJ-2",
 			Fields: struct {
-				Summary   string      `json:"summary"`
-				Status    *api.Status `json:"status,omitempty"`
+				Summary   string         `json:"summary"`
+				Status    *api.Status    `json:"status,omitempty"`
 				IssueType *api.IssueType `json:"issuetype,omitempty"`
 			}{Summary: "Target", Status: &api.Status{Name: "Open"}},
 		},
@@ -71,8 +71,8 @@ func TestLinkPresenter_PresentList_Extended(t *testing.T) {
 		OutwardIssue: &api.LinkedIssue{
 			Key: "MON-4819",
 			Fields: struct {
-				Summary   string      `json:"summary"`
-				Status    *api.Status `json:"status,omitempty"`
+				Summary   string         `json:"summary"`
+				Status    *api.Status    `json:"status,omitempty"`
 				IssueType *api.IssueType `json:"issuetype,omitempty"`
 			}{Summary: "Linked issue B", Status: &api.Status{Name: "Backlog"}},
 		},


### PR DESCRIPTION
## Summary

- Migrate comments, links, and attachments read surfaces to the output model (Emit path, --id, --extended, --fields)
- Comments: add UPDATED extended column, migrate add/delete to Emit
- Links: add LinkListSpec (extended: TYPE_ID, STATUS), LinkTypesSpec, --id, --fields projection, Emit on all paths
- Attachments: add AttachmentListSpec (extended: BYTES, MIME_TYPE), --id, --fields projection, Emit on all paths
- Spec/header parity tests for all new registries

Closes #241

## Test plan

- [x] `make build` passes
- [x] `make test` passes (1370 tests)
- [x] `make lint` clean
- [ ] Manual: `jtk links list MON-4810 --extended` — TYPE_ID and STATUS columns
- [ ] Manual: `jtk attachments list MON-4810 --extended` — BYTES and MIME_TYPE columns
- [ ] Manual: `jtk comments list MON-4810 --extended` — UPDATED column