### PR TITLE
feat(jtk): use fields cache for read-only field metadata paths

### DIFF
--- a/tools/jtk/internal/cache/fields_lookup.go
+++ b/tools/jtk/internal/cache/fields_lookup.go
@@ -34,12 +34,16 @@ func GetFieldsCacheFirst(ctx context.Context, client *api.Client) ([]api.Field, 
 		return client.GetFields(ctx)
 	}
 
-	// Classify never returns StatusUnavailable (that is only set by refresh
-	// via Entry.IsAvailable); list the remaining cases explicitly so the
-	// exhaustive linter is satisfied.
-	switch Classify(env.FetchedAt, entry.TTL, time.Now()) { //nolint:exhaustive
+	switch Classify(env.FetchedAt, entry.TTL, time.Now()) {
 	case StatusFresh, StatusManual:
 		return env.Data, nil
+	case StatusStale, StatusUninitialized:
+		return client.GetFields(ctx)
+	case StatusUnavailable:
+		// Classify never emits StatusUnavailable (that status is set by refresh
+		// via Entry.IsAvailable, not by Classify). Listed explicitly so the
+		// exhaustive linter is satisfied and future callers see the intent.
+		return client.GetFields(ctx)
 	}
 	return client.GetFields(ctx)
 }

--- a/tools/jtk/internal/cache/fields_lookup.go
+++ b/tools/jtk/internal/cache/fields_lookup.go
@@ -1,0 +1,44 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// GetFieldsCacheFirst returns []api.Field from the fields cache when fresh,
+// falling back to a live client.GetFields call otherwise.
+//
+// Fall-through cases (all result in a live call):
+//   - Lookup("fields") fails (unexpected — registry not populated)
+//   - ReadResource returns any error: cache miss, ErrNoInstance, I/O, decode
+//   - freshness is StatusStale
+//
+// StatusFresh and StatusManual are treated as authoritative and avoid the
+// network call entirely.
+//
+// Design note: this helper checks freshness against the registry TTL (not the
+// envelope's stored TTL field) so it stays in sync with `jtk refresh --status`.
+// It diverges from internal/resolve/* which accepts any non-miss as
+// authoritative — here #274 requires that cache-first reads only serve fresh
+// data. Sibling helpers for #276–#278 should follow the same pattern.
+func GetFieldsCacheFirst(ctx context.Context, client *api.Client) ([]api.Field, error) {
+	entry, err := Lookup("fields")
+	if err != nil {
+		return client.GetFields(ctx)
+	}
+
+	env, err := ReadResource[[]api.Field]("fields")
+	if err != nil {
+		return client.GetFields(ctx)
+	}
+
+	switch Classify(env.FetchedAt, entry.TTL, time.Now()) {
+	case StatusFresh, StatusManual:
+		return env.Data, nil
+	case StatusStale, StatusUninitialized, StatusUnavailable:
+		return client.GetFields(ctx)
+	}
+	return client.GetFields(ctx)
+}

--- a/tools/jtk/internal/cache/fields_lookup.go
+++ b/tools/jtk/internal/cache/fields_lookup.go
@@ -34,11 +34,12 @@ func GetFieldsCacheFirst(ctx context.Context, client *api.Client) ([]api.Field, 
 		return client.GetFields(ctx)
 	}
 
-	switch Classify(env.FetchedAt, entry.TTL, time.Now()) {
+	// Classify never returns StatusUnavailable (that is only set by refresh
+	// via Entry.IsAvailable); list the remaining cases explicitly so the
+	// exhaustive linter is satisfied.
+	switch Classify(env.FetchedAt, entry.TTL, time.Now()) { //nolint:exhaustive
 	case StatusFresh, StatusManual:
 		return env.Data, nil
-	case StatusStale, StatusUninitialized, StatusUnavailable:
-		return client.GetFields(ctx)
 	}
 	return client.GetFields(ctx)
 }

--- a/tools/jtk/internal/cache/fields_lookup_test.go
+++ b/tools/jtk/internal/cache/fields_lookup_test.go
@@ -68,6 +68,41 @@ func TestGetFieldsCacheFirst_ManualRegistryTTL_SkipsLive(t *testing.T) {
 	testutil.Equal(t, len(got), len(testFields))
 }
 
