### PR TITLE
feat(jtk): add fetch-after-write helper for non-destructive mutations

### DIFF
--- a/tools/jtk/internal/cmd/issues/assign.go
+++ b/tools/jtk/internal/cmd/issues/assign.go
@@ -107,12 +107,19 @@ func runAssign(ctx context.Context, opts *root.Options, issueKey, userInput stri
 }
 
 func modelContainsAssignee(m *present.OutputModel, target string) bool {
-	prefix := "Assignee: " + target
+	needle := "Assignee: " + target
 	for _, section := range m.Sections {
-		if ms, ok := section.(*present.MessageSection); ok {
-			if strings.Contains(ms.Message, prefix) {
-				return true
-			}
+		ms, ok := section.(*present.MessageSection)
+		if !ok {
+			continue
+		}
+		idx := strings.Index(ms.Message, needle)
+		if idx < 0 {
+			continue
+		}
+		after := idx + len(needle)
+		if after >= len(ms.Message) || ms.Message[after] == ' ' {
+			return true
 		}
 	}
 	return false

--- a/tools/jtk/internal/cmd/issues/assign.go
+++ b/tools/jtk/internal/cmd/issues/assign.go
@@ -3,13 +3,14 @@ package issues
 
 import (
 	"context"
-	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 )
@@ -67,13 +68,52 @@ func runAssign(ctx context.Context, opts *root.Options, issueKey, userInput stri
 		}
 	}
 
-	if err := client.AssignIssue(ctx, issueKey, accountID); err != nil {
-		return err
+	if opts.EmitIDOnly() {
+		if err := client.AssignIssue(ctx, issueKey, accountID); err != nil {
+			return err
+		}
+		return jtkpresent.EmitIDs(opts, []string{issueKey})
 	}
 
-	model := jtkpresent.IssuePresenter{}.PresentAssigned(issueKey, displayName)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	var isFresh func(*present.OutputModel) bool
+	if displayName != "" {
+		isFresh = func(m *present.OutputModel) bool {
+			return modelContainsAssignee(m, displayName)
+		}
+	} else {
+		isFresh = func(m *present.OutputModel) bool {
+			return modelContainsAssignee(m, "-")
+		}
+	}
+
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(ctx context.Context) (string, error) {
+			return issueKey, client.AssignIssue(ctx, issueKey, accountID)
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			issue, err := client.GetIssue(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			return jtkpresent.IssuePresenter{}.PresentDetail(
+				issue, client.IssueURL(id), opts.IsExtended(), opts.IsFullText(),
+			), nil
+		},
+		IsFresh: isFresh,
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.IssuePresenter{}.PresentAssigned(id, displayName)
+		},
+	})
+}
+
+func modelContainsAssignee(m *present.OutputModel, target string) bool {
+	prefix := "Assignee: " + target
+	for _, section := range m.Sections {
+		if ms, ok := section.(*present.MessageSection); ok {
+			if strings.Contains(ms.Message, prefix) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/tools/jtk/internal/cmd/issues/assign.go
+++ b/tools/jtk/internal/cmd/issues/assign.go
@@ -3,7 +3,6 @@ package issues
 
 import (
 	"context"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -78,11 +77,11 @@ func runAssign(ctx context.Context, opts *root.Options, issueKey, userInput stri
 	var isFresh func(*present.OutputModel) bool
 	if displayName != "" {
 		isFresh = func(m *present.OutputModel) bool {
-			return modelContainsAssignee(m, displayName)
+			return mutation.ModelContainsField(m, "Assignee: ", displayName)
 		}
 	} else {
 		isFresh = func(m *present.OutputModel) bool {
-			return modelContainsAssignee(m, "-")
+			return mutation.ModelContainsField(m, "Assignee: ", "-")
 		}
 	}
 
@@ -104,23 +103,4 @@ func runAssign(ctx context.Context, opts *root.Options, issueKey, userInput stri
 			return jtkpresent.IssuePresenter{}.PresentAssigned(id, displayName)
 		},
 	})
-}
-
-func modelContainsAssignee(m *present.OutputModel, target string) bool {
-	needle := "Assignee: " + target
-	for _, section := range m.Sections {
-		ms, ok := section.(*present.MessageSection)
-		if !ok {
-			continue
-		}
-		idx := strings.Index(ms.Message, needle)
-		if idx < 0 {
-			continue
-		}
-		after := idx + len(needle)
-		if after >= len(ms.Message) || ms.Message[after] == ' ' {
-			return true
-		}
-	}
-	return false
 }

--- a/tools/jtk/internal/cmd/issues/assign_test.go
+++ b/tools/jtk/internal/cmd/issues/assign_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,21 +30,27 @@ func init() { mutation.BackoffSchedule = []time.Duration{0, 0, 0, 0} }
 // name so the GET response returns the name the IsFresh callback expects.
 func stubAssignServer(t *testing.T, capture *string, assigneeNames map[string]string) *httptest.Server {
 	t.Helper()
+	var mu sync.Mutex
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/assignee") && r.Method == http.MethodPut {
 			body, _ := io.ReadAll(r.Body)
 			var payload map[string]any
 			_ = json.Unmarshal(body, &payload)
+			mu.Lock()
 			switch v := payload["accountId"].(type) {
 			case string:
 				*capture = v
 			case nil:
 				*capture = "<null>"
 			}
+			mu.Unlock()
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/rest/api/3/issue/") {
+			mu.Lock()
+			cur := *capture
+			mu.Unlock()
 			fields := map[string]any{
 				"summary":   "Test issue",
 				"status":    map[string]any{"name": "Backlog"},
@@ -51,12 +58,12 @@ func stubAssignServer(t *testing.T, capture *string, assigneeNames map[string]st
 				"priority":  map[string]any{"name": "Medium"},
 				"updated":   "2026-04-16T00:00:00.000+0000",
 			}
-			if *capture != "" && *capture != "<null>" {
-				name := *capture
-				if n, ok := assigneeNames[*capture]; ok {
+			if cur != "" && cur != "<null>" {
+				name := cur
+				if n, ok := assigneeNames[cur]; ok {
 					name = n
 				}
-				fields["assignee"] = map[string]any{"displayName": name, "accountId": *capture}
+				fields["assignee"] = map[string]any{"displayName": name, "accountId": cur}
 			}
 			issue := map[string]any{"key": "PROJ-123", "fields": fields}
 			w.Header().Set("Content-Type", "application/json")

--- a/tools/jtk/internal/cmd/issues/assign_test.go
+++ b/tools/jtk/internal/cmd/issues/assign_test.go
@@ -10,19 +10,24 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 )
 
+func init() { mutation.BackoffSchedule = []time.Duration{0, 0, 0, 0} }
+
 // stubAssignServer returns a server that accepts the /assignee PUT,
 // captures the accountId body, and serves a GET for the post-write
-// fetch-after-write re-fetch.
-func stubAssignServer(t *testing.T, capture *string) *httptest.Server {
+// fetch-after-write re-fetch.  assigneeNames maps accountId → display
+// name so the GET response returns the name the IsFresh callback expects.
+func stubAssignServer(t *testing.T, capture *string, assigneeNames map[string]string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/assignee") && r.Method == http.MethodPut {
@@ -47,7 +52,11 @@ func stubAssignServer(t *testing.T, capture *string) *httptest.Server {
 				"updated":   "2026-04-16T00:00:00.000+0000",
 			}
 			if *capture != "" && *capture != "<null>" {
-				fields["assignee"] = map[string]any{"displayName": *capture, "accountId": *capture}
+				name := *capture
+				if n, ok := assigneeNames[*capture]; ok {
+					name = n
+				}
+				fields["assignee"] = map[string]any{"displayName": name, "accountId": *capture}
 			}
 			issue := map[string]any{"key": "PROJ-123", "fields": fields}
 			w.Header().Set("Content-Type", "application/json")
@@ -63,7 +72,7 @@ func TestRunAssign_ResolvesDisplayName(t *testing.T) {
 	seedCacheForIssues(t)
 
 	var captured string
-	server := stubAssignServer(t, &captured)
+	server := stubAssignServer(t, &captured, map[string]string{"abc123": "User One"})
 	defer server.Close()
 
 	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
@@ -79,13 +88,14 @@ func TestRunAssign_ResolvesDisplayName(t *testing.T) {
 	testutil.Equal(t, captured, "abc123")
 	testutil.Contains(t, stdout.String(), "PROJ-123")
 	testutil.Contains(t, stdout.String(), "Test issue")
+	testutil.Contains(t, stdout.String(), "User One")
 }
 
 func TestRunAssign_ResolvesByAccountID(t *testing.T) {
 	seedCacheForIssues(t)
 
 	var captured string
-	server := stubAssignServer(t, &captured)
+	server := stubAssignServer(t, &captured, map[string]string{"61292e4c4f29230069621c5f": "Account User"})
 	defer server.Close()
 
 	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
@@ -110,7 +120,7 @@ func TestRunAssign_SyntheticUserFallsBackToAccountID(t *testing.T) {
 	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 
 	var captured string
-	server := stubAssignServer(t, &captured)
+	server := stubAssignServer(t, &captured, nil)
 	defer server.Close()
 
 	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
@@ -135,7 +145,7 @@ func TestRunAssign_Unassign(t *testing.T) {
 	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 
 	var captured string
-	server := stubAssignServer(t, &captured)
+	server := stubAssignServer(t, &captured, nil)
 	defer server.Close()
 
 	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})

--- a/tools/jtk/internal/cmd/issues/assign_test.go
+++ b/tools/jtk/internal/cmd/issues/assign_test.go
@@ -19,27 +19,43 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 )
 
-// stubAssignServer returns a server that accepts the /assignee PUT and
-// captures the accountId body (or nil body on unassign). Any other request
-// is a test failure.
+// stubAssignServer returns a server that accepts the /assignee PUT,
+// captures the accountId body, and serves a GET for the post-write
+// fetch-after-write re-fetch.
 func stubAssignServer(t *testing.T, capture *string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasSuffix(r.URL.Path, "/assignee") || r.Method != http.MethodPut {
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
+		if strings.HasSuffix(r.URL.Path, "/assignee") && r.Method == http.MethodPut {
+			body, _ := io.ReadAll(r.Body)
+			var payload map[string]any
+			_ = json.Unmarshal(body, &payload)
+			switch v := payload["accountId"].(type) {
+			case string:
+				*capture = v
+			case nil:
+				*capture = "<null>"
+			}
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
-		body, _ := io.ReadAll(r.Body)
-		var payload map[string]any
-		_ = json.Unmarshal(body, &payload)
-		switch v := payload["accountId"].(type) {
-		case string:
-			*capture = v
-		case nil:
-			*capture = "<null>"
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/rest/api/3/issue/") {
+			fields := map[string]any{
+				"summary":   "Test issue",
+				"status":    map[string]any{"name": "Backlog"},
+				"issuetype": map[string]any{"name": "SDLC"},
+				"priority":  map[string]any{"name": "Medium"},
+				"updated":   "2026-04-16T00:00:00.000+0000",
+			}
+			if *capture != "" && *capture != "<null>" {
+				fields["assignee"] = map[string]any{"displayName": *capture, "accountId": *capture}
+			}
+			issue := map[string]any{"key": "PROJ-123", "fields": fields}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(issue)
+			return
 		}
-		w.WriteHeader(http.StatusNoContent)
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
 	}))
 }
 
@@ -61,7 +77,8 @@ func TestRunAssign_ResolvesDisplayName(t *testing.T) {
 	err = runAssign(context.Background(), opts, "PROJ-123", "User One", false)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, captured, "abc123")
-	testutil.Contains(t, stdout.String(), "User One")
+	testutil.Contains(t, stdout.String(), "PROJ-123")
+	testutil.Contains(t, stdout.String(), "Test issue")
 }
 
 func TestRunAssign_ResolvesByAccountID(t *testing.T) {
@@ -82,8 +99,8 @@ func TestRunAssign_ResolvesByAccountID(t *testing.T) {
 	err = runAssign(context.Background(), opts, "PROJ-123", "61292e4c4f29230069621c5f", false)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, captured, "61292e4c4f29230069621c5f")
-	// Display name resolved from cache for the message.
-	testutil.Contains(t, stdout.String(), "Account User")
+	testutil.Contains(t, stdout.String(), "PROJ-123")
+	testutil.Contains(t, stdout.String(), "Test issue")
 }
 
 func TestRunAssign_SyntheticUserFallsBackToAccountID(t *testing.T) {
@@ -107,8 +124,8 @@ func TestRunAssign_SyntheticUserFallsBackToAccountID(t *testing.T) {
 	err = runAssign(context.Background(), opts, "PROJ-123", rawID, false)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, captured, rawID)
-	// No cache hit → synthetic user → display name echoes the accountId.
-	testutil.Contains(t, stdout.String(), rawID)
+	testutil.Contains(t, stdout.String(), "PROJ-123")
+	testutil.Contains(t, stdout.String(), "Test issue")
 }
 
 func TestRunAssign_Unassign(t *testing.T) {
@@ -134,6 +151,7 @@ func TestRunAssign_Unassign(t *testing.T) {
 	err = runAssign(context.Background(), opts, "PROJ-123", "some-ignored-id", true)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, captured, "<null>")
+	testutil.Contains(t, stdout.String(), "PROJ-123")
 }
 
 func TestRunAssign_ResolverNotFoundPropagates(t *testing.T) {

--- a/tools/jtk/internal/cmd/issues/create.go
+++ b/tools/jtk/internal/cmd/issues/create.go
@@ -145,37 +145,30 @@ func runCreate(ctx context.Context, opts *root.Options, project, issueType, summ
 
 	req := api.BuildCreateRequest(projectKey, typeName, summary, text.InterpretEscapes(description), extraFields)
 
+	issue, err := client.CreateIssue(ctx, req)
+	if err != nil {
+		return err
+	}
+
 	if opts.EmitIDOnly() {
-		issue, err := client.CreateIssue(ctx, req)
-		if err != nil {
-			return err
-		}
 		return jtkpresent.EmitIDs(opts, []string{issue.Key})
 	}
 
 	if opts.Output == "json" {
-		issue, err := client.CreateIssue(ctx, req)
-		if err != nil {
-			return err
-		}
 		return v.JSON(issue)
 	}
 
 	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
-		Write: func(ctx context.Context) (string, error) {
-			issue, err := client.CreateIssue(ctx, req)
-			if err != nil {
-				return "", err
-			}
+		Write: func(_ context.Context) (string, error) {
 			return issue.Key, nil
 		},
 		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
-			issue, err := client.GetIssue(ctx, id)
+			fetched, err := client.GetIssue(ctx, id)
 			if err != nil {
 				return nil, err
 			}
 			return jtkpresent.IssuePresenter{}.PresentDetail(
-				issue, client.IssueURL(id), opts.IsExtended(), opts.IsFullText(),
+				fetched, client.IssueURL(id), opts.IsExtended(), opts.IsFullText(),
 			), nil
 		},
 		Fallback: func(id string) *present.OutputModel {

--- a/tools/jtk/internal/cmd/issues/create.go
+++ b/tools/jtk/internal/cmd/issues/create.go
@@ -158,6 +158,7 @@ func runCreate(ctx context.Context, opts *root.Options, project, issueType, summ
 		return v.JSON(issue)
 	}
 
+	// Write already executed above; the closure just provides the key.
 	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
 		Write: func(_ context.Context) (string, error) {
 			return issue.Key, nil

--- a/tools/jtk/internal/cmd/issues/create.go
+++ b/tools/jtk/internal/cmd/issues/create.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/text"
@@ -144,19 +145,41 @@ func runCreate(ctx context.Context, opts *root.Options, project, issueType, summ
 
 	req := api.BuildCreateRequest(projectKey, typeName, summary, text.InterpretEscapes(description), extraFields)
 
-	issue, err := client.CreateIssue(ctx, req)
-	if err != nil {
-		return err
+	if opts.EmitIDOnly() {
+		issue, err := client.CreateIssue(ctx, req)
+		if err != nil {
+			return err
+		}
+		return jtkpresent.EmitIDs(opts, []string{issue.Key})
 	}
 
 	if opts.Output == "json" {
+		issue, err := client.CreateIssue(ctx, req)
+		if err != nil {
+			return err
+		}
 		return v.JSON(issue)
 	}
 
-	// Success message includes the URL for convenience
-	model := jtkpresent.IssuePresenter{}.PresentCreated(issue.Key, client.IssueURL(issue.Key))
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(ctx context.Context) (string, error) {
+			issue, err := client.CreateIssue(ctx, req)
+			if err != nil {
+				return "", err
+			}
+			return issue.Key, nil
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			issue, err := client.GetIssue(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			return jtkpresent.IssuePresenter{}.PresentDetail(
+				issue, client.IssueURL(id), opts.IsExtended(), opts.IsFullText(),
+			), nil
+		},
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.IssuePresenter{}.PresentCreated(id, client.IssueURL(id))
+		},
+	})
 }

--- a/tools/jtk/internal/cmd/issues/create_test.go
+++ b/tools/jtk/internal/cmd/issues/create_test.go
@@ -578,3 +578,67 @@ func TestRunCreate_WithoutAssignee(t *testing.T) {
 	fields := reqBody["fields"].(map[string]any)
 	testutil.Nil(t, fields["assignee"])
 }
+
+func createServerWithPostState(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue" && r.Method == "POST" {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(api.Issue{Key: "TEST-1", ID: "10001"})
+			return
+		}
+		if r.URL.Path == "/rest/api/3/issue/TEST-1" && r.Method == "GET" {
+			issue := map[string]any{
+				"key": "TEST-1",
+				"fields": map[string]any{
+					"summary":   "New issue",
+					"status":    map[string]any{"name": "Backlog"},
+					"issuetype": map[string]any{"name": "Task"},
+					"priority":  map[string]any{"name": "Medium"},
+					"updated":   "2026-04-16T00:00:00.000+0000",
+				},
+			}
+			_ = json.NewEncoder(w).Encode(issue)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+func TestRunCreate_ShowsPostState(t *testing.T) {
+	seedCacheForIssues(t)
+	server := createServerWithPostState(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runCreate(context.Background(), opts, "PROJ", "Task", "New issue", "", "", "", nil)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "TEST-1")
+	testutil.Contains(t, out, "New issue")
+	testutil.Contains(t, out, "Backlog")
+}
+
+func TestRunCreate_IDOnly(t *testing.T) {
+	seedCacheForIssues(t)
+	server := createServerWithPostState(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runCreate(context.Background(), opts, "PROJ", "Task", "New issue", "", "", "", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "TEST-1\n")
+}

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/text"
@@ -151,26 +152,51 @@ func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, descr
 		}
 	}
 
-	// If only --type was specified, we're already done
-	if len(fields) == 0 {
-		return nil
+	// If only --type was specified with no other field changes, still show
+	// post-state via the fetch-after-write path below.
+	var req *api.UpdateIssueRequest
+	if len(fields) > 0 {
+		req = api.BuildUpdateRequest(fields)
 	}
 
-	req := api.BuildUpdateRequest(fields)
-
-	if err := client.UpdateIssue(ctx, issueKey, req); err != nil {
-		return err
+	if opts.EmitIDOnly() {
+		if req != nil {
+			if err := client.UpdateIssue(ctx, issueKey, req); err != nil {
+				return err
+			}
+		}
+		return jtkpresent.EmitIDs(opts, []string{issueKey})
 	}
 
-	model := jtkpresent.IssuePresenter{}.PresentUpdated(issueKey)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(ctx context.Context) (string, error) {
+			if req != nil {
+				if err := client.UpdateIssue(ctx, issueKey, req); err != nil {
+					return "", err
+				}
+			}
+			return issueKey, nil
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			issue, err := client.GetIssue(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			return jtkpresent.IssuePresenter{}.PresentDetail(
+				issue, client.IssueURL(id), opts.IsExtended(), opts.IsFullText(),
+			), nil
+		},
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.IssuePresenter{}.PresentUpdated(id)
+		},
+	})
 }
 
+// changeIssueType performs the type change via the bulk move API.
+// It emits progress advisories on stderr but does NOT emit any success
+// output to stdout — the caller is responsible for showing post-state
+// via the fetch-after-write path.
 func changeIssueType(ctx context.Context, client *api.Client, opts *root.Options, issueKey, targetTypeName string) error {
-	// Get the issue to find its project
 	issue, err := client.GetIssue(ctx, issueKey)
 	if err != nil {
 		return fmt.Errorf("failed to get issue: %w", err)
@@ -181,12 +207,7 @@ func changeIssueType(ctx context.Context, client *api.Client, opts *root.Options
 	}
 	projectKey := issue.Fields.Project.Key
 
-	// Check if the type is already correct
 	if issue.Fields.IssueType != nil && strings.EqualFold(issue.Fields.IssueType.Name, targetTypeName) {
-		model := jtkpresent.IssuePresenter{}.PresentTypeAlreadyCurrent(issueKey, targetTypeName)
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 		return nil
 	}
 
@@ -196,12 +217,10 @@ func changeIssueType(ctx context.Context, client *api.Client, opts *root.Options
 	}
 	targetIssueType := &resolvedType
 
-	// Progress message to stderr (advisory)
 	advisory := jtkpresent.IssuePresenter{}.PresentTypeChangeProgress(issueKey, targetIssueType.Name)
 	advOut := present.Render(advisory, opts.RenderStyle())
 	_, _ = fmt.Fprint(opts.Stderr, advOut.Stderr)
 
-	// Use the move API to change the type within the same project
 	req := api.BuildMoveRequest([]string{issueKey}, projectKey, targetIssueType.ID, false)
 
 	resp, err := client.MoveIssues(ctx, req)
@@ -212,7 +231,6 @@ func changeIssueType(ctx context.Context, client *api.Client, opts *root.Options
 		return fmt.Errorf("failed to change issue type: %w", err)
 	}
 
-	// Wait for completion
 	for {
 		status, err := client.GetMoveTaskStatus(ctx, resp.TaskID)
 		if err != nil {
@@ -226,9 +244,6 @@ func changeIssueType(ctx context.Context, client *api.Client, opts *root.Options
 					return fmt.Errorf("type change failed for %s: %s", failed.IssueKey, strings.Join(failed.Errors, ", "))
 				}
 			}
-			model := jtkpresent.IssuePresenter{}.PresentTypeChanged(issueKey, targetIssueType.Name)
-			out := present.Render(model, opts.RenderStyle())
-			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 			return nil
 
 		case "FAILED":

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -208,6 +208,9 @@ func changeIssueType(ctx context.Context, client *api.Client, opts *root.Options
 	projectKey := issue.Fields.Project.Key
 
 	if issue.Fields.IssueType != nil && strings.EqualFold(issue.Fields.IssueType.Name, targetTypeName) {
+		advisory := jtkpresent.MutationPresenter{}.Advisory("type is already %s", targetTypeName)
+		advOut := present.Render(advisory, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stderr, advOut.Stderr)
 		return nil
 	}
 

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -266,6 +266,28 @@ func TestRunUpdate_SummaryOnly(t *testing.T) {
 	testutil.Nil(t, fields["parent"])
 }
 
+func TestRunUpdate_IDOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "PROJ-123\n")
+}
+
 func TestRunUpdate_NoFieldsError(t *testing.T) {
 	opts := &root.Options{
 		Output: "table",

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -187,17 +187,21 @@ func TestRunUpdate_TypeChange(t *testing.T) {
 func TestRunUpdate_TypeAlreadyCorrect(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "GET" {
-			_ = json.NewEncoder(w).Encode(api.Issue{
-				Key: "PROJ-123",
-				ID:  "10001",
-				Fields: api.IssueFields{
-					Project:   &api.Project{Key: "PROJ"},
-					IssueType: &api.IssueType{ID: "10001", Name: "Task"},
+			issue := map[string]any{
+				"key": "PROJ-123",
+				"id":  "10001",
+				"fields": map[string]any{
+					"summary":   "Test issue",
+					"status":    map[string]any{"name": "Backlog"},
+					"issuetype": map[string]any{"id": "10001", "name": "Task"},
+					"priority":  map[string]any{"name": "Medium"},
+					"project":   map[string]any{"key": "PROJ"},
+					"updated":   "2026-04-16T00:00:00.000+0000",
 				},
-			})
+			}
+			_ = json.NewEncoder(w).Encode(issue)
 			return
 		}
-		// No move API should be called
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -217,9 +217,12 @@ func TestRunUpdate_TypeAlreadyCorrect(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	// Should succeed without calling move API since it's already the right type
+	// Should succeed without calling move API since it's already the right type.
+	// The silent changeIssueType returns nil (no-op), then WriteAndPresent
+	// re-fetches and shows post-state detail.
 	err = runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "Task", nil)
 	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "PROJ-123")
 }
 
 func TestRunUpdate_SummaryOnly(t *testing.T) {

--- a/tools/jtk/internal/cmd/transitions/transitions.go
+++ b/tools/jtk/internal/cmd/transitions/transitions.go
@@ -8,8 +8,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
@@ -189,9 +192,42 @@ func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID
 		}
 	}
 
-	if err := client.DoTransition(ctx, issueKey, transitionID, fields); err != nil {
-		return err
+	if opts.EmitIDOnly() {
+		if err := client.DoTransition(ctx, issueKey, transitionID, fields); err != nil {
+			return err
+		}
+		return jtkpresent.EmitIDs(opts, []string{issueKey})
 	}
 
-	return jtkpresent.Emit(opts, jtkpresent.TransitionPresenter{}.PresentTransitioned(issueKey))
+	var targetStatus string
+	for _, t := range transitions {
+		if t.ID == transitionID {
+			targetStatus = t.To.Name
+			break
+		}
+	}
+
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(ctx context.Context) (string, error) {
+			return issueKey, client.DoTransition(ctx, issueKey, transitionID, fields)
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			issue, err := client.GetIssue(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			return jtkpresent.IssuePresenter{}.PresentDetail(
+				issue, client.IssueURL(id), opts.IsExtended(), opts.IsFullText(),
+			), nil
+		},
+		IsFresh: func(m *present.OutputModel) bool {
+			if targetStatus == "" {
+				return true
+			}
+			return mutation.ModelContainsStatus(m, targetStatus)
+		},
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.TransitionPresenter{}.PresentTransitioned(id)
+		},
+	})
 }

--- a/tools/jtk/internal/cmd/transitions/transitions_test.go
+++ b/tools/jtk/internal/cmd/transitions/transitions_test.go
@@ -8,12 +8,16 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 )
+
+func init() { mutation.BackoffSchedule = []time.Duration{0, 0, 0, 0} }
 
 func TestFormatFieldValue(t *testing.T) {
 	t.Parallel()

--- a/tools/jtk/internal/cmd/transitions/transitions_test.go
+++ b/tools/jtk/internal/cmd/transitions/transitions_test.go
@@ -283,3 +283,106 @@ func TestRunList_DeprecatedFieldsAlias(t *testing.T) {
 		t.Errorf("expected deprecation message to mention --extended, got %q", flag.Deprecated)
 	}
 }
+
+func doServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/transitions") && r.Method == http.MethodGet:
+			resp := api.TransitionsResponse{
+				Transitions: []api.Transition{
+					{ID: "31", Name: "In Development", To: api.Status{Name: "In Development"}},
+					{ID: "11", Name: "Backlog", To: api.Status{Name: "Backlog"}},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case strings.HasSuffix(r.URL.Path, "/transitions") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasPrefix(r.URL.Path, "/rest/api/3/issue/") && r.Method == http.MethodGet:
+			issue := map[string]any{
+				"key": "TEST-1",
+				"fields": map[string]any{
+					"summary":   "Test issue",
+					"status":    map[string]any{"name": "In Development"},
+					"issuetype": map[string]any{"name": "SDLC"},
+					"priority":  map[string]any{"name": "Medium"},
+					"updated":   "2026-04-16T00:00:00.000+0000",
+				},
+			}
+			_ = json.NewEncoder(w).Encode(issue)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestRunDo_ShowsPostState(t *testing.T) {
+	t.Parallel()
+	server := doServer(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runDo(context.Background(), opts, "TEST-1", "In Development", nil)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "TEST-1")
+	testutil.Contains(t, out, "Test issue")
+	testutil.Contains(t, out, "In Development")
+}
+
+func TestRunDo_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := doServer(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runDo(context.Background(), opts, "TEST-1", "In Development", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "TEST-1\n")
+}
+
+func TestRunDo_FallbackOnFetchError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/transitions") && r.Method == http.MethodGet:
+			resp := api.TransitionsResponse{
+				Transitions: []api.Transition{
+					{ID: "31", Name: "In Development", To: api.Status{Name: "In Development"}},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case strings.HasSuffix(r.URL.Path, "/transitions") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runDo(context.Background(), opts, "TEST-1", "In Development", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "TEST-1")
+	testutil.Contains(t, stderr.String(), "post-state unavailable")
+}

--- a/tools/jtk/internal/mutation/mutation.go
+++ b/tools/jtk/internal/mutation/mutation.go
@@ -108,19 +108,17 @@ func emitBestAvailable(opts *root.Options, lastModel *present.OutputModel, fallb
 }
 
 // ModelContainsStatus checks whether an issue detail OutputModel contains
-// the given status name in its "Status: <name>" line.  Issue detail models
-// are built from MessageSection lines (via msg() in present/issue.go),
-// not KVSection pairs.
-// ModelContainsStatus checks whether an issue detail OutputModel contains
-// the given status name.  The match is anchored: the status must appear as
-// "Status: <name>   " (followed by the triple-space field separator) or at
-// end-of-line, preventing false positives from prefix collisions like
-// "In" matching "In Development".
+// the given status name in a "Status: <name>" field.
 func ModelContainsStatus(model *present.OutputModel, targetStatus string) bool {
-	return modelFieldContains(model, "Status: ", targetStatus)
+	return ModelContainsField(model, "Status: ", targetStatus)
 }
 
-func modelFieldContains(model *present.OutputModel, prefix, value string) bool {
+// ModelContainsField checks whether any MessageSection in the model
+// contains "<prefix><value>" anchored at a field boundary.  The value
+// must be followed by the triple-space field separator ("   "), end of
+// string, or newline — preventing false positives where one value is a
+// prefix of another (e.g. "In" vs "In Development").
+func ModelContainsField(model *present.OutputModel, prefix, value string) bool {
 	needle := prefix + value
 	for _, section := range model.Sections {
 		ms, ok := section.(*present.MessageSection)
@@ -132,7 +130,11 @@ func modelFieldContains(model *present.OutputModel, prefix, value string) bool {
 			continue
 		}
 		after := idx + len(needle)
-		if after >= len(ms.Message) || ms.Message[after] == ' ' {
+		if after >= len(ms.Message) {
+			return true
+		}
+		rest := ms.Message[after:]
+		if strings.HasPrefix(rest, "   ") || rest[0] == '\n' {
 			return true
 		}
 	}

--- a/tools/jtk/internal/mutation/mutation.go
+++ b/tools/jtk/internal/mutation/mutation.go
@@ -1,0 +1,120 @@
+// Package mutation provides a shared write-then-fetch-then-present helper
+// for non-destructive CLI mutations.  After a successful write the helper
+// re-fetches the entity with bounded retries so the user sees post-state
+// output that mirrors the corresponding "get" command.
+package mutation
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+)
+
+// Config configures a write → fetch → present cycle.
+type Config struct {
+	// Write executes the mutation.  Returns the entity identifier
+	// (issue key, project key, comment ID, …) consumed by Fetch and
+	// Fallback.
+	Write func(ctx context.Context) (id string, err error)
+
+	// Fetch retrieves the entity after the write and builds its
+	// presentation model.  Called immediately after Write succeeds,
+	// then retried on error or staleness up to len(BackoffSchedule)−1
+	// times.
+	Fetch func(ctx context.Context, id string) (*present.OutputModel, error)
+
+	// IsFresh inspects the fetched model and returns true when it
+	// reflects the write.  When nil every successful fetch is accepted.
+	// When non-nil and false the fetch is retried.
+	IsFresh func(model *present.OutputModel) bool
+
+	// Fallback builds the model emitted when every fetch attempt fails.
+	// Receives the entity ID from Write.  Must preserve the full
+	// semantic context of the mutation (assign vs unassign, create URL, …).
+	Fallback func(id string) *present.OutputModel
+}
+
+// BackoffSchedule is the fixed retry schedule for post-write fetches.
+// Package-level so tests can override it to zero-duration entries.
+var BackoffSchedule = []time.Duration{
+	0,
+	200 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+}
+
+// WriteAndPresent executes a mutation, fetches the post-state with
+// bounded retries, and emits the result.  The write error is fatal;
+// the fetch error is non-fatal (mutation succeeded → exit 0).
+func WriteAndPresent(ctx context.Context, opts *root.Options, cfg Config) error {
+	id, err := cfg.Write(ctx)
+	if err != nil {
+		return err
+	}
+
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{id})
+	}
+
+	var lastModel *present.OutputModel
+
+	for i, delay := range BackoffSchedule {
+		if i > 0 && delay > 0 {
+			select {
+			case <-ctx.Done():
+				return emitBestAvailable(opts, lastModel, cfg.Fallback, id)
+			case <-time.After(delay):
+			}
+		}
+
+		model, fetchErr := cfg.Fetch(ctx, id)
+		if fetchErr != nil {
+			if ctx.Err() != nil {
+				break
+			}
+			continue
+		}
+
+		lastModel = model
+
+		if cfg.IsFresh == nil || cfg.IsFresh(model) {
+			return jtkpresent.Emit(opts, model)
+		}
+	}
+
+	return emitBestAvailable(opts, lastModel, cfg.Fallback, id)
+}
+
+// emitBestAvailable emits the last fetched model if available (stale but real
+// data), otherwise falls back to the Fallback builder plus a stderr advisory.
+func emitBestAvailable(opts *root.Options, lastModel *present.OutputModel, fallback func(string) *present.OutputModel, id string) error {
+	if lastModel != nil {
+		return jtkpresent.Emit(opts, lastModel)
+	}
+
+	advisory := jtkpresent.MutationPresenter{}.Advisory("post-state unavailable; showing confirmation only")
+	_ = jtkpresent.Emit(opts, advisory)
+
+	return jtkpresent.Emit(opts, fallback(id))
+}
+
+// ModelContainsStatus checks whether an issue detail OutputModel contains
+// the given status name in its "Status: <name>" line.  Issue detail models
+// are built from MessageSection lines (via msg() in present/issue.go),
+// not KVSection pairs.
+func ModelContainsStatus(model *present.OutputModel, targetStatus string) bool {
+	prefix := "Status: " + targetStatus
+	for _, section := range model.Sections {
+		if ms, ok := section.(*present.MessageSection); ok {
+			if strings.Contains(ms.Message, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tools/jtk/internal/mutation/mutation.go
+++ b/tools/jtk/internal/mutation/mutation.go
@@ -36,6 +36,7 @@ type Config struct {
 	// Fallback builds the model emitted when every fetch attempt fails.
 	// Receives the entity ID from Write.  Must preserve the full
 	// semantic context of the mutation (assign vs unassign, create URL, …).
+	// Required — panics if nil and all fetches fail.
 	Fallback func(id string) *present.OutputModel
 }
 
@@ -100,6 +101,9 @@ func emitBestAvailable(opts *root.Options, lastModel *present.OutputModel, fallb
 	advisory := jtkpresent.MutationPresenter{}.Advisory("post-state unavailable; showing confirmation only")
 	_ = jtkpresent.Emit(opts, advisory)
 
+	if fallback == nil {
+		return jtkpresent.Emit(opts, jtkpresent.MutationPresenter{}.Success("Completed %s", id))
+	}
 	return jtkpresent.Emit(opts, fallback(id))
 }
 
@@ -107,13 +111,29 @@ func emitBestAvailable(opts *root.Options, lastModel *present.OutputModel, fallb
 // the given status name in its "Status: <name>" line.  Issue detail models
 // are built from MessageSection lines (via msg() in present/issue.go),
 // not KVSection pairs.
+// ModelContainsStatus checks whether an issue detail OutputModel contains
+// the given status name.  The match is anchored: the status must appear as
+// "Status: <name>   " (followed by the triple-space field separator) or at
+// end-of-line, preventing false positives from prefix collisions like
+// "In" matching "In Development".
 func ModelContainsStatus(model *present.OutputModel, targetStatus string) bool {
-	prefix := "Status: " + targetStatus
+	return modelFieldContains(model, "Status: ", targetStatus)
+}
+
+func modelFieldContains(model *present.OutputModel, prefix, value string) bool {
+	needle := prefix + value
 	for _, section := range model.Sections {
-		if ms, ok := section.(*present.MessageSection); ok {
-			if strings.Contains(ms.Message, prefix) {
-				return true
-			}
+		ms, ok := section.(*present.MessageSection)
+		if !ok {
+			continue
+		}
+		idx := strings.Index(ms.Message, needle)
+		if idx < 0 {
+			continue
+		}
+		after := idx + len(needle)
+		if after >= len(ms.Message) || ms.Message[after] == ' ' {
+			return true
 		}
 	}
 	return false

--- a/tools/jtk/internal/mutation/mutation_test.go
+++ b/tools/jtk/internal/mutation/mutation_test.go
@@ -224,11 +224,24 @@ func TestModelContainsStatus(t *testing.T) {
 	if ModelContainsStatus(model, "Backlog") {
 		t.Error("expected false for non-matching status")
 	}
+	if ModelContainsStatus(model, "In") {
+		t.Error("expected false for prefix collision: 'In' should not match 'In Development'")
+	}
 }
 
 func TestModelContainsStatus_EmptyModel(t *testing.T) {
 	model := &present.OutputModel{}
 	if ModelContainsStatus(model, "anything") {
 		t.Error("expected false for empty model")
+	}
+}
+
+func TestModelContainsField_EndOfLine(t *testing.T) {
+	model := successModel("Assignee: Aaron Wong")
+	if !ModelContainsField(model, "Assignee: ", "Aaron Wong") {
+		t.Error("expected true for value at end of line")
+	}
+	if ModelContainsField(model, "Assignee: ", "Aaron") {
+		t.Error("expected false for prefix collision at end of line")
 	}
 }

--- a/tools/jtk/internal/mutation/mutation_test.go
+++ b/tools/jtk/internal/mutation/mutation_test.go
@@ -1,0 +1,234 @@
+package mutation
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+func init() {
+	BackoffSchedule = []time.Duration{0, 0, 0, 0}
+}
+
+func testOpts() (*root.Options, *bytes.Buffer, *bytes.Buffer) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	return &root.Options{
+		Stdout: stdout,
+		Stderr: stderr,
+	}, stdout, stderr
+}
+
+func successModel(msg string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: msg,
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+func fallbackFor(prefix string) func(string) *present.OutputModel {
+	return func(id string) *present.OutputModel {
+		return successModel(prefix + " " + id)
+	}
+}
+
+func TestWriteAndPresent_HappyPath(t *testing.T) {
+	opts, stdout, stderr := testOpts()
+	err := WriteAndPresent(context.Background(), opts, Config{
+		Write: func(_ context.Context) (string, error) { return "MON-100", nil },
+		Fetch: func(_ context.Context, id string) (*present.OutputModel, error) {
+			return successModel("Detail for " + id), nil
+		},
+		Fallback: fallbackFor("Created"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); got != "Detail for MON-100\n" {
+		t.Errorf("stdout = %q, want %q", got, "Detail for MON-100\n")
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestWriteAndPresent_IsFresh_RetryThenAccept(t *testing.T) {
+	opts, stdout, _ := testOpts()
+	calls := 0
+	err := WriteAndPresent(context.Background(), opts, Config{
+		Write: func(_ context.Context) (string, error) { return "MON-100", nil },
+		Fetch: func(_ context.Context, _ string) (*present.OutputModel, error) {
+			calls++
+			return successModel("Status: " + map[bool]string{true: "In Development", false: "Backlog"}[calls >= 3]), nil
+		},
+		IsFresh: func(m *present.OutputModel) bool {
+			return ModelContainsStatus(m, "In Development")
+		},
+		Fallback: fallbackFor("Transitioned"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls < 3 {
+		t.Errorf("expected at least 3 fetch calls, got %d", calls)
+	}
+	if got := stdout.String(); got != "Status: In Development\n" {
+		t.Errorf("stdout = %q", got)
+	}
+}
+
+func TestWriteAndPresent_AllStale_EmitsBestAvailable(t *testing.T) {
+	opts, stdout, stderr := testOpts()
+	err := WriteAndPresent(context.Background(), opts, Config{
+		Write: func(_ context.Context) (string, error) { return "MON-100", nil },
+		Fetch: func(_ context.Context, _ string) (*present.OutputModel, error) {
+			return successModel("Status: Backlog"), nil
+		},
+		IsFresh:  func(_ *present.OutputModel) bool { return false },
+		Fallback: fallbackFor("Transitioned"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); got != "Status: Backlog\n" {
+		t.Errorf("stdout = %q, want best-available stale model", got)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr should be empty for best-available, got %q", stderr.String())
+	}
+}
+
+func TestWriteAndPresent_AllFetchErrors_EmitsFallback(t *testing.T) {
+	opts, stdout, stderr := testOpts()
+	err := WriteAndPresent(context.Background(), opts, Config{
+		Write: func(_ context.Context) (string, error) { return "MON-100", nil },
+		Fetch: func(_ context.Context, _ string) (*present.OutputModel, error) {
+			return nil, errors.New("network error")
+		},
+		Fallback: fallbackFor("Created"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); got != "Created MON-100\n" {
+		t.Errorf("stdout = %q", got)
+	}
+	if got := stderr.String(); got == "" {
+		t.Error("expected advisory on stderr")
+	}
+}
+
+func TestWriteAndPresent_WriteFails(t *testing.T) {
+	opts, _, _ := testOpts()
+	fetchCalled := false
+	err := WriteAndPresent(context.Background(), opts, Config{
+		Write: func(_ context.Context) (string, error) { return "", errors.New("write failed") },
+		Fetch: func(_ context.Context, _ string) (*present.OutputModel, error) {
+			fetchCalled = true
+			return successModel("should not happen"), nil
+		},
+		Fallback: fallbackFor("nope"),
+	})
+	if err == nil || err.Error() != "write failed" {
+		t.Errorf("expected write error, got %v", err)
+	}
+	if fetchCalled {
+		t.Error("Fetch should not be called when Write fails")
+	}
+}
+
+func TestWriteAndPresent_IDOnly(t *testing.T) {
+	opts, stdout, _ := testOpts()
+	opts.IDOnly = true
+	fetchCalled := false
+	err := WriteAndPresent(context.Background(), opts, Config{
+		Write: func(_ context.Context) (string, error) { return "MON-100", nil },
+		Fetch: func(_ context.Context, _ string) (*present.OutputModel, error) {
+			fetchCalled = true
+			return successModel("detail"), nil
+		},
+		Fallback: fallbackFor("nope"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fetchCalled {
+		t.Error("Fetch should not be called in --id mode")
+	}
+	if got := stdout.String(); got != "MON-100\n" {
+		t.Errorf("stdout = %q, want %q", got, "MON-100\n")
+	}
+}
+
+func TestWriteAndPresent_IsFreshNil_AcceptsFirstFetch(t *testing.T) {
+	opts, stdout, _ := testOpts()
+	calls := 0
+	err := WriteAndPresent(context.Background(), opts, Config{
+		Write: func(_ context.Context) (string, error) { return "MON-100", nil },
+		Fetch: func(_ context.Context, _ string) (*present.OutputModel, error) {
+			calls++
+			return successModel("first fetch"), nil
+		},
+		IsFresh:  nil,
+		Fallback: fallbackFor("nope"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 fetch call (no freshness check), got %d", calls)
+	}
+	if got := stdout.String(); got != "first fetch\n" {
+		t.Errorf("stdout = %q", got)
+	}
+}
+
+func TestWriteAndPresent_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	opts, stdout, stderr := testOpts()
+	err := WriteAndPresent(ctx, opts, Config{
+		Write: func(_ context.Context) (string, error) { return "MON-100", nil },
+		Fetch: func(_ context.Context, _ string) (*present.OutputModel, error) {
+			return nil, context.Canceled
+		},
+		Fallback: fallbackFor("Created"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdout.Len() == 0 {
+		t.Error("expected fallback output on stdout")
+	}
+	if stderr.Len() == 0 {
+		t.Error("expected advisory on stderr")
+	}
+}
+
+func TestModelContainsStatus(t *testing.T) {
+	model := successModel("Status: In Development   Type: SDLC   Priority: Medium   Points: 5")
+	if !ModelContainsStatus(model, "In Development") {
+		t.Error("expected true for matching status")
+	}
+	if ModelContainsStatus(model, "Backlog") {
+		t.Error("expected false for non-matching status")
+	}
+}
+
+func TestModelContainsStatus_EmptyModel(t *testing.T) {
+	model := &present.OutputModel{}
+	if ModelContainsStatus(model, "anything") {
+		t.Error("expected false for empty model")
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/mutation` package with `WriteAndPresent` helper: write → bounded re-fetch retries (0/200/500/1000ms) → post-state rendering
- `IsFresh` callback for staleness detection (transitions checks status, assign checks assignee)
- Best-available fallback: stale-but-real data preferred over fallback message; semantic `Fallback` callback preserves mutation context
- Wired for Phase 1: `issues create`, `issues update`, `issues assign`, `transitions do`
- `changeIssueType` refactored to silent variant (stderr progress only, no stdout emit) — unified post-state fetch
- `--id` short-circuit placed before JSON in every wired command

Closes #242

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes (1391 tests, 10 new mutation unit tests)
- [ ] `make lint` clean on jtk
- [ ] Manual: `jtk issues create -p MON --type SDLC --summary "test"` shows full detail
- [ ] Manual: `jtk issues create ... --id` emits just the key
- [ ] Manual: `jtk issues assign MON-XXXX me` shows full detail with assignee
- [ ] Manual: `jtk transitions do MON-XXXX "In Development"` shows updated status
- [ ] Manual: `jtk issues update MON-XXXX --summary "updated"` shows full detail