### PR TITLE
feat(jtk): migrate block-returning mutations to canonical post-state output

### DIFF
--- a/tools/jtk/api/links.go
+++ b/tools/jtk/api/links.go
@@ -53,7 +53,7 @@ type IssueRef struct {
 }
 
 // GetIssueLinks returns the links on an issue by fetching the issue and extracting the issuelinks field
-func (c *Client) GetIssueLinks(issueKey string) ([]IssueLink, error) {
+func (c *Client) GetIssueLinks(ctx context.Context, issueKey string) ([]IssueLink, error) {
 	if issueKey == "" {
 		return nil, ErrIssueKeyRequired
 	}
@@ -63,7 +63,7 @@ func (c *Client) GetIssueLinks(issueKey string) ([]IssueLink, error) {
 		map[string]string{"fields": "issuelinks"},
 	)
 
-	body, err := c.Get(context.Background(), urlStr)
+	body, err := c.Get(ctx, urlStr)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (c *Client) GetIssueLinks(issueKey string) ([]IssueLink, error) {
 }
 
 // CreateIssueLink creates a link between two issues
-func (c *Client) CreateIssueLink(outwardKey, inwardKey, linkTypeName string) error {
+func (c *Client) CreateIssueLink(ctx context.Context, outwardKey, inwardKey, linkTypeName string) error {
 	if outwardKey == "" || inwardKey == "" {
 		return ErrIssueKeyRequired
 	}
@@ -96,26 +96,26 @@ func (c *Client) CreateIssueLink(outwardKey, inwardKey, linkTypeName string) err
 		InwardIssue:  IssueRef{Key: inwardKey},
 	}
 
-	_, err := c.Post(context.Background(), urlStr, req)
+	_, err := c.Post(ctx, urlStr, req)
 	return err
 }
 
 // DeleteIssueLink deletes an issue link by its ID
-func (c *Client) DeleteIssueLink(linkID string) error {
+func (c *Client) DeleteIssueLink(ctx context.Context, linkID string) error {
 	if linkID == "" {
 		return fmt.Errorf("link ID is required")
 	}
 
 	urlStr := fmt.Sprintf("%s/issueLink/%s", c.BaseURL, url.PathEscape(linkID))
-	_, err := c.Delete(context.Background(), urlStr)
+	_, err := c.Delete(ctx, urlStr)
 	return err
 }
 
 // GetIssueLinkTypes returns all available issue link types
-func (c *Client) GetIssueLinkTypes() ([]IssueLinkType, error) {
+func (c *Client) GetIssueLinkTypes(ctx context.Context) ([]IssueLinkType, error) {
 	urlStr := fmt.Sprintf("%s/issueLinkType", c.BaseURL)
 
-	body, err := c.Get(context.Background(), urlStr)
+	body, err := c.Get(ctx, urlStr)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/jtk/api/links_test.go
+++ b/tools/jtk/api/links_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -37,7 +38,7 @@ func TestGetIssueLinks(t *testing.T) {
 	client, err := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
 	testutil.RequireNoError(t, err)
 
-	links, err := client.GetIssueLinks("PROJ-123")
+	links, err := client.GetIssueLinks(context.Background(), "PROJ-123")
 	testutil.RequireNoError(t, err)
 	testutil.Len(t, links, 1)
 	testutil.Equal(t, links[0].ID, "10001")
@@ -47,7 +48,7 @@ func TestGetIssueLinks(t *testing.T) {
 }
 
 func TestGetIssueLinks_EmptyKey(t *testing.T) {
-	_, err := (&Client{}).GetIssueLinks("")
+	_, err := (&Client{}).GetIssueLinks(context.Background(), "")
 	testutil.Equal(t, err, ErrIssueKeyRequired)
 }
 
@@ -64,7 +65,7 @@ func TestCreateIssueLink(t *testing.T) {
 	client, err := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
 	testutil.RequireNoError(t, err)
 
-	err = client.CreateIssueLink("PROJ-123", "PROJ-456", "Blocks")
+	err = client.CreateIssueLink(context.Background(), "PROJ-123", "PROJ-456", "Blocks")
 	testutil.RequireNoError(t, err)
 
 	var req CreateIssueLinkRequest
@@ -76,9 +77,9 @@ func TestCreateIssueLink(t *testing.T) {
 }
 
 func TestCreateIssueLink_EmptyKeys(t *testing.T) {
-	testutil.Error(t, (&Client{}).CreateIssueLink("", "B", "t"))
-	testutil.Error(t, (&Client{}).CreateIssueLink("A", "", "t"))
-	testutil.Error(t, (&Client{}).CreateIssueLink("A", "B", ""))
+	testutil.Error(t, (&Client{}).CreateIssueLink(context.Background(), "", "B", "t"))
+	testutil.Error(t, (&Client{}).CreateIssueLink(context.Background(), "A", "", "t"))
+	testutil.Error(t, (&Client{}).CreateIssueLink(context.Background(), "A", "B", ""))
 }
 
 func TestDeleteIssueLink(t *testing.T) {
@@ -92,12 +93,12 @@ func TestDeleteIssueLink(t *testing.T) {
 	client, err := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
 	testutil.RequireNoError(t, err)
 
-	err = client.DeleteIssueLink("10001")
+	err = client.DeleteIssueLink(context.Background(), "10001")
 	testutil.RequireNoError(t, err)
 }
 
 func TestDeleteIssueLink_EmptyID(t *testing.T) {
-	testutil.Error(t, (&Client{}).DeleteIssueLink(""))
+	testutil.Error(t, (&Client{}).DeleteIssueLink(context.Background(), ""))
 }
 
 func TestGetIssueLinkTypes(t *testing.T) {
@@ -115,7 +116,7 @@ func TestGetIssueLinkTypes(t *testing.T) {
 	client, err := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
 	testutil.RequireNoError(t, err)
 
-	types, err := client.GetIssueLinkTypes()
+	types, err := client.GetIssueLinkTypes(context.Background())
 	testutil.RequireNoError(t, err)
 	testutil.Len(t, types, 2)
 	testutil.Equal(t, types[0].Name, "Blocks")

--- a/tools/jtk/internal/cache/fetchers.go
+++ b/tools/jtk/internal/cache/fetchers.go
@@ -122,8 +122,8 @@ func fetchBoards(ctx context.Context, c *api.Client) (int, error) {
 	return len(all), nil
 }
 
-func fetchLinkTypes(_ context.Context, c *api.Client) (int, error) {
-	types, err := c.GetIssueLinkTypes()
+func fetchLinkTypes(ctx context.Context, c *api.Client) (int, error) {
+	types, err := c.GetIssueLinkTypes(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/tools/jtk/internal/cmd/attachments/attachments.go
+++ b/tools/jtk/internal/cmd/attachments/attachments.go
@@ -159,29 +159,46 @@ func runAdd(ctx context.Context, opts *root.Options, issueKey string, files []st
 		return err
 	}
 
+	var allAttachments []api.Attachment
 	for _, filePath := range files {
-		// Expand path
 		absPath, err := filepath.Abs(filePath)
 		if err != nil {
 			return fmt.Errorf("invalid file path %s: %w", filePath, err)
 		}
 
-		// Check file exists
 		if _, err := os.Stat(absPath); os.IsNotExist(err) {
 			return fmt.Errorf("file not found: %s", filePath)
 		}
 
 		attachments, err := client.AddAttachment(ctx, issueKey, absPath)
 		if err != nil {
+			// Emit results for files that succeeded before returning the error
+			if len(allAttachments) > 0 {
+				if opts.EmitIDOnly() {
+					ids := make([]string, len(allAttachments))
+					for i, a := range allAttachments {
+						ids[i] = a.ID.String()
+					}
+					_ = jtkpresent.EmitIDs(opts, ids)
+				} else {
+					_ = jtkpresent.Emit(opts, jtkpresent.AttachmentPresenter{}.PresentList(allAttachments, opts.IsExtended()))
+				}
+			}
 			return fmt.Errorf("uploading %s: %w", filepath.Base(filePath), err)
 		}
 
-		for _, att := range attachments {
-			_ = jtkpresent.Emit(opts, jtkpresent.AttachmentPresenter{}.PresentUploaded(att.Filename, att.ID.String(), api.FormatFileSize(att.Size)))
-		}
+		allAttachments = append(allAttachments, attachments...)
 	}
 
-	return nil
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(allAttachments))
+		for i, a := range allAttachments {
+			ids[i] = a.ID.String()
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	return jtkpresent.Emit(opts, jtkpresent.AttachmentPresenter{}.PresentList(allAttachments, opts.IsExtended()))
 }
 
 func newGetCmd(opts *root.Options) *cobra.Command {

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -309,6 +309,68 @@ func TestRunAdd_Success(t *testing.T) {
 	testutil.Contains(t, output, "10001")
 }
 
+func TestRunAdd_PartialFailure(t *testing.T) {
+	t.Parallel()
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]api.Attachment{
+				{ID: "10001", Filename: "good.txt", Size: 42, Author: api.User{DisplayName: "Alice"}, Created: "2024-06-15T10:00:00Z"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"errorMessages":["upload failed"]}`))
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	tmpDir := t.TempDir()
+	good := filepath.Join(tmpDir, "good.txt")
+	bad := filepath.Join(tmpDir, "bad.txt")
+	_ = os.WriteFile(good, []byte("ok"), 0600)
+	_ = os.WriteFile(bad, []byte("fail"), 0600)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runAdd(context.Background(), opts, "TEST-1", []string{good, bad})
+	testutil.RequireError(t, err)
+	testutil.Contains(t, stdout.String(), "good.txt")
+	testutil.Contains(t, stdout.String(), "10001")
+}
+
+func TestRunAdd_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]api.Attachment{
+			{ID: "10001", Filename: "file.txt", Size: 42},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	tmpDir := t.TempDir()
+	f := filepath.Join(tmpDir, "file.txt")
+	_ = os.WriteFile(f, []byte("data"), 0600)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runAdd(context.Background(), opts, "TEST-1", []string{f})
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "10001\n")
+}
+
 // --- get/download tests ---
 
 func TestNewGetCmd(t *testing.T) {

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -305,7 +305,7 @@ func TestRunAdd_Success(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
-	testutil.Contains(t, output, "Uploaded testfile.txt")
+	testutil.Contains(t, output, "testfile.txt")
 	testutil.Contains(t, output, "10001")
 }
 

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -312,7 +312,7 @@ func TestRunAdd_Success(t *testing.T) {
 func TestRunAdd_PartialFailure(t *testing.T) {
 	t.Parallel()
 	callCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		callCount++
 		if callCount == 1 {
 			w.WriteHeader(http.StatusOK)

--- a/tools/jtk/internal/cmd/automation/create.go
+++ b/tools/jtk/internal/cmd/automation/create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
@@ -83,22 +84,15 @@ func runCreate(ctx context.Context, opts *root.Options, filePath string) error {
 		return err
 	}
 
-	// Parse the response to extract the new rule's identifier.
 	var created struct {
-		// Legacy/documented response fields.
-		ID      json.Number `json:"id"`
-		RuleKey string      `json:"ruleKey"`
-		// Observed Cloud response fields.
-		UUID     string `json:"uuid"`
-		RuleUUID string `json:"ruleUuid"`
-		Name     string `json:"name"`
+		ID       json.Number `json:"id"`
+		RuleKey  string      `json:"ruleKey"`
+		UUID     string      `json:"uuid"`
+		RuleUUID string      `json:"ruleUuid"`
+		Name     string      `json:"name"`
 	}
 	if err := json.Unmarshal(respBody, &created); err != nil {
-		// Even if we can't parse the response, the rule was created.
-		model := jtkpresent.AutomationPresenter{}.PresentCreatedUnparsed()
-		out := present.Render(model, opts.RenderStyle())
-		fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.AutomationPresenter{}.PresentCreatedUnparsed())
 	}
 
 	identifier := created.UUID
@@ -112,14 +106,23 @@ func runCreate(ctx context.Context, opts *root.Options, filePath string) error {
 		identifier = created.ID.String()
 	}
 
-	var model *present.OutputModel
-	if created.Name != "" {
-		model = jtkpresent.AutomationPresenter{}.PresentCreated(created.Name, identifier)
-	} else {
-		model = jtkpresent.AutomationPresenter{}.PresentCreatedMinimal(identifier)
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{identifier})
 	}
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
 
-	return nil
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(_ context.Context) (string, error) {
+			return identifier, nil
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			rule, err := client.GetAutomationRule(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			return jtkpresent.AutomationPresenter{}.PresentDetail(rule, false), nil
+		},
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.AutomationPresenter{}.PresentCreatedMinimal(id)
+		},
+	})
 }

--- a/tools/jtk/internal/cmd/automation/create_test.go
+++ b/tools/jtk/internal/cmd/automation/create_test.go
@@ -36,6 +36,13 @@ func TestRunCreate(t *testing.T) {
 				return
 			}
 
+			if r.Method == http.MethodGet {
+				_ = json.NewEncoder(w).Encode(api.AutomationRule{
+					ID: json.Number("99"), UUID: "new-uuid-456", Name: "Test Rule", State: "DISABLED",
+				})
+				return
+			}
+
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}))
 		defer server.Close()
@@ -55,7 +62,6 @@ func TestRunCreate(t *testing.T) {
 		}
 		opts.SetAPIClient(client)
 
-		// Write test JSON with server-assigned fields that should be stripped
 		dir := t.TempDir()
 		filePath := filepath.Join(dir, "rule.json")
 		inputJSON := `{
@@ -97,6 +103,13 @@ func TestRunCreate(t *testing.T) {
 				return
 			}
 
+			if r.Method == http.MethodGet {
+				_ = json.NewEncoder(w).Encode(api.AutomationRule{
+					ID: json.Number("0"), Name: "New Rule", State: "DISABLED",
+				})
+				return
+			}
+
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(`{"ruleUuid":"rule-uuid-789","name":"New Rule"}`))
 		}))
@@ -124,7 +137,7 @@ func TestRunCreate(t *testing.T) {
 
 		err = runCreate(context.Background(), opts, filePath)
 		testutil.RequireNoError(t, err)
-		testutil.Contains(t, stdout.String(), "rule-uuid-789")
+		testutil.Contains(t, stdout.String(), "New Rule")
 	})
 
 	t.Run("response prefers uuid over ruleUuid", func(t *testing.T) {
@@ -132,6 +145,13 @@ func TestRunCreate(t *testing.T) {
 			if r.URL.Path == "/_edge/tenant_info" {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+				return
+			}
+
+			if r.Method == http.MethodGet {
+				_ = json.NewEncoder(w).Encode(api.AutomationRule{
+					ID: json.Number("0"), Name: "Both UUIDs", State: "DISABLED",
+				})
 				return
 			}
 
@@ -162,8 +182,7 @@ func TestRunCreate(t *testing.T) {
 
 		err = runCreate(context.Background(), opts, filePath)
 		testutil.RequireNoError(t, err)
-		testutil.Contains(t, stdout.String(), "preferred-uuid")
-		testutil.NotContains(t, stdout.String(), "fallback-uuid")
+		testutil.Contains(t, stdout.String(), "Both UUIDs")
 	})
 
 	t.Run("invalid JSON file", func(t *testing.T) {

--- a/tools/jtk/internal/cmd/automation/enable.go
+++ b/tools/jtk/internal/cmd/automation/enable.go
@@ -72,7 +72,7 @@ func runSetState(ctx context.Context, opts *root.Options, ruleID string, enabled
 		IsFresh: func(model *present.OutputModel) bool {
 			return mutation.DetailFieldEquals(model, "State", newState)
 		},
-		Fallback: func(id string) *present.OutputModel {
+		Fallback: func(_ string) *present.OutputModel {
 			return jtkpresent.AutomationPresenter{}.PresentStateChanged(savedName, savedState, newState)
 		},
 	})

--- a/tools/jtk/internal/cmd/automation/enable.go
+++ b/tools/jtk/internal/cmd/automation/enable.go
@@ -2,13 +2,13 @@ package automation
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
@@ -34,7 +34,6 @@ func runSetState(ctx context.Context, opts *root.Options, ruleID string, enabled
 		return err
 	}
 
-	// Fetch current rule to show context
 	current, err := client.GetAutomationRule(ctx, ruleID)
 	if err != nil {
 		return err
@@ -46,20 +45,35 @@ func runSetState(ctx context.Context, opts *root.Options, ruleID string, enabled
 	}
 
 	if current.State == newState {
-		model := jtkpresent.AutomationPresenter{}.PresentNoChange(current.Name, newState)
-		out := present.Render(model, opts.RenderStyle())
-		fmt.Fprint(opts.Stdout, out.Stdout)
-		fmt.Fprint(opts.Stderr, out.Stderr)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.AutomationPresenter{}.PresentNoChange(current.Name, newState))
 	}
 
 	if err := client.SetAutomationRuleState(ctx, ruleID, enabled); err != nil {
 		return err
 	}
 
-	model := jtkpresent.AutomationPresenter{}.PresentStateChanged(current.Name, current.State, newState)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{ruleID})
+	}
+
+	savedName := current.Name
+	savedState := current.State
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(_ context.Context) (string, error) {
+			return ruleID, nil
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			rule, err := client.GetAutomationRule(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			return jtkpresent.AutomationPresenter{}.PresentDetail(rule, false), nil
+		},
+		IsFresh: func(model *present.OutputModel) bool {
+			return mutation.ModelContainsField(model, "State: ", newState)
+		},
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.AutomationPresenter{}.PresentStateChanged(savedName, savedState, newState)
+		},
+	})
 }

--- a/tools/jtk/internal/cmd/automation/enable.go
+++ b/tools/jtk/internal/cmd/automation/enable.go
@@ -70,7 +70,7 @@ func runSetState(ctx context.Context, opts *root.Options, ruleID string, enabled
 			return jtkpresent.AutomationPresenter{}.PresentDetail(rule, false), nil
 		},
 		IsFresh: func(model *present.OutputModel) bool {
-			return mutation.ModelContainsField(model, "State: ", newState)
+			return mutation.DetailFieldEquals(model, "State", newState)
 		},
 		Fallback: func(id string) *present.OutputModel {
 			return jtkpresent.AutomationPresenter{}.PresentStateChanged(savedName, savedState, newState)

--- a/tools/jtk/internal/cmd/automation/enable_test.go
+++ b/tools/jtk/internal/cmd/automation/enable_test.go
@@ -94,7 +94,7 @@ func TestRunSetState_AlreadyDisabled(t *testing.T) {
 
 func TestRunSetState_EnableDisabledRule(t *testing.T) {
 	t.Parallel()
-	requestCount := 0
+	stateChanged := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/_edge/tenant_info" {
 			w.WriteHeader(http.StatusOK)
@@ -102,20 +102,24 @@ func TestRunSetState_EnableDisabledRule(t *testing.T) {
 			return
 		}
 
-		requestCount++
 		w.WriteHeader(http.StatusOK)
 
 		if r.Method == http.MethodGet {
+			state := "DISABLED"
+			if stateChanged {
+				state = "ENABLED"
+			}
 			rule := api.AutomationRule{
 				ID:    json.Number("42"),
 				Name:  "Test Rule",
-				State: "DISABLED",
+				State: state,
 			}
 			_ = json.NewEncoder(w).Encode(rule)
 			return
 		}
 
 		// PUT state
+		stateChanged = true
 		_, _ = w.Write([]byte(`{}`))
 	}))
 	defer server.Close()
@@ -137,7 +141,6 @@ func TestRunSetState_EnableDisabledRule(t *testing.T) {
 
 	err = runSetState(context.Background(), opts, "42", true)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "DISABLED")
 	testutil.Contains(t, stdout.String(), "ENABLED")
-	testutil.Equal(t, requestCount, 2) // GET + PUT
+	testutil.Contains(t, stdout.String(), "Test Rule")
 }

--- a/tools/jtk/internal/cmd/automation/update.go
+++ b/tools/jtk/internal/cmd/automation/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
@@ -51,11 +52,9 @@ field mappings and workflow configuration.`,
 }
 
 func runUpdate(ctx context.Context, opts *root.Options, ruleID, filePath string) error {
-	// Read and validate file before creating the API client so we fail
-	// fast on bad input without needing network access.
 	data, err := os.ReadFile(filePath) //nolint:gosec // CLI tool reads user-provided file paths
 	if err != nil {
-		return fmt.Errorf("reading file %s: %w", filePath, err)
+		return err
 	}
 
 	if !json.Valid(data) {
@@ -67,19 +66,27 @@ func runUpdate(ctx context.Context, opts *root.Options, ruleID, filePath string)
 		return err
 	}
 
-	// Fetch current rule to show what we're updating
-	current, err := client.GetAutomationRule(ctx, ruleID)
-	if err != nil {
-		return fmt.Errorf("fetching current rule: %w", err)
-	}
-
 	if err := client.UpdateAutomationRule(ctx, ruleID, json.RawMessage(data)); err != nil {
 		return err
 	}
 
-	model := jtkpresent.AutomationPresenter{}.PresentUpdateComplete(current.Name, current.Identifier(), current.State, ruleID)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{ruleID})
+	}
+
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(_ context.Context) (string, error) {
+			return ruleID, nil
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			rule, err := client.GetAutomationRule(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			return jtkpresent.AutomationPresenter{}.PresentDetail(rule, false), nil
+		},
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.AutomationPresenter{}.PresentUpdated(id)
+		},
+	})
 }

--- a/tools/jtk/internal/cmd/automation/update_test.go
+++ b/tools/jtk/internal/cmd/automation/update_test.go
@@ -44,6 +44,6 @@ func TestRunUpdate(t *testing.T) {
 
 		err := runUpdate(context.Background(), opts, "12345", "/nonexistent/path/rule.json")
 		testutil.RequireError(t, err)
-		testutil.Contains(t, err.Error(), "reading file")
+		testutil.Contains(t, err.Error(), "no such file or directory")
 	})
 }

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -206,11 +206,15 @@ func runAdd(ctx context.Context, opts *root.Options, issueKey, body string) erro
 		return err
 	}
 
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{comment.ID})
+	}
+
 	if opts.Output == "json" {
 		return v.JSON(comment)
 	}
 
-	return jtkpresent.Emit(opts, jtkpresent.CommentPresenter{}.PresentAdded(comment.ID, issueKey))
+	return jtkpresent.Emit(opts, jtkpresent.CommentPresenter{}.PresentAddedDetail(issueKey, comment))
 }
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -595,3 +595,59 @@ func TestRunList_MultipleCommentsFullMode(t *testing.T) {
 	testutil.Contains(t, output, "Second comment")
 	// Comments are now rendered as DetailSections with blank line separators (renderer-owned)
 }
+
+func TestRunAdd_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(api.Comment{
+				ID:     "21276",
+				Author: api.User{DisplayName: "Alice"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runAdd(context.Background(), opts, "TEST-1", "test body")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "21276\n")
+}
+
+func TestRunAdd_PostState(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(api.Comment{
+				ID:      "21276",
+				Author:  api.User{DisplayName: "Alice"},
+				Created: "2024-06-15T10:00:00Z",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runAdd(context.Background(), opts, "TEST-1", "test body")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "TEST-1 #21276")
+	testutil.Contains(t, stdout.String(), "Alice")
+}

--- a/tools/jtk/internal/cmd/dashboards/dashboards.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards.go
@@ -202,20 +202,15 @@ func runCreate(opts *root.Options, name, description string) error {
 		return err
 	}
 
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{dash.ID})
+	}
+
 	if v.Format == view.FormatJSON {
 		return v.JSON(dash)
 	}
 
-	var model *present.OutputModel
-	if dash.View != "" {
-		model = jtkpresent.DashboardPresenter{}.PresentCreatedWithURL(dash.Name, dash.ID, dash.View)
-	} else {
-		model = jtkpresent.DashboardPresenter{}.PresentCreated(dash.Name, dash.ID)
-	}
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.DashboardPresenter{}.PresentList([]api.Dashboard{*dash}))
 }
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -112,7 +112,7 @@ func TestRunCreate(t *testing.T) {
 
 	err = runCreate(opts, "New Board", "Description")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Created")
+	testutil.Contains(t, stdout.String(), "New Board")
 
 	var req api.CreateDashboardRequest
 	err = json.Unmarshal(capturedBody, &req)

--- a/tools/jtk/internal/cmd/fields/contexts.go
+++ b/tools/jtk/internal/cmd/fields/contexts.go
@@ -121,14 +121,15 @@ func runContextsCreate(ctx context.Context, opts *root.Options, fieldID, name, p
 		return err
 	}
 
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{fc.ID})
+	}
+
 	if v.Format == view.FormatJSON {
 		return v.JSON(fc)
 	}
 
-	model := jtkpresent.FieldPresenter{}.PresentContextCreated(fc.ID, fc.Name)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentContexts([]api.FieldContext{*fc}))
 }
 
 func newContextsDeleteCmd(opts *root.Options) *cobra.Command {

--- a/tools/jtk/internal/cmd/fields/fields.go
+++ b/tools/jtk/internal/cmd/fields/fields.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
@@ -164,14 +165,15 @@ func runCreate(ctx context.Context, opts *root.Options, name, fieldType, descrip
 
 	_ = cache.AppendOnCreate[api.Field]("fields", *field)
 
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{field.ID})
+	}
+
 	if v.Format == view.FormatJSON {
 		return v.JSON(field)
 	}
 
-	model := jtkpresent.FieldPresenter{}.PresentCreated(field.ID, field.Name)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentList([]api.Field{*field}, opts.IsExtended()))
 }
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {
@@ -261,8 +263,28 @@ func runRestore(ctx context.Context, opts *root.Options, fieldID string) error {
 
 	_ = cache.Touch("fields")
 
-	model := jtkpresent.FieldPresenter{}.PresentRestored(fieldID)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{fieldID})
+	}
+
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(_ context.Context) (string, error) {
+			return fieldID, nil
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			fields, err := client.GetFields(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for _, f := range fields {
+				if f.ID == id {
+					return jtkpresent.FieldPresenter{}.PresentList([]api.Field{f}, opts.IsExtended()), nil
+				}
+			}
+			return nil, fmt.Errorf("field %s not found after restore", id)
+		},
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.FieldPresenter{}.PresentRestored(id)
+		},
+	})
 }

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -262,7 +262,7 @@ func TestRunCreate(t *testing.T) {
 
 	err = runCreate(context.Background(), opts, "Environment", "com.atlassian.jira.plugin.system.customfieldtypes:select", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Created field customfield_10100")
+	testutil.Contains(t, stdout.String(), "customfield_10100")
 	testutil.Contains(t, stdout.String(), "Environment")
 }
 
@@ -370,9 +370,18 @@ func TestRunDelete_NoForce_Accepted(t *testing.T) {
 func TestRunRestore(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		testutil.Equal(t, r.Method, http.MethodPost)
-		testutil.Contains(t, r.URL.Path, "/restore")
-		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodPost {
+			testutil.Contains(t, r.URL.Path, "/restore")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode([]api.Field{
+				{ID: "customfield_10100", Name: "Environment", Custom: true},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
 	}))
 	defer server.Close()
 
@@ -385,7 +394,7 @@ func TestRunRestore(t *testing.T) {
 
 	err = runRestore(context.Background(), opts, "customfield_10100")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Restored field customfield_10100")
+	testutil.Contains(t, stdout.String(), "customfield_10100")
 }
 
 // --- Contexts tests ---
@@ -466,7 +475,7 @@ func TestRunContextsCreate(t *testing.T) {
 
 	err = runContextsCreate(context.Background(), opts, "customfield_10100", "Bug Context", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Created context 10003")
+	testutil.Contains(t, stdout.String(), "10003")
 	testutil.Contains(t, stdout.String(), "Bug Context")
 }
 
@@ -640,7 +649,7 @@ func TestRunOptionsAdd(t *testing.T) {
 
 	err = runOptionsAdd(context.Background(), opts, "customfield_10100", "Option A", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Added option 3")
+	testutil.Contains(t, stdout.String(), "3")
 	testutil.Contains(t, stdout.String(), "Option A")
 }
 
@@ -673,7 +682,7 @@ func TestRunOptionsUpdate(t *testing.T) {
 
 	err = runOptionsUpdate(context.Background(), opts, "customfield_10100", "3", "Option A (updated)", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Updated option 3")
+	testutil.Contains(t, stdout.String(), "Option A (updated)")
 }
 
 func TestRunOptionsDelete_Force(t *testing.T) {

--- a/tools/jtk/internal/cmd/fields/options.go
+++ b/tools/jtk/internal/cmd/fields/options.go
@@ -153,20 +153,19 @@ func runOptionsAdd(ctx context.Context, opts *root.Options, fieldID, value, cont
 		return err
 	}
 
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(options))
+		for i, o := range options {
+			ids[i] = o.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
 	if v.Format == view.FormatJSON {
 		return v.JSON(options)
 	}
 
-	optionID := ""
-	optionValue := value
-	if len(options) > 0 {
-		optionID = options[0].ID
-		optionValue = options[0].Value
-	}
-	model := jtkpresent.FieldPresenter{}.PresentOptionAdded(optionID, optionValue)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentContextOptions(options))
 }
 
 func newOptionsUpdateCmd(opts *root.Options) *cobra.Command {
@@ -216,14 +215,19 @@ func runOptionsUpdate(ctx context.Context, opts *root.Options, fieldID, optionID
 		return err
 	}
 
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(options))
+		for i, o := range options {
+			ids[i] = o.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
 	if v.Format == view.FormatJSON {
 		return v.JSON(options)
 	}
 
-	model := jtkpresent.FieldPresenter{}.PresentOptionUpdated(optionID)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentContextOptions(options))
 }
 
 func newOptionsDeleteCmd(opts *root.Options) *cobra.Command {

--- a/tools/jtk/internal/cmd/links/links.go
+++ b/tools/jtk/internal/cmd/links/links.go
@@ -193,7 +193,7 @@ func runCreate(ctx context.Context, opts *root.Options, outwardKey, inwardKey, l
 		return err
 	}
 
-	if v.Format == view.FormatJSON {
+	if !opts.EmitIDOnly() && v.Format == view.FormatJSON {
 		return v.JSON(map[string]string{
 			"status":       "created",
 			"outwardIssue": outwardKey,

--- a/tools/jtk/internal/cmd/links/links.go
+++ b/tools/jtk/internal/cmd/links/links.go
@@ -238,25 +238,30 @@ fallback:
 	return jtkpresent.Emit(opts, jtkpresent.LinkPresenter{}.PresentCreated(linkType, outwardKey, inwardKey))
 }
 
+// findCreatedLink searches the outward issue's link list for the newly
+// created link. After the inward-verb swap in runCreate, outwardKey is
+// always the outward issue and inwardKey is always the inward issue.
+// When querying the outward issue's links, the created link appears with
+// InwardIssue set (the other side). We match on type (ID when available,
+// name as fallback) and the inward issue key.
 func findCreatedLink(links []api.IssueLink, resolvedType api.IssueLinkType, inwardKey string) *api.IssueLink {
 	for i := range links {
 		l := &links[i]
-		if !strings.EqualFold(l.Type.Name, resolvedType.Name) {
-			if resolvedType.ID != "" && l.Type.ID != resolvedType.ID {
-				continue
-			}
-			if resolvedType.ID == "" {
-				continue
-			}
+		if !linkTypeMatches(l.Type, resolvedType) {
+			continue
 		}
 		if l.InwardIssue != nil && strings.EqualFold(l.InwardIssue.Key, inwardKey) {
 			return l
 		}
-		if l.OutwardIssue != nil && strings.EqualFold(l.OutwardIssue.Key, inwardKey) {
-			return l
-		}
 	}
 	return nil
+}
+
+func linkTypeMatches(actual, expected api.IssueLinkType) bool {
+	if expected.ID != "" && actual.ID == expected.ID {
+		return true
+	}
+	return strings.EqualFold(actual.Name, expected.Name)
 }
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {

--- a/tools/jtk/internal/cmd/links/links.go
+++ b/tools/jtk/internal/cmd/links/links.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -12,6 +13,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
@@ -88,7 +90,7 @@ func runList(ctx context.Context, opts *root.Options, issueKey, fieldsFlag strin
 		return err
 	}
 
-	links, err := client.GetIssueLinks(issueKey)
+	links, err := client.GetIssueLinks(ctx, issueKey)
 	if err != nil {
 		return err
 	}
@@ -187,7 +189,7 @@ func runCreate(ctx context.Context, opts *root.Options, outwardKey, inwardKey, l
 	}
 	linkType = resolvedLinkType.Name
 
-	if err := client.CreateIssueLink(outwardKey, inwardKey, linkType); err != nil {
+	if err := client.CreateIssueLink(ctx, outwardKey, inwardKey, linkType); err != nil {
 		return err
 	}
 
@@ -200,7 +202,61 @@ func runCreate(ctx context.Context, opts *root.Options, outwardKey, inwardKey, l
 		})
 	}
 
+	// Discover the created link via re-query (Jira returns no link ID from create).
+	var matched *api.IssueLink
+	for i, delay := range mutation.BackoffSchedule {
+		if i > 0 && delay > 0 {
+			select {
+			case <-ctx.Done():
+				goto fallback
+			case <-time.After(delay):
+			}
+		}
+		links, err := client.GetIssueLinks(ctx, outwardKey)
+		if err != nil {
+			continue
+		}
+		matched = findCreatedLink(links, resolvedLinkType, inwardKey)
+		if matched != nil {
+			break
+		}
+	}
+
+	if matched != nil {
+		if opts.EmitIDOnly() {
+			return jtkpresent.EmitIDs(opts, []string{matched.ID})
+		}
+		return jtkpresent.Emit(opts, jtkpresent.LinkPresenter{}.PresentList([]api.IssueLink{*matched}, opts.IsExtended()))
+	}
+
+fallback:
+	if opts.EmitIDOnly() {
+		_ = jtkpresent.Emit(opts, jtkpresent.MutationPresenter{}.Advisory("link ID unavailable — re-query failed"))
+		return nil
+	}
+	_ = jtkpresent.Emit(opts, jtkpresent.MutationPresenter{}.Advisory("post-state unavailable; showing confirmation only"))
 	return jtkpresent.Emit(opts, jtkpresent.LinkPresenter{}.PresentCreated(linkType, outwardKey, inwardKey))
+}
+
+func findCreatedLink(links []api.IssueLink, resolvedType api.IssueLinkType, inwardKey string) *api.IssueLink {
+	for i := range links {
+		l := &links[i]
+		if !strings.EqualFold(l.Type.Name, resolvedType.Name) {
+			if resolvedType.ID != "" && l.Type.ID != resolvedType.ID {
+				continue
+			}
+			if resolvedType.ID == "" {
+				continue
+			}
+		}
+		if l.InwardIssue != nil && strings.EqualFold(l.InwardIssue.Key, inwardKey) {
+			return l
+		}
+		if l.OutwardIssue != nil && strings.EqualFold(l.OutwardIssue.Key, inwardKey) {
+			return l
+		}
+	}
+	return nil
 }
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {
@@ -211,15 +267,15 @@ func newDeleteCmd(opts *root.Options) *cobra.Command {
 		Example: `  jtk links delete 10001
   jtk links list PROJ-123   # find link IDs first`,
 		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			return runDelete(opts, args[0])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDelete(cmd.Context(), opts, args[0])
 		},
 	}
 
 	return cmd
 }
 
-func runDelete(opts *root.Options, linkID string) error {
+func runDelete(ctx context.Context, opts *root.Options, linkID string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -227,7 +283,7 @@ func runDelete(opts *root.Options, linkID string) error {
 		return err
 	}
 
-	if err := client.DeleteIssueLink(linkID); err != nil {
+	if err := client.DeleteIssueLink(ctx, linkID); err != nil {
 		return err
 	}
 
@@ -287,7 +343,7 @@ func runTypes(ctx context.Context, opts *root.Options, fieldsFlag string) error 
 		return err
 	}
 
-	linkTypes, err := client.GetIssueLinkTypes()
+	linkTypes, err := client.GetIssueLinkTypes(ctx)
 	if err != nil {
 		return err
 	}
@@ -316,6 +372,6 @@ func runTypes(ctx context.Context, opts *root.Options, fieldsFlag string) error 
 }
 
 // GetIssueLinkTypes returns all link types (exported for use by other commands)
-func GetIssueLinkTypes(client *api.Client) ([]api.IssueLinkType, error) {
-	return client.GetIssueLinkTypes()
+func GetIssueLinkTypes(ctx context.Context, client *api.Client) ([]api.IssueLinkType, error) {
+	return client.GetIssueLinkTypes(ctx)
 }

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -459,3 +459,56 @@ func TestRunTypes_IDOnly(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "1\n2\n")
 }
+
+func TestFindCreatedLink_MatchByName(t *testing.T) {
+	t.Parallel()
+	links := []api.IssueLink{
+		{ID: "100", Type: api.IssueLinkType{ID: "1", Name: "Blocks"}, InwardIssue: &api.LinkedIssue{Key: "PROJ-456"}},
+		{ID: "200", Type: api.IssueLinkType{ID: "2", Name: "Relates"}, InwardIssue: &api.LinkedIssue{Key: "PROJ-789"}},
+	}
+	resolved := api.IssueLinkType{ID: "1", Name: "Blocks"}
+	got := findCreatedLink(links, resolved, "PROJ-456")
+	testutil.NotNil(t, got)
+	testutil.Equal(t, got.ID, "100")
+}
+
+func TestFindCreatedLink_MatchByID(t *testing.T) {
+	t.Parallel()
+	links := []api.IssueLink{
+		{ID: "100", Type: api.IssueLinkType{ID: "1", Name: "DifferentName"}, InwardIssue: &api.LinkedIssue{Key: "PROJ-456"}},
+	}
+	resolved := api.IssueLinkType{ID: "1", Name: "Blocks"}
+	got := findCreatedLink(links, resolved, "PROJ-456")
+	testutil.NotNil(t, got)
+	testutil.Equal(t, got.ID, "100")
+}
+
+func TestFindCreatedLink_DirectionAware(t *testing.T) {
+	t.Parallel()
+	links := []api.IssueLink{
+		{ID: "100", Type: api.IssueLinkType{ID: "1", Name: "Blocks"}, OutwardIssue: &api.LinkedIssue{Key: "PROJ-456"}},
+	}
+	resolved := api.IssueLinkType{ID: "1", Name: "Blocks"}
+	got := findCreatedLink(links, resolved, "PROJ-456")
+	testutil.Nil(t, got)
+}
+
+func TestFindCreatedLink_NoMatch(t *testing.T) {
+	t.Parallel()
+	links := []api.IssueLink{
+		{ID: "100", Type: api.IssueLinkType{ID: "1", Name: "Blocks"}, InwardIssue: &api.LinkedIssue{Key: "PROJ-999"}},
+	}
+	resolved := api.IssueLinkType{ID: "1", Name: "Blocks"}
+	got := findCreatedLink(links, resolved, "PROJ-456")
+	testutil.Nil(t, got)
+}
+
+func TestFindCreatedLink_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	links := []api.IssueLink{
+		{ID: "100", Type: api.IssueLinkType{ID: "1", Name: "blocks"}, InwardIssue: &api.LinkedIssue{Key: "proj-456"}},
+	}
+	resolved := api.IssueLinkType{Name: "Blocks"}
+	got := findCreatedLink(links, resolved, "PROJ-456")
+	testutil.NotNil(t, got)
+}

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -407,7 +407,7 @@ func TestRunDelete(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runDelete(opts, "10001")
+	err = runDelete(context.Background(), opts, "10001")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Deleted")
 }

--- a/tools/jtk/internal/cmd/projects/create.go
+++ b/tools/jtk/internal/cmd/projects/create.go
@@ -3,7 +3,6 @@ package projects
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 )
@@ -88,12 +88,27 @@ func runCreate(ctx context.Context, opts *root.Options, key, name, projectType, 
 
 	_ = cache.Touch(cache.ProjectDependents()...)
 
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{project.Key})
+	}
+
 	if v.Format == view.FormatJSON {
 		return v.JSON(project)
 	}
 
-	model := jtkpresent.ProjectPresenter{}.PresentCreated(project.Key, name)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(_ context.Context) (string, error) {
+			return project.Key, nil
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			fetched, err := client.GetProject(ctx, id, api.ProjectGetExpand)
+			if err != nil {
+				return nil, err
+			}
+			return jtkpresent.ProjectPresenter{}.PresentProjectDetail(fetched, opts.IsExtended()), nil
+		},
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.ProjectPresenter{}.PresentCreated(id, name)
+		},
+	})
 }

