### PR TITLE
feat(jtk): fix fields, field-options, archive, and get --extended compliance gaps

### DIFF
--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -3,6 +3,7 @@ package api //nolint:revive // package name is intentional
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -220,7 +221,7 @@ func (c *Client) GetFieldOptionsFromEditMeta(ctx context.Context, issueKey, fiel
 
 	fieldData, ok := fieldsData[fieldID].(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("field %s not found in edit metadata", fieldID)
+		return nil, fmt.Errorf("%w: %s", ErrFieldNotInEditMeta, fieldID)
 	}
 
 	allowedValues, ok := fieldData["allowedValues"].([]any)
@@ -261,19 +262,15 @@ func ResolveFieldOptions(ctx context.Context, c *Client, issueKey, fieldID strin
 	if editErr == nil && len(opts) > 0 {
 		return opts, nil
 	}
-	fieldAbsent := editErr != nil && strings.Contains(editErr.Error(), "not found in edit metadata")
+	fieldAbsent := editErr != nil && errors.Is(editErr, ErrFieldNotInEditMeta)
 	if editErr != nil && !fieldAbsent {
 		return nil, fmt.Errorf("resolving field options for %s on %s: %w", fieldID, issueKey, editErr)
 	}
 
 	ctxResult, ctxErr := c.GetDefaultFieldContext(ctx, fieldID)
 	if ctxErr == nil {
-		page, pageErr := c.GetFieldContextOptions(ctx, fieldID, ctxResult.ID)
-		if pageErr == nil && len(page.Values) > 0 {
-			allOpts := make([]FieldOptionValue, len(page.Values))
-			for i, o := range page.Values {
-				allOpts[i] = FieldOptionValue{ID: o.ID, Value: o.Value, Disabled: o.Disabled}
-			}
+		allOpts, pageErr := getAllContextOptions(ctx, c, fieldID, ctxResult.ID)
+		if pageErr == nil && len(allOpts) > 0 {
 			return allOpts, nil
 		}
 	}
@@ -284,4 +281,33 @@ func ResolveFieldOptions(ctx context.Context, c *Client, issueKey, fieldID strin
 	}
 
 	return nil, fmt.Errorf("no options found for field %s on %s", fieldID, issueKey)
+}
+
+// ErrFieldNotInEditMeta is returned when a field is not present in the issue's
+// edit metadata (i.e., it is not editable for that issue).
+var ErrFieldNotInEditMeta = fmt.Errorf("field not found in edit metadata")
+
+func getAllContextOptions(ctx context.Context, c *Client, fieldID, contextID string) ([]FieldOptionValue, error) {
+	var all []FieldOptionValue
+	startAt := 0
+	for {
+		urlStr := fmt.Sprintf("%s/field/%s/context/%s/option?startAt=%d",
+			c.BaseURL, fieldID, contextID, startAt)
+		body, err := c.Get(ctx, urlStr)
+		if err != nil {
+			return nil, err
+		}
+		var page FieldContextOptionsResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, err
+		}
+		for _, o := range page.Values {
+			all = append(all, FieldOptionValue{ID: o.ID, Value: o.Value, Disabled: o.Disabled})
+		}
+		if page.IsLast || len(page.Values) == 0 {
+			break
+		}
+		startAt += len(page.Values)
+	}
+	return all, nil
 }

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -250,3 +250,49 @@ func (c *Client) GetFieldOptionsFromEditMeta(ctx context.Context, issueKey, fiel
 
 	return options, nil
 }
+
+// ResolveFieldOptions returns allowed values for a field in the context of a
+// specific issue. It uses a three-tier resolution strategy:
+//  1. Edit metadata (reliable for editable fields, already project-scoped)
+//  2. Default field context + context options (handles read-only custom fields)
+//  3. Global field options (last resort)
+func ResolveFieldOptions(ctx context.Context, c *Client, issueKey, fieldID string) ([]FieldOptionValue, error) {
+	opts, err := c.GetFieldOptionsFromEditMeta(ctx, issueKey, fieldID)
+	if err == nil && len(opts) > 0 {
+		return opts, nil
+	}
+
+	ctxResult, ctxErr := c.GetDefaultFieldContext(ctx, fieldID)
+	if ctxErr == nil {
+		var allOpts []FieldOptionValue
+		for {
+			page, pageErr := c.GetFieldContextOptions(ctx, fieldID, ctxResult.ID)
+			if pageErr != nil {
+				break
+			}
+			for _, o := range page.Values {
+				allOpts = append(allOpts, FieldOptionValue{
+					ID:       o.ID,
+					Value:    o.Value,
+					Disabled: o.Disabled,
+				})
+			}
+			if page.IsLast || len(page.Values) == 0 {
+				break
+			}
+		}
+		if len(allOpts) > 0 {
+			return allOpts, nil
+		}
+	}
+
+	globalOpts, globalErr := c.GetFieldOptions(ctx, fieldID)
+	if globalErr == nil && len(globalOpts) > 0 {
+		return globalOpts, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("resolving field options for %s on %s: %w", fieldID, issueKey, err)
+	}
+	return nil, fmt.Errorf("no options found for field %s on %s", fieldID, issueKey)
+}

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -285,7 +285,7 @@ func ResolveFieldOptions(ctx context.Context, c *Client, issueKey, fieldID strin
 
 // ErrFieldNotInEditMeta is returned when a field is not present in the issue's
 // edit metadata (i.e., it is not editable for that issue).
-var ErrFieldNotInEditMeta = fmt.Errorf("field not found in edit metadata")
+var ErrFieldNotInEditMeta = errors.New("field not found in edit metadata")
 
 func getAllContextOptions(ctx context.Context, c *Client, fieldID, contextID string) ([]FieldOptionValue, error) {
 	var all []FieldOptionValue

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -257,31 +257,23 @@ func (c *Client) GetFieldOptionsFromEditMeta(ctx context.Context, issueKey, fiel
 //  2. Default field context + context options (handles read-only custom fields)
 //  3. Global field options (last resort)
 func ResolveFieldOptions(ctx context.Context, c *Client, issueKey, fieldID string) ([]FieldOptionValue, error) {
-	opts, err := c.GetFieldOptionsFromEditMeta(ctx, issueKey, fieldID)
-	if err == nil && len(opts) > 0 {
+	opts, editErr := c.GetFieldOptionsFromEditMeta(ctx, issueKey, fieldID)
+	if editErr == nil && len(opts) > 0 {
 		return opts, nil
+	}
+	fieldAbsent := editErr != nil && strings.Contains(editErr.Error(), "not found in edit metadata")
+	if editErr != nil && !fieldAbsent {
+		return nil, fmt.Errorf("resolving field options for %s on %s: %w", fieldID, issueKey, editErr)
 	}
 
 	ctxResult, ctxErr := c.GetDefaultFieldContext(ctx, fieldID)
 	if ctxErr == nil {
-		var allOpts []FieldOptionValue
-		for {
-			page, pageErr := c.GetFieldContextOptions(ctx, fieldID, ctxResult.ID)
-			if pageErr != nil {
-				break
+		page, pageErr := c.GetFieldContextOptions(ctx, fieldID, ctxResult.ID)
+		if pageErr == nil && len(page.Values) > 0 {
+			allOpts := make([]FieldOptionValue, len(page.Values))
+			for i, o := range page.Values {
+				allOpts[i] = FieldOptionValue{ID: o.ID, Value: o.Value, Disabled: o.Disabled}
 			}
-			for _, o := range page.Values {
-				allOpts = append(allOpts, FieldOptionValue{
-					ID:       o.ID,
-					Value:    o.Value,
-					Disabled: o.Disabled,
-				})
-			}
-			if page.IsLast || len(page.Values) == 0 {
-				break
-			}
-		}
-		if len(allOpts) > 0 {
 			return allOpts, nil
 		}
 	}
@@ -291,8 +283,5 @@ func ResolveFieldOptions(ctx context.Context, c *Client, issueKey, fieldID strin
 		return globalOpts, nil
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("resolving field options for %s on %s: %w", fieldID, issueKey, err)
-	}
 	return nil, fmt.Errorf("no options found for field %s on %s", fieldID, issueKey)
 }

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -270,7 +270,10 @@ func ResolveFieldOptions(ctx context.Context, c *Client, issueKey, fieldID strin
 	ctxResult, ctxErr := c.GetDefaultFieldContext(ctx, fieldID)
 	if ctxErr == nil {
 		allOpts, pageErr := getAllContextOptions(ctx, c, fieldID, ctxResult.ID)
-		if pageErr == nil && len(allOpts) > 0 {
+		if pageErr != nil {
+			return nil, fmt.Errorf("fetching context options for %s: %w", fieldID, pageErr)
+		}
+		if len(allOpts) > 0 {
 			return allOpts, nil
 		}
 	}

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -259,11 +260,10 @@ func (c *Client) GetFieldOptionsFromEditMeta(ctx context.Context, issueKey, fiel
 //  3. Global field options (last resort)
 func ResolveFieldOptions(ctx context.Context, c *Client, issueKey, fieldID string) ([]FieldOptionValue, error) {
 	opts, editErr := c.GetFieldOptionsFromEditMeta(ctx, issueKey, fieldID)
-	if editErr == nil && len(opts) > 0 {
+	if editErr == nil {
 		return opts, nil
 	}
-	fieldAbsent := editErr != nil && errors.Is(editErr, ErrFieldNotInEditMeta)
-	if editErr != nil && !fieldAbsent {
+	if !errors.Is(editErr, ErrFieldNotInEditMeta) {
 		return nil, fmt.Errorf("resolving field options for %s on %s: %w", fieldID, issueKey, editErr)
 	}
 
@@ -292,7 +292,7 @@ func getAllContextOptions(ctx context.Context, c *Client, fieldID, contextID str
 	startAt := 0
 	for {
 		urlStr := fmt.Sprintf("%s/field/%s/context/%s/option?startAt=%d",
-			c.BaseURL, fieldID, contextID, startAt)
+			c.BaseURL, url.PathEscape(fieldID), url.PathEscape(contextID), startAt)
 		body, err := c.Get(ctx, urlStr)
 		if err != nil {
 			return nil, err

--- a/tools/jtk/api/fields_resolve_test.go
+++ b/tools/jtk/api/fields_resolve_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestResolveFieldOptions_EditMetaHit(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/editmeta") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"fields": map[string]any{
+					"priority": map[string]any{
+						"allowedValues": []map[string]any{
+							{"id": "1", "name": "High"},
+							{"id": "2", "name": "Low"},
+						},
+					},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, _ := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	opts, err := ResolveFieldOptions(context.Background(), client, "TEST-1", "priority")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(opts), 2)
+	testutil.Equal(t, opts[0].Name, "High")
+}
+
+func TestResolveFieldOptions_FallsBackToContext(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/editmeta"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"fields": map[string]any{}})
+		case strings.HasSuffix(r.URL.Path, "/context") && !strings.Contains(r.URL.Path, "/option"):
+			_ = json.NewEncoder(w).Encode(FieldContextsResponse{
+				Values: []FieldContext{{ID: "100", Name: "Default", IsGlobalContext: true}},
+				IsLast: true,
+			})
+		case strings.Contains(r.URL.Path, "/context/100/option"):
+			_ = json.NewEncoder(w).Encode(FieldContextOptionsResponse{
+				Values: []FieldContextOption{
+					{ID: "10", Value: "Platform"},
+					{ID: "20", Value: "Integration"},
+				},
+				IsLast: true,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, _ := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	opts, err := ResolveFieldOptions(context.Background(), client, "TEST-1", "customfield_10050")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(opts), 2)
+	testutil.Equal(t, opts[0].Value, "Platform")
+}
+
+func TestResolveFieldOptions_NonAbsentEditMetaError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client, _ := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	_, err := ResolveFieldOptions(context.Background(), client, "TEST-1", "priority")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "resolving field options")
+}

--- a/tools/jtk/api/issues.go
+++ b/tools/jtk/api/issues.go
@@ -210,7 +210,7 @@ func (c *Client) ArchiveIssues(ctx context.Context, keys []string) (*ArchiveResu
 
 	var result ArchiveResult
 	if err := json.Unmarshal(body, &result); err != nil {
-		return &ArchiveResult{NumberUpdated: len(keys)}, nil
+		return nil, fmt.Errorf("parsing archive response: %w", err)
 	}
 	return &result, nil
 }

--- a/tools/jtk/api/issues.go
+++ b/tools/jtk/api/issues.go
@@ -302,8 +302,9 @@ var knownFieldExtractors = map[string]func(*Issue) string{
 			return ""
 		}
 		t := i.Fields.Description.ToPlainText()
-		if len(t) > 80 {
-			return t[:80] + "..."
+		runes := []rune(t)
+		if len(runes) > 80 {
+			return string(runes[:80]) + "..."
 		}
 		return t
 	},
@@ -398,8 +399,8 @@ func FormatCustomFieldValue(v any) string {
 	case string:
 		return val
 	case float64:
-		if val == float64(int(val)) {
-			return fmt.Sprintf("%d", int(val))
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%d", int64(val))
 		}
 		return fmt.Sprintf("%g", val)
 	case map[string]any:

--- a/tools/jtk/api/issues.go
+++ b/tools/jtk/api/issues.go
@@ -391,6 +391,9 @@ func versionNames(vs []Version) string {
 
 // FormatCustomFieldValue formats an arbitrary custom field value as a display string.
 func FormatCustomFieldValue(v any) string {
+	if v == nil {
+		return ""
+	}
 	switch val := v.(type) {
 	case string:
 		return val

--- a/tools/jtk/api/issues.go
+++ b/tools/jtk/api/issues.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
+	"strings"
 )
 
 // GetIssue retrieves an issue by key
@@ -177,6 +179,260 @@ func ParseEditMeta(fieldsData map[string]any) []EditFieldMeta {
 	}
 
 	return result
+}
+
+// ArchiveError represents a single error category from the archive response.
+type ArchiveError struct {
+	Count          int      `json:"count"`
+	IssueIdsOrKeys []string `json:"issueIdsOrKeys"`
+	Message        string   `json:"message"`
+}
+
+// ArchiveResult represents the response from archiving issues.
+type ArchiveResult struct {
+	NumberUpdated int                     `json:"numberOfIssuesUpdated"`
+	Errors        map[string]ArchiveError `json:"errors,omitempty"`
+}
+
+// ArchiveIssues archives one or more issues by key.
+func (c *Client) ArchiveIssues(ctx context.Context, keys []string) (*ArchiveResult, error) {
+	if len(keys) == 0 {
+		return nil, ErrIssueKeyRequired
+	}
+
+	urlStr := fmt.Sprintf("%s/issue/archive", c.BaseURL)
+	body, err := c.Put(ctx, urlStr, map[string]any{
+		"issueIdsOrKeys": keys,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("archiving issues: %w", err)
+	}
+
+	var result ArchiveResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return &ArchiveResult{NumberUpdated: len(keys)}, nil
+	}
+	return &result, nil
+}
+
+// WatchersInfo represents the watchers summary for an issue.
+type WatchersInfo struct {
+	WatchCount int  `json:"watchCount"`
+	IsWatching bool `json:"isWatching"`
+}
+
+// GetWatchers returns watchers info for an issue.
+func (c *Client) GetWatchers(ctx context.Context, issueKey string) (*WatchersInfo, error) {
+	if issueKey == "" {
+		return nil, ErrIssueKeyRequired
+	}
+
+	urlStr := fmt.Sprintf("%s/issue/%s/watchers", c.BaseURL, url.PathEscape(issueKey))
+	body, err := c.Get(ctx, urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("fetching watchers: %w", err)
+	}
+
+	var info WatchersInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("parsing watchers: %w", err)
+	}
+	return &info, nil
+}
+
+// IssueFieldEntry represents a single field's current value on an issue,
+// used by `issues fields <key>` to display FIELD_ID|NAME|TYPE|VALUE.
+type IssueFieldEntry struct {
+	ID    string
+	Name  string
+	Type  string
+	Value string
+}
+
+// ExtractIssueFieldValues builds a sorted slice of IssueFieldEntry from an
+// issue's typed struct fields and its CustomFields map. Field metadata (name,
+// type) comes from the fields cache.
+func ExtractIssueFieldValues(issue *Issue, fields []Field) []IssueFieldEntry {
+	fieldIndex := make(map[string]*Field, len(fields))
+	for i := range fields {
+		fieldIndex[fields[i].ID] = &fields[i]
+	}
+
+	var entries []IssueFieldEntry
+
+	for id, extract := range knownFieldExtractors {
+		val := extract(issue)
+		if val == "" {
+			continue
+		}
+		name, typ := id, ""
+		if f := fieldIndex[id]; f != nil {
+			name = f.Name
+			typ = f.Schema.Type
+		}
+		entries = append(entries, IssueFieldEntry{ID: id, Name: name, Type: typ, Value: val})
+	}
+
+	for id, raw := range issue.Fields.CustomFields {
+		if raw == nil {
+			continue
+		}
+		val := FormatCustomFieldValue(raw)
+		if val == "" {
+			continue
+		}
+		name, typ := id, ""
+		if f := fieldIndex[id]; f != nil {
+			name = f.Name
+			typ = f.Schema.Type
+		}
+		entries = append(entries, IssueFieldEntry{ID: id, Name: name, Type: typ, Value: val})
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
+	return entries
+}
+
+// knownFieldExtractors maps typed IssueFields struct field IDs to value
+// extractors. Must stay in sync with knownFieldKeys (enforced by test).
+var knownFieldExtractors = map[string]func(*Issue) string{
+	"summary": func(i *Issue) string { return i.Fields.Summary },
+	"description": func(i *Issue) string {
+		if i.Fields.Description == nil {
+			return ""
+		}
+		t := i.Fields.Description.ToPlainText()
+		if len(t) > 80 {
+			return t[:80] + "..."
+		}
+		return t
+	},
+	"status": func(i *Issue) string {
+		if i.Fields.Status == nil {
+			return ""
+		}
+		return i.Fields.Status.Name
+	},
+	"issuetype": func(i *Issue) string {
+		if i.Fields.IssueType == nil {
+			return ""
+		}
+		return i.Fields.IssueType.Name
+	},
+	"priority": func(i *Issue) string {
+		if i.Fields.Priority == nil {
+			return ""
+		}
+		return i.Fields.Priority.Name
+	},
+	"assignee":   func(i *Issue) string { return displayNameOrEmpty(i.Fields.Assignee) },
+	"reporter":   func(i *Issue) string { return displayNameOrEmpty(i.Fields.Reporter) },
+	"project":    func(i *Issue) string { return projectKeyOrEmpty(i.Fields.Project) },
+	"created":    func(i *Issue) string { return i.Fields.Created },
+	"updated":    func(i *Issue) string { return i.Fields.Updated },
+	"labels":     func(i *Issue) string { return strings.Join(i.Fields.Labels, ", ") },
+	"components": func(i *Issue) string { return componentNames(i.Fields.Components) },
+	"sprint": func(i *Issue) string {
+		if i.Fields.Sprint == nil {
+			return ""
+		}
+		return i.Fields.Sprint.Name
+	},
+	"parent": func(i *Issue) string {
+		if i.Fields.Parent == nil {
+			return ""
+		}
+		return i.Fields.Parent.Key
+	},
+	"resolution": func(i *Issue) string {
+		if i.Fields.Resolution == nil {
+			return ""
+		}
+		return i.Fields.Resolution.Name
+	},
+	"fixVersions": func(i *Issue) string { return versionNames(i.Fields.FixVersions) },
+}
+
+func displayNameOrEmpty(u *User) string {
+	if u == nil {
+		return ""
+	}
+	return u.DisplayName
+}
+
+func projectKeyOrEmpty(p *Project) string {
+	if p == nil {
+		return ""
+	}
+	return p.Key
+}
+
+func componentNames(cs []Component) string {
+	if len(cs) == 0 {
+		return ""
+	}
+	names := make([]string, len(cs))
+	for i, c := range cs {
+		names[i] = c.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+func versionNames(vs []Version) string {
+	if len(vs) == 0 {
+		return ""
+	}
+	names := make([]string, len(vs))
+	for i, v := range vs {
+		names[i] = v.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+// FormatCustomFieldValue formats an arbitrary custom field value as a display string.
+func FormatCustomFieldValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		if val == float64(int(val)) {
+			return fmt.Sprintf("%d", int(val))
+		}
+		return fmt.Sprintf("%g", val)
+	case map[string]any:
+		if s, ok := val["value"].(string); ok {
+			return s
+		}
+		if s, ok := val["name"].(string); ok {
+			return s
+		}
+		if s, ok := val["displayName"].(string); ok {
+			return s
+		}
+		return fmt.Sprintf("%v", val)
+	case []any:
+		parts := make([]string, 0, len(val))
+		for _, item := range val {
+			switch elem := item.(type) {
+			case string:
+				parts = append(parts, elem)
+			case map[string]any:
+				if s, ok := elem["value"].(string); ok {
+					parts = append(parts, s)
+				} else if s, ok := elem["name"].(string); ok {
+					parts = append(parts, s)
+				}
+			}
+		}
+		return strings.Join(parts, ", ")
+	case bool:
+		if val {
+			return "yes"
+		}
+		return "no"
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }
 
 // safeString extracts a string from an interface value.

--- a/tools/jtk/api/issues_archive_test.go
+++ b/tools/jtk/api/issues_archive_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestArchiveIssues_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, r.Method, "PUT")
+		testutil.Equal(t, r.URL.Path, "/rest/api/3/issue/archive")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ArchiveResult{NumberUpdated: 2})
+	}))
+	defer server.Close()
+
+	client, _ := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	result, err := client.ArchiveIssues(context.Background(), []string{"TEST-1", "TEST-2"})
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, result.NumberUpdated, 2)
+	testutil.Equal(t, len(result.Errors), 0)
+}
+
+func TestArchiveIssues_PartialFailure(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ArchiveResult{
+			NumberUpdated: 1,
+			Errors: map[string]ArchiveError{
+				"PERM": {Count: 1, IssueIdsOrKeys: []string{"TEST-2"}, Message: "denied"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, _ := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	result, err := client.ArchiveIssues(context.Background(), []string{"TEST-1", "TEST-2"})
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, result.NumberUpdated, 1)
+	testutil.Equal(t, len(result.Errors), 1)
+	testutil.Equal(t, result.Errors["PERM"].IssueIdsOrKeys[0], "TEST-2")
+}
+
+func TestArchiveIssues_EmptyKeys(t *testing.T) {
+	t.Parallel()
+	client, _ := New(ClientConfig{URL: "http://unused", Email: "t@t.com", APIToken: "tok"})
+	_, err := client.ArchiveIssues(context.Background(), nil)
+	testutil.NotNil(t, err)
+}
+
+func TestGetWatchers_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(WatchersInfo{WatchCount: 3, IsWatching: true})
+	}))
+	defer server.Close()
+
+	client, _ := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	info, err := client.GetWatchers(context.Background(), "TEST-1")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, info.WatchCount, 3)
+	testutil.Equal(t, info.IsWatching, true)
+}
+
+func TestGetWatchers_EmptyKey(t *testing.T) {
+	t.Parallel()
+	client, _ := New(ClientConfig{URL: "http://unused", Email: "t@t.com", APIToken: "tok"})
+	_, err := client.GetWatchers(context.Background(), "")
+	testutil.NotNil(t, err)
+}

--- a/tools/jtk/api/issues_extract_test.go
+++ b/tools/jtk/api/issues_extract_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestExtractIssueFieldValues_TypedFields(t *testing.T) {
+	t.Parallel()
+	issue := &Issue{
+		Key: "TEST-1",
+		Fields: IssueFields{
+			Summary:   "My summary",
+			Status:    &Status{Name: "Open"},
+			IssueType: &IssueType{Name: "Task"},
+			Priority:  &Priority{Name: "High"},
+			Assignee:  &User{DisplayName: "Alice"},
+		},
+	}
+	fields := []Field{
+		{ID: "summary", Name: "Summary", Schema: FieldSchema{Type: "string"}},
+		{ID: "status", Name: "Status", Schema: FieldSchema{Type: "status"}},
+		{ID: "issuetype", Name: "Issue Type", Schema: FieldSchema{Type: "issuetype"}},
+		{ID: "priority", Name: "Priority", Schema: FieldSchema{Type: "priority"}},
+		{ID: "assignee", Name: "Assignee", Schema: FieldSchema{Type: "user"}},
+	}
+
+	entries := ExtractIssueFieldValues(issue, fields)
+	found := make(map[string]string)
+	for _, e := range entries {
+		found[e.ID] = e.Value
+	}
+
+	testutil.Equal(t, found["summary"], "My summary")
+	testutil.Equal(t, found["status"], "Open")
+	testutil.Equal(t, found["issuetype"], "Task")
+	testutil.Equal(t, found["assignee"], "Alice")
+}
+
+func TestExtractIssueFieldValues_CustomFields(t *testing.T) {
+	t.Parallel()
+	issue := &Issue{
+		Key: "TEST-1",
+		Fields: IssueFields{
+			Summary: "Test",
+			CustomFields: map[string]any{
+				"customfield_10035": float64(5),
+				"customfield_10050": map[string]any{"value": "Platform"},
+				"customfield_10099": nil,
+			},
+		},
+	}
+	fields := []Field{
+		{ID: "summary", Name: "Summary", Schema: FieldSchema{Type: "string"}},
+		{ID: "customfield_10035", Name: "Story Points", Schema: FieldSchema{Type: "number"}},
+		{ID: "customfield_10050", Name: "Team", Schema: FieldSchema{Type: "option"}},
+	}
+
+	entries := ExtractIssueFieldValues(issue, fields)
+	found := make(map[string]string)
+	for _, e := range entries {
+		found[e.ID] = e.Value
+	}
+
+	testutil.Equal(t, found["customfield_10035"], "5")
+	testutil.Equal(t, found["customfield_10050"], "Platform")
+	if _, ok := found["customfield_10099"]; ok {
+		t.Error("nil custom field should be excluded")
+	}
+}
+
+func TestExtractIssueFieldValues_Sorted(t *testing.T) {
+	t.Parallel()
+	issue := &Issue{
+		Key: "TEST-1",
+		Fields: IssueFields{
+			Summary: "Test",
+			Status:  &Status{Name: "Open"},
+		},
+	}
+	entries := ExtractIssueFieldValues(issue, nil)
+	for i := 1; i < len(entries); i++ {
+		if entries[i].ID < entries[i-1].ID {
+			t.Errorf("entries not sorted: %s < %s", entries[i].ID, entries[i-1].ID)
+		}
+	}
+}
+
+func TestFormatCustomFieldValue_Types(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{"string", "hello", "hello"},
+		{"float_int", float64(5), "5"},
+		{"float_decimal", float64(3.14), "3.14"},
+		{"option_value", map[string]any{"value": "Platform"}, "Platform"},
+		{"option_name", map[string]any{"name": "High"}, "High"},
+		{"user", map[string]any{"displayName": "Alice"}, "Alice"},
+		{"array_strings", []any{"a", "b"}, "a, b"},
+		{"array_options", []any{map[string]any{"value": "X"}, map[string]any{"value": "Y"}}, "X, Y"},
+		{"bool_true", true, "yes"},
+		{"bool_false", false, "no"},
+		{"nil", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatCustomFieldValue(tt.input)
+			testutil.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestKnownFieldExtractors_ParityWithKnownFieldKeys(t *testing.T) {
+	t.Parallel()
+	for key := range knownFieldKeys {
+		if _, ok := knownFieldExtractors[key]; !ok {
+			t.Errorf("knownFieldKeys has %q but knownFieldExtractors does not", key)
+		}
+	}
+	for key := range knownFieldExtractors {
+		if !knownFieldKeys[key] {
+			t.Errorf("knownFieldExtractors has %q but knownFieldKeys does not", key)
+		}
+	}
+}

--- a/tools/jtk/api/types.go
+++ b/tools/jtk/api/types.go
@@ -32,6 +32,8 @@ type IssueFields struct {
 	Components  []Component  `json:"components,omitempty"`
 	Sprint      *Sprint      `json:"sprint,omitempty"`
 	Parent      *Issue       `json:"parent,omitempty"`
+	Resolution  *Resolution  `json:"resolution,omitempty"`
+	FixVersions []Version    `json:"fixVersions,omitempty"`
 
 	// CustomFields holds any fields not mapped to struct fields (e.g., customfield_10001)
 	CustomFields map[string]any `json:"-"`
@@ -43,7 +45,8 @@ var knownFieldKeys = map[string]bool{
 	"issuetype": true, "priority": true, "assignee": true,
 	"reporter": true, "project": true, "created": true,
 	"updated": true, "labels": true, "components": true,
-	"sprint": true, "parent": true,
+	"sprint": true, "parent": true, "resolution": true,
+	"fixVersions": true,
 }
 
 // UnmarshalJSON custom unmarshaler to capture custom fields
@@ -123,6 +126,12 @@ func (f IssueFields) MarshalJSON() ([]byte, error) {
 	}
 	if f.Parent != nil {
 		result["parent"] = f.Parent
+	}
+	if f.Resolution != nil {
+		result["resolution"] = f.Resolution
+	}
+	if len(f.FixVersions) > 0 {
+		result["fixVersions"] = f.FixVersions
 	}
 
 	// Add custom fields

--- a/tools/jtk/internal/cmd/issues/archive.go
+++ b/tools/jtk/internal/cmd/issues/archive.go
@@ -38,18 +38,25 @@ func runArchive(ctx context.Context, opts *root.Options, keys []string) error {
 		return err
 	}
 
-	failedKeys := make(map[string]bool)
+	hasErrors := len(result.Errors) > 0
 	for _, ae := range result.Errors {
-		for _, k := range ae.IssueIdsOrKeys {
-			failedKeys[k] = true
-		}
 		fmt.Fprintf(opts.Stderr, "Archive error: %s (%s)\n", ae.Message, strings.Join(ae.IssueIdsOrKeys, ", "))
 	}
 
 	var successKeys []string
-	for _, key := range keys {
-		if !failedKeys[key] {
-			successKeys = append(successKeys, key)
+	if result.NumberUpdated > 0 && !hasErrors {
+		successKeys = keys
+	} else if result.NumberUpdated > 0 {
+		failedIDs := make(map[string]bool)
+		for _, ae := range result.Errors {
+			for _, k := range ae.IssueIdsOrKeys {
+				failedIDs[k] = true
+			}
+		}
+		for _, key := range keys {
+			if !failedIDs[key] {
+				successKeys = append(successKeys, key)
+			}
 		}
 	}
 
@@ -65,8 +72,9 @@ func runArchive(ctx context.Context, opts *root.Options, keys []string) error {
 		}
 	}
 
-	if len(failedKeys) > 0 {
-		return fmt.Errorf("%w (%d of %d issue(s) failed)", root.ErrAlreadyReported, len(failedKeys), len(keys))
+	if hasErrors {
+		failedCount := len(keys) - len(successKeys)
+		return fmt.Errorf("%w (%d of %d issue(s) failed)", root.ErrAlreadyReported, failedCount, len(keys))
 	}
 	return nil
 }

--- a/tools/jtk/internal/cmd/issues/archive.go
+++ b/tools/jtk/internal/cmd/issues/archive.go
@@ -46,10 +46,18 @@ func runArchive(ctx context.Context, opts *root.Options, keys []string) error {
 		fmt.Fprintf(opts.Stderr, "Archive error: %s (%s)\n", ae.Message, strings.Join(ae.IssueIdsOrKeys, ", "))
 	}
 
+	var successKeys []string
 	for _, key := range keys {
-		if failedKeys[key] {
-			continue
+		if !failedKeys[key] {
+			successKeys = append(successKeys, key)
 		}
+	}
+
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, successKeys)
+	}
+
+	for _, key := range successKeys {
 		model := jtkpresent.IssuePresenter{}.PresentArchived(key)
 		out := present.Render(model, opts.RenderStyle())
 		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)

--- a/tools/jtk/internal/cmd/issues/archive.go
+++ b/tools/jtk/internal/cmd/issues/archive.go
@@ -54,13 +54,15 @@ func runArchive(ctx context.Context, opts *root.Options, keys []string) error {
 	}
 
 	if opts.EmitIDOnly() {
-		return jtkpresent.EmitIDs(opts, successKeys)
-	}
-
-	for _, key := range successKeys {
-		model := jtkpresent.IssuePresenter{}.PresentArchived(key)
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		if err := jtkpresent.EmitIDs(opts, successKeys); err != nil {
+			return err
+		}
+	} else {
+		for _, key := range successKeys {
+			model := jtkpresent.IssuePresenter{}.PresentArchived(key)
+			out := present.Render(model, opts.RenderStyle())
+			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		}
 	}
 
 	if len(failedKeys) > 0 {

--- a/tools/jtk/internal/cmd/issues/archive.go
+++ b/tools/jtk/internal/cmd/issues/archive.go
@@ -1,0 +1,62 @@
+package issues
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+)
+
+func newArchiveCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "archive <issue-key> [<issue-key>...]",
+		Short: "Archive one or more issues",
+		Long:  "Archive one or more Jira issues. Archived issues can be restored later.",
+		Example: `  jtk issues archive PROJ-123
+  jtk issues archive PROJ-123 PROJ-124 PROJ-125`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runArchive(cmd.Context(), opts, args)
+		},
+	}
+}
+
+func runArchive(ctx context.Context, opts *root.Options, keys []string) error {
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	result, err := client.ArchiveIssues(ctx, keys)
+	if err != nil {
+		return err
+	}
+
+	failedKeys := make(map[string]bool)
+	for _, ae := range result.Errors {
+		for _, k := range ae.IssueIdsOrKeys {
+			failedKeys[k] = true
+		}
+		fmt.Fprintf(opts.Stderr, "Archive error: %s (%s)\n", ae.Message, strings.Join(ae.IssueIdsOrKeys, ", "))
+	}
+
+	for _, key := range keys {
+		if failedKeys[key] {
+			continue
+		}
+		model := jtkpresent.IssuePresenter{}.PresentArchived(key)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+	}
+
+	if len(failedKeys) > 0 {
+		return fmt.Errorf("%w (%d of %d issue(s) failed)", root.ErrAlreadyReported, len(failedKeys), len(keys))
+	}
+	return nil
+}

--- a/tools/jtk/internal/cmd/issues/archive.go
+++ b/tools/jtk/internal/cmd/issues/archive.go
@@ -3,6 +3,7 @@ package issues
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -39,14 +40,24 @@ func runArchive(ctx context.Context, opts *root.Options, keys []string) error {
 	}
 
 	hasErrors := len(result.Errors) > 0
-	for _, ae := range result.Errors {
+
+	errorCategories := make([]string, 0, len(result.Errors))
+	for cat := range result.Errors {
+		errorCategories = append(errorCategories, cat)
+	}
+	sort.Strings(errorCategories)
+	for _, cat := range errorCategories {
+		ae := result.Errors[cat]
 		fmt.Fprintf(opts.Stderr, "Archive error: %s (%s)\n", ae.Message, strings.Join(ae.IssueIdsOrKeys, ", "))
 	}
 
 	var successKeys []string
-	if result.NumberUpdated > 0 && !hasErrors {
+	switch {
+	case result.NumberUpdated == 0 && !hasErrors:
+		fmt.Fprintln(opts.Stderr, "No issues were archived (already archived or no effect)")
+	case result.NumberUpdated > 0 && !hasErrors && result.NumberUpdated >= len(keys):
 		successKeys = keys
-	} else if result.NumberUpdated > 0 {
+	case result.NumberUpdated > 0:
 		failedIDs := make(map[string]bool)
 		for _, ae := range result.Errors {
 			for _, k := range ae.IssueIdsOrKeys {

--- a/tools/jtk/internal/cmd/issues/archive_test.go
+++ b/tools/jtk/internal/cmd/issues/archive_test.go
@@ -1,0 +1,98 @@
+package issues
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+func TestRunArchive_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue/archive" && r.Method == "PUT" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ArchiveResult{NumberUpdated: 1})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runArchive(context.Background(), opts, []string{"TEST-1"})
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Archived TEST-1")
+}
+
+func TestRunArchive_PartialFailure(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue/archive" && r.Method == "PUT" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ArchiveResult{
+				NumberUpdated: 1,
+				Errors: map[string]api.ArchiveError{
+					"PERMISSION_DENIED": {
+						Count:          1,
+						IssueIdsOrKeys: []string{"TEST-2"},
+						Message:        "Permission denied",
+					},
+				},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runArchive(context.Background(), opts, []string{"TEST-1", "TEST-2"})
+	testutil.NotNil(t, err)
+	testutil.Contains(t, stdout.String(), "Archived TEST-1")
+	testutil.Contains(t, stderr.String(), "Permission denied")
+}
+
+func TestRunArchive_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issue/archive" && r.Method == "PUT" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ArchiveResult{NumberUpdated: 2})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runArchive(context.Background(), opts, []string{"TEST-1", "TEST-2"})
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "TEST-1")
+	testutil.Contains(t, stdout.String(), "TEST-2")
+}

--- a/tools/jtk/internal/cmd/issues/field_options.go
+++ b/tools/jtk/internal/cmd/issues/field_options.go
@@ -52,8 +52,8 @@ metadata, the default field context is used.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&issueFlag, "issue", "", "Issue key for context-specific options (deprecated: use positional arg)")
-	_ = cmd.Flags().MarkHidden("issue")
+	cmd.Flags().StringVar(&issueFlag, "issue", "", "Issue key for context-specific options")
+	_ = cmd.Flags().MarkDeprecated("issue", "use positional arg: jtk issues field-options <issue-key> <field>")
 
 	return cmd
 }

--- a/tools/jtk/internal/cmd/issues/field_options.go
+++ b/tools/jtk/internal/cmd/issues/field_options.go
@@ -15,27 +15,45 @@ import (
 )
 
 func newFieldOptionsCmd(opts *root.Options) *cobra.Command {
-	var issueKey string
+	var issueFlag string
 
 	cmd := &cobra.Command{
-		Use:   "field-options <field-name-or-id>",
+		Use:   "field-options <issue-key> <field-name-or-id>",
 		Short: "List allowed values for a field",
 		Long: `List the allowed values for an option/select field.
 
-When used with --issue, shows the allowed values in the context of that specific issue.
-Without --issue, attempts to show all possible values for the field.`,
-		Example: `  # List options for a field using issue context
-  jtk issues field-options "Priority" --issue PROJ-123
+Provide an issue key and a field name or ID to see allowed values in that
+issue's project context. For read-only fields that don't appear in edit
+metadata, the default field context is used.`,
+		Example: `  # List options using issue context (recommended)
+  jtk issues field-options PROJ-123 "Priority"
+
+  # List options for a custom field
+  jtk issues field-options PROJ-123 customfield_10050
+
+  # List options without issue context (global)
+  jtk issues field-options "Priority"
 
   # Emit only option IDs
-  jtk issues field-options "Priority" --issue PROJ-123 --id`,
-		Args: cobra.ExactArgs(1),
+  jtk issues field-options PROJ-123 "Priority" --id`,
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runFieldOptions(cmd.Context(), opts, args[0], issueKey)
+			var issueKey, fieldNameOrID string
+			if len(args) == 2 {
+				issueKey = args[0]
+				fieldNameOrID = args[1]
+			} else {
+				fieldNameOrID = args[0]
+				if issueFlag != "" {
+					issueKey = issueFlag
+				}
+			}
+			return runFieldOptions(cmd.Context(), opts, fieldNameOrID, issueKey)
 		},
 	}
 
-	cmd.Flags().StringVar(&issueKey, "issue", "", "Issue key for context-specific options (recommended)")
+	cmd.Flags().StringVar(&issueFlag, "issue", "", "Issue key for context-specific options (deprecated: use positional arg)")
+	_ = cmd.Flags().MarkHidden("issue")
 
 	return cmd
 }
@@ -67,7 +85,7 @@ func runFieldOptions(ctx context.Context, opts *root.Options, fieldNameOrID, iss
 	var options []api.FieldOptionValue
 
 	if issueKey != "" {
-		options, err = client.GetFieldOptionsFromEditMeta(ctx, issueKey, fieldID)
+		options, err = api.ResolveFieldOptions(ctx, client, issueKey, fieldID)
 		if err != nil {
 			return fmt.Errorf("getting options for field %s: %w", fieldName, err)
 		}

--- a/tools/jtk/internal/cmd/issues/field_options_test.go
+++ b/tools/jtk/internal/cmd/issues/field_options_test.go
@@ -95,3 +95,51 @@ func TestRunFieldOptions_CacheMiss_FallsBackToLive(t *testing.T) {
 		t.Fatal("expected live /field call on cache miss")
 	}
 }
+
+func TestRunFieldOptions_FallbackToContext(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "customfield_10050", Name: "Team", Custom: true, Schema: api.FieldSchema{Type: "option"}},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/rest/api/3/field":
+			t.Fatal("live /field must not be called when cache is fresh")
+		case strings.Contains(r.URL.Path, "/editmeta"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"fields": map[string]any{}})
+		case strings.HasSuffix(r.URL.Path, "/context") && !strings.Contains(r.URL.Path, "/option"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"id": "10100", "name": "Default", "isGlobalContext": true, "isAnyIssueType": true},
+				},
+				"isLast": true,
+			})
+		case strings.Contains(r.URL.Path, "/context/10100/option"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"id": "20001", "value": "Platform", "disabled": false},
+					{"id": "20002", "value": "Integration", "disabled": false},
+				},
+				"isLast": true,
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runFieldOptions(context.Background(), opts, "Team", "TEST-1")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Platform")
+	testutil.Contains(t, stdout.String(), "Integration")
+	testutil.Contains(t, stdout.String(), "DISABLED")
+}

--- a/tools/jtk/internal/cmd/issues/fields.go
+++ b/tools/jtk/internal/cmd/issues/fields.go
@@ -2,6 +2,7 @@ package issues
 
 import (
 	"context"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -19,15 +20,18 @@ func newFieldsCmd(opts *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fields [issue-key]",
 		Short: "List available fields",
-		Long:  "List fields that can be used when creating or updating issues. If an issue key is provided, shows the editable fields for that specific issue.",
+		Long:  "List fields and their metadata. If an issue key is provided, shows all fields with their current values for that issue.",
 		Example: `  # List all fields
   jtk issues fields
 
   # List only custom fields
   jtk issues fields --custom-fields
 
-  # List editable fields for a specific issue
+  # Show field values for a specific issue
   jtk issues fields PROJ-123
+
+  # Show only custom field values for an issue
+  jtk issues fields PROJ-123 --custom-fields
 
   # Extended output with searchable/navigable/orderable/clause names
   jtk issues fields --extended
@@ -58,7 +62,7 @@ func runFields(ctx context.Context, opts *root.Options, issueKey string, customO
 	}
 
 	if issueKey != "" {
-		return runEditableFields(ctx, opts, client, issueKey)
+		return runIssueFields(ctx, opts, client, issueKey, customOnly)
 	}
 	return runGlobalFields(ctx, opts, client, customOnly)
 }
@@ -99,32 +103,46 @@ func runGlobalFields(ctx context.Context, opts *root.Options, client *api.Client
 	return jtkpresent.Emit(opts, model)
 }
 
-func runEditableFields(ctx context.Context, opts *root.Options, client *api.Client, issueKey string) error {
-	meta, err := client.GetIssueEditMeta(ctx, issueKey)
+func runIssueFields(ctx context.Context, opts *root.Options, client *api.Client, issueKey string, customOnly bool) error {
+	issue, err := client.GetIssue(ctx, issueKey)
 	if err != nil {
 		return err
 	}
 
-	v := opts.View()
-	if v.Format == view.FormatJSON {
-		return v.JSON(meta)
+	fields, err := cache.GetFieldsCacheFirst(ctx, client)
+	if err != nil {
+		return err
 	}
 
-	fieldsData, ok := meta["fields"].(map[string]any)
-	if !ok {
-		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentNoEditableFields(issueKey))
+	entries := api.ExtractIssueFieldValues(issue, fields)
+
+	if customOnly {
+		var filtered []api.IssueFieldEntry
+		for _, e := range entries {
+			if strings.HasPrefix(e.ID, "customfield_") {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
 	}
 
-	editableFields := api.ParseEditMeta(fieldsData)
+	if len(entries) == 0 {
+		return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentEmpty())
+	}
 
 	if opts.EmitIDOnly() {
-		ids := make([]string, len(editableFields))
-		for i, f := range editableFields {
-			ids[i] = f.ID
+		ids := make([]string, len(entries))
+		for i, e := range entries {
+			ids[i] = e.ID
 		}
 		return jtkpresent.EmitIDs(opts, ids)
 	}
 
-	model := jtkpresent.FieldPresenter{}.PresentEditableFields(editableFields)
+	v := opts.View()
+	if v.Format == view.FormatJSON {
+		return v.JSON(entries)
+	}
+
+	model := jtkpresent.FieldPresenter{}.PresentIssueFields(entries)
 	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/issues/fields_test.go
+++ b/tools/jtk/internal/cmd/issues/fields_test.go
@@ -3,6 +3,7 @@ package issues
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -71,6 +72,75 @@ func TestRunGlobalFields_CacheHit_CustomFilter_SkipsLiveCall(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Story Points")
 	testutil.NotContains(t, stdout.String(), "Summary")
+}
+
+func TestRunIssueFields_ShowsFieldValues(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+		{ID: "status", Name: "Status", Schema: api.FieldSchema{Type: "status"}},
+		{ID: "customfield_10035", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+	}))
+
+	issue := api.Issue{
+		Key: "TEST-1",
+		Fields: api.IssueFields{
+			Summary: "Test issue",
+			Status:  &api.Status{Name: "Open"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			t.Fatal("live /field must not be called when cache is fresh")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issue)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runIssueFields(context.Background(), opts, client, "TEST-1", false)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Summary")
+	testutil.Contains(t, stdout.String(), "Test issue")
+	testutil.Contains(t, stdout.String(), "VALUE")
+}
+
+func TestRunIssueFields_CustomOnly(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", []api.Field{
+		{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+		{ID: "customfield_10035", Name: "Story Points", Custom: true, Schema: api.FieldSchema{Type: "number"}},
+	}))
+
+	issueJSON := `{"key":"TEST-1","fields":{"summary":"Test","customfield_10035":5}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			t.Fatal("live /field must not be called when cache is fresh")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(issueJSON))
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runIssueFields(context.Background(), opts, client, "TEST-1", true)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Story Points")
+	testutil.NotContains(t, stdout.String(), "summary")
 }
 
 func TestRunGlobalFields_CacheMiss_FallsBackToLive(t *testing.T) {

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -95,7 +95,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		}
 
 		if projected {
-			model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate)
+			model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate, dctx)
 			projection.ApplyToDetailInModel(model, selected)
 			return jtkpresent.Emit(opts, model)
 		}
@@ -104,7 +104,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	}
 
 	if projected {
-		model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate)
+		model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate, nil)
 		projection.ApplyToDetailInModel(model, selected)
 		return jtkpresent.Emit(opts, model)
 	}

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -83,27 +83,29 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 
 	presenter := jtkpresent.IssuePresenter{}
 
-	// projected takes precedence over full extended rendering
-	if projected {
-		model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate)
-		projection.ApplyToDetailInModel(model, selected)
-		return jtkpresent.Emit(opts, model)
-	}
-
 	if opts.IsExtended() {
+		noTruncate = true
 		transitions, _ := client.GetTransitions(ctx, issueKey)
-
 		watchers, _ := client.GetWatchers(ctx, issueKey)
-
 		fields, _ := cache.GetFieldsCacheFirst(ctx, client)
-
 		dctx := &jtkpresent.DetailContext{
 			Transitions: transitions,
 			Watchers:    watchers,
 			Fields:      fields,
 		}
 
+		if projected {
+			model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate)
+			projection.ApplyToDetailInModel(model, selected)
+			return jtkpresent.Emit(opts, model)
+		}
 		model := presenter.PresentDetailExtended(issue, client.IssueURL(issue.Key), dctx)
+		return jtkpresent.Emit(opts, model)
+	}
+
+	if projected {
+		model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate)
+		projection.ApplyToDetailInModel(model, selected)
 		return jtkpresent.Emit(opts, model)
 	}
 

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -8,6 +8,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
@@ -47,10 +48,6 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 		return err
 	}
 
-	// --id wins over --fields: skip projection entirely when --id is set so
-	// we don't waste a GetFields() call on a token whose result will be
-	// thrown away. Also defensively skip JSON + --fields error in this case
-	// — --id also overrides --output json semantics.
 	if opts.EmitIDOnly() {
 		issue, err := client.GetIssue(ctx, issueKey)
 		if err != nil {
@@ -85,12 +82,31 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	}
 
 	presenter := jtkpresent.IssuePresenter{}
+
+	// projected takes precedence over full extended rendering
 	if projected {
 		model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate)
 		projection.ApplyToDetailInModel(model, selected)
 		return jtkpresent.Emit(opts, model)
 	}
 
-	model := presenter.PresentDetail(issue, client.IssueURL(issue.Key), opts.IsExtended(), noTruncate)
+	if opts.IsExtended() {
+		transitions, _ := client.GetTransitions(ctx, issueKey)
+
+		watchers, _ := client.GetWatchers(ctx, issueKey)
+
+		fields, _ := cache.GetFieldsCacheFirst(ctx, client)
+
+		dctx := &jtkpresent.DetailContext{
+			Transitions: transitions,
+			Watchers:    watchers,
+			Fields:      fields,
+		}
+
+		model := presenter.PresentDetailExtended(issue, client.IssueURL(issue.Key), dctx)
+		return jtkpresent.Emit(opts, model)
+	}
+
+	model := presenter.PresentDetail(issue, client.IssueURL(issue.Key), false, noTruncate)
 	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -85,13 +85,14 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 
 	if opts.IsExtended() {
 		noTruncate = true
-		transitions, _ := client.GetTransitions(ctx, issueKey)
+		transitions, transErr := client.GetTransitions(ctx, issueKey)
 		watchers, _ := client.GetWatchers(ctx, issueKey)
 		fields, _ := cache.GetFieldsCacheFirst(ctx, client)
 		dctx := &jtkpresent.DetailContext{
-			Transitions: transitions,
-			Watchers:    watchers,
-			Fields:      fields,
+			Transitions:       transitions,
+			TransitionsFailed: transErr != nil,
+			Watchers:          watchers,
+			Fields:            fields,
 		}
 
 		if projected {

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -387,3 +387,52 @@ func TestRunGet_Extended_ShowsNewSections(t *testing.T) {
 	// Extended implies fulltext — full description present
 	testutil.NotContains(t, output, "[truncated")
 }
+
+func TestRunGet_ExtendedFields_ProjectionUsesDetailContext(t *testing.T) {
+	t.Parallel()
+	longDesc := strings.Repeat("B", 300)
+	issue := api.Issue{
+		Key: "TEST-1",
+		Fields: api.IssueFields{
+			Summary:     "Test issue",
+			Status:      &api.Status{Name: "Open"},
+			IssueType:   &api.IssueType{Name: "Task"},
+			Description: &api.Description{Text: longDesc},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/transitions"):
+			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{
+				Transitions: []api.Transition{
+					{ID: "11", Name: "Backlog"},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/watchers"):
+			_ = json.NewEncoder(w).Encode(api.WatchersInfo{WatchCount: 5, IsWatching: false})
+		case strings.HasSuffix(r.URL.Path, "/field"):
+			_ = json.NewEncoder(w).Encode([]api.Field{})
+		default:
+			_ = json.NewEncoder(w).Encode(issue)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "TEST-1", false, "Watchers,Transitions,Description")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "5 (watching: no)")
+	testutil.Contains(t, output, "11:Backlog")
+	testutil.Contains(t, output, longDesc)
+	testutil.NotContains(t, output, "[truncated")
+}

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -332,3 +332,58 @@ func TestRunGet_JSONOutputIgnoresFullFlag(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, result.Key, "TEST-1")
 }
+
+func TestRunGet_Extended_ShowsNewSections(t *testing.T) {
+	t.Parallel()
+	issue := api.Issue{
+		Key: "TEST-1",
+		Fields: api.IssueFields{
+			Summary:   "Test issue",
+			Status:    &api.Status{Name: "Open", StatusCategory: api.StatusCategory{Name: "To Do"}},
+			IssueType: &api.IssueType{Name: "Task"},
+			Resolution: &api.Resolution{Name: "Done"},
+			FixVersions: []api.Version{{ID: "1", Name: "v1.0"}},
+			Description: &api.Description{Text: strings.Repeat("A", 300)},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/transitions"):
+			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{
+				Transitions: []api.Transition{
+					{ID: "11", Name: "Backlog"},
+					{ID: "21", Name: "In Progress"},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/watchers"):
+			_ = json.NewEncoder(w).Encode(api.WatchersInfo{WatchCount: 3, IsWatching: true})
+		case strings.Contains(r.URL.Path, "/field"):
+			_ = json.NewEncoder(w).Encode([]api.Field{})
+		default:
+			_ = json.NewEncoder(w).Encode(issue)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "TEST-1", false, "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Fix Versions: v1.0")
+	testutil.Contains(t, output, "Watchers: 3 (watching: yes)")
+	testutil.Contains(t, output, "Resolution: Done")
+	testutil.Contains(t, output, "Transitions:")
+	testutil.Contains(t, output, "Backlog")
+	testutil.Contains(t, output, "In Progress")
+	// Extended implies fulltext — full description present
+	testutil.NotContains(t, output, "[truncated")
+}

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -338,10 +338,10 @@ func TestRunGet_Extended_ShowsNewSections(t *testing.T) {
 	issue := api.Issue{
 		Key: "TEST-1",
 		Fields: api.IssueFields{
-			Summary:   "Test issue",
-			Status:    &api.Status{Name: "Open", StatusCategory: api.StatusCategory{Name: "To Do"}},
-			IssueType: &api.IssueType{Name: "Task"},
-			Resolution: &api.Resolution{Name: "Done"},
+			Summary:     "Test issue",
+			Status:      &api.Status{Name: "Open", StatusCategory: api.StatusCategory{Name: "To Do"}},
+			IssueType:   &api.IssueType{Name: "Task"},
+			Resolution:  &api.Resolution{Name: "Done"},
 			FixVersions: []api.Version{{ID: "1", Name: "v1.0"}},
 			Description: &api.Description{Text: strings.Repeat("A", 300)},
 		},

--- a/tools/jtk/internal/cmd/issues/issues.go
+++ b/tools/jtk/internal/cmd/issues/issues.go
@@ -15,6 +15,7 @@ func Register(parent *cobra.Command, opts *root.Options) {
 		Long:    "Commands for creating, viewing, updating, and searching Jira issues.",
 	}
 
+	cmd.AddCommand(newArchiveCmd(opts))
 	cmd.AddCommand(newGetCmd(opts))
 	cmd.AddCommand(newListCmd(opts))
 	cmd.AddCommand(newSearchCmd(opts))

--- a/tools/jtk/internal/present/field.go
+++ b/tools/jtk/internal/present/field.go
@@ -354,7 +354,7 @@ func (FieldPresenter) PresentOptionsNoContext() *present.OutputModel {
 }
 
 // PresentFieldOptionsWithHeader creates a header + table for field options.
-func (FieldPresenter) PresentFieldOptionsWithHeader(fieldName string, options []api.FieldOptionValue) *present.OutputModel {
+func (FieldPresenter) PresentFieldOptionsWithHeader(_ string, options []api.FieldOptionValue) *present.OutputModel {
 	rows := make([]present.Row, len(options))
 	for i, opt := range options {
 		value := opt.Value

--- a/tools/jtk/internal/present/field.go
+++ b/tools/jtk/internal/present/field.go
@@ -59,6 +59,25 @@ func (FieldPresenter) PresentList(fields []api.Field, extended bool) *present.Ou
 	}
 }
 
+// PresentIssueFields creates a table view for an issue's field values.
+// Output: FIELD_ID|NAME|TYPE|VALUE per #230 spec.
+func (FieldPresenter) PresentIssueFields(entries []api.IssueFieldEntry) *present.OutputModel {
+	rows := make([]present.Row, len(entries))
+	for i, e := range entries {
+		rows[i] = present.Row{
+			Cells: []string{e.ID, e.Name, OrDash(e.Type), e.Value},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"FIELD_ID", "NAME", "TYPE", "VALUE"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
 // PresentEditableFields creates a table view for editable fields.
 func (FieldPresenter) PresentEditableFields(fields []api.EditFieldMeta) *present.OutputModel {
 	rows := make([]present.Row, len(fields))
@@ -342,23 +361,19 @@ func (FieldPresenter) PresentFieldOptionsWithHeader(fieldName string, options []
 		if value == "" {
 			value = opt.Name
 		}
+		disabled := "no"
 		if opt.Disabled {
-			value = value + " (disabled)"
+			disabled = "yes"
 		}
 		rows[i] = present.Row{
-			Cells: []string{opt.ID, value},
+			Cells: []string{opt.ID, value, disabled},
 		}
 	}
 
 	return &present.OutputModel{
 		Sections: []present.Section{
-			&present.MessageSection{
-				Kind:    present.MessageInfo,
-				Message: fmt.Sprintf("Allowed values for field '%s':", fieldName),
-				Stream:  present.StreamStdout,
-			},
 			&present.TableSection{
-				Headers: []string{"ID", "VALUE"},
+				Headers: []string{"ID", "VALUE", "DISABLED"},
 				Rows:    rows,
 			},
 		},

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -13,9 +13,10 @@ import (
 
 // DetailContext carries extended-only data fetched by the command layer.
 type DetailContext struct {
-	Transitions []api.Transition
-	Watchers    *api.WatchersInfo // nil = unavailable
-	Fields      []api.Field       // nil = degrade to raw field IDs
+	Transitions       []api.Transition
+	TransitionsFailed bool              // true when the API call failed
+	Watchers          *api.WatchersInfo // nil = unavailable
+	Fields            []api.Field       // nil = degrade to raw field IDs
 }
 
 // IssuePresenter creates presentation models for issue data.
@@ -377,7 +378,9 @@ func (IssuePresenter) PresentDetailExtended(issue *api.Issue, _ string, dctx *De
 	sections = append(sections, issueDescriptionSection(issue, true)...)
 
 	sections = append(sections, msg(""), msg("Transitions:"))
-	if dctx != nil && len(dctx.Transitions) > 0 {
+	if dctx != nil && dctx.TransitionsFailed {
+		sections = append(sections, msg("  (unavailable)"))
+	} else if dctx != nil && len(dctx.Transitions) > 0 {
 		rows := make([]present.Row, len(dctx.Transitions))
 		for i, t := range dctx.Transitions {
 			rows[i] = present.Row{Cells: []string{t.ID, t.Name}}
@@ -387,7 +390,7 @@ func (IssuePresenter) PresentDetailExtended(issue *api.Issue, _ string, dctx *De
 			Rows:    rows,
 		})
 	} else {
-		sections = append(sections, msg("  (none available)"))
+		sections = append(sections, msg("  (none)"))
 	}
 
 	return &present.OutputModel{Sections: sections}

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -2,6 +2,7 @@ package present
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/present"
@@ -9,6 +10,13 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
+
+// DetailContext carries extended-only data fetched by the command layer.
+type DetailContext struct {
+	Transitions []api.Transition
+	Watchers    *api.WatchersInfo // nil = unavailable
+	Fields      []api.Field       // nil = degrade to raw field IDs
+}
 
 // IssuePresenter creates presentation models for issue data.
 type IssuePresenter struct{}
@@ -56,6 +64,11 @@ var IssueDetailSpec = projection.Registry{
 	{Header: "Status_Category", Extended: true},
 	{Header: "Sprint_Dates", Extended: true},
 	{Header: "Component_IDs", Extended: true},
+	{Header: "Fix_Versions", FieldID: "fixVersions", Extended: true},
+	{Header: "Watchers", Extended: true},
+	{Header: "Resolution", FieldID: "resolution", Extended: true},
+	{Header: "Custom_Fields", Extended: true},
+	{Header: "Transitions", Extended: true},
 }
 
 // PresentDetail creates a spec-shaped detail view for a single issue.
@@ -238,6 +251,191 @@ func issueDescriptionSection(issue *api.Issue, fulltext bool) []present.Section 
 	}
 }
 
+// PresentDetailExtended builds the full extended detail view with additional
+// context data (transitions, watchers, custom fields). Extended always implies
+// fulltext — description is never truncated.
+func (IssuePresenter) PresentDetailExtended(issue *api.Issue, _ string, dctx *DetailContext) *present.OutputModel {
+	sections := []present.Section{
+		msg(fmt.Sprintf("%s  %s", issue.Key, issue.Fields.Summary)),
+	}
+
+	status := issueStatusName(issue)
+	statusCategory := ""
+	if issue.Fields.Status != nil {
+		statusCategory = issue.Fields.Status.StatusCategory.Name
+	}
+	issueType := issueTypeName(issue)
+	priority := issuePriorityName(issue)
+	points := formatStoryPoints(issue)
+
+	assignee := "Unassigned"
+	assigneeID := ""
+	if issue.Fields.Assignee != nil {
+		assignee = issue.Fields.Assignee.DisplayName
+		assigneeID = issue.Fields.Assignee.AccountID
+	}
+
+	reporter := "-"
+	reporterID := ""
+	if issue.Fields.Reporter != nil {
+		reporter = issue.Fields.Reporter.DisplayName
+		reporterID = issue.Fields.Reporter.AccountID
+	}
+
+	statusLine := fmt.Sprintf("Status: %s", OrDash(status))
+	if statusCategory != "" {
+		statusLine += fmt.Sprintf(" (category: %s)", statusCategory)
+	}
+	statusLine += fmt.Sprintf("   Type: %s   Priority: %s   Points: %s",
+		OrDash(issueType), OrDash(priority), points)
+
+	assigneeLine := fmt.Sprintf("Assignee: %s", assignee)
+	if assigneeID != "" {
+		assigneeLine += fmt.Sprintf(" (%s)", assigneeID)
+	}
+	assigneeLine += fmt.Sprintf("   Reporter: %s", reporter)
+	if reporterID != "" {
+		assigneeLine += fmt.Sprintf(" (%s)", reporterID)
+	}
+
+	sections = append(sections,
+		msg(statusLine),
+		msg(assigneeLine),
+		msg(fmt.Sprintf("Updated: %s   Created: %s",
+			OrDash(issue.Fields.Updated), OrDash(issue.Fields.Created))),
+	)
+
+	if issue.Fields.Sprint != nil {
+		s := issue.Fields.Sprint
+		sprintRef := s.Name
+		sprintMeta := fmt.Sprintf("id: %d, %s", s.ID, OrDash(s.State))
+		if s.StartDate != nil {
+			sprintMeta += ", " + FormatDateOrDash(s.StartDate) + " → " + FormatDateOrDash(s.EndDate)
+		}
+		sections = append(sections, msg(fmt.Sprintf("Sprint: %s (%s)", sprintRef, sprintMeta)))
+	} else {
+		sections = append(sections, msg("Sprint: -"))
+	}
+
+	if issue.Fields.Parent != nil {
+		parentRef := issue.Fields.Parent.Key
+		if issue.Fields.Parent.Fields.Summary != "" {
+			parentRef += " — " + issue.Fields.Parent.Fields.Summary
+		}
+		if issue.Fields.Parent.Fields.IssueType != nil {
+			parentRef += " (" + issue.Fields.Parent.Fields.IssueType.Name + ")"
+		}
+		sections = append(sections, msg("Parent: "+parentRef))
+	} else {
+		sections = append(sections, msg("Parent: -"))
+	}
+
+	labels := "-"
+	if len(issue.Fields.Labels) > 0 {
+		labels = strings.Join(issue.Fields.Labels, ", ")
+	}
+	sections = append(sections, msg("Labels: "+labels))
+
+	if len(issue.Fields.Components) > 0 {
+		names := make([]string, len(issue.Fields.Components))
+		for i, c := range issue.Fields.Components {
+			names[i] = fmt.Sprintf("%s (%s)", c.Name, c.ID)
+		}
+		sections = append(sections, msg("Components: "+strings.Join(names, ", ")))
+	} else {
+		sections = append(sections, msg("Components: -"))
+	}
+
+	fixVersions := "-"
+	if len(issue.Fields.FixVersions) > 0 {
+		names := make([]string, len(issue.Fields.FixVersions))
+		for i, v := range issue.Fields.FixVersions {
+			names[i] = v.Name
+		}
+		fixVersions = strings.Join(names, ", ")
+	}
+	sections = append(sections, msg("Fix Versions: "+fixVersions))
+
+	if dctx != nil && dctx.Watchers != nil {
+		watching := "no"
+		if dctx.Watchers.IsWatching {
+			watching = "yes"
+		}
+		sections = append(sections, msg(fmt.Sprintf("Watchers: %d (watching: %s)", dctx.Watchers.WatchCount, watching)))
+	} else {
+		sections = append(sections, msg("Watchers: -"))
+	}
+
+	resolution := "-"
+	if issue.Fields.Resolution != nil {
+		resolution = issue.Fields.Resolution.Name
+	}
+	sections = append(sections, msg("Resolution: "+resolution))
+
+	sections = append(sections, issueExtendedCustomFields(issue, dctx)...)
+
+	sections = append(sections, issueDescriptionSection(issue, true)...)
+
+	if dctx != nil && len(dctx.Transitions) > 0 {
+		sections = append(sections, msg(""), msg("Transitions:"))
+		rows := make([]present.Row, len(dctx.Transitions))
+		for i, t := range dctx.Transitions {
+			rows[i] = present.Row{Cells: []string{t.ID, t.Name}}
+		}
+		sections = append(sections, &present.TableSection{
+			Headers: []string{"ID", "NAME"},
+			Rows:    rows,
+		})
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+func issueExtendedCustomFields(issue *api.Issue, dctx *DetailContext) []present.Section {
+	if issue.Fields.CustomFields == nil {
+		return nil
+	}
+
+	fieldIndex := make(map[string]string)
+	if dctx != nil && dctx.Fields != nil {
+		for _, f := range dctx.Fields {
+			fieldIndex[f.ID] = f.Name
+		}
+	}
+
+	type entry struct {
+		id, value, name string
+	}
+	var entries []entry
+	for id, raw := range issue.Fields.CustomFields {
+		if !strings.HasPrefix(id, "customfield_") || raw == nil {
+			continue
+		}
+		val := api.FormatCustomFieldValue(raw)
+		if val == "" {
+			continue
+		}
+		name := fieldIndex[id]
+		entries = append(entries, entry{id: id, value: val, name: name})
+	}
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].id < entries[j].id })
+
+	var sections []present.Section
+	for _, e := range entries {
+		line := fmt.Sprintf("%s: %s", e.id, e.value)
+		if e.name != "" {
+			line += fmt.Sprintf("   (%s)", e.name)
+		}
+		sections = append(sections, msg(line))
+	}
+	return sections
+}
+
 // PresentDetailProjection builds a DetailSection view for `issues get --fields`.
 func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fulltext bool) *present.OutputModel {
 	fields := []present.Field{
@@ -259,6 +457,11 @@ func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fullte
 		{Label: "Status_Category", Value: issueStatusCategory(issue)},
 		{Label: "Sprint_Dates", Value: issueSprintDates(issue)},
 		{Label: "Component_IDs", Value: issueComponentIDs(issue)},
+		{Label: "Fix_Versions", Value: issueFixVersions(issue)},
+		{Label: "Watchers", Value: "-"},
+		{Label: "Resolution", Value: issueResolution(issue)},
+		{Label: "Custom_Fields", Value: "-"},
+		{Label: "Transitions", Value: "-"},
 	}
 	return &present.OutputModel{
 		Sections: []present.Section{&present.DetailSection{Fields: fields}},
@@ -353,6 +556,24 @@ func issueSprintDates(issue *api.Issue) string {
 	}
 	s := issue.Fields.Sprint
 	return fmt.Sprintf("%s → %s", FormatDateOrDash(s.StartDate), FormatDateOrDash(s.EndDate))
+}
+
+func issueFixVersions(issue *api.Issue) string {
+	if len(issue.Fields.FixVersions) == 0 {
+		return "-"
+	}
+	names := make([]string, len(issue.Fields.FixVersions))
+	for i, v := range issue.Fields.FixVersions {
+		names[i] = v.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+func issueResolution(issue *api.Issue) string {
+	if issue.Fields.Resolution == nil {
+		return "-"
+	}
+	return issue.Fields.Resolution.Name
 }
 
 func issueDescriptionText(issue *api.Issue, fulltext bool) string {
@@ -526,6 +747,19 @@ func (IssuePresenter) PresentUpdated(key string) *present.OutputModel {
 			&present.MessageSection{
 				Kind:    present.MessageSuccess,
 				Message: fmt.Sprintf("Updated issue %s", key),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentArchived creates a confirmation message for issue archival.
+func (IssuePresenter) PresentArchived(key string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageSuccess,
+				Message: fmt.Sprintf("Archived %s", key),
 				Stream:  present.StreamStdout,
 			},
 		},

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -376,8 +376,8 @@ func (IssuePresenter) PresentDetailExtended(issue *api.Issue, _ string, dctx *De
 
 	sections = append(sections, issueDescriptionSection(issue, true)...)
 
+	sections = append(sections, msg(""), msg("Transitions:"))
 	if dctx != nil && len(dctx.Transitions) > 0 {
-		sections = append(sections, msg(""), msg("Transitions:"))
 		rows := make([]present.Row, len(dctx.Transitions))
 		for i, t := range dctx.Transitions {
 			rows[i] = present.Row{Cells: []string{t.ID, t.Name}}
@@ -386,6 +386,8 @@ func (IssuePresenter) PresentDetailExtended(issue *api.Issue, _ string, dctx *De
 			Headers: []string{"ID", "NAME"},
 			Rows:    rows,
 		})
+	} else {
+		sections = append(sections, msg("  (none available)"))
 	}
 
 	return &present.OutputModel{Sections: sections}
@@ -437,7 +439,45 @@ func issueExtendedCustomFields(issue *api.Issue, dctx *DetailContext) []present.
 }
 
 // PresentDetailProjection builds a DetailSection view for `issues get --fields`.
-func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fulltext bool) *present.OutputModel {
+// When dctx is non-nil, extended fields (Watchers, Custom_Fields, Transitions)
+// are populated from it; otherwise they render as "-".
+func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fulltext bool, dctx *DetailContext) *present.OutputModel {
+	watchersVal := "-"
+	if dctx != nil && dctx.Watchers != nil {
+		watching := "no"
+		if dctx.Watchers.IsWatching {
+			watching = "yes"
+		}
+		watchersVal = fmt.Sprintf("%d (watching: %s)", dctx.Watchers.WatchCount, watching)
+	}
+
+	customFieldsVal := "-"
+	if dctx != nil && issue.Fields.CustomFields != nil {
+		var parts []string
+		for id, raw := range issue.Fields.CustomFields {
+			if !strings.HasPrefix(id, "customfield_") || raw == nil {
+				continue
+			}
+			val := api.FormatCustomFieldValue(raw)
+			if val != "" {
+				parts = append(parts, fmt.Sprintf("%s=%s", id, val))
+			}
+		}
+		if len(parts) > 0 {
+			sort.Strings(parts)
+			customFieldsVal = strings.Join(parts, "; ")
+		}
+	}
+
+	transitionsVal := "-"
+	if dctx != nil && len(dctx.Transitions) > 0 {
+		var parts []string
+		for _, t := range dctx.Transitions {
+			parts = append(parts, fmt.Sprintf("%s:%s", t.ID, t.Name))
+		}
+		transitionsVal = strings.Join(parts, ", ")
+	}
+
 	fields := []present.Field{
 		{Label: "Key", Value: issue.Key},
 		{Label: "Summary", Value: issue.Fields.Summary},
@@ -458,10 +498,10 @@ func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fullte
 		{Label: "Sprint_Dates", Value: issueSprintDates(issue)},
 		{Label: "Component_IDs", Value: issueComponentIDs(issue)},
 		{Label: "Fix_Versions", Value: issueFixVersions(issue)},
-		{Label: "Watchers", Value: "-"},
+		{Label: "Watchers", Value: watchersVal},
 		{Label: "Resolution", Value: issueResolution(issue)},
-		{Label: "Custom_Fields", Value: "-"},
-		{Label: "Transitions", Value: "-"},
+		{Label: "Custom_Fields", Value: customFieldsVal},
+		{Label: "Transitions", Value: transitionsVal},
 	}
 	return &present.OutputModel{
 		Sections: []present.Section{&present.DetailSection{Fields: fields}},

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -285,7 +285,7 @@ func TestIssueDetailSpec_MatchesPresentDetailProjectionLabels(t *testing.T) {
 			Description: &api.Description{},
 		},
 	}
-	model := IssuePresenter{}.PresentDetailProjection(issue, "https://example.com/PROJ-1", true)
+	model := IssuePresenter{}.PresentDetailProjection(issue, "https://example.com/PROJ-1", true, nil)
 	detail := model.Sections[0].(*present.DetailSection)
 
 	renderedLabels := make(map[string]bool, len(detail.Fields))


### PR DESCRIPTION
## Summary
- **`issues fields <key>`**: Shows all fields with current values (FIELD_ID|NAME|TYPE|VALUE) instead of only editable fields
- **`issues fields <key> --custom-fields`**: Now correctly filters to `customfield_*` rows only
- **`issues field-options <issue-key> <field>`**: Three-tier resolution (edit meta → default context → global) so read-only fields work
- **`issues archive <key>`**: New command using bulk `PUT /rest/api/3/issue/archive` API with partial failure handling
- **`issues get <key> --extended`**: Adds Fix Versions, Watchers, Resolution, non-null custom fields block, and Transitions table. Extended always implies fulltext.

## Test plan
- [ ] `make build` passes
- [ ] `make test` passes (all existing + new tests)
- [ ] `make lint` clean (no new issues)
- [ ] `jtk issues fields MON-4810` shows field values
- [ ] `jtk issues fields MON-4810 --custom-fields` shows only custom fields
- [ ] `jtk issues field-options MON-4810 customfield_10050` works for read-only fields
- [ ] `jtk issues archive MON-XXXX` archives an issue
- [ ] `jtk issues get MON-4810 --extended` shows all new sections

Closes #282