### PR TITLE
fix(jtk): address pr-review-daemon and TDD findings

### DIFF
--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // --- list tests ---
@@ -148,7 +150,10 @@ func TestRunList_Empty(t *testing.T) {
 
 func attachmentServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("attachmentServer: expected GET, got %s", r.Method)
+		}
 		var response struct {
 			Fields struct {
 				Attachment []api.Attachment `json:"attachment"`
@@ -242,10 +247,9 @@ func TestRunList_FieldsWithJSON_Error(t *testing.T) {
 	opts.SetAPIClient(client)
 
 	err = runList(context.Background(), opts, "TEST-1", "FILENAME")
-	if err == nil {
-		t.Fatal("expected error for --fields + --output json")
+	if !errors.Is(err, jtkpresent.ErrFieldsWithJSON) {
+		t.Fatalf("expected ErrFieldsWithJSON, got %v", err)
 	}
-	testutil.Contains(t, err.Error(), "not supported")
 }
 
 // --- add tests ---

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -153,6 +153,8 @@ func attachmentServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("attachmentServer: expected GET, got %s", r.Method)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
 		}
 		var response struct {
 			Fields struct {

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -129,6 +129,8 @@ func linkServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("linkServer: expected GET, got %s", r.Method)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"fields": map[string]any{

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
-	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
 // isolateCache points cache I/O at a temp directory and overrides the

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -124,7 +126,10 @@ func TestRunList_IDOnly(t *testing.T) {
 
 func linkServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("linkServer: expected GET, got %s", r.Method)
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"fields": map[string]any{
 				"issuelinks": []any{
@@ -180,10 +185,12 @@ func TestRunList_FieldsProjection(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	out := stdout.String()
+	// LINK_ID is always present (Identity pin) even though not in --fields
 	testutil.Contains(t, out, "LINK_ID")
 	testutil.Contains(t, out, "TYPE")
 	testutil.Contains(t, out, "ISSUE")
 	testutil.NotContains(t, out, "SUMMARY")
+	testutil.NotContains(t, out, "DIRECTION")
 }
 
 func TestRunList_FieldsWithJSON_Error(t *testing.T) {
@@ -198,10 +205,9 @@ func TestRunList_FieldsWithJSON_Error(t *testing.T) {
 	opts.SetAPIClient(client)
 
 	err = runList(context.Background(), opts, "PROJ-123", "TYPE")
-	if err == nil {
-		t.Fatal("expected error for --fields + --output json")
+	if !errors.Is(err, jtkpresent.ErrFieldsWithJSON) {
+		t.Fatalf("expected ErrFieldsWithJSON, got %v", err)
 	}
-	testutil.Contains(t, err.Error(), "not supported")
 }
 
 func TestRunCreate(t *testing.T) {

--- a/tools/jtk/internal/present/comment_test.go
+++ b/tools/jtk/internal/present/comment_test.go
@@ -196,4 +196,31 @@ func TestCommentDetailSpec_ExtendedMatchesPresentDetailLabels(t *testing.T) {
 			t.Errorf("spec Header %q not emitted in extended mode", spec.Header)
 		}
 	}
+
+	specLabels := make(map[string]bool, len(extendedSpec))
+	for _, spec := range extendedSpec {
+		specLabels[spec.Header] = true
+	}
+	for _, f := range detail.Fields {
+		if !specLabels[f.Label] {
+			t.Errorf("rendered field %q has no matching CommentDetailSpec entry in extended mode", f.Label)
+		}
+	}
+
+	specOrder := make([]string, 0, len(extendedSpec))
+	for _, spec := range extendedSpec {
+		specOrder = append(specOrder, spec.Header)
+	}
+	renderedOrder := make([]string, 0, len(detail.Fields))
+	for _, f := range detail.Fields {
+		renderedOrder = append(renderedOrder, f.Label)
+	}
+	if len(specOrder) != len(renderedOrder) {
+		t.Fatalf("extended spec has %d entries, rendered has %d", len(specOrder), len(renderedOrder))
+	}
+	for i := range specOrder {
+		if specOrder[i] != renderedOrder[i] {
+			t.Errorf("extended order mismatch at index %d: spec=%q rendered=%q", i, specOrder[i], renderedOrder[i])
+		}
+	}
 }

--- a/tools/jtk/internal/present/comment_test.go
+++ b/tools/jtk/internal/present/comment_test.go
@@ -201,10 +201,15 @@ func TestCommentDetailSpec_ExtendedMatchesPresentDetailLabels(t *testing.T) {
 	for _, spec := range extendedSpec {
 		specLabels[spec.Header] = true
 	}
+	mismatch := false
 	for _, f := range detail.Fields {
 		if !specLabels[f.Label] {
 			t.Errorf("rendered field %q has no matching CommentDetailSpec entry in extended mode", f.Label)
+			mismatch = true
 		}
+	}
+	if mismatch {
+		t.Fatal("reverse-direction check failed; skipping order check")
 	}
 
 	specOrder := make([]string, 0, len(extendedSpec))


### PR DESCRIPTION
## Summary

- Address all 5 inline findings from pr-review-daemon on #264
- Fix comment extended detail test asymmetry (check both directions + order)
- Use `errors.Is(err, ErrFieldsWithJSON)` instead of string matching
- Add DIRECTION absence assertion to links projection test
- Validate HTTP method in linkServer/attachmentServer fixtures

## Test plan

- [x] `make build` passes
- [x] `make test` passes (1381 tests)