--- a/tools/jtk/internal/cmd/projects/create.go
+++ b/tools/jtk/internal/cmd/projects/create.go
@@ -107,6 +107,9 @@ func runCreate(ctx context.Context, opts *root.Options, key, name, projectType, 
 			}
 			return jtkpresent.ProjectPresenter{}.PresentProjectDetail(fetched, opts.IsExtended()), nil
 		},
+		IsFresh: func(model *present.OutputModel) bool {
+			return mutation.ModelContainsField(model, "", name)
+		},
 		Fallback: func(id string) *present.OutputModel {
 			return jtkpresent.ProjectPresenter{}.PresentCreated(id, name)
 		},

--- a/tools/jtk/internal/cmd/projects/projects_test.go
+++ b/tools/jtk/internal/cmd/projects/projects_test.go
@@ -675,7 +675,7 @@ func TestRunDelete_NoForce_Accepted(t *testing.T) {
 
 func TestRunUpdate(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(api.ProjectDetail{
 			ID:   json.Number("10001"),
 			Key:  "TST",

--- a/tools/jtk/internal/cmd/projects/projects_test.go
+++ b/tools/jtk/internal/cmd/projects/projects_test.go
@@ -570,14 +570,18 @@ func TestRunCreate(t *testing.T) {
 		{AccountID: "557058:295fe89c-10c2-4b0c-ba84-a4dd14ea7729", DisplayName: "Lead"},
 	}))
 
-	// Jira's create endpoint returns an empty name, so the success message
-	// should use the input name, not the response name.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusCreated)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(api.ProjectDetail{
+				ID: json.Number("10001"), Key: "TST", Name: "",
+			})
+			return
+		}
+		// GET for post-state fetch
 		_ = json.NewEncoder(w).Encode(api.ProjectDetail{
-			ID:   json.Number("10001"),
-			Key:  "TST",
-			Name: "",
+			ID: json.Number("10001"), Key: "TST", Name: "Test Project",
+			ProjectTypeKey: "software",
 		})
 	}))
 	defer server.Close()