+func TestGetFieldsCacheFirst_UninitializedEnvelopeFallsBackToLive(t *testing.T) {
+	// StatusUninitialized is returned by Classify when FetchedAt.IsZero() —
+	// e.g. an envelope written by a placeholder write before population.
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	uninitEnv := Envelope[[]api.Field]{
+		Resource:  "fields",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Time{}, // zero → StatusUninitialized
+		TTL:       "24h",
+		Version:   Version,
+		Data:      testFields,
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("fields", uninitEnv))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"summary","name":"Summary"}]`))
+		}
+	}))
+	defer server.Close()
+
+	client := newFieldsTestClient(t, server.URL)
+	got, err := GetFieldsCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call for uninitialized (zero FetchedAt) envelope")
+	}
+	testutil.Equal(t, got[0].ID, "summary")
+}
+
 func TestGetFieldsCacheFirst_StaleCacheFallsBackToLive(t *testing.T) {
 	t.Cleanup(SetRootForTest(t.TempDir()))
 	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))

--- a/tools/jtk/internal/cache/fields_lookup_test.go
+++ b/tools/jtk/internal/cache/fields_lookup_test.go
@@ -46,14 +46,19 @@ func TestGetFieldsCacheFirst_FreshCacheSkipsLive(t *testing.T) {
 	testutil.Equal(t, got[0].ID, testFields[0].ID)
 }
 
-func TestGetFieldsCacheFirst_ManualCacheSkipsLive(t *testing.T) {
+func TestGetFieldsCacheFirst_ManualRegistryTTL_SkipsLive(t *testing.T) {
+	// GetFieldsCacheFirst uses registry TTL (not env.TTL) for Classify. Override
+	// the "fields" entry to TTL "manual" so this test exercises StatusManual.
+	t.Cleanup(SetEntriesForTest([]Entry{
+		{Name: "fields", TTL: "manual"},
+	}))
 	t.Cleanup(SetRootForTest(t.TempDir()))
 	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
 
-	testutil.RequireNoError(t, WriteResource("fields", "manual", testFields))
+	testutil.RequireNoError(t, WriteResource("fields", "24h", testFields))
 
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Fatal("live API must not be called when cache TTL is manual")
+		t.Fatal("live API must not be called when registry TTL is manual")
 	}))
 	defer server.Close()
 

--- a/tools/jtk/internal/cache/fields_lookup_test.go
+++ b/tools/jtk/internal/cache/fields_lookup_test.go
@@ -1,0 +1,161 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+var testFields = []api.Field{
+	{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+	{ID: "customfield_10100", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+}
+
+// newFieldsTestClient builds a client pointed at server. The server call count
+// is tracked externally by the caller (via request tracking in the handler).
+func newFieldsTestClient(t *testing.T, serverURL string) *api.Client {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: serverURL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	return client
+}
+
+func TestGetFieldsCacheFirst_FreshCacheSkipsLive(t *testing.T) {
+	// Non-parallel: SetRootForTest / SetInstanceKeyForTest are process-globals.
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("fields", "24h", testFields))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newFieldsTestClient(t, server.URL)
+	got, err := GetFieldsCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), len(testFields))
+	testutil.Equal(t, got[0].ID, testFields[0].ID)
+}
+
+func TestGetFieldsCacheFirst_ManualCacheSkipsLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("fields", "manual", testFields))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache TTL is manual")
+	}))
+	defer server.Close()
+
+	client := newFieldsTestClient(t, server.URL)
+	got, err := GetFieldsCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), len(testFields))
+}
+
+func TestGetFieldsCacheFirst_StaleCacheFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	// Write a stale envelope: FetchedAt set well in the past, TTL very short.
+	staleEnv := Envelope[[]api.Field]{
+		Resource:  "fields",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Now().Add(-48 * time.Hour),
+		TTL:       "1s",
+		Version:   Version,
+		Data:      []api.Field{{ID: "stale", Name: "Stale"}},
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("fields", staleEnv))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"summary","name":"Summary"}]`))
+		}
+	}))
+	defer server.Close()
+
+	client := newFieldsTestClient(t, server.URL)
+	got, err := GetFieldsCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call for stale cache")
+	}
+	testutil.Equal(t, got[0].ID, "summary")
+}
+
+func TestGetFieldsCacheFirst_MissFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+	// No WriteResource call: cache miss.
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"summary","name":"Summary"}]`))
+		}
+	}))
+	defer server.Close()
+
+	client := newFieldsTestClient(t, server.URL)
+	_, err := GetFieldsCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call on cache miss")
+	}
+}
+
+func TestGetFieldsCacheFirst_NoInstanceFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	// No SetInstanceKeyForTest and no JIRA_URL → ErrNoInstance from ReadResource.
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"summary","name":"Summary"}]`))
+		}
+	}))
+	defer server.Close()
+
+	client := newFieldsTestClient(t, server.URL)
+	_, err := GetFieldsCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call when no instance is configured")
+	}
+}
+
+func TestGetFieldsCacheFirst_LiveErrorPropagated(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+	// Cache miss.
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"errorMessages":["server error"]}`)
+	}))
+	defer server.Close()
+
+	client := newFieldsTestClient(t, server.URL)
+	_, err := GetFieldsCacheFirst(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected error from live API failure, got nil")
+	}
+}

--- a/tools/jtk/internal/cache/fields_lookup_test.go
+++ b/tools/jtk/internal/cache/fields_lookup_test.go
@@ -127,7 +127,12 @@ func TestGetFieldsCacheFirst_MissFallsBackToLive(t *testing.T) {
 
 func TestGetFieldsCacheFirst_NoInstanceFallsBackToLive(t *testing.T) {
 	t.Cleanup(SetRootForTest(t.TempDir()))
-	// No SetInstanceKeyForTest and no JIRA_URL → ErrNoInstance from ReadResource.
+	// Explicitly unset JIRA_URL and related env vars so InstanceKey() reliably
+	// returns ErrNoInstance regardless of the developer's shell environment.
+	t.Setenv("JIRA_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
 
 	liveCalled := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/jtk/internal/cmd/fields/fields.go
+++ b/tools/jtk/internal/cmd/fields/fields.go
@@ -72,14 +72,18 @@ func runList(ctx context.Context, opts *root.Options, customOnly bool, nameFilte
 		return err
 	}
 
-	var fields []api.Field
-	if customOnly {
-		fields, err = client.GetCustomFields(ctx)
-	} else {
-		fields, err = client.GetFields(ctx)
-	}
+	fields, err := cache.GetFieldsCacheFirst(ctx, client)
 	if err != nil {
 		return err
+	}
+	if customOnly {
+		var custom []api.Field
+		for _, f := range fields {
+			if f.Custom {
+				custom = append(custom, f)
+			}
+		}
+		fields = custom
 	}
 
 	if nameFilter != "" {

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -224,6 +224,7 @@ func TestRunList_NameFilter_WithCustom(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Story Points")
 	testutil.NotContains(t, stdout.String(), "Sprint")
+	testutil.NotContains(t, stdout.String(), "Summary")
 }
 
 func TestNewCreateCmd(t *testing.T) {

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -44,7 +45,7 @@ func TestNewListCmd(t *testing.T) {
 }
 
 func TestRunList_Table(t *testing.T) {
-	t.Parallel()
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode([]api.Field{
 			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
@@ -68,7 +69,7 @@ func TestRunList_Table(t *testing.T) {
 }
 
 func TestRunList_JSON(t *testing.T) {
-	t.Parallel()
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode([]api.Field{
 			{ID: "customfield_10100", Name: "Environment", Custom: true},
@@ -90,7 +91,7 @@ func TestRunList_JSON(t *testing.T) {
 }
 
 func TestRunList_Empty(t *testing.T) {
-	t.Parallel()
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode([]api.Field{})
 	}))
@@ -109,7 +110,7 @@ func TestRunList_Empty(t *testing.T) {
 }
 
 func TestRunList_NameFilter(t *testing.T) {
-	t.Parallel()
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode([]api.Field{
 			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
@@ -134,7 +135,7 @@ func TestRunList_NameFilter(t *testing.T) {
 }
 
 func TestRunList_NameFilter_CaseInsensitive(t *testing.T) {
-	t.Parallel()
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode([]api.Field{
 			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
@@ -157,7 +158,7 @@ func TestRunList_NameFilter_CaseInsensitive(t *testing.T) {
 }
 
 func TestRunList_NameFilter_NoMatch(t *testing.T) {
-	t.Parallel()
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode([]api.Field{
 			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
@@ -178,7 +179,7 @@ func TestRunList_NameFilter_NoMatch(t *testing.T) {
 }
 
 func TestRunList_NameFilter_JSON(t *testing.T) {
-	t.Parallel()
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode([]api.Field{
 			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
@@ -201,10 +202,11 @@ func TestRunList_NameFilter_JSON(t *testing.T) {
 }
 
 func TestRunList_NameFilter_WithCustom(t *testing.T) {
-	t.Parallel()
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// GetCustomFields returns only custom fields
+		// Server returns a mix; the custom-only filter is applied locally after fetching all fields.
 		_ = json.NewEncoder(w).Encode([]api.Field{
+			{ID: "summary", Name: "Summary", Custom: false, Schema: api.FieldSchema{Type: "string"}},
 			{ID: "customfield_10016", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
 			{ID: "customfield_10020", Name: "Sprint", Custom: true, Schema: api.FieldSchema{Type: "array"}},
 		})
@@ -943,4 +945,62 @@ func TestRunOptionsDelete_JSONOutputEmitsText(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "Deleted option 3 from context 10001\n")
 	testutil.Equal(t, stderr.String(), "")
+}
+
+// --- Cache-hit tests ---
+// These tests are non-parallel: SetRootForTest / SetInstanceKeyForTest are
+// process-globals that races with t.Parallel() tests writing them.
+
+func TestRunList_CacheHit_SkipsLiveCall(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+		{ID: "customfield_10016", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when fields cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, false, "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Summary")
+	testutil.Contains(t, stdout.String(), "Story Points")
+}
+
+func TestRunList_CacheHit_CustomFilter_SkipsLiveCall(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "summary", Name: "Summary", Custom: false, Schema: api.FieldSchema{Type: "string"}},
+		{ID: "customfield_10016", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+		{ID: "customfield_10020", Name: "Sprint", Custom: true, Schema: api.FieldSchema{Type: "array"}},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when fields cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, true, "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Story Points")
+	testutil.Contains(t, stdout.String(), "Sprint")
+	testutil.NotContains(t, stdout.String(), "Summary")
 }

--- a/tools/jtk/internal/cmd/issues/cache_helpers.go
+++ b/tools/jtk/internal/cmd/issues/cache_helpers.go
@@ -1,0 +1,17 @@
+package issues
+
+import (
+	"context"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+)
+
+// fieldsFetcher returns a function that satisfies the projection.Resolve
+// fetchFields parameter by reading from the fields cache first (fresh only)
+// and falling back to a live client.GetFields call.
+func fieldsFetcher(client *api.Client) func(context.Context) ([]api.Field, error) {
+	return func(ctx context.Context) ([]api.Field, error) {
+		return cache.GetFieldsCacheFirst(ctx, client)
+	}
+}

--- a/tools/jtk/internal/cmd/issues/field_options.go
+++ b/tools/jtk/internal/cmd/issues/field_options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
@@ -47,7 +48,7 @@ func runFieldOptions(ctx context.Context, opts *root.Options, fieldNameOrID, iss
 		return err
 	}
 
-	fields, err := client.GetFields(ctx)
+	fields, err := cache.GetFieldsCacheFirst(ctx, client)
 	if err != nil {
 		return err
 	}

--- a/tools/jtk/internal/cmd/issues/field_options_test.go
+++ b/tools/jtk/internal/cmd/issues/field_options_test.go
@@ -1,0 +1,97 @@
+package issues
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+// These tests are non-parallel: SetRootForTest / SetInstanceKeyForTest are
+// process-globals that race with t.Parallel() tests writing them.
+
+func TestRunFieldOptions_CacheHit_SkipsFieldsFetch(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "priority", Name: "Priority", Schema: api.FieldSchema{Type: "priority"}},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			t.Fatal("live /field must not be called when cache is fresh")
+		}
+		// Serve options for the priority field.
+		if strings.Contains(r.URL.Path, "/field/priority/option") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []api.FieldOptionValue{
+					{ID: "1", Value: "Highest"},
+					{ID: "2", Value: "High"},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runFieldOptions(context.Background(), opts, "Priority", "")
+	testutil.RequireNoError(t, err)
+}
+
+func TestRunFieldOptions_CacheMiss_FallsBackToLive(t *testing.T) {
+	seedCacheForIssues(t)
+	// No fields cache → miss → live /field call expected.
+
+	fieldsCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			fieldsCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]api.Field{
+				{ID: "priority", Name: "Priority", Schema: api.FieldSchema{Type: "priority"}},
+			})
+			return
+		}
+		if strings.Contains(r.URL.Path, "/field/priority/option") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []api.FieldOptionValue{
+					{ID: "1", Value: "Highest"},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runFieldOptions(context.Background(), opts, "Priority", "")
+	testutil.RequireNoError(t, err)
+	if !fieldsCalled {
+		t.Fatal("expected live /field call on cache miss")
+	}
+}

--- a/tools/jtk/internal/cmd/issues/fields.go
+++ b/tools/jtk/internal/cmd/issues/fields.go
@@ -8,6 +8,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
@@ -63,15 +64,18 @@ func runFields(ctx context.Context, opts *root.Options, issueKey string, customO
 }
 
 func runGlobalFields(ctx context.Context, opts *root.Options, client *api.Client, customOnly bool) error {
-	var fields []api.Field
-	var err error
-	if customOnly {
-		fields, err = client.GetCustomFields(ctx)
-	} else {
-		fields, err = client.GetFields(ctx)
-	}
+	fields, err := cache.GetFieldsCacheFirst(ctx, client)
 	if err != nil {
 		return err
+	}
+	if customOnly {
+		var custom []api.Field
+		for _, f := range fields {
+			if f.Custom {
+				custom = append(custom, f)
+			}
+		}
+		fields = custom
 	}
 
 	if opts.EmitIDOnly() {

--- a/tools/jtk/internal/cmd/issues/fields_test.go
+++ b/tools/jtk/internal/cmd/issues/fields_test.go
@@ -1,0 +1,105 @@
+package issues
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+// These tests are non-parallel: SetRootForTest / SetInstanceKeyForTest are
+// process-globals that race with t.Parallel() tests writing them.
+
+func TestRunGlobalFields_CacheHit_SkipsLiveCall(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+		{ID: "customfield_10016", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			t.Fatal("live /field must not be called when cache is fresh")
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGlobalFields(context.Background(), opts, client, false)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Summary")
+	testutil.Contains(t, stdout.String(), "Story Points")
+}
+
+func TestRunGlobalFields_CacheHit_CustomFilter_SkipsLiveCall(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "summary", Name: "Summary", Custom: false, Schema: api.FieldSchema{Type: "string"}},
+		{ID: "customfield_10016", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			t.Fatal("live /field must not be called when cache is fresh")
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGlobalFields(context.Background(), opts, client, true)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Story Points")
+	testutil.NotContains(t, stdout.String(), "Summary")
+}
+
+func TestRunGlobalFields_CacheMiss_FallsBackToLive(t *testing.T) {
+	seedCacheForIssues(t)
+	// No fields cache written → cache miss → live call expected.
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"summary","name":"Summary"}]`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGlobalFields(context.Background(), opts, client, false)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live /field call on cache miss")
+	}
+	testutil.Contains(t, stdout.String(), "Summary")
+}

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
@@ -68,7 +70,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		jtkpresent.IssueDetailSpec,
 		opts.IsExtended(),
 		fieldsFlag,
