### PR TITLE
feat(jtk): migrate destructive mutations to confirmation-line output

### DIFF
--- a/tools/jtk/cmd/jtk/main.go
+++ b/tools/jtk/cmd/jtk/main.go
@@ -36,7 +36,7 @@ func main() {
 	defer stop()
 
 	if err := run(ctx); err != nil {
-		if !errors.Is(err, refresh.ErrAlreadyReported) {
+		if !errors.Is(err, root.ErrAlreadyReported) {
 			fmt.Fprintln(os.Stderr, err)
 		}
 		os.Exit(exitcode.GeneralError)

--- a/tools/jtk/internal/cmd/automation/delete.go
+++ b/tools/jtk/internal/cmd/automation/delete.go
@@ -81,12 +81,7 @@ func runDelete(ctx context.Context, opts *root.Options, ruleID string, force boo
 		return err
 	}
 
-	if opts.Output == "json" {
-		v := opts.View()
-		return v.JSON(map[string]string{"status": "deleted", "ruleId": ruleID, "name": current.Name})
-	}
-
-	model := jtkpresent.AutomationPresenter{}.PresentDeleted(current.Name, ruleID)
+	model := jtkpresent.AutomationPresenter{}.PresentDeleted(ruleID)
 	out := present.Render(model, opts.RenderStyle())
 	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil

--- a/tools/jtk/internal/cmd/automation/delete_test.go
+++ b/tools/jtk/internal/cmd/automation/delete_test.go
@@ -56,8 +56,8 @@ func TestRunDelete_DisabledRule(t *testing.T) {
 
 	err = runDelete(context.Background(), opts, "42", true)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Deleted")
-	testutil.Contains(t, stdout.String(), "Test Rule")
+	testutil.Equal(t, stdout.String(), "Deleted automation 42\n")
+	testutil.Equal(t, stderr.String(), "")
 	// Should be GET + DELETE (no disable needed)
 	testutil.Len(t, methods, 2)
 	testutil.Equal(t, methods[0], http.MethodGet)
@@ -106,7 +106,8 @@ func TestRunDelete_EnabledRule_DisablesFirst(t *testing.T) {
 
 	err = runDelete(context.Background(), opts, "42", true)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Deleted")
+	testutil.Equal(t, stdout.String(), "Deleted automation 42\n")
+	testutil.Equal(t, stderr.String(), "")
 	// Should be GET + PUT (disable) + DELETE
 	testutil.Len(t, methods, 3)
 	testutil.Equal(t, methods[0], http.MethodGet)
@@ -155,10 +156,10 @@ func TestRunDelete_PromptDeclined(t *testing.T) {
 	err = runDelete(context.Background(), opts, "42", false)
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stderr.String(), "permanently delete")
-	testutil.Contains(t, stdout.String(), "cancelled")
+	testutil.Equal(t, stdout.String(), "Deletion cancelled.\n")
 }
 
-func TestRunDelete_JSONOutput(t *testing.T) {
+func TestRunDelete_JSONOutputIgnored(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -197,9 +198,6 @@ func TestRunDelete_JSONOutput(t *testing.T) {
 
 	err = runDelete(context.Background(), opts, "42", true)
 	testutil.RequireNoError(t, err)
-
-	var result map[string]string
-	testutil.RequireNoError(t, json.Unmarshal(stdout.Bytes(), &result))
-	testutil.Equal(t, result["status"], "deleted")
-	testutil.Equal(t, result["name"], "JSON Rule")
+	testutil.Equal(t, stdout.String(), "Deleted automation 42\n")
+	testutil.Equal(t, stderr.String(), "")
 }

--- a/tools/jtk/internal/cmd/comments/comments.go
+++ b/tools/jtk/internal/cmd/comments/comments.go
@@ -233,8 +233,6 @@ func newDeleteCmd(opts *root.Options) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, opts *root.Options, issueKey, commentID string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -242,10 +240,6 @@ func runDelete(ctx context.Context, opts *root.Options, issueKey, commentID stri
 
 	if err := client.DeleteComment(ctx, issueKey, commentID); err != nil {
 		return err
-	}
-
-	if opts.Output == "json" {
-		return v.JSON(map[string]string{"status": "deleted", "commentId": commentID})
 	}
 
 	return jtkpresent.Emit(opts, jtkpresent.CommentPresenter{}.PresentDeleted(commentID, issueKey))

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -651,3 +651,43 @@ func TestRunAdd_PostState(t *testing.T) {
 	testutil.Contains(t, stdout.String(), "TEST-1 #21276")
 	testutil.Contains(t, stdout.String(), "Alice")
 }
+
+func TestRunDelete_TextConfirmation(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, "PROJ-1", "12345")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted comment 12345 from PROJ-1\n")
+	testutil.Equal(t, stderr.String(), "")
+}
+
+func TestRunDelete_JSONOutputEmitsText(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, "PROJ-1", "12345")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted comment 12345 from PROJ-1\n")
+	testutil.Equal(t, stderr.String(), "")
+}

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -654,7 +654,7 @@ func TestRunAdd_PostState(t *testing.T) {
 
 func TestRunDelete_TextConfirmation(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
@@ -674,7 +674,7 @@ func TestRunDelete_TextConfirmation(t *testing.T) {
 
 func TestRunDelete_JSONOutputEmitsText(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()

--- a/tools/jtk/internal/cmd/dashboards/dashboards.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards.go
@@ -230,8 +230,6 @@ func newDeleteCmd(opts *root.Options) *cobra.Command {
 }
 
 func runDelete(opts *root.Options, dashboardID string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -239,10 +237,6 @@ func runDelete(opts *root.Options, dashboardID string) error {
 
 	if err := client.DeleteDashboard(dashboardID); err != nil {
 		return err
-	}
-
-	if v.Format == view.FormatJSON {
-		return v.JSON(map[string]string{"status": "deleted", "dashboardId": dashboardID})
 	}
 
 	model := jtkpresent.DashboardPresenter{}.PresentDeleted(dashboardID)
@@ -409,8 +403,6 @@ func newGadgetsRemoveCmd(opts *root.Options) *cobra.Command {
 }
 
 func runGadgetsRemove(opts *root.Options, dashboardID string, gadgetID int) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -418,14 +410,6 @@ func runGadgetsRemove(opts *root.Options, dashboardID string, gadgetID int) erro
 
 	if err := client.RemoveDashboardGadget(dashboardID, gadgetID); err != nil {
 		return err
-	}
-
-	if v.Format == view.FormatJSON {
-		return v.JSON(map[string]interface{}{
-			"status":      "removed",
-			"dashboardId": dashboardID,
-			"gadgetId":    gadgetID,
-		})
 	}
 
 	model := jtkpresent.DashboardPresenter{}.PresentGadgetRemoved(gadgetID, dashboardID)

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -167,6 +167,7 @@ func TestRunDelete(t *testing.T) {
 }
 
 func TestRunDelete_JSONOutputEmitsText(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -230,6 +231,7 @@ func TestRunGadgetsRemove(t *testing.T) {
 }
 
 func TestRunGadgetsRemove_JSONOutputEmitsText(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -163,7 +163,26 @@ func TestRunDelete(t *testing.T) {
 
 	err = runDelete(opts, "10001")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Deleted")
+	testutil.Equal(t, stdout.String(), "Deleted dashboard 10001\n")
+}
+
+func TestRunDelete_JSONOutputEmitsText(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runDelete(opts, "10001")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted dashboard 10001\n")
+	testutil.Equal(t, stderr.String(), "")
 }
 
 func TestRunGadgetsList(t *testing.T) {
@@ -207,7 +226,26 @@ func TestRunGadgetsRemove(t *testing.T) {
 
 	err = runGadgetsRemove(opts, "10001", 42)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Removed")
+	testutil.Equal(t, stdout.String(), "Removed gadget 42 from dashboard 10001\n")
+}
+
+func TestRunGadgetsRemove_JSONOutputEmitsText(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runGadgetsRemove(opts, "10001", 42)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Removed gadget 42 from dashboard 10001\n")
+	testutil.Equal(t, stderr.String(), "")
 }
 
 func TestRunGadgetsAdd(t *testing.T) {

--- a/tools/jtk/internal/cmd/fields/fields.go
+++ b/tools/jtk/internal/cmd/fields/fields.go
@@ -231,7 +231,7 @@ func runDelete(ctx context.Context, opts *root.Options, fieldID string, force bo
 
 	_ = cache.RemoveOnDelete[api.Field]("fields", func(f api.Field) bool { return f.ID == fieldID })
 
-	model := jtkpresent.FieldPresenter{}.PresentTrashed(fieldID)
+	model := jtkpresent.FieldPresenter{}.PresentDeleted(fieldID)
 	out := present.Render(model, opts.RenderStyle())
 	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -893,5 +893,54 @@ func TestRunOptionsDelete_NoForce_Declined(t *testing.T) {
 
 	err = runOptionsDelete(context.Background(), opts, "customfield_10100", "3", "", false)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Deletion cancelled")
+	testutil.Equal(t, stdout.String(), "Deletion cancelled.\n")
+}
+
+func TestRunDelete_JSONOutputEmitsText(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, "customfield_10100", true)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted field customfield_10100 (moved to trash — use fields restore to recover)\n")
+	testutil.Equal(t, stderr.String(), "")
+}
+
+func TestRunOptionsDelete_JSONOutputEmitsText(t *testing.T) {
+	t.Parallel()
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+				Values: []api.FieldContext{{ID: "10001", Name: "Default"}},
+			})
+			return
+		}
+		testutil.Equal(t, r.Method, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runOptionsDelete(context.Background(), opts, "customfield_10100", "3", "", true)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted option 3 from context 10001\n")
+	testutil.Equal(t, stderr.String(), "")
 }

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -352,7 +352,7 @@ func TestRunDelete_Force(t *testing.T) {
 
 	err = runDelete(context.Background(), opts, "customfield_10100", true)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Deleted field customfield_10100 (moved to trash")
+	testutil.Equal(t, stdout.String(), "Deleted field customfield_10100 (moved to trash — use fields restore to recover)\n")
 }
 
 func TestRunDelete_NoForce_Declined(t *testing.T) {
@@ -371,7 +371,7 @@ func TestRunDelete_NoForce_Declined(t *testing.T) {
 
 	err = runDelete(context.Background(), opts, "customfield_10100", false)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Deletion cancelled")
+	testutil.Equal(t, stdout.String(), "Deletion cancelled.\n")
 }
 
 func TestRunDelete_NoForce_Accepted(t *testing.T) {
@@ -396,7 +396,7 @@ func TestRunDelete_NoForce_Accepted(t *testing.T) {
 
 	err = runDelete(context.Background(), opts, "customfield_10100", false)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Deleted field customfield_10100 (moved to trash")
+	testutil.Equal(t, stdout.String(), "Deleted field customfield_10100 (moved to trash — use fields restore to recover)\n")
 }
 
 func TestRunRestore(t *testing.T) {

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -352,7 +352,7 @@ func TestRunDelete_Force(t *testing.T) {
 
 	err = runDelete(context.Background(), opts, "customfield_10100", true)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Trashed field customfield_10100")
+	testutil.Contains(t, stdout.String(), "Deleted field customfield_10100 (moved to trash")
 }
 
 func TestRunDelete_NoForce_Declined(t *testing.T) {
@@ -396,7 +396,7 @@ func TestRunDelete_NoForce_Accepted(t *testing.T) {
 
 	err = runDelete(context.Background(), opts, "customfield_10100", false)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Trashed field customfield_10100")
+	testutil.Contains(t, stdout.String(), "Deleted field customfield_10100 (moved to trash")
 }
 
 func TestRunRestore(t *testing.T) {
@@ -874,7 +874,7 @@ func TestRunOptionsDelete_Force(t *testing.T) {
 
 	err = runOptionsDelete(context.Background(), opts, "customfield_10100", "3", "", true)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Deleted option 3")
+	testutil.Equal(t, stdout.String(), "Deleted option 3 from context 10001\n")
 }
 
 func TestRunOptionsDelete_NoForce_Declined(t *testing.T) {

--- a/tools/jtk/internal/cmd/fields/options.go
+++ b/tools/jtk/internal/cmd/fields/options.go
@@ -290,7 +290,7 @@ func runOptionsDelete(ctx context.Context, opts *root.Options, fieldID, optionID
 		return err
 	}
 
-	model := jtkpresent.FieldPresenter{}.PresentOptionDeleted(optionID, fieldID)
+	model := jtkpresent.FieldPresenter{}.PresentOptionDeleted(optionID, ctxID)
 	out := present.Render(model, opts.RenderStyle())
 	fmt.Fprint(opts.Stdout, out.Stdout)
 	return nil

--- a/tools/jtk/internal/cmd/issues/delete.go
+++ b/tools/jtk/internal/cmd/issues/delete.go
@@ -3,6 +3,7 @@ package issues
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -17,17 +18,20 @@ func newDeleteCmd(opts *root.Options) *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:   "delete <issue-key>",
-		Short: "Delete an issue",
-		Long:  "Permanently delete a Jira issue. This action cannot be undone.",
+		Use:   "delete <issue-key> [<issue-key>...]",
+		Short: "Delete one or more issues",
+		Long:  "Permanently delete one or more Jira issues. This action cannot be undone.",
 		Example: `  # Delete an issue (will prompt for confirmation)
   jtk issues delete PROJ-123
 
+  # Delete multiple issues
+  jtk issues delete PROJ-123 PROJ-124 PROJ-125
+
   # Delete without confirmation
   jtk issues delete PROJ-123 --force`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDelete(cmd.Context(), opts, args[0], force)
+			return runDelete(cmd.Context(), opts, args, force)
 		},
 	}
 
@@ -36,10 +40,15 @@ func newDeleteCmd(opts *root.Options) *cobra.Command {
 	return cmd
 }
 
-func runDelete(ctx context.Context, opts *root.Options, issueKey string, force bool) error {
+func runDelete(ctx context.Context, opts *root.Options, issueKeys []string, force bool) error {
 	if !force {
-		// Interactive prompt goes directly to stderr
-		fmt.Fprintf(opts.Stderr, "This will permanently delete issue %s. This action cannot be undone.\n", issueKey)
+		var msg string
+		if len(issueKeys) == 1 {
+			msg = fmt.Sprintf("This will permanently delete issue %s. This action cannot be undone.", issueKeys[0])
+		} else {
+			msg = fmt.Sprintf("This will permanently delete %d issues: %s. This action cannot be undone.", len(issueKeys), strings.Join(issueKeys, ", "))
+		}
+		fmt.Fprintln(opts.Stderr, msg)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
 
 		confirmed, err := prompt.Confirm(opts.Stdin)
@@ -59,13 +68,21 @@ func runDelete(ctx context.Context, opts *root.Options, issueKey string, force b
 		return err
 	}
 
-	if err := client.DeleteIssue(ctx, issueKey); err != nil {
-		return err
+	var failed int
+	for _, key := range issueKeys {
+		if err := client.DeleteIssue(ctx, key); err != nil {
+			fmt.Fprintf(opts.Stderr, "Failed to delete %s: %s\n", key, err)
+			failed++
+			continue
+		}
+
+		model := jtkpresent.IssuePresenter{}.PresentDeleted(key)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
 	}
 
-	model := jtkpresent.IssuePresenter{}.PresentDeleted(issueKey)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+	if failed > 0 {
+		return fmt.Errorf("%w (%d of %d issue(s) failed)", root.ErrAlreadyReported, failed, len(issueKeys))
+	}
 	return nil
 }

--- a/tools/jtk/internal/cmd/issues/delete.go
+++ b/tools/jtk/internal/cmd/issues/delete.go
@@ -70,6 +70,10 @@ func runDelete(ctx context.Context, opts *root.Options, issueKeys []string, forc
 
 	var failed int
 	for _, key := range issueKeys {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		if err := client.DeleteIssue(ctx, key); err != nil {
 			fmt.Fprintf(opts.Stderr, "Failed to delete %s: %s\n", key, err)
 			failed++
@@ -79,6 +83,7 @@ func runDelete(ctx context.Context, opts *root.Options, issueKeys []string, forc
 		model := jtkpresent.IssuePresenter{}.PresentDeleted(key)
 		out := present.Render(model, opts.RenderStyle())
 		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 	}
 
 	if failed > 0 {

--- a/tools/jtk/internal/cmd/issues/delete_test.go
+++ b/tools/jtk/internal/cmd/issues/delete_test.go
@@ -131,3 +131,79 @@ func TestRunDelete_BatchPromptDeclined(t *testing.T) {
 	testutil.Contains(t, stderr.String(), "3 issues")
 	testutil.Equal(t, stdout.String(), "Deletion cancelled.\n")
 }
+
+func TestRunDelete_PromptAccepted(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Stdin:  bytes.NewBufferString("y\n"),
+	}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, []string{"PROJ-123"}, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted PROJ-123\n")
+}
+
+func TestRunDelete_BatchPromptAccepted(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Stdin:  bytes.NewBufferString("y\n"),
+	}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, []string{"PROJ-1", "PROJ-2"}, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted PROJ-1\nDeleted PROJ-2\n")
+}
+
+func TestRunDelete_AllFailures(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errorMessages":["Issue does not exist"]}`))
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, []string{"PROJ-1", "PROJ-2"}, true)
+	testutil.Error(t, err)
+	if !errors.Is(err, root.ErrAlreadyReported) {
+		t.Fatalf("expected ErrAlreadyReported, got %v", err)
+	}
+	testutil.Equal(t, stdout.String(), "")
+	testutil.Contains(t, stderr.String(), "Failed to delete PROJ-1")
+	testutil.Contains(t, stderr.String(), "Failed to delete PROJ-2")
+}

--- a/tools/jtk/internal/cmd/issues/delete_test.go
+++ b/tools/jtk/internal/cmd/issues/delete_test.go
@@ -39,12 +39,9 @@ func TestRunDelete_SingleIssue(t *testing.T) {
 func TestRunDelete_MultipleIssues(t *testing.T) {
 	t.Parallel()
 
-	var deleted []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete {
-			deleted = append(deleted, r.URL.Path)
-			w.WriteHeader(http.StatusNoContent)
-		}
+		testutil.Equal(t, r.Method, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 
@@ -59,7 +56,6 @@ func TestRunDelete_MultipleIssues(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "Deleted PROJ-1\nDeleted PROJ-2\nDeleted PROJ-3\n")
 	testutil.Equal(t, stderr.String(), "")
-	testutil.Len(t, deleted, 3)
 }
 
 func TestRunDelete_PartialFailure(t *testing.T) {

--- a/tools/jtk/internal/cmd/issues/delete_test.go
+++ b/tools/jtk/internal/cmd/issues/delete_test.go
@@ -87,8 +87,7 @@ func TestRunDelete_PartialFailure(t *testing.T) {
 	if !errors.Is(err, root.ErrAlreadyReported) {
 		t.Fatalf("expected ErrAlreadyReported, got %v", err)
 	}
-	testutil.Contains(t, stdout.String(), "Deleted PROJ-1")
-	testutil.Contains(t, stdout.String(), "Deleted PROJ-3")
+	testutil.Equal(t, stdout.String(), "Deleted PROJ-1\nDeleted PROJ-3\n")
 	testutil.Contains(t, stderr.String(), "Failed to delete PROJ-2")
 }
 

--- a/tools/jtk/internal/cmd/issues/delete_test.go
+++ b/tools/jtk/internal/cmd/issues/delete_test.go
@@ -105,6 +105,7 @@ func TestRunDelete_PromptDeclined(t *testing.T) {
 	err = runDelete(context.Background(), opts, []string{"PROJ-123"}, false)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "Deletion cancelled.\n")
+	testutil.Contains(t, stderr.String(), "permanently delete issue PROJ-123")
 }
 
 func TestRunDelete_BatchPromptDeclined(t *testing.T) {

--- a/tools/jtk/internal/cmd/issues/delete_test.go
+++ b/tools/jtk/internal/cmd/issues/delete_test.go
@@ -1,0 +1,134 @@
+package issues
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+func TestRunDelete_SingleIssue(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, r.Method, http.MethodDelete)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, []string{"PROJ-123"}, true)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted PROJ-123\n")
+	testutil.Equal(t, stderr.String(), "")
+}
+
+func TestRunDelete_MultipleIssues(t *testing.T) {
+	t.Parallel()
+
+	var deleted []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted = append(deleted, r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, []string{"PROJ-1", "PROJ-2", "PROJ-3"}, true)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted PROJ-1\nDeleted PROJ-2\nDeleted PROJ-3\n")
+	testutil.Equal(t, stderr.String(), "")
+	testutil.Len(t, deleted, 3)
+}
+
+func TestRunDelete_PartialFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue/PROJ-2" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errorMessages":["Issue does not exist"]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, []string{"PROJ-1", "PROJ-2", "PROJ-3"}, true)
+	testutil.Error(t, err)
+	if !errors.Is(err, root.ErrAlreadyReported) {
+		t.Fatalf("expected ErrAlreadyReported, got %v", err)
+	}
+	testutil.Contains(t, stdout.String(), "Deleted PROJ-1")
+	testutil.Contains(t, stdout.String(), "Deleted PROJ-3")
+	testutil.Contains(t, stderr.String(), "Failed to delete PROJ-2")
+}
+
+func TestRunDelete_PromptDeclined(t *testing.T) {
+	t.Parallel()
+
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Stdin:  bytes.NewBufferString("n\n"),
+	}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, []string{"PROJ-123"}, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deletion cancelled.\n")
+}
+
+func TestRunDelete_BatchPromptDeclined(t *testing.T) {
+	t.Parallel()
+
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{
+		Output: "table",
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Stdin:  bytes.NewBufferString("n\n"),
+	}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, []string{"PROJ-1", "PROJ-2", "PROJ-3"}, false)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stderr.String(), "3 issues")
+	testutil.Equal(t, stdout.String(), "Deletion cancelled.\n")
+}

--- a/tools/jtk/internal/cmd/links/links.go
+++ b/tools/jtk/internal/cmd/links/links.go
@@ -281,8 +281,6 @@ func newDeleteCmd(opts *root.Options) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, opts *root.Options, linkID string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -290,10 +288,6 @@ func runDelete(ctx context.Context, opts *root.Options, linkID string) error {
 
 	if err := client.DeleteIssueLink(ctx, linkID); err != nil {
 		return err
-	}
-
-	if v.Format == view.FormatJSON {
-		return v.JSON(map[string]string{"status": "deleted", "linkId": linkID})
 	}
 
 	return jtkpresent.Emit(opts, jtkpresent.LinkPresenter{}.PresentDeleted(linkID))

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -498,7 +498,26 @@ func TestRunDelete(t *testing.T) {
 
 	err = runDelete(context.Background(), opts, "10001")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "Deleted")
+	testutil.Equal(t, stdout.String(), "Deleted link 10001\n")
+}
+
+func TestRunDelete_JSONOutputEmitsText(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, "10001")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted link 10001\n")
+	testutil.Equal(t, stderr.String(), "")
 }
 
 func TestRunTypes(t *testing.T) {

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -502,6 +502,7 @@ func TestRunDelete(t *testing.T) {
 }
 
 func TestRunDelete_JSONOutputEmitsText(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))

--- a/tools/jtk/internal/cmd/refresh/refresh.go
+++ b/tools/jtk/internal/cmd/refresh/refresh.go
@@ -18,11 +18,6 @@ import (
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
-// ErrAlreadyReported signals that the command has already rendered its failure
-// output via the modeled path; the process entrypoint should exit non-zero
-// without re-printing the error.
-var ErrAlreadyReported = errors.New("refresh had failures; already reported")
-
 // Register registers the refresh command.
 func Register(parent *cobra.Command, opts *root.Options) {
 	var statusOnly bool
@@ -154,7 +149,7 @@ func runRefresh(ctx context.Context, opts *root.Options, client *api.Client, sel
 	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
 
 	if failed > 0 {
-		return fmt.Errorf("%w (%d resource(s))", ErrAlreadyReported, failed)
+		return fmt.Errorf("%w (%d resource(s))", root.ErrAlreadyReported, failed)
 	}
 	return nil
 }

--- a/tools/jtk/internal/cmd/refresh/refresh_test.go
+++ b/tools/jtk/internal/cmd/refresh/refresh_test.go
@@ -172,7 +172,7 @@ func TestRun_Refresh_ContinuesOnError(t *testing.T) {
 	testutil.Error(t, err)
 	// Returned error signals "already reported" so main.go won't re-print; the
 	// failure detail lives in the stderr section rendered by the presenter.
-	if !errors.Is(err, ErrAlreadyReported) {
+	if !errors.Is(err, root.ErrAlreadyReported) {
 		t.Fatalf("expected ErrAlreadyReported, got %v", err)
 	}
 	testutil.Contains(t, stdout.String(), "Refreshing ok")

--- a/tools/jtk/internal/cmd/root/root.go
+++ b/tools/jtk/internal/cmd/root/root.go
@@ -2,6 +2,7 @@
 package root
 
 import (
+	"errors"
 	"io"
 	"os"
 
@@ -15,6 +16,10 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
 )
+
+// ErrAlreadyReported signals that the command has already rendered its failure
+// output to stderr. main.go checks for this to avoid double-printing.
+var ErrAlreadyReported = errors.New("already reported")
 
 // Options contains global options for commands
 type Options struct {

--- a/tools/jtk/internal/present/automation.go
+++ b/tools/jtk/internal/present/automation.go
@@ -180,12 +180,12 @@ func (AutomationPresenter) PresentUpdateComplete(name, uuid, state, ruleID strin
 }
 
 // PresentDeleted creates a success message for rule deletion.
-func (AutomationPresenter) PresentDeleted(name, ruleID string) *present.OutputModel {
+func (AutomationPresenter) PresentDeleted(ruleID string) *present.OutputModel {
 	return &present.OutputModel{
 		Sections: []present.Section{
 			&present.MessageSection{
 				Kind:    present.MessageSuccess,
-				Message: fmt.Sprintf("Deleted automation rule %q (%s)", name, ruleID),
+				Message: fmt.Sprintf("Deleted automation %s", ruleID),
 				Stream:  present.StreamStdout,
 			},
 		},

--- a/tools/jtk/internal/present/field.go
+++ b/tools/jtk/internal/present/field.go
@@ -171,8 +171,8 @@ func (FieldPresenter) PresentCreated(id, name string) *present.OutputModel {
 	}
 }
 
-// PresentTrashed creates a success message for field trashing.
-func (FieldPresenter) PresentTrashed(fieldID string) *present.OutputModel {
+// PresentDeleted creates a success message for field deletion (soft-delete to trash).
+func (FieldPresenter) PresentDeleted(fieldID string) *present.OutputModel {
 	return &present.OutputModel{
 		Sections: []present.Section{
 			&present.MessageSection{

--- a/tools/jtk/internal/present/field.go
+++ b/tools/jtk/internal/present/field.go
@@ -177,7 +177,7 @@ func (FieldPresenter) PresentTrashed(fieldID string) *present.OutputModel {
 		Sections: []present.Section{
 			&present.MessageSection{
 				Kind:    present.MessageSuccess,
-				Message: fmt.Sprintf("Trashed field %s", fieldID),
+				Message: fmt.Sprintf("Deleted field %s (moved to trash — use fields restore to recover)", fieldID),
 				Stream:  present.StreamStdout,
 			},
 		},
@@ -307,12 +307,12 @@ func (FieldPresenter) PresentOptionUpdated(optionID string) *present.OutputModel
 }
 
 // PresentOptionDeleted creates a success message for option deletion.
-func (FieldPresenter) PresentOptionDeleted(optionID, fieldID string) *present.OutputModel {
+func (FieldPresenter) PresentOptionDeleted(optionID, contextID string) *present.OutputModel {
 	return &present.OutputModel{
 		Sections: []present.Section{
 			&present.MessageSection{
 				Kind:    present.MessageSuccess,
-				Message: fmt.Sprintf("Deleted option %s from field %s", optionID, fieldID),
+				Message: fmt.Sprintf("Deleted option %s from context %s", optionID, contextID),
 				Stream:  present.StreamStdout,
 			},
 		},

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -531,7 +531,7 @@ func (IssuePresenter) PresentDeleted(key string) *present.OutputModel {
 		Sections: []present.Section{
 			&present.MessageSection{
 				Kind:    present.MessageSuccess,
-				Message: fmt.Sprintf("Deleted issue %s", key),
+				Message: fmt.Sprintf("Deleted %s", key),
 				Stream:  present.StreamStdout,
 			},
 		},

--- a/tools/jtk/internal/present/project.go
+++ b/tools/jtk/internal/present/project.go
@@ -254,7 +254,7 @@ func (ProjectPresenter) PresentDeleted(key string) *present.OutputModel {
 		Sections: []present.Section{
 			&present.MessageSection{
 				Kind:    present.MessageSuccess,
-				Message: fmt.Sprintf("Deleted project %s (moved to trash)", key),
+				Message: fmt.Sprintf("Deleted project %s (moved to trash — recoverable for 60 days via projects restore)", key),
 				Stream:  present.StreamStdout,
 			},
 		},


### PR DESCRIPTION
## Summary
- Align all delete/archive/remove confirmation messages with the #230 output specification
- Remove legacy JSON output blocks from destructive mutations (automation, comments, links, dashboards, gadgets)
- Add multi-delete support to `issues delete` with continue-on-error semantics and `ErrAlreadyReported` sentinel for proper exit codes
- Move `ErrAlreadyReported` from `refresh` to `root` package for cross-command reuse

## Changes by category

**Presenter message fixes** (5 presenters):
- `issues delete`: "Deleted issue X" → "Deleted X"
- `projects delete`: add "recoverable for 60 days via projects restore" detail
- `automation delete`: "Deleted automation rule 'name' (id)" → "Deleted automation id"
- `fields delete`: "Trashed field X" → "Deleted field X (moved to trash — use fields restore to recover)"
- `fields options delete`: "from field X" → "from context X" (pass contextID instead of fieldID)

**JSON removal**: Destructive ops now always emit text confirmation — JSON is reserved for round-trip payloads per spec.

**Multi-delete**: `issues delete` accepts variadic args, emits one line per key, continues on error, reports failures to stderr.

## Test plan
- [x] `make build` — passes
- [x] `make test` — all tests pass (including new delete_test.go with multi-delete, partial failure, and prompt-declined scenarios)
- [x] `make lint` — only pre-existing gosec issue in config.go remains

Closes #245