@@ -591,7 +595,7 @@ func TestRunCreate(t *testing.T) {
 
 	err = runCreate(context.Background(), opts, "TST", "Test Project", "software", "557058:295fe89c-10c2-4b0c-ba84-a4dd14ea7729", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Created project TST")
+	testutil.Contains(t, stdout.String(), "TST")
 	testutil.Contains(t, stdout.String(), "Test Project")
 }
 
@@ -672,7 +676,6 @@ func TestRunDelete_NoForce_Accepted(t *testing.T) {
 func TestRunUpdate(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		testutil.Equal(t, r.Method, http.MethodPut)
 		_ = json.NewEncoder(w).Encode(api.ProjectDetail{
 			ID:   json.Number("10001"),
 			Key:  "TST",
@@ -690,7 +693,7 @@ func TestRunUpdate(t *testing.T) {
 
 	err = runUpdate(context.Background(), opts, "TST", "Updated Name", "", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Updated project TST")
+	testutil.Contains(t, stdout.String(), "Updated Name")
 }
 
 func TestRunRestore(t *testing.T) {
@@ -713,7 +716,8 @@ func TestRunRestore(t *testing.T) {
 
 	err = runRestore(context.Background(), opts, "TST")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Restored project TST")
+	testutil.Contains(t, stdout.String(), "TST")
+	testutil.Contains(t, stdout.String(), "Test Project")
 }
 
 func TestRunTypes(t *testing.T) {

--- a/tools/jtk/internal/cmd/projects/restore.go
+++ b/tools/jtk/internal/cmd/projects/restore.go
@@ -2,15 +2,16 @@ package projects
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
@@ -42,12 +43,28 @@ func runRestore(ctx context.Context, opts *root.Options, keyOrID string) error {
 
 	_ = cache.Touch(cache.ProjectDependents()...)
 
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{project.Key})
+	}
+
 	if v.Format == view.FormatJSON {
 		return v.JSON(project)
 	}
 
-	model := jtkpresent.ProjectPresenter{}.PresentRestored(project.Key, project.Name)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	restoredName := project.Name
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(_ context.Context) (string, error) {
+			return project.Key, nil
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			fetched, err := client.GetProject(ctx, id, api.ProjectGetExpand)
+			if err != nil {
+				return nil, err
+			}
+			return jtkpresent.ProjectPresenter{}.PresentProjectDetail(fetched, opts.IsExtended()), nil
+		},
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.ProjectPresenter{}.PresentRestored(id, restoredName)
+		},
+	})
 }

--- a/tools/jtk/internal/cmd/projects/update.go
+++ b/tools/jtk/internal/cmd/projects/update.go
@@ -2,7 +2,6 @@ package projects
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
 )
@@ -75,12 +75,33 @@ func runUpdate(ctx context.Context, opts *root.Options, keyOrID, name, descripti
 
 	_ = cache.Touch(cache.ProjectDependents()...)
 
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{project.Key})
+	}
+
 	if v.Format == view.FormatJSON {
 		return v.JSON(project)
 	}
 
-	model := jtkpresent.ProjectPresenter{}.PresentUpdated(project.Key)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
+		Write: func(_ context.Context) (string, error) {
+			return project.Key, nil
+		},
+		Fetch: func(ctx context.Context, id string) (*present.OutputModel, error) {
+			fetched, err := client.GetProject(ctx, id, api.ProjectGetExpand)
+			if err != nil {
+				return nil, err
+			}
+			return jtkpresent.ProjectPresenter{}.PresentProjectDetail(fetched, opts.IsExtended()), nil
+		},
+		IsFresh: func(model *present.OutputModel) bool {
+			if name != "" {
+				return mutation.ModelContainsField(model, "", name)
+			}
+			return true
+		},
+		Fallback: func(id string) *present.OutputModel {
+			return jtkpresent.ProjectPresenter{}.PresentUpdated(id)
+		},
+	})
 }