-		client.GetFields,
+		func(ctx context.Context) ([]api.Field, error) { return cache.GetFieldsCacheFirst(ctx, client) },
 		"issues get",
 	)
 	if err != nil {

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/view"
 
-	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
-	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
@@ -70,7 +68,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		jtkpresent.IssueDetailSpec,
 		opts.IsExtended(),
 		fieldsFlag,
-		func(ctx context.Context) ([]api.Field, error) { return cache.GetFieldsCacheFirst(ctx, client) },
+		fieldsFetcher(client),
 		"issues get",
 	)
 	if err != nil {

--- a/tools/jtk/internal/cmd/issues/get_fields_test.go
+++ b/tools/jtk/internal/cmd/issues/get_fields_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
@@ -108,7 +109,8 @@ func TestRunGet_Fields_Points_Column(t *testing.T) {
 }
 
 func TestRunGet_Fields_HumanName_TriggersFieldsFetch(t *testing.T) {
-	t.Parallel()
+	// Non-parallel: cache isolation uses process-global SetRootForTest.
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	cs := newCapturingGetServer(t, fullIssue(), []api.Field{
 		{ID: "issuetype", Name: "Issue Type"},
 	})
@@ -140,7 +142,8 @@ func TestRunGet_Fields_UnknownToken_Errors(t *testing.T) {
 }
 
 func TestRunGet_Fields_UnrenderedField_ByFieldID_Errors(t *testing.T) {
-	t.Parallel()
+	// Non-parallel: cache isolation uses process-global SetRootForTest.
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	cs := newCapturingGetServer(t, fullIssue(), []api.Field{
 		{ID: "customfield_99999", Name: "Phantom"},
 	})
@@ -312,5 +315,30 @@ func TestRunGet_Fields_FullTextNoOp_WhenDescriptionNotSelected(t *testing.T) {
 	}
 	if strings.Contains(output, "DDDD") {
 		t.Errorf("Description body text leaked even though Description not selected: %q", output)
+	}
+}
+
+// TestRunGet_Fields_HumanName_CacheHit_SkipsFieldsFetch verifies that when the
+// fields cache is fresh, a human-name --fields token is resolved from the cache
+// and the live /field endpoint is not called.
+// Non-parallel: SetRootForTest / SetInstanceKeyForTest are process-globals.
+func TestRunGet_Fields_HumanName_CacheHit_SkipsFieldsFetch(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	}))
+
+	cs := newCapturingGetServer(t, fullIssue(), nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newGetOpts(t, cs)
+	err := runGet(context.Background(), opts, "TEST-1", false, "Issue Type")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Key: TEST-1")
+	testutil.Contains(t, output, "Type: Task")
+	if cs.fieldsCalls != 0 {
+		t.Errorf("fresh cache must suppress live GetFields; got %d call(s)", cs.fieldsCalls)
 	}
 }

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
-	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
@@ -93,7 +92,7 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 			jtkpresent.IssueListSpec,
 			opts.IsExtended(),
 			fieldsFlag,
