### PR TITLE
feat(jtk): migrate row-returning mutations to canonical row output

### DIFF
--- a/tools/jtk/api/dashboards.go
+++ b/tools/jtk/api/dashboards.go
@@ -64,6 +64,15 @@ type CreateDashboardRequest struct {
 	SharePermissions []SharePerm `json:"sharePermissions"`
 }
 
+// AddDashboardGadgetRequest represents a request to add a gadget to a dashboard
+type AddDashboardGadgetRequest struct {
+	ModuleKey string              `json:"moduleKey,omitempty"`
+	Title     string              `json:"title,omitempty"`
+	Color     string              `json:"color,omitempty"`
+	Position  *DashboardGadgetPos `json:"position,omitempty"`
+	URI       string              `json:"uri,omitempty"`
+}
+
 // DashboardSearchResponse represents the response from dashboard search
 type DashboardSearchResponse struct {
 	StartAt    int         `json:"startAt"`
@@ -201,4 +210,25 @@ func (c *Client) RemoveDashboardGadget(dashboardID string, gadgetID int) error {
 	urlStr := fmt.Sprintf("%s/dashboard/%s/gadget/%d", c.BaseURL, url.PathEscape(dashboardID), gadgetID)
 	_, err := c.Delete(context.Background(), urlStr)
 	return err
+}
+
+// AddDashboardGadget adds a gadget to a dashboard
+func (c *Client) AddDashboardGadget(dashboardID string, req AddDashboardGadgetRequest) (*DashboardGadget, error) {
+	if dashboardID == "" {
+		return nil, fmt.Errorf("dashboard ID is required")
+	}
+
+	urlStr := fmt.Sprintf("%s/dashboard/%s/gadget", c.BaseURL, url.PathEscape(dashboardID))
+
+	body, err := c.Post(context.Background(), urlStr, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var gadget DashboardGadget
+	if err := json.Unmarshal(body, &gadget); err != nil {
+		return nil, fmt.Errorf("parsing gadget: %w", err)
+	}
+
+	return &gadget, nil
 }

--- a/tools/jtk/api/dashboards_test.go
+++ b/tools/jtk/api/dashboards_test.go
@@ -158,3 +158,42 @@ func TestRemoveDashboardGadget(t *testing.T) {
 	err = client.RemoveDashboardGadget("10001", 42)
 	testutil.RequireNoError(t, err)
 }
+
+func TestAddDashboardGadget(t *testing.T) {
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, r.URL.Path, "/rest/api/3/dashboard/10001/gadget")
+		testutil.Equal(t, r.Method, "POST")
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(DashboardGadget{
+			ID:       10124,
+			Title:    "Sprint Burndown",
+			ModuleID: "sprint-burndown-gadget",
+			Position: DashboardGadgetPos{Row: 1, Column: 0},
+		})
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	gadget, err := client.AddDashboardGadget("10001", AddDashboardGadgetRequest{
+		ModuleKey: "sprint-burndown-gadget",
+		Position:  &DashboardGadgetPos{Row: 1, Column: 0},
+	})
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, gadget.ID, 10124)
+	testutil.Equal(t, gadget.Title, "Sprint Burndown")
+	testutil.Equal(t, gadget.ModuleID, "sprint-burndown-gadget")
+
+	var req AddDashboardGadgetRequest
+	err = json.Unmarshal(capturedBody, &req)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, req.ModuleKey, "sprint-burndown-gadget")
+}
+
+func TestAddDashboardGadget_EmptyID(t *testing.T) {
+	_, err := (&Client{}).AddDashboardGadget("", AddDashboardGadgetRequest{})
+	testutil.Error(t, err)
+}

--- a/tools/jtk/api/dashboards_test.go
+++ b/tools/jtk/api/dashboards_test.go
@@ -191,6 +191,9 @@ func TestAddDashboardGadget(t *testing.T) {
 	err = json.Unmarshal(capturedBody, &req)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, req.ModuleKey, "sprint-burndown-gadget")
+	testutil.NotNil(t, req.Position)
+	testutil.Equal(t, req.Position.Row, 1)
+	testutil.Equal(t, req.Position.Column, 0)
 }
 
 func TestAddDashboardGadget_EmptyID(t *testing.T) {

--- a/tools/jtk/api/field_management.go
+++ b/tools/jtk/api/field_management.go
@@ -68,6 +68,13 @@ type CreateFieldContextOptionEntry struct {
 	Disabled bool   `json:"disabled,omitempty"`
 }
 
+// fieldContextOptionsMutationResponse is the response shape for create/update
+// operations. The Jira API returns {"options":[...]} for POST/PUT, unlike the
+// GET endpoint which returns {"values":[...]}.
+type fieldContextOptionsMutationResponse struct {
+	Options []FieldContextOption `json:"options"`
+}
+
 // UpdateFieldContextOptionsRequest represents a request to update options
 type UpdateFieldContextOptionsRequest struct {
 	Options []UpdateFieldContextOptionEntry `json:"options"`
@@ -225,12 +232,12 @@ func (c *Client) CreateFieldContextOptions(ctx context.Context, fieldID, context
 		return nil, fmt.Errorf("creating field context options: %w", err)
 	}
 
-	var result FieldContextOptionsResponse
+	var result fieldContextOptionsMutationResponse
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("parsing created field context options: %w", err)
 	}
 
-	return result.Values, nil
+	return result.Options, nil
 }
 
 // UpdateFieldContextOptions updates existing options in a field context