--- a/tools/jtk/internal/cmd/projects/update.go
+++ b/tools/jtk/internal/cmd/projects/update.go
@@ -83,6 +83,7 @@ func runUpdate(ctx context.Context, opts *root.Options, keyOrID, name, descripti
 		return v.JSON(project)
 	}
 
+	var lastFetched *api.ProjectDetail
 	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
 		Write: func(_ context.Context) (string, error) {
 			return project.Key, nil
@@ -92,13 +93,20 @@ func runUpdate(ctx context.Context, opts *root.Options, keyOrID, name, descripti
 			if err != nil {
 				return nil, err
 			}
+			lastFetched = fetched
 			return jtkpresent.ProjectPresenter{}.PresentProjectDetail(fetched, opts.IsExtended()), nil
 		},
-		IsFresh: func(model *present.OutputModel) bool {
-			if name != "" && !mutation.ModelContainsField(model, "", name) {
+		IsFresh: func(_ *present.OutputModel) bool {
+			if lastFetched == nil {
 				return false
 			}
-			if description != "" && !mutation.ModelContainsField(model, "", description) {
+			if name != "" && lastFetched.Name != name {
+				return false
+			}
+			if description != "" && lastFetched.Description != description {
+				return false
+			}
+			if req.LeadAccountID != "" && lastFetched.Lead != nil && lastFetched.Lead.AccountID != req.LeadAccountID {
 				return false
 			}
 			return true

--- a/tools/jtk/internal/cmd/projects/update.go
+++ b/tools/jtk/internal/cmd/projects/update.go
@@ -95,8 +95,11 @@ func runUpdate(ctx context.Context, opts *root.Options, keyOrID, name, descripti
 			return jtkpresent.ProjectPresenter{}.PresentProjectDetail(fetched, opts.IsExtended()), nil
 		},
 		IsFresh: func(model *present.OutputModel) bool {
-			if name != "" {
-				return mutation.ModelContainsField(model, "", name)
+			if name != "" && !mutation.ModelContainsField(model, "", name) {
+				return false
+			}
+			if description != "" && !mutation.ModelContainsField(model, "", description) {
+				return false
 			}
 			return true
 		},

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
@@ -379,6 +381,58 @@ func runAdd(ctx context.Context, opts *root.Options, client *api.Client, sprintI
 		return err
 	}
 
-	model := jtkpresent.SprintPresenter{}.PresentMoved(issueKeys, sprintID)
-	return jtkpresent.Emit(opts, model)
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, issueKeys)
+	}
+
+	// Verify membership via GetSprintIssues and present matched issues.
+	keySet := make(map[string]bool, len(issueKeys))
+	for _, k := range issueKeys {
+		keySet[k] = true
+	}
+
+	var matched []api.Issue
+	for i, delay := range mutation.BackoffSchedule {
+		if i > 0 && delay > 0 {
+			select {
+			case <-ctx.Done():
+				goto fallback
+			case <-time.After(delay):
+			}
+		}
+
+		matched = nil
+		found := make(map[string]bool)
+		startAt := 0
+		for {
+			result, err := client.GetSprintIssues(ctx, sprintID, startAt, 50)
+			if err != nil {
+				break
+			}
+			for _, issue := range result.Issues {
+				if keySet[issue.Key] {
+					matched = append(matched, issue)
+					found[issue.Key] = true
+				}
+			}
+			if len(found) == len(issueKeys) {
+				break
+			}
+			if startAt+len(result.Issues) >= result.Total {
+				break
+			}
+			startAt += len(result.Issues)
+		}
+		if len(found) == len(issueKeys) {
+			break
+		}
+	}
+
+	if len(matched) == len(issueKeys) {
+		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentList(matched, opts.IsExtended()))
+	}
+
+fallback:
+	_ = jtkpresent.Emit(opts, jtkpresent.MutationPresenter{}.Advisory("post-state unavailable; showing confirmation only"))
+	return jtkpresent.Emit(opts, jtkpresent.SprintPresenter{}.PresentMoved(issueKeys, sprintID))
 }

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -418,7 +418,7 @@ func runAdd(ctx context.Context, opts *root.Options, client *api.Client, sprintI
 			if len(found) == len(issueKeys) {
 				break
 			}
-			if startAt+len(result.Issues) >= result.Total {
+			if len(result.Issues) == 0 || startAt+len(result.Issues) >= result.Total {
 				break
 			}
 			startAt += len(result.Issues)

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -571,18 +571,34 @@ func TestNewAddCmd(t *testing.T) {
 }
 
 func TestRunAdd_Success(t *testing.T) {
+	postDone := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		testutil.Equal(t, r.Method, http.MethodPost)
+		if r.Method == http.MethodPost {
+			postDone = true
+			var body map[string]any
+			err := json.NewDecoder(r.Body).Decode(&body)
+			testutil.RequireNoError(t, err)
 
-		var body map[string]any
-		err := json.NewDecoder(r.Body).Decode(&body)
-		testutil.RequireNoError(t, err)
+			issues, ok := body["issues"].([]any)
+			testutil.True(t, ok)
+			testutil.Len(t, issues, 2)
 
-		issues, ok := body["issues"].([]any)
-		testutil.True(t, ok)
-		testutil.Len(t, issues, 2)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 
-		w.WriteHeader(http.StatusNoContent)
+		if r.Method == http.MethodGet && postDone {
+			_ = json.NewEncoder(w).Encode(api.SearchResult{
+				Total: 2,
+				Issues: []api.Issue{
+					{Key: "PROJ-101", Fields: api.IssueFields{Summary: "Issue 1"}},
+					{Key: "PROJ-102", Fields: api.IssueFields{Summary: "Issue 2"}},
+				},
+			})
+			return
+		}
+
+		w.WriteHeader(http.StatusMethodNotAllowed)
 	}))
 	defer server.Close()
 
@@ -596,12 +612,26 @@ func TestRunAdd_Success(t *testing.T) {
 	err = runAdd(context.Background(), opts, client, 123, []string{"PROJ-101", "PROJ-102"})
 	testutil.RequireNoError(t, err)
 
-	testutil.Contains(t, stdout.String(), fmt.Sprintf("Moved 2 issues to sprint %d", 123))
+	testutil.Contains(t, stdout.String(), "PROJ-101")
+	testutil.Contains(t, stdout.String(), "PROJ-102")
 }
 
 func TestRunAdd_SingleIssue(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
+	postDone := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			postDone = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method == http.MethodGet && postDone {
+			_ = json.NewEncoder(w).Encode(api.SearchResult{
+				Total:  1,
+				Issues: []api.Issue{{Key: "PROJ-101", Fields: api.IssueFields{Summary: "Issue 1"}}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
 	}))
 	defer server.Close()
 
@@ -615,7 +645,7 @@ func TestRunAdd_SingleIssue(t *testing.T) {
 	err = runAdd(context.Background(), opts, client, 123, []string{"PROJ-101"})
 	testutil.RequireNoError(t, err)
 
-	testutil.Contains(t, stdout.String(), "Moved PROJ-101 to sprint 123")
+	testutil.Contains(t, stdout.String(), "PROJ-101")
 }
 
 // --- Cobra entry-point tests that exercise the resolver ---

--- a/tools/jtk/internal/mutation/mutation.go
+++ b/tools/jtk/internal/mutation/mutation.go
@@ -113,6 +113,25 @@ func ModelContainsStatus(model *present.OutputModel, targetStatus string) bool {
 	return ModelContainsField(model, "Status: ", targetStatus)
 }
 
+// DetailFieldEquals checks whether any DetailSection in the model has a
+// field with the given label whose value equals the expected string.
+// Used for IsFresh checks on presenters that emit DetailSection (e.g.,
+// AutomationPresenter.PresentDetail) rather than MessageSection.
+func DetailFieldEquals(model *present.OutputModel, label, expected string) bool {
+	for _, section := range model.Sections {
+		ds, ok := section.(*present.DetailSection)
+		if !ok {
+			continue
+		}
+		for _, f := range ds.Fields {
+			if f.Label == label && f.Value == expected {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ModelContainsField checks whether any MessageSection in the model
 // contains "<prefix><value>" anchored at a field boundary.  The value
 // must be followed by the triple-space field separator ("   "), end of

--- a/tools/jtk/internal/present/comment.go
+++ b/tools/jtk/internal/present/comment.go
@@ -121,6 +121,35 @@ func (p CommentPresenter) PresentListFullWithPagination(comments []api.Comment, 
 	return model
 }
 
+// PresentAddedDetail creates a post-state detail block for a newly added comment.
+// Matches the spec shape: "ISSUE-KEY #ID — Author, Date\nBody text"
+func (CommentPresenter) PresentAddedDetail(issueKey string, c *api.Comment) *present.OutputModel {
+	author := "Unknown"
+	if c.Author.DisplayName != "" {
+		author = c.Author.DisplayName
+	}
+	body := ""
+	if c.Body != nil {
+		body = strings.TrimRight(c.Body.ToPlainText(), "\n")
+	}
+	header := fmt.Sprintf("%s #%s — %s, %s", issueKey, c.ID, author, FormatTime(c.Created))
+	sections := []present.Section{
+		&present.MessageSection{
+			Kind:    present.MessageSuccess,
+			Message: header,
+			Stream:  present.StreamStdout,
+		},
+	}
+	if body != "" {
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: body,
+			Stream:  present.StreamStdout,
+		})
+	}
+	return &present.OutputModel{Sections: sections}
+}
+
 // PresentAdded creates a success message for comment addition.
 func (CommentPresenter) PresentAdded(commentID, issueKey string) *present.OutputModel {
 	return &present.OutputModel{


### PR DESCRIPTION
## Summary

- Migrates 16 mutation commands to render canonical post-state output matching `get` command format per #230 spec
- Adds `--id` support to all migrated mutations (emits identifier after write)
- Threads `context.Context` through all link API methods

Closes #243

## Test plan

- [x] `make build` passes
- [x] `make test` passes (all tests, race detection enabled)
- [x] `make lint` passes (zero new issues)
- [ ] Manual spot-check: `jtk projects create`, `jtk comments add` show post-state detail blocks
- [ ] Verify `--id` on migrated commands emits only the identifier
- [ ] Verify fallback path when fetch fails shows confirmation + stderr advisory