-			func(ctx context.Context) ([]api.Field, error) { return cache.GetFieldsCacheFirst(ctx, client) },
+			fieldsFetcher(client),
 			"issues list",
 		)
 		if err != nil {

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
@@ -92,7 +93,7 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 			jtkpresent.IssueListSpec,
 			opts.IsExtended(),
 			fieldsFlag,
-			client.GetFields,
+			func(ctx context.Context) ([]api.Field, error) { return cache.GetFieldsCacheFirst(ctx, client) },
 			"issues list",
 		)
 		if err != nil {

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -627,3 +627,28 @@ func TestBuildSprintClause_WarnBranches(t *testing.T) {
 		}
 	})
 }
+
+// TestRunList_Fields_HumanName_CacheHit_SkipsFieldsFetch verifies that a fresh
+// fields cache suppresses the live /field call during human-name resolution.
+// Non-parallel: cache isolation uses process-global SetRootForTest.
+func TestRunList_Fields_HumanName_CacheHit_SkipsFieldsFetch(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	}))
+
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "Issue Type")
+	testutil.RequireNoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if lines[0] != "KEY | TYPE" {
+		t.Errorf("header mismatch: got %q", lines[0])
+	}
+	if cs.fieldsCalls != 0 {
+		t.Errorf("fresh cache must suppress live GetFields; got %d call(s)", cs.fieldsCalls)
+	}
+}

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -367,7 +367,8 @@ func TestRunList_Fields_JiraFieldIDs_ProjectsTable(t *testing.T) {
 }
 
 func TestRunList_Fields_HumanName_TriggersFieldsFetch(t *testing.T) {
-	t.Parallel()
+	// Non-parallel: cache isolation uses process-global SetRootForTest.
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
 		{ID: "issuetype", Name: "Issue Type"},
 	})