@@ -245,12 +252,12 @@ func (c *Client) UpdateFieldContextOptions(ctx context.Context, fieldID, context
 		return nil, fmt.Errorf("updating field context options: %w", err)
 	}
 
-	var result FieldContextOptionsResponse
+	var result fieldContextOptionsMutationResponse
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("parsing updated field context options: %w", err)
 	}
 
-	return result.Values, nil
+	return result.Options, nil
 }
 
 // DeleteFieldContextOption deletes an option from a field context

--- a/tools/jtk/api/field_management_test.go
+++ b/tools/jtk/api/field_management_test.go
@@ -274,8 +274,8 @@ func TestCreateFieldContextOptions(t *testing.T) {
 		testutil.Len(t, req.Options, 1)
 		testutil.Equal(t, req.Options[0].Value, "Option A")
 
-		_ = json.NewEncoder(w).Encode(FieldContextOptionsResponse{
-			Values: []FieldContextOption{
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"options": []FieldContextOption{
 				{ID: "3", Value: "Option A"},
 			},
 		})
@@ -313,8 +313,8 @@ func TestUpdateFieldContextOptions(t *testing.T) {
 		testutil.Equal(t, req.Options[0].ID, "3")
 		testutil.Equal(t, req.Options[0].Value, "Option A (updated)")
 
-		_ = json.NewEncoder(w).Encode(FieldContextOptionsResponse{
-			Values: []FieldContextOption{
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"options": []FieldContextOption{
 				{ID: "3", Value: "Option A (updated)"},
 			},
 		})

--- a/tools/jtk/integration-tests.md
+++ b/tools/jtk/integration-tests.md
@@ -301,6 +301,16 @@ jtk fields list --custom
 | 1 | `jtk dashboards gadgets list $DASHBOARD_ID` | Table with columns: ID, TITLE, MODULE, POSITION |
 | 2 | `jtk dashboards gadgets list $DASHBOARD_ID -o json` | Valid JSON array |
 
+### dashboards gadgets add
+
+| # | Command | Expected Output |
+|---|---------|-----------------|
+| 1 | `jtk dashboards gadgets add $DASHBOARD_ID --type com.atlassian.jira.gadgets:filter-results-gadget` | Single table row with ID, TITLE, MODULE, POSITION |
+| 2 | `jtk dashboards gadgets add $DASHBOARD_ID --type com.atlassian.jira.gadgets:filter-results-gadget --id` | Gadget ID only |
+| 3 | `jtk dashboards gadgets add $DASHBOARD_ID --type com.atlassian.jira.gadgets:filter-results-gadget -o json` | Valid JSON object |
+| 4 | `jtk dashboards gadgets add $DASHBOARD_ID --type com.atlassian.jira.gadgets:filter-results-gadget --position 1,0` | Table row with position 1,0 |
+| 5 | `jtk dashboards gadgets add 99999 --type foo` | Error: 404 |
+
 ---
 
 ## 7. Users (Read-Only)
@@ -675,13 +685,25 @@ Run these steps in order.
    ```
    Expected: `No gadgets on dashboard $TEST_DASH_ID`
 
-5. **Delete:**
+5. **Add gadget:**
+   ```bash
+   jtk dashboards gadgets add $TEST_DASH_ID --type com.atlassian.jira.gadgets:filter-results-gadget
+   ```
+   Expected: Single table row with gadget ID, title, module, position
+
+6. **List gadgets (populated):**
+   ```bash
+   jtk dashboards gadgets list $TEST_DASH_ID
+   ```
+   Expected: Table with the added gadget
+
+7. **Delete:**
    ```bash
    jtk dashboards delete $TEST_DASH_ID
    ```
    Expected: `Deleted dashboard $TEST_DASH_ID`
 
-6. **Verify deletion:**
+8. **Verify deletion:**
    ```bash
    jtk dashboards get $TEST_DASH_ID
    ```
@@ -1022,7 +1044,8 @@ Verify each alias produces the same output as the full command:
 | 15 | `jtk dashboards create --name "x"` | Same Dashboard error |
 | 16 | `jtk dashboards delete 1` | Same Dashboard error |
 | 17 | `jtk dashboards gadgets list 1` | Same Dashboard error |
-| 18 | `jtk dashboards gadgets remove 1 1` | Same Dashboard error |
+| 18 | `jtk dashboards gadgets add 1 --type foo` | Same Dashboard error |
+| 19 | `jtk dashboards gadgets remove 1 1` | Same Dashboard error |
 
 ---
 
@@ -1071,6 +1094,7 @@ Verify each alias produces the same output as the full command:
 - [ ] `dashboards list` (table, search, JSON, no results)
 - [ ] `dashboards get` (table, JSON, 404)
 - [ ] `dashboards gadgets list` (table, JSON)
+- [ ] `dashboards gadgets add` (table, --id, JSON, 404)
 
 #### Users Read-Only (Section 7)
 - [ ] `users search` (results, JSON, no results)
@@ -1101,7 +1125,7 @@ Verify each alias produces the same output as the full command:
 - [ ] Error cases
 
 #### Dashboard Mutations (Section 13)
-- [ ] Create → verify → list+search → gadgets list → delete → verify 404
+- [ ] Create → verify → list+search → gadgets add → gadgets list → delete → verify 404
 - [ ] Error cases (missing flags, 404)
 
 #### Automation Mutations (Section 14)

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -305,6 +306,11 @@ func TestRunAdd_Success(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	testutil.Contains(t, lines[0], "ID")
+	testutil.Contains(t, lines[0], "FILENAME")
+	testutil.Contains(t, lines[0], "SIZE")
 	testutil.Contains(t, output, "testfile.txt")
 	testutil.Contains(t, output, "10001")
 }

--- a/tools/jtk/internal/cmd/dashboards/dashboards.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -254,10 +255,11 @@ func newGadgetsCmd(opts *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gadgets",
 		Short: "Manage dashboard gadgets",
-		Long:  "Commands for listing and removing gadgets on dashboards.",
+		Long:  "Commands for listing, adding, and removing gadgets on dashboards.",
 	}
 
 	cmd.AddCommand(newGadgetsListCmd(opts))
+	cmd.AddCommand(newGadgetsAddCmd(opts))
 	cmd.AddCommand(newGadgetsRemoveCmd(opts))
 
 	return cmd
@@ -308,6 +310,80 @@ func runGadgetsList(_ context.Context, opts *root.Options, dashboardID string) e
 	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	return nil
+}
+
+func newGadgetsAddCmd(opts *root.Options) *cobra.Command {
+	var moduleKey, title, color, position string
+
+	cmd := &cobra.Command{
+		Use:   "add <dashboard-id>",
+		Short: "Add a gadget to a dashboard",
+		Long:  "Add a gadget to a dashboard by its module key.",
+		Example: `  # Add a sprint burndown gadget
+  jtk dashboards gadgets add 10001 --type com.atlassian.jira.gadgets:sprint-burndown-gadget
+
+  # Add with position and title
+  jtk dashboards gadgets add 10001 --type com.atlassian.jira.gadgets:filter-results-gadget --position 1,0 --title "My Filter"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runGadgetsAdd(opts, args[0], moduleKey, title, color, position)
+		},
+	}
+
+	cmd.Flags().StringVarP(&moduleKey, "type", "t", "", "Gadget module key (required)")
+	cmd.Flags().StringVar(&title, "title", "", "Gadget title")
+	cmd.Flags().StringVar(&color, "color", "", "Gadget color")
+	cmd.Flags().StringVarP(&position, "position", "p", "", "Position as row,column (e.g. 1,0)")
+
+	_ = cmd.MarkFlagRequired("type")
+
+	return cmd
+}
+
+func runGadgetsAdd(opts *root.Options, dashboardID, moduleKey, title, color, positionStr string) error {
+	v := opts.View()
+
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	req := api.AddDashboardGadgetRequest{
+		ModuleKey: moduleKey,
+		Title:     title,
+		Color:     color,
+	}
+
+	if positionStr != "" {
+		parts := strings.SplitN(positionStr, ",", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid position %q: expected row,column (e.g. 1,0)", positionStr)
+		}
+		row, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return fmt.Errorf("invalid position row %q: %w", parts[0], err)
+		}
+		col, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return fmt.Errorf("invalid position column %q: %w", parts[1], err)
+		}
+		req.Position = &api.DashboardGadgetPos{Row: row, Column: col}
+	}
+
+	gadget, err := client.AddDashboardGadget(dashboardID, req)
+	if err != nil {
+		return err
+	}
+
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{strconv.Itoa(gadget.ID)})
+	}
+
+	if v.Format == view.FormatJSON {
+		return v.JSON(gadget)
+	}
+
+	return jtkpresent.Emit(opts, jtkpresent.DashboardPresenter{}.PresentGadgets([]api.DashboardGadget{*gadget}))
 }
 
 func newGadgetsRemoveCmd(opts *root.Options) *cobra.Command {

--- a/tools/jtk/internal/cmd/dashboards/dashboards.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards.go
@@ -325,8 +325,8 @@ func newGadgetsAddCmd(opts *root.Options) *cobra.Command {
   # Add with position and title
   jtk dashboards gadgets add 10001 --type com.atlassian.jira.gadgets:filter-results-gadget --position 1,0 --title "My Filter"`,
 		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			return runGadgetsAdd(opts, args[0], moduleKey, title, color, position)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGadgetsAdd(cmd.Context(), opts, args[0], moduleKey, title, color, position)
 		},
 	}
 
@@ -340,7 +340,7 @@ func newGadgetsAddCmd(opts *root.Options) *cobra.Command {
 	return cmd
 }
 
-func runGadgetsAdd(opts *root.Options, dashboardID, moduleKey, title, color, positionStr string) error {
+func runGadgetsAdd(_ context.Context, opts *root.Options, dashboardID, moduleKey, title, color, positionStr string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -366,6 +366,9 @@ func runGadgetsAdd(opts *root.Options, dashboardID, moduleKey, title, color, pos
 		col, err := strconv.Atoi(strings.TrimSpace(parts[1]))
 		if err != nil {
 			return fmt.Errorf("invalid position column %q: %w", parts[1], err)
+		}
+		if row < 0 || col < 0 {
+			return fmt.Errorf("invalid position %q: row and column must be non-negative", positionStr)
 		}
 		req.Position = &api.DashboardGadgetPos{Row: row, Column: col}
 	}

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -232,7 +232,7 @@ func TestRunGadgetsAdd(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGadgetsAdd(opts, "10001", "sprint-burndown-gadget", "Sprint Burndown", "", "1,0")
+	err = runGadgetsAdd(context.Background(), opts,"10001", "sprint-burndown-gadget", "Sprint Burndown", "", "1,0")
 	testutil.RequireNoError(t, err)
 
 	out := stdout.String()
@@ -250,6 +250,10 @@ func TestRunGadgetsAdd(t *testing.T) {
 	err = json.Unmarshal(capturedBody, &req)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, req.ModuleKey, "sprint-burndown-gadget")
+	testutil.Equal(t, req.Title, "Sprint Burndown")
+	testutil.NotNil(t, req.Position)
+	testutil.Equal(t, req.Position.Row, 1)
+	testutil.Equal(t, req.Position.Column, 0)
 }
 
 func TestRunGadgetsAdd_IDOnly(t *testing.T) {
@@ -269,7 +273,7 @@ func TestRunGadgetsAdd_IDOnly(t *testing.T) {
 	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
 	opts.SetAPIClient(client)
 
-	err = runGadgetsAdd(opts, "10001", "sprint-burndown-gadget", "", "", "")
+	err = runGadgetsAdd(context.Background(), opts,"10001", "sprint-burndown-gadget", "", "", "")
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "10124\n")
 }
@@ -291,7 +295,7 @@ func TestRunGadgetsAdd_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGadgetsAdd(opts, "10001", "sprint-burndown-gadget", "", "", "")
+	err = runGadgetsAdd(context.Background(), opts,"10001", "sprint-burndown-gadget", "", "", "")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), `"id"`)
 	testutil.Contains(t, stdout.String(), "10124")
@@ -314,11 +318,23 @@ func TestRunGadgetsAdd_InvalidPosition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
 			opts.SetAPIClient(client)
-			err := runGadgetsAdd(opts, "10001", "gadget", "", "", tt.position)
+			err := runGadgetsAdd(context.Background(), opts,"10001", "gadget", "", "", tt.position)
 			testutil.RequireError(t, err)
 			testutil.Contains(t, err.Error(), tt.errMsg)
 		})
 	}
+}
+
+func TestRunGadgetsAdd_NegativePosition(t *testing.T) {
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGadgetsAdd(context.Background(), opts, "10001", "gadget", "", "", "-1,0")
+	testutil.RequireError(t, err)
+	testutil.Contains(t, err.Error(), "non-negative")
 }
 
 func TestRunGadgetsAdd_ZeroPosition(t *testing.T) {
@@ -341,7 +357,7 @@ func TestRunGadgetsAdd_ZeroPosition(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGadgetsAdd(opts, "10001", "test-gadget", "", "", "0,0")
+	err = runGadgetsAdd(context.Background(), opts,"10001", "test-gadget", "", "", "0,0")
 	testutil.RequireNoError(t, err)
 
 	var req api.AddDashboardGadgetRequest

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -274,13 +274,80 @@ func TestRunGadgetsAdd_IDOnly(t *testing.T) {
 	testutil.Equal(t, stdout.String(), "10124\n")
 }
 
-func TestRunGadgetsAdd_InvalidPosition(t *testing.T) {
-	opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
-	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "tok"})
+func TestRunGadgetsAdd_JSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.DashboardGadget{
+			ID:       10124,
+			Title:    "Sprint Burndown",
+			ModuleID: "sprint-burndown-gadget",
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
 	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGadgetsAdd(opts, "10001", "some-gadget", "", "", "invalid")
-	testutil.RequireError(t, err)
-	testutil.Contains(t, err.Error(), "invalid position")
+	err = runGadgetsAdd(opts, "10001", "sprint-burndown-gadget", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), `"id"`)
+	testutil.Contains(t, stdout.String(), "10124")
+}
+
+func TestRunGadgetsAdd_InvalidPosition(t *testing.T) {
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	tests := []struct {
+		name     string
+		position string
+		errMsg   string
+	}{
+		{"no comma", "invalid", "invalid position"},
+		{"bad row", "abc,0", "invalid position row"},
+		{"bad column", "1,xyz", "invalid position column"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+			opts.SetAPIClient(client)
+			err := runGadgetsAdd(opts, "10001", "gadget", "", "", tt.position)
+			testutil.RequireError(t, err)
+			testutil.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+func TestRunGadgetsAdd_ZeroPosition(t *testing.T) {
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(api.DashboardGadget{
+			ID:       10125,
+			Title:    "Gadget",
+			ModuleID: "test-gadget",
+			Position: api.DashboardGadgetPos{Row: 0, Column: 0},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGadgetsAdd(opts, "10001", "test-gadget", "", "", "0,0")
+	testutil.RequireNoError(t, err)
+
+	var req api.AddDashboardGadgetRequest
+	err = json.Unmarshal(capturedBody, &req)
+	testutil.RequireNoError(t, err)
+	testutil.NotNil(t, req.Position)
+	testutil.Equal(t, req.Position.Row, 0)
+	testutil.Equal(t, req.Position.Column, 0)
 }

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -121,6 +121,24 @@ func TestRunCreate(t *testing.T) {
 	testutil.Equal(t, req.Description, "Description")
 }
 
+func TestRunCreate_IDOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.Dashboard{ID: "10099", Name: "New Board"})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runCreate(opts, "New Board", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "10099\n")
+}
+
 func TestRunDelete(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testutil.Equal(t, r.URL.Path, "/rest/api/3/dashboard/10001")
@@ -183,4 +201,74 @@ func TestRunGadgetsRemove(t *testing.T) {
 	err = runGadgetsRemove(opts, "10001", 42)
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Removed")
+}
+
+func TestRunGadgetsAdd(t *testing.T) {
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, r.URL.Path, "/rest/api/3/dashboard/10001/gadget")
+		testutil.Equal(t, r.Method, "POST")
+		capturedBody, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(api.DashboardGadget{
+			ID:       10124,
+			Title:    "Sprint Burndown",
+			ModuleID: "sprint-burndown-gadget",
+			Position: api.DashboardGadgetPos{Row: 1, Column: 0},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGadgetsAdd(opts, "10001", "sprint-burndown-gadget", "Sprint Burndown", "", "1,0")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "10124")
+	testutil.Contains(t, out, "Sprint Burndown")
+	testutil.Contains(t, out, "sprint-burndown-gadget")
+	testutil.Contains(t, out, "1,0")
+
+	var req api.AddDashboardGadgetRequest
+	err = json.Unmarshal(capturedBody, &req)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, req.ModuleKey, "sprint-burndown-gadget")
+}
+
+func TestRunGadgetsAdd_IDOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.DashboardGadget{
+			ID:       10124,
+			Title:    "Sprint Burndown",
+			ModuleID: "sprint-burndown-gadget",
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runGadgetsAdd(opts, "10001", "sprint-burndown-gadget", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "10124\n")
+}
+
+func TestRunGadgetsAdd_InvalidPosition(t *testing.T) {
+	opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	opts.SetAPIClient(client)
+
+	err = runGadgetsAdd(opts, "10001", "some-gadget", "", "", "invalid")
+	testutil.RequireError(t, err)
+	testutil.Contains(t, err.Error(), "invalid position")
 }

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -232,7 +232,7 @@ func TestRunGadgetsAdd(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGadgetsAdd(context.Background(), opts,"10001", "sprint-burndown-gadget", "Sprint Burndown", "", "1,0")
+	err = runGadgetsAdd(context.Background(), opts, "10001", "sprint-burndown-gadget", "Sprint Burndown", "", "1,0")
 	testutil.RequireNoError(t, err)
 
 	out := stdout.String()
@@ -273,7 +273,7 @@ func TestRunGadgetsAdd_IDOnly(t *testing.T) {
 	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
 	opts.SetAPIClient(client)
 
-	err = runGadgetsAdd(context.Background(), opts,"10001", "sprint-burndown-gadget", "", "", "")
+	err = runGadgetsAdd(context.Background(), opts, "10001", "sprint-burndown-gadget", "", "", "")
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "10124\n")
 }
@@ -295,7 +295,7 @@ func TestRunGadgetsAdd_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGadgetsAdd(context.Background(), opts,"10001", "sprint-burndown-gadget", "", "", "")
+	err = runGadgetsAdd(context.Background(), opts, "10001", "sprint-burndown-gadget", "", "", "")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), `"id"`)
 	testutil.Contains(t, stdout.String(), "10124")
@@ -318,7 +318,7 @@ func TestRunGadgetsAdd_InvalidPosition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
 			opts.SetAPIClient(client)
-			err := runGadgetsAdd(context.Background(), opts,"10001", "gadget", "", "", tt.position)
+			err := runGadgetsAdd(context.Background(), opts, "10001", "gadget", "", "", tt.position)
 			testutil.RequireError(t, err)
 			testutil.Contains(t, err.Error(), tt.errMsg)
 		})
@@ -357,7 +357,7 @@ func TestRunGadgetsAdd_ZeroPosition(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGadgetsAdd(context.Background(), opts,"10001", "test-gadget", "", "", "0,0")
+	err = runGadgetsAdd(context.Background(), opts, "10001", "test-gadget", "", "", "0,0")
 	testutil.RequireNoError(t, err)
 
 	var req api.AddDashboardGadgetRequest

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -112,7 +113,13 @@ func TestRunCreate(t *testing.T) {
 
 	err = runCreate(opts, "New Board", "Description")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "New Board")
+
+	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	testutil.Contains(t, lines[0], "ID")
+	testutil.Contains(t, lines[0], "NAME")
+	testutil.Contains(t, out, "New Board")
 
 	var req api.CreateDashboardRequest
 	err = json.Unmarshal(capturedBody, &req)
@@ -229,6 +236,11 @@ func TestRunGadgetsAdd(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	testutil.Contains(t, lines[0], "ID")
+	testutil.Contains(t, lines[0], "TITLE")
+	testutil.Contains(t, lines[0], "MODULE")
 	testutil.Contains(t, out, "10124")
 	testutil.Contains(t, out, "Sprint Burndown")
 	testutil.Contains(t, out, "sprint-burndown-gadget")

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -426,7 +426,13 @@ func TestRunRestore(t *testing.T) {
 
 	err = runRestore(context.Background(), opts, "customfield_10100")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "customfield_10100")
+
+	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	testutil.Contains(t, lines[0], "ID")
+	testutil.Contains(t, lines[0], "NAME")
+	testutil.Contains(t, out, "customfield_10100")
 }
 
 func TestRunRestore_IDOnly(t *testing.T) {
@@ -530,8 +536,14 @@ func TestRunContextsCreate(t *testing.T) {
 
 	err = runContextsCreate(context.Background(), opts, "customfield_10100", "Bug Context", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "10003")
-	testutil.Contains(t, stdout.String(), "Bug Context")
+
+	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	testutil.Contains(t, lines[0], "ID")
+	testutil.Contains(t, lines[0], "NAME")
+	testutil.Contains(t, out, "10003")
+	testutil.Contains(t, out, "Bug Context")
 }
 
 func TestRunContextsCreate_IDOnly(t *testing.T) {

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -640,7 +640,7 @@ func TestRunOptionsList_Table(t *testing.T) {
 			})
 			return
 		}
-		// GetFieldContextOptions
+		// GetFieldContextOptions (GET uses "values" key)
 		_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
 			Values: []api.FieldContextOption{
 				{ID: "1", Value: "Production", Disabled: false},
@@ -702,8 +702,8 @@ func TestRunOptionsAdd(t *testing.T) {
 			return
 		}
 		testutil.Equal(t, r.Method, http.MethodPost)
-		_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
-			Values: []api.FieldContextOption{
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"options": []api.FieldContextOption{
 				{ID: "3", Value: "Option A"},
 			},
 		})
@@ -734,8 +734,8 @@ func TestRunOptionsAdd_IDOnly(t *testing.T) {
 			})
 			return
 		}
-		_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
-			Values: []api.FieldContextOption{
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"options": []api.FieldContextOption{
 				{ID: "3", Value: "Option A"},
 			},
 		})
@@ -766,8 +766,8 @@ func TestRunOptionsUpdate(t *testing.T) {
 			return
 		}
 		testutil.Equal(t, r.Method, http.MethodPut)
-		_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
-			Values: []api.FieldContextOption{
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"options": []api.FieldContextOption{
 				{ID: "3", Value: "Option A (updated)"},
 			},
 		})
@@ -797,8 +797,8 @@ func TestRunOptionsUpdate_IDOnly(t *testing.T) {
 			})
 			return
 		}
-		_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
-			Values: []api.FieldContextOption{
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"options": []api.FieldContextOption{
 				{ID: "3", Value: "Option A (updated)"},
 			},
 		})

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -262,8 +263,15 @@ func TestRunCreate(t *testing.T) {
 
 	err = runCreate(context.Background(), opts, "Environment", "com.atlassian.jira.plugin.system.customfieldtypes:select", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "customfield_10100")
-	testutil.Contains(t, stdout.String(), "Environment")
+
+	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	testutil.Contains(t, lines[0], "ID")
+	testutil.Contains(t, lines[0], "NAME")
+	testutil.Contains(t, lines[0], "TYPE")
+	testutil.Contains(t, out, "customfield_10100")
+	testutil.Contains(t, out, "Environment")
 }
 
 func TestRunCreate_IDOnly(t *testing.T) {
@@ -719,8 +727,14 @@ func TestRunOptionsAdd(t *testing.T) {
 
 	err = runOptionsAdd(context.Background(), opts, "customfield_10100", "Option A", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "3")
-	testutil.Contains(t, stdout.String(), "Option A")
+
+	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	testutil.Contains(t, lines[0], "ID")
+	testutil.Contains(t, lines[0], "VALUE")
+	testutil.Contains(t, out, "3")
+	testutil.Contains(t, out, "Option A")
 }
 
 func TestRunOptionsAdd_IDOnly(t *testing.T) {
@@ -783,7 +797,13 @@ func TestRunOptionsUpdate(t *testing.T) {
 
 	err = runOptionsUpdate(context.Background(), opts, "customfield_10100", "3", "Option A (updated)", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Option A (updated)")
+
+	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	testutil.Contains(t, lines[0], "ID")
+	testutil.Contains(t, lines[0], "VALUE")
+	testutil.Contains(t, out, "Option A (updated)")
 }
 
 func TestRunOptionsUpdate_IDOnly(t *testing.T) {

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -266,6 +266,30 @@ func TestRunCreate(t *testing.T) {
 	testutil.Contains(t, stdout.String(), "Environment")
 }
 
+func TestRunCreate_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(api.Field{
+			ID:     "customfield_10100",
+			Name:   "Environment",
+			Custom: true,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runCreate(context.Background(), opts, "Environment", "select", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "customfield_10100\n")
+}
+
 func TestRunCreate_JSON(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -397,6 +421,29 @@ func TestRunRestore(t *testing.T) {
 	testutil.Contains(t, stdout.String(), "customfield_10100")
 }
 
+func TestRunRestore_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runRestore(context.Background(), opts, "customfield_10100")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "customfield_10100\n")
+}
+
 // --- Contexts tests ---
 
 func TestNewContextsCmd(t *testing.T) {
@@ -477,6 +524,29 @@ func TestRunContextsCreate(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "10003")
 	testutil.Contains(t, stdout.String(), "Bug Context")
+}
+
+func TestRunContextsCreate_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(api.FieldContext{
+			ID:   "10003",
+			Name: "Bug Context",
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runContextsCreate(context.Background(), opts, "customfield_10100", "Bug Context", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "10003\n")
 }
 
 func TestRunContextsDelete_Force(t *testing.T) {
@@ -653,6 +723,37 @@ func TestRunOptionsAdd(t *testing.T) {
 	testutil.Contains(t, stdout.String(), "Option A")
 }
 
+func TestRunOptionsAdd_IDOnly(t *testing.T) {
+	t.Parallel()
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		if callCount == 1 {
+			_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+				Values: []api.FieldContext{{ID: "10001", Name: "Default"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
+			Values: []api.FieldContextOption{
+				{ID: "3", Value: "Option A"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runOptionsAdd(context.Background(), opts, "customfield_10100", "Option A", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "3\n")
+}
+
 func TestRunOptionsUpdate(t *testing.T) {
 	t.Parallel()
 	callCount := 0
@@ -683,6 +784,37 @@ func TestRunOptionsUpdate(t *testing.T) {
 	err = runOptionsUpdate(context.Background(), opts, "customfield_10100", "3", "Option A (updated)", "")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Option A (updated)")
+}
+
+func TestRunOptionsUpdate_IDOnly(t *testing.T) {
+	t.Parallel()
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		if callCount == 1 {
+			_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+				Values: []api.FieldContext{{ID: "10001", Name: "Default"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
+			Values: []api.FieldContextOption{
+				{ID: "3", Value: "Option A (updated)"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runOptionsUpdate(context.Background(), opts, "customfield_10100", "3", "Option A (updated)", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "3\n")
 }
 
 func TestRunOptionsDelete_Force(t *testing.T) {

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -419,6 +420,12 @@ func TestRunCreate_CanonicalRow(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	testutil.Contains(t, lines[0], "LINK_ID")
+	testutil.Contains(t, lines[0], "TYPE")
+	testutil.Contains(t, lines[0], "DIRECTION")
+	testutil.Contains(t, lines[0], "ISSUE")
 	testutil.Contains(t, out, "17844")
 	testutil.Contains(t, out, "Blocker")
 	testutil.Contains(t, out, "PROJ-456")

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -403,6 +403,14 @@ func createServerWithRefetch(t *testing.T) *httptest.Server {
 	}))
 }
 
+func seedLinkTypesForTest(t *testing.T) {
+	t.Helper()
+	isolateCache(t)
+	testutil.RequireNoError(t, cache.WriteResource("linktypes", "24h", []api.IssueLinkType{
+		{ID: "10100", Name: "Blocker", Inward: "is blocked by", Outward: "blocks"},
+	}))
+}
+
 func TestRunCreate_CanonicalRow(t *testing.T) {
 	t.Parallel()
 	server := createServerWithRefetch(t)
@@ -411,7 +419,7 @@ func TestRunCreate_CanonicalRow(t *testing.T) {
 	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
 	testutil.RequireNoError(t, err)
 
-	isolateCache(t)
+	seedLinkTypesForTest(t)
 	var stdout bytes.Buffer
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
@@ -440,7 +448,7 @@ func TestRunCreate_IDOnly(t *testing.T) {
 	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
 	testutil.RequireNoError(t, err)
 
-	isolateCache(t)
+	seedLinkTypesForTest(t)
 	var stdout bytes.Buffer
 	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
 	opts.SetAPIClient(client)

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -369,6 +369,80 @@ func TestRunCreate_SymmetricVerbNoSwap(t *testing.T) {
 	testutil.Equal(t, req.InwardIssue.Key, "PROJ-2")
 }
 
+func createServerWithRefetch(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/issueLinkType":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issueLinkTypes": []map[string]string{
+					{"id": "10100", "name": "Blocker", "inward": "is blocked by", "outward": "blocks"},
+				},
+			})
+		case r.URL.Path == "/rest/api/3/issueLink" && r.Method == "POST":
+			w.WriteHeader(http.StatusCreated)
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"fields": map[string]any{
+					"issuelinks": []map[string]any{
+						{
+							"id":   "17844",
+							"type": map[string]any{"id": "10100", "name": "Blocker", "inward": "is blocked by", "outward": "blocks"},
+							"inwardIssue": map[string]any{
+								"key":    "PROJ-456",
+								"fields": map[string]any{"summary": "Blocked issue", "status": map[string]any{"name": "Open"}},
+							},
+						},
+					},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestRunCreate_CanonicalRow(t *testing.T) {
+	t.Parallel()
+	server := createServerWithRefetch(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	isolateCache(t)
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runCreate(context.Background(), opts, "PROJ-123", "PROJ-456", "Blocker")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "17844")
+	testutil.Contains(t, out, "Blocker")
+	testutil.Contains(t, out, "PROJ-456")
+	testutil.NotContains(t, out, "Created")
+}
+
+func TestRunCreate_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := createServerWithRefetch(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	isolateCache(t)
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runCreate(context.Background(), opts, "PROJ-123", "PROJ-456", "Blocker")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "17844\n")
+}
+
 func TestRunCreate_InvalidType(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{


### PR DESCRIPTION
Closes #244

## Summary

- Add `dashboards gadgets add` command: API method (`AddDashboardGadget`), CLI command with `--type`, `--position`, `--title`, `--color` flags, canonical table row output via `PresentGadgets`, and `--id` support
- Add `--id` tests for 6 existing mutation commands that were missing them: `fields create`, `fields restore`, `fields contexts create`, `fields options add`, `fields options update`, `dashboards create`
- Add canonical-row test for `links create` that exercises the re-fetch success path (existing test only covered the fallback message path)
- Update integration test docs with `gadgets add` test cases, bearer-auth error table, and e2e workflow

## Test plan

- [x] `make test` — all 1420 tests pass
- [x] `golangci-lint run` — no new issues (only pre-existing `config.go` gosec)
- [ ] Integration test: `jtk dashboards gadgets add <id> --type com.atlassian.jira.gadgets:filter-results-gadget`
- [ ] Integration test: `jtk dashboards gadgets add <id> --type ... --id`