@@ -400,7 +401,8 @@ func TestRunList_Fields_UnknownToken_Errors(t *testing.T) {
 }
 
 func TestRunList_Fields_UnrenderedField_ByHumanName_Errors(t *testing.T) {
-	t.Parallel()
+	// Non-parallel: cache isolation uses process-global SetRootForTest.
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
 		{ID: "customfield_99999", Name: "Phantom"},
 	})
@@ -417,7 +419,8 @@ func TestRunList_Fields_UnrenderedField_ByHumanName_Errors(t *testing.T) {
 }
 
 func TestRunList_Fields_UnrenderedField_ByFieldID_Errors(t *testing.T) {
-	t.Parallel()
+	// Non-parallel: cache isolation uses process-global SetRootForTest.
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
 		{ID: "customfield_99999", Name: "Phantom"},
 	})

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
-	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
@@ -85,7 +84,7 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 			jtkpresent.IssueListSpec,
 			opts.IsExtended(),
 			fieldsFlag,
-			func(ctx context.Context) ([]api.Field, error) { return cache.GetFieldsCacheFirst(ctx, client) },
+			fieldsFetcher(client),
 			"issues search",
 		)
 		if err != nil {

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
@@ -84,7 +85,7 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 			jtkpresent.IssueListSpec,
 			opts.IsExtended(),
 			fieldsFlag,
-			client.GetFields,
+			func(ctx context.Context) ([]api.Field, error) { return cache.GetFieldsCacheFirst(ctx, client) },
 			"issues search",
 		)
 		if err != nil {

--- a/tools/jtk/internal/cmd/issues/search_test.go
+++ b/tools/jtk/internal/cmd/issues/search_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
@@ -35,7 +36,8 @@ func TestRunSearch_Fields_HeaderAliases_ProjectsTable(t *testing.T) {
 }
 
 func TestRunSearch_Fields_HumanName_TriggersFieldsFetch(t *testing.T) {
-	t.Parallel()
+	// Non-parallel: cache isolation uses process-global SetRootForTest.
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
 		{ID: "issuetype", Name: "Issue Type"},
 	})
@@ -196,5 +198,31 @@ func TestRunSearch_IDOnly_BypassesJSONFieldsRejection(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	if stdout.String() != "TEST-1\n" {
 		t.Errorf("expected bare key, got %q", stdout.String())
+	}
+}
+
+// TestRunSearch_Fields_HumanName_CacheHit_SkipsFieldsFetch verifies that a
+// fresh fields cache suppresses the live /field call during human-name
+// resolution.
+// Non-parallel: cache isolation uses process-global SetRootForTest.
+func TestRunSearch_Fields_HumanName_CacheHit_SkipsFieldsFetch(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "issuetype", Name: "Issue Type"},
+	}))
+
+	cs := newCapturingServer(t, []string{"TEST-1"}, true, nil)
+	defer cs.server.Close()
+
+	opts, stdout, _ := newOptsFor(t, cs)
+	err := runSearch(context.Background(), opts, "project = TEST", 25, "", false, "Issue Type")
+	testutil.RequireNoError(t, err)
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if lines[0] != "KEY | TYPE" {
+		t.Errorf("header mismatch: got %q", lines[0])
+	}
+	if cs.fieldsCalls != 0 {
+		t.Errorf("fresh cache must suppress live GetFields; got %d call(s)", cs.fieldsCalls)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `cache.GetFieldsCacheFirst(ctx, client)` — a cache-first helper for `[]api.Field` that returns the fresh fields envelope without a live API call, falling back to `client.GetFields` on cache miss, stale cache, `ErrNoInstance`, any I/O error, or `StatusUnavailable`
- Routes `jtk fields list`, `jtk issues fields` (no-key path), and `jtk issues field-options` through the helper; the `--custom` filter is now applied locally after a single full fetch
- Passes the helper as a closure to `projection.Resolve` in `jtk issues get/list/search` for human-name `--fields` resolution

## Test plan

- [ ] `cache/fields_lookup_test.go`: table-driven unit tests for fresh-hit, manual-hit, stale-fallback, miss-fallback, no-instance-fallback, live-error-propagation
- [ ] `fields/fields_test.go`: two cache-hit tests (all-fields and custom-filter) assert live `/field` not called; existing live-path tests get `SetRootForTest` isolation to avoid reading real dev-machine cache
- [ ] `issues/fields_test.go`: cache-hit and cache-miss tests for `runGlobalFields` (both non-custom and custom-only)
- [ ] `issues/field_options_test.go`: cache-hit and cache-miss tests for `runFieldOptions` field name resolution
- [ ] `issues/get_fields_test.go`: `TestRunGet_Fields_HumanName_CacheHit_SkipsFieldsFetch` asserts `fieldsCalls == 0` with fresh cache; existing `TriggersFieldsFetch` gets isolation
- [ ] All 1482 tests pass; `golangci-lint` clean for jtk

[#275]