### PR TITLE
feat(jtk): fix automation list/get output format and wire --id/--extended flags

### DIFF
--- a/tools/jtk/api/automation_types.go
+++ b/tools/jtk/api/automation_types.go
@@ -25,6 +25,8 @@ type AutomationRule struct {
 	Labels          []string        `json:"labels,omitempty"`
 	Tags            []string        `json:"tags,omitempty"`
 	Projects        []RuleProject   `json:"projects,omitempty"`
+	Created         string          `json:"created,omitempty"`
+	Updated         string          `json:"updated,omitempty"`
 	Trigger         *RuleComponent  `json:"trigger,omitempty"`
 	Components      []RuleComponent `json:"components,omitempty"`
 
@@ -89,6 +91,8 @@ type AutomationRuleSummary struct {
 	Labels          []string      `json:"labels,omitempty"`
 	Tags            []string      `json:"tags,omitempty"`
 	Projects        []RuleProject `json:"projects,omitempty"`
+	Created         string        `json:"created,omitempty"`
+	Updated         string        `json:"updated,omitempty"`
 	RuleScopeARIs   []string      `json:"ruleScopeARIs,omitempty"`
 }
 

--- a/tools/jtk/internal/cmd/automation/get.go
+++ b/tools/jtk/internal/cmd/automation/get.go
@@ -2,11 +2,9 @@ package automation
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
@@ -22,13 +20,14 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Short: "Get automation rule details",
 		Long: `Retrieve and display details for a specific automation rule.
 
-Shows rule metadata and a summary of components. Use --show-components to see
-component type details. Use --extended for additional fields (description,
-labels, tags).
+Shows rule identifier, name, state, components summary, and description.
+Use --show-components to see component type details.
+Use --extended for additional fields (labels, tags, author, scope, timestamps).
 
 For the exact JSON needed for editing, use 'jtk auto export' instead.`,
 		Example: `  jtk automation get 12345
-  jtk auto get 12345 --show-components`,
+  jtk auto get 12345 --show-components
+  jtk auto get 12345 --extended`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(cmd.Context(), opts, args[0], showComponents)
@@ -53,13 +52,28 @@ func runGet(ctx context.Context, opts *root.Options, ruleID string, showComponen
 		return err
 	}
 
+	if opts.EmitIDOnly() {
+		return jtkpresent.EmitIDs(opts, []string{rule.Identifier()})
+	}
+
 	if v.Format == view.FormatJSON {
 		return v.RenderArtifact(jtkartifact.ProjectAutomationRule(rule, opts.ArtifactMode()))
 	}
 
-	model := jtkpresent.AutomationPresenter{}.PresentDetail(rule, showComponents)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	presenter := jtkpresent.AutomationPresenter{}
+
+	if opts.IsExtended() {
+		authorName := ""
+		if rule.AuthorAccountID != "" {
+			user, err := client.GetUser(ctx, rule.AuthorAccountID, "")
+			if err == nil && user.DisplayName != "" {
+				authorName = user.DisplayName
+			} else {
+				authorName = rule.AuthorAccountID
+			}
+		}
+		return jtkpresent.Emit(opts, presenter.PresentGetDetailExtended(rule, showComponents, authorName))
+	}
+
+	return jtkpresent.Emit(opts, presenter.PresentGetDetail(rule, showComponents))
 }

--- a/tools/jtk/internal/cmd/automation/get_test.go
+++ b/tools/jtk/internal/cmd/automation/get_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -75,12 +76,15 @@ func TestSummarizeComponents(t *testing.T) {
 func newGetTestServer(t *testing.T, rule api.AutomationRule) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/_edge/tenant_info" {
+		switch {
+		case r.URL.Path == "/_edge/tenant_info":
 			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
-			return
+		case strings.HasPrefix(r.URL.Path, "/gateway/api/automation/"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(rule)
+		default:
+			w.WriteHeader(http.StatusNotFound)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(rule)
 	}))
 }
 
@@ -188,6 +192,45 @@ func TestRunGet_Extended(t *testing.T) {
 	testutil.Contains(t, out, "Scope: project (MON, ON)")
 	testutil.Contains(t, out, "Created: 2023-12-04")
 	testutil.Contains(t, out, "Updated: 2026-03-15")
+}
+
+func TestRunGet_Extended_AuthorLookupFails(t *testing.T) {
+	rule := api.AutomationRule{
+		UUID:            "uuid-123",
+		Name:            "My Rule",
+		State:           "ENABLED",
+		AuthorAccountID: "acct-unknown",
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "issue.created"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+			return
+		}
+		if r.URL.Path == "/rest/api/3/user" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rule)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "uuid-123", false)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "Author: acct-unknown")
 }
 
 func TestRunGet_Extended_NoAuthor(t *testing.T) {

--- a/tools/jtk/internal/cmd/automation/get_test.go
+++ b/tools/jtk/internal/cmd/automation/get_test.go
@@ -190,6 +190,33 @@ func TestRunGet_Extended(t *testing.T) {
 	testutil.Contains(t, out, "Updated: 2026-03-15")
 }
 
+func TestRunGet_Extended_NoAuthor(t *testing.T) {
+	rule := api.AutomationRule{
+		UUID:  "uuid-123",
+		Name:  "My Rule",
+		State: "ENABLED",
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "issue.created"},
+		},
+	}
+
+	server := newGetTestServer(t, rule)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "uuid-123", false)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "Author: -")
+}
+
 func TestRunGet_ShowComponents(t *testing.T) {
 	rule := api.AutomationRule{
 		UUID:  "uuid-123",

--- a/tools/jtk/internal/cmd/automation/get_test.go
+++ b/tools/jtk/internal/cmd/automation/get_test.go
@@ -1,11 +1,17 @@
 package automation
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
 
@@ -26,7 +32,7 @@ func TestSummarizeComponents(t *testing.T) {
 			components: []api.RuleComponent{
 				{Component: "TRIGGER", Type: "jira.issue.create"},
 			},
-			want: "1 total — 1 trigger(s)",
+			want: "1 total — 1 triggers",
 		},
 		{
 			name: "all types",
@@ -35,7 +41,7 @@ func TestSummarizeComponents(t *testing.T) {
 				{Component: "CONDITION", Type: "jira.jql.condition"},
 				{Component: "ACTION", Type: "jira.issue.assign"},
 			},
-			want: "3 total — 1 trigger(s), 1 condition(s), 1 action(s)",
+			want: "3 total — 1 triggers, 1 conditions, 1 actions",
 		},
 		{
 			name: "multiple actions",
@@ -45,7 +51,7 @@ func TestSummarizeComponents(t *testing.T) {
 				{Component: "ACTION", Type: "jira.issue.transition"},
 				{Component: "ACTION", Type: "jira.issue.comment"},
 			},
-			want: "4 total — 1 trigger(s), 3 action(s)",
+			want: "4 total — 1 triggers, 3 actions",
 		},
 		{
 			name: "unknown component types ignored in breakdown",
@@ -53,7 +59,7 @@ func TestSummarizeComponents(t *testing.T) {
 				{Component: "TRIGGER", Type: "jira.issue.create"},
 				{Component: "BRANCH", Type: "jira.issue.branch"},
 			},
-			want: "2 total — 1 trigger(s)",
+			want: "2 total — 1 triggers",
 		},
 	}
 
@@ -64,4 +70,152 @@ func TestSummarizeComponents(t *testing.T) {
 			testutil.Equal(t, got, tt.want)
 		})
 	}
+}
+
+func newGetTestServer(t *testing.T, rule api.AutomationRule) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rule)
+	}))
+}
+
+func TestRunGet_Default(t *testing.T) {
+	rule := api.AutomationRule{
+		UUID:        "uuid-123",
+		Name:        "My Rule",
+		State:       "ENABLED",
+		Description: "Does stuff",
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "issue.created"},
+			{Component: "ACTION", Type: "assign.issue"},
+		},
+	}
+
+	server := newGetTestServer(t, rule)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "uuid-123", false)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "uuid-123  My Rule")
+	testutil.Contains(t, out, "State: ENABLED")
+	testutil.Contains(t, out, "Components:")
+	testutil.Contains(t, out, "Description: Does stuff")
+}
+
+func TestRunGet_IDOnly(t *testing.T) {
+	rule := api.AutomationRule{UUID: "uuid-123", Name: "My Rule", State: "ENABLED"}
+
+	server := newGetTestServer(t, rule)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "uuid-123", false)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "uuid-123")
+	testutil.NotContains(t, out, "My Rule")
+	testutil.NotContains(t, out, "State")
+}
+
+func TestRunGet_Extended(t *testing.T) {
+	rule := api.AutomationRule{
+		UUID:            "uuid-123",
+		Name:            "My Rule",
+		State:           "ENABLED",
+		Description:     "Does stuff",
+		Labels:          []string{"onboarding"},
+		Tags:            []string{"auto-create"},
+		AuthorAccountID: "acct-1",
+		Created:         "2023-12-04T10:00:00.000+0000",
+		Updated:         "2026-03-15T14:30:00.000+0000",
+		Projects:        []api.RuleProject{{ProjectKey: "MON"}, {ProjectKey: "ON"}},
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "issue.created"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+			return
+		}
+		if r.URL.Path == "/rest/api/3/user" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"accountId":"acct-1","displayName":"Rian Stockbower"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rule)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "uuid-123", false)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "uuid-123  My Rule")
+	testutil.Contains(t, out, "Labels: onboarding")
+	testutil.Contains(t, out, "Tags: auto-create")
+	testutil.Contains(t, out, "Author: Rian Stockbower")
+	testutil.Contains(t, out, "Scope: project (MON, ON)")
+	testutil.Contains(t, out, "Created: 2023-12-04")
+	testutil.Contains(t, out, "Updated: 2026-03-15")
+}
+
+func TestRunGet_ShowComponents(t *testing.T) {
+	rule := api.AutomationRule{
+		UUID:  "uuid-123",
+		Name:  "My Rule",
+		State: "ENABLED",
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "issue.created"},
+			{Component: "ACTION", Type: "assign.issue"},
+		},
+	}
+
+	server := newGetTestServer(t, rule)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "uuid-123", true)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "COMPONENT")
+	testutil.Contains(t, out, "TRIGGER")
+	testutil.Contains(t, out, "ACTION")
 }

--- a/tools/jtk/internal/cmd/automation/get_test.go
+++ b/tools/jtk/internal/cmd/automation/get_test.go
@@ -32,7 +32,7 @@ func TestSummarizeComponents(t *testing.T) {
 			components: []api.RuleComponent{
 				{Component: "TRIGGER", Type: "jira.issue.create"},
 			},
-			want: "1 total — 1 triggers",
+			want: "1 total — 1 trigger",
 		},
 		{
 			name: "all types",
@@ -41,7 +41,7 @@ func TestSummarizeComponents(t *testing.T) {
 				{Component: "CONDITION", Type: "jira.jql.condition"},
 				{Component: "ACTION", Type: "jira.issue.assign"},
 			},
-			want: "3 total — 1 triggers, 1 conditions, 1 actions",
+			want: "3 total — 1 trigger, 1 condition, 1 action",
 		},
 		{
 			name: "multiple actions",
@@ -51,7 +51,7 @@ func TestSummarizeComponents(t *testing.T) {
 				{Component: "ACTION", Type: "jira.issue.transition"},
 				{Component: "ACTION", Type: "jira.issue.comment"},
 			},
-			want: "4 total — 1 triggers, 3 actions",
+			want: "4 total — 1 trigger, 3 actions",
 		},
 		{
 			name: "unknown component types ignored in breakdown",
@@ -59,7 +59,7 @@ func TestSummarizeComponents(t *testing.T) {
 				{Component: "TRIGGER", Type: "jira.issue.create"},
 				{Component: "BRANCH", Type: "jira.issue.branch"},
 			},
-			want: "2 total — 1 triggers",
+			want: "2 total — 1 trigger",
 		},
 	}
 

--- a/tools/jtk/internal/cmd/automation/list.go
+++ b/tools/jtk/internal/cmd/automation/list.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/view"
+
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
@@ -56,7 +58,7 @@ func runList(ctx context.Context, opts *root.Options, state string) error {
 	}
 
 	v := opts.View()
-	if v.Format == "json" {
+	if v.Format == view.FormatJSON {
 		return v.JSON(rules)
 	}
 

--- a/tools/jtk/internal/cmd/automation/list.go
+++ b/tools/jtk/internal/cmd/automation/list.go
@@ -43,16 +43,16 @@ func runList(ctx context.Context, opts *root.Options, state string) error {
 		return err
 	}
 
-	if len(rules) == 0 {
-		return jtkpresent.Emit(opts, jtkpresent.AutomationPresenter{}.PresentEmpty())
-	}
-
 	if opts.EmitIDOnly() {
 		ids := make([]string, len(rules))
 		for i, r := range rules {
 			ids[i] = r.Identifier()
 		}
 		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	if len(rules) == 0 {
+		return jtkpresent.Emit(opts, jtkpresent.AutomationPresenter{}.PresentEmpty())
 	}
 
 	v := opts.View()

--- a/tools/jtk/internal/cmd/automation/list.go
+++ b/tools/jtk/internal/cmd/automation/list.go
@@ -2,13 +2,11 @@ package automation
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
-
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 )
@@ -21,7 +19,9 @@ func newListCmd(opts *root.Options) *cobra.Command {
 		Short: "List automation rules",
 		Long:  "List all automation rules with optional state filtering.",
 		Example: `  jtk automation list
-  jtk automation list --state ENABLED`,
+  jtk automation list --state ENABLED
+  jtk automation list --id
+  jtk automation list --extended`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runList(cmd.Context(), opts, strings.ToUpper(state))
 		},
@@ -44,21 +44,52 @@ func runList(ctx context.Context, opts *root.Options, state string) error {
 	}
 
 	if len(rules) == 0 {
-		model := jtkpresent.AutomationPresenter{}.PresentEmpty()
-		out := present.Render(model, opts.RenderStyle())
-		fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.AutomationPresenter{}.PresentEmpty())
 	}
 
-	if opts.Output == "json" {
-		v := opts.View()
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(rules))
+		for i, r := range rules {
+			ids[i] = r.Identifier()
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	v := opts.View()
+	if v.Format == "json" {
 		return v.JSON(rules)
 	}
 
-	model := jtkpresent.AutomationPresenter{}.PresentList(rules)
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	fmt.Fprint(opts.Stderr, out.Stderr)
+	if opts.IsExtended() {
+		authorNames := resolveAuthorNames(ctx, client, automationSummaryAuthorIDs(rules))
+		return jtkpresent.Emit(opts, jtkpresent.AutomationPresenter{}.PresentListExtended(rules, authorNames))
+	}
 
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.AutomationPresenter{}.PresentList(rules))
+}
+
+func automationSummaryAuthorIDs(rules []api.AutomationRuleSummary) []string {
+	seen := make(map[string]bool)
+	var ids []string
+	for _, r := range rules {
+		if r.AuthorAccountID != "" && !seen[r.AuthorAccountID] {
+			seen[r.AuthorAccountID] = true
+			ids = append(ids, r.AuthorAccountID)
+		}
+	}
+	return ids
+}
+
+func resolveAuthorNames(ctx context.Context, client *api.Client, accountIDs []string) map[string]string {
+	names := make(map[string]string, len(accountIDs))
+	for _, id := range accountIDs {
+		user, err := client.GetUser(ctx, id, "")
+		if err != nil {
+			continue
+		}
+		if user.DisplayName != "" {
+			names[id] = user.DisplayName
+		}
+	}
+	return names
 }

--- a/tools/jtk/internal/cmd/automation/list_test.go
+++ b/tools/jtk/internal/cmd/automation/list_test.go
@@ -126,6 +126,44 @@ func TestRunList_Extended(t *testing.T) {
 	testutil.Contains(t, out, "auto-create")
 }
 
+func TestRunList_Extended_AuthorFallback(t *testing.T) {
+	rules := []api.AutomationRuleSummary{
+		{
+			UUID:            "uuid-1",
+			Name:            "Rule A",
+			State:           "ENABLED",
+			AuthorAccountID: "acct-unknown",
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+			return
+		}
+		if r.URL.Path == "/rest/api/3/user" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.AutomationRuleSummaryResponse{Data: rules})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "acct-unknown")
+}
+
 func TestRunList_IDOnly_Empty(t *testing.T) {
 	server := newListTestServer(t, nil)
 	defer server.Close()

--- a/tools/jtk/internal/cmd/automation/list_test.go
+++ b/tools/jtk/internal/cmd/automation/list_test.go
@@ -126,6 +126,24 @@ func TestRunList_Extended(t *testing.T) {
 	testutil.Contains(t, out, "auto-create")
 }
 
+func TestRunList_IDOnly_Empty(t *testing.T) {
+	server := newListTestServer(t, nil)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "")
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "" {
+		t.Errorf("--id with empty results should emit nothing, got %q", stdout.String())
+	}
+}
+
 func TestRunList_Empty(t *testing.T) {
 	server := newListTestServer(t, nil)
 	defer server.Close()

--- a/tools/jtk/internal/cmd/automation/list_test.go
+++ b/tools/jtk/internal/cmd/automation/list_test.go
@@ -1,0 +1,143 @@
+package automation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+func newListTestServer(t *testing.T, rules []api.AutomationRuleSummary) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.AutomationRuleSummaryResponse{Data: rules})
+	}))
+}
+
+func TestRunList_Default_ColumnOrder(t *testing.T) {
+	rules := []api.AutomationRuleSummary{
+		{UUID: "uuid-1", Name: "Rule A", State: "ENABLED"},
+		{UUID: "uuid-2", Name: "Rule B", State: "DISABLED"},
+	}
+
+	server := newListTestServer(t, rules)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "ID")
+	testutil.Contains(t, out, "STATE")
+	testutil.Contains(t, out, "NAME")
+	testutil.Contains(t, out, "uuid-1")
+	testutil.Contains(t, out, "ENABLED")
+	testutil.NotContains(t, out, "UUID")
+}
+
+func TestRunList_IDOnly(t *testing.T) {
+	rules := []api.AutomationRuleSummary{
+		{UUID: "uuid-1", Name: "Rule A", State: "ENABLED"},
+		{UUID: "uuid-2", Name: "Rule B", State: "DISABLED"},
+	}
+
+	server := newListTestServer(t, rules)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "uuid-1")
+	testutil.Contains(t, out, "uuid-2")
+	testutil.NotContains(t, out, "Rule A")
+	testutil.NotContains(t, out, "STATE")
+}
+
+func TestRunList_Extended(t *testing.T) {
+	rules := []api.AutomationRuleSummary{
+		{
+			UUID:            "uuid-1",
+			Name:            "Rule A",
+			State:           "ENABLED",
+			Labels:          []string{"onboarding"},
+			Tags:            []string{"auto-create"},
+			AuthorAccountID: "acct-1",
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+			return
+		}
+		if r.URL.Path == "/rest/api/3/user" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"accountId":"acct-1","displayName":"Rian Stockbower"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.AutomationRuleSummaryResponse{Data: rules})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "LABELS")
+	testutil.Contains(t, out, "TAGS")
+	testutil.Contains(t, out, "AUTHOR")
+	testutil.Contains(t, out, "Rian Stockbower")
+	testutil.Contains(t, out, "onboarding")
+	testutil.Contains(t, out, "auto-create")
+}
+
+func TestRunList_Empty(t *testing.T) {
+	server := newListTestServer(t, nil)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "No automation rules found")
+}

--- a/tools/jtk/internal/present/automation.go
+++ b/tools/jtk/internal/present/automation.go
@@ -218,23 +218,134 @@ func (AutomationPresenter) PresentEmpty() *present.OutputModel {
 	}
 }
 
-// PresentList creates a table view of automation rules.
+// PresentList creates a table view of automation rules: ID | STATE | NAME.
 func (AutomationPresenter) PresentList(rules []api.AutomationRuleSummary) *present.OutputModel {
 	rows := make([]present.Row, len(rules))
 	for i, r := range rules {
 		rows[i] = present.Row{
-			Cells: []string{r.Identifier(), r.Name, r.State},
+			Cells: []string{r.Identifier(), r.State, r.Name},
 		}
 	}
 
 	return &present.OutputModel{
 		Sections: []present.Section{
 			&present.TableSection{
-				Headers: []string{"UUID", "NAME", "STATE"},
+				Headers: []string{"ID", "STATE", "NAME"},
 				Rows:    rows,
 			},
 		},
 	}
+}
+
+// PresentListExtended creates an extended table: ID | STATE | LABELS | TAGS | AUTHOR | NAME.
+// authorNames maps AuthorAccountID → display name; missing entries render as the raw account ID.
+func (AutomationPresenter) PresentListExtended(rules []api.AutomationRuleSummary, authorNames map[string]string) *present.OutputModel {
+	rows := make([]present.Row, len(rules))
+	for i, r := range rules {
+		labels := OrDash(strings.Join(r.Labels, ", "))
+		tags := OrDash(strings.Join(r.Tags, ", "))
+		author := resolveAuthor(r.AuthorAccountID, authorNames)
+		rows[i] = present.Row{
+			Cells: []string{r.Identifier(), r.State, labels, tags, author, r.Name},
+		}
+	}
+
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "STATE", "LABELS", "TAGS", "AUTHOR", "NAME"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentGetDetail creates the get-specific detail view with header line + KV rows.
+func (AutomationPresenter) PresentGetDetail(rule *api.AutomationRule, showComponents bool) *present.OutputModel {
+	sections := []present.Section{
+		msg(fmt.Sprintf("%s  %s", rule.Identifier(), rule.Name)),
+		msg(fmt.Sprintf("State: %s", rule.State)),
+		msg(fmt.Sprintf("Components: %s", SummarizeComponents(rule.Components))),
+	}
+
+	if rule.Description != "" {
+		sections = append(sections, msg(fmt.Sprintf("Description: %s", rule.Description)))
+	}
+
+	if showComponents && len(rule.Components) > 0 {
+		sections = append(sections, componentTable(rule.Components))
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// PresentGetDetailExtended creates the extended detail view, adding Labels, Tags,
+// Author, Scope, Created, Updated on top of the default get layout.
+func (AutomationPresenter) PresentGetDetailExtended(rule *api.AutomationRule, showComponents bool, authorName string) *present.OutputModel {
+	sections := []present.Section{
+		msg(fmt.Sprintf("%s  %s", rule.Identifier(), rule.Name)),
+		msg(fmt.Sprintf("State: %s", rule.State)),
+		msg(fmt.Sprintf("Components: %s", SummarizeComponents(rule.Components))),
+	}
+
+	if rule.Description != "" {
+		sections = append(sections, msg(fmt.Sprintf("Description: %s", rule.Description)))
+	}
+
+	sections = append(sections, msg(fmt.Sprintf("Labels: %s", OrDash(strings.Join(rule.Labels, ", ")))))
+	sections = append(sections, msg(fmt.Sprintf("Tags: %s", OrDash(strings.Join(rule.Tags, ", ")))))
+	sections = append(sections, msg(fmt.Sprintf("Author: %s", OrDash(authorName))))
+	sections = append(sections, msg(fmt.Sprintf("Scope: %s", automationScope(rule))))
+	sections = append(sections, msg(fmt.Sprintf("Created: %s   Updated: %s", OrDash(FormatTime(rule.Created)), OrDash(FormatTime(rule.Updated)))))
+
+	if showComponents && len(rule.Components) > 0 {
+		sections = append(sections, componentTable(rule.Components))
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+func componentTable(components []api.RuleComponent) *present.TableSection {
+	rows := make([]present.Row, len(components))
+	for i, c := range components {
+		rows[i] = present.Row{
+			Cells: []string{fmt.Sprintf("%d", i+1), c.Component, c.Type},
+		}
+	}
+	return &present.TableSection{
+		Headers: []string{"#", "COMPONENT", "TYPE"},
+		Rows:    rows,
+	}
+}
+
+func automationScope(rule *api.AutomationRule) string {
+	if len(rule.Projects) > 0 {
+		keys := make([]string, 0, len(rule.Projects))
+		for _, p := range rule.Projects {
+			if p.ProjectKey != "" {
+				keys = append(keys, p.ProjectKey)
+			} else if p.ProjectName != "" {
+				keys = append(keys, p.ProjectName)
+			}
+		}
+		if len(keys) > 0 {
+			return fmt.Sprintf("project (%s)", strings.Join(keys, ", "))
+		}
+	}
+	if len(rule.RuleScopeARIs) > 0 {
+		return "scoped"
+	}
+	return "global"
+}
+
+func resolveAuthor(accountID string, authorNames map[string]string) string {
+	if accountID == "" {
+		return "-"
+	}
+	if name, ok := authorNames[accountID]; ok {
+		return name
+	}
+	return accountID
 }
 
 // SummarizeComponents creates a compact summary of rule components.
@@ -258,13 +369,13 @@ func SummarizeComponents(components []api.RuleComponent) string {
 
 	parts := make([]string, 0, 3)
 	if triggers > 0 {
-		parts = append(parts, fmt.Sprintf("%d trigger(s)", triggers))
+		parts = append(parts, fmt.Sprintf("%d triggers", triggers))
 	}
 	if conditions > 0 {
-		parts = append(parts, fmt.Sprintf("%d condition(s)", conditions))
+		parts = append(parts, fmt.Sprintf("%d conditions", conditions))
 	}
 	if actions > 0 {
-		parts = append(parts, fmt.Sprintf("%d action(s)", actions))
+		parts = append(parts, fmt.Sprintf("%d actions", actions))
 	}
 
 	return fmt.Sprintf("%d total — %s", len(components), strings.Join(parts, ", "))

--- a/tools/jtk/internal/present/automation.go
+++ b/tools/jtk/internal/present/automation.go
@@ -319,18 +319,16 @@ func componentTable(components []api.RuleComponent) *present.TableSection {
 }
 
 func automationScope(rule *api.AutomationRule) string {
-	if len(rule.Projects) > 0 {
-		keys := make([]string, 0, len(rule.Projects))
-		for _, p := range rule.Projects {
-			if p.ProjectKey != "" {
-				keys = append(keys, p.ProjectKey)
-			} else if p.ProjectName != "" {
-				keys = append(keys, p.ProjectName)
-			}
+	keys := make([]string, 0, len(rule.Projects))
+	for _, p := range rule.Projects {
+		if p.ProjectKey != "" {
+			keys = append(keys, p.ProjectKey)
+		} else if p.ProjectName != "" {
+			keys = append(keys, p.ProjectName)
 		}
-		if len(keys) > 0 {
-			return fmt.Sprintf("project (%s)", strings.Join(keys, ", "))
-		}
+	}
+	if len(keys) > 0 {
+		return fmt.Sprintf("project (%s)", strings.Join(keys, ", "))
 	}
 	if len(rule.RuleScopeARIs) > 0 {
 		return "scoped"

--- a/tools/jtk/internal/present/automation.go
+++ b/tools/jtk/internal/present/automation.go
@@ -338,6 +338,13 @@ func automationScope(rule *api.AutomationRule) string {
 	return "global"
 }
 
+func pluralize(word string, count int) string {
+	if count == 1 {
+		return word
+	}
+	return word + "s"
+}
+
 func resolveAuthor(accountID string, authorNames map[string]string) string {
 	if accountID == "" {
 		return "-"
@@ -369,13 +376,13 @@ func SummarizeComponents(components []api.RuleComponent) string {
 
 	parts := make([]string, 0, 3)
 	if triggers > 0 {
-		parts = append(parts, fmt.Sprintf("%d triggers", triggers))
+		parts = append(parts, fmt.Sprintf("%d %s", triggers, pluralize("trigger", triggers)))
 	}
 	if conditions > 0 {
-		parts = append(parts, fmt.Sprintf("%d conditions", conditions))
+		parts = append(parts, fmt.Sprintf("%d %s", conditions, pluralize("condition", conditions)))
 	}
 	if actions > 0 {
-		parts = append(parts, fmt.Sprintf("%d actions", actions))
+		parts = append(parts, fmt.Sprintf("%d %s", actions, pluralize("action", actions)))
 	}
 
 	return fmt.Sprintf("%d total — %s", len(components), strings.Join(parts, ", "))

--- a/tools/jtk/internal/present/automation_test.go
+++ b/tools/jtk/internal/present/automation_test.go
@@ -158,7 +158,7 @@ func TestSummarizeComponents(t *testing.T) {
 				{Component: "ACTION"},
 				{Component: "ACTION"},
 			},
-			want: "6 total — 1 triggers, 2 conditions, 3 actions",
+			want: "6 total — 1 trigger, 2 conditions, 3 actions",
 		},
 	}
 

--- a/tools/jtk/internal/present/automation_test.go
+++ b/tools/jtk/internal/present/automation_test.go
@@ -61,9 +61,8 @@ func TestAutomationPresenter_PresentDetail_WithComponents(t *testing.T) {
 	}
 
 	p := AutomationPresenter{}
-	model := p.PresentDetail(rule, true) // showComponents=true
+	model := p.PresentDetail(rule, true)
 
-	// Should have 2 sections: detail + component table
 	if len(model.Sections) != 2 {
 		t.Fatalf("expected 2 sections with components, got %d", len(model.Sections))
 	}
@@ -83,7 +82,6 @@ func TestAutomationPresenter_PresentUpdateComplete(t *testing.T) {
 	p := AutomationPresenter{}
 	model := p.PresentUpdateComplete("My Rule", "uuid-123", "ENABLED", "456")
 
-	// Should have 2 sections: progress (stderr) + success (stdout)
 	if len(model.Sections) != 2 {
 		t.Fatalf("expected 2 sections, got %d", len(model.Sections))
 	}
@@ -114,11 +112,11 @@ func TestAutomationPresenter_PresentStateChanged(t *testing.T) {
 		t.Fatalf("expected 1 section, got %d", len(model.Sections))
 	}
 
-	msg := model.Sections[0].(*present.MessageSection)
-	if msg.Kind != present.MessageSuccess {
-		t.Errorf("expected success, got %v", msg.Kind)
+	msgSec := model.Sections[0].(*present.MessageSection)
+	if msgSec.Kind != present.MessageSuccess {
+		t.Errorf("expected success, got %v", msgSec.Kind)
 	}
-	if msg.Stream != present.StreamStdout {
+	if msgSec.Stream != present.StreamStdout {
 		t.Errorf("state change should go to stdout")
 	}
 }
@@ -128,11 +126,11 @@ func TestAutomationPresenter_PresentNoChange(t *testing.T) {
 	p := AutomationPresenter{}
 	model := p.PresentNoChange("My Rule", "ENABLED")
 
-	msg := model.Sections[0].(*present.MessageSection)
-	if msg.Kind != present.MessageInfo {
-		t.Errorf("expected info for no-change, got %v", msg.Kind)
+	msgSec := model.Sections[0].(*present.MessageSection)
+	if msgSec.Kind != present.MessageInfo {
+		t.Errorf("expected info for no-change, got %v", msgSec.Kind)
 	}
-	if msg.Stream != present.StreamStderr {
+	if msgSec.Stream != present.StreamStderr {
 		t.Errorf("no-change should go to stderr (advisory)")
 	}
 }
@@ -160,7 +158,7 @@ func TestSummarizeComponents(t *testing.T) {
 				{Component: "ACTION"},
 				{Component: "ACTION"},
 			},
-			want: "6 total — 1 trigger(s), 2 condition(s), 3 action(s)",
+			want: "6 total — 1 triggers, 2 conditions, 3 actions",
 		},
 	}
 
@@ -169,6 +167,204 @@ func TestSummarizeComponents(t *testing.T) {
 			got := SummarizeComponents(tt.components)
 			if got != tt.want {
 				t.Errorf("SummarizeComponents() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAutomationPresenter_PresentList_ColumnOrder(t *testing.T) {
+	t.Parallel()
+	rules := []api.AutomationRuleSummary{
+		{UUID: "uuid-1", Name: "Rule A", State: "ENABLED"},
+		{UUID: "uuid-2", Name: "Rule B", State: "DISABLED"},
+	}
+
+	model := AutomationPresenter{}.PresentList(rules)
+	table := model.Sections[0].(*present.TableSection)
+
+	wantHeaders := []string{"ID", "STATE", "NAME"}
+	for i, h := range wantHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d] = %q, want %q", i, table.Headers[i], h)
+		}
+	}
+	if table.Rows[0].Cells[0] != "uuid-1" {
+		t.Errorf("first cell should be ID, got %q", table.Rows[0].Cells[0])
+	}
+	if table.Rows[0].Cells[1] != "ENABLED" {
+		t.Errorf("second cell should be STATE, got %q", table.Rows[0].Cells[1])
+	}
+	if table.Rows[0].Cells[2] != "Rule A" {
+		t.Errorf("third cell should be NAME, got %q", table.Rows[0].Cells[2])
+	}
+}
+
+func TestAutomationPresenter_PresentListExtended(t *testing.T) {
+	t.Parallel()
+	rules := []api.AutomationRuleSummary{
+		{
+			UUID:            "uuid-1",
+			Name:            "Rule A",
+			State:           "ENABLED",
+			Labels:          []string{"onboarding"},
+			Tags:            []string{"auto-create"},
+			AuthorAccountID: "acct-1",
+		},
+		{
+			UUID:  "uuid-2",
+			Name:  "Rule B",
+			State: "DISABLED",
+		},
+	}
+
+	authorNames := map[string]string{"acct-1": "Rian Stockbower"}
+	model := AutomationPresenter{}.PresentListExtended(rules, authorNames)
+	table := model.Sections[0].(*present.TableSection)
+
+	wantHeaders := []string{"ID", "STATE", "LABELS", "TAGS", "AUTHOR", "NAME"}
+	for i, h := range wantHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d] = %q, want %q", i, table.Headers[i], h)
+		}
+	}
+
+	if table.Rows[0].Cells[4] != "Rian Stockbower" {
+		t.Errorf("author should be resolved, got %q", table.Rows[0].Cells[4])
+	}
+	if table.Rows[1].Cells[2] != "-" {
+		t.Errorf("empty labels should be dash, got %q", table.Rows[1].Cells[2])
+	}
+}
+
+func TestAutomationPresenter_PresentGetDetail(t *testing.T) {
+	t.Parallel()
+	rule := &api.AutomationRule{
+		UUID:        "uuid-123",
+		Name:        "My Rule",
+		State:       "ENABLED",
+		Description: "Does stuff",
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "issue.created"},
+			{Component: "ACTION", Type: "assign.issue"},
+		},
+	}
+
+	model := AutomationPresenter{}.PresentGetDetail(rule, false)
+
+	// Header + State + Components + Description = 4 message sections
+	if len(model.Sections) != 4 {
+		t.Fatalf("expected 4 sections, got %d", len(model.Sections))
+	}
+
+	header := model.Sections[0].(*present.MessageSection)
+	if header.Message != "uuid-123  My Rule" {
+		t.Errorf("header = %q", header.Message)
+	}
+
+	state := model.Sections[1].(*present.MessageSection)
+	if state.Message != "State: ENABLED" {
+		t.Errorf("state = %q", state.Message)
+	}
+}
+
+func TestAutomationPresenter_PresentGetDetail_ShowComponents(t *testing.T) {
+	t.Parallel()
+	rule := &api.AutomationRule{
+		UUID:  "uuid-123",
+		Name:  "My Rule",
+		State: "ENABLED",
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "issue.created"},
+			{Component: "ACTION", Type: "assign.issue"},
+		},
+	}
+
+	model := AutomationPresenter{}.PresentGetDetail(rule, true)
+
+	// Header + State + Components + component table = 4
+	// (no description, so 3 msg sections + 1 table)
+	if len(model.Sections) != 4 {
+		t.Fatalf("expected 4 sections (3 msg + table), got %d", len(model.Sections))
+	}
+
+	table, ok := model.Sections[3].(*present.TableSection)
+	if !ok {
+		t.Fatalf("expected TableSection at [3], got %T", model.Sections[3])
+	}
+	if len(table.Rows) != 2 {
+		t.Errorf("expected 2 component rows, got %d", len(table.Rows))
+	}
+}
+
+func TestAutomationPresenter_PresentGetDetailExtended(t *testing.T) {
+	t.Parallel()
+	rule := &api.AutomationRule{
+		UUID:        "uuid-123",
+		Name:        "My Rule",
+		State:       "ENABLED",
+		Description: "Does stuff",
+		Labels:      []string{"onboarding"},
+		Tags:        []string{"auto-create"},
+		Created:     "2023-12-04T10:00:00.000+0000",
+		Updated:     "2026-03-15T14:30:00.000+0000",
+		Projects: []api.RuleProject{
+			{ProjectKey: "MON"},
+			{ProjectKey: "ON"},
+		},
+		Components: []api.RuleComponent{
+			{Component: "TRIGGER", Type: "issue.created"},
+		},
+	}
+
+	model := AutomationPresenter{}.PresentGetDetailExtended(rule, false, "Rian Stockbower")
+
+	// Header + State + Components + Description + Labels + Tags + Author + Scope + Created/Updated = 9
+	if len(model.Sections) != 9 {
+		t.Fatalf("expected 9 sections, got %d", len(model.Sections))
+	}
+
+	// Check scope
+	scope := model.Sections[7].(*present.MessageSection)
+	if scope.Message != "Scope: project (MON, ON)" {
+		t.Errorf("scope = %q", scope.Message)
+	}
+
+	// Check timestamps
+	timestamps := model.Sections[8].(*present.MessageSection)
+	if timestamps.Message != "Created: 2023-12-04   Updated: 2026-03-15" {
+		t.Errorf("timestamps = %q", timestamps.Message)
+	}
+}
+
+func TestAutomationScope(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		rule *api.AutomationRule
+		want string
+	}{
+		{
+			name: "projects",
+			rule: &api.AutomationRule{Projects: []api.RuleProject{{ProjectKey: "MON"}, {ProjectKey: "ON"}}},
+			want: "project (MON, ON)",
+		},
+		{
+			name: "ARIs",
+			rule: &api.AutomationRule{RuleScopeARIs: []string{"ari:cloud:jira::site/123"}},
+			want: "scoped",
+		},
+		{
+			name: "global",
+			rule: &api.AutomationRule{},
+			want: "global",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := automationScope(tt.rule)
+			if got != tt.want {
+				t.Errorf("automationScope() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #283

## Summary
- Reorder `automation list` columns to ID|STATE|NAME (was UUID|NAME|STATE)
- Wire `--id` flag for both list and get (one ID per line)
- Wire `--extended` for list (adds LABELS, TAGS, AUTHOR columns with live user resolution)
- Add get-specific detail format: header line (ID + Name) + KV rows, matching issue/project pattern
- Extended get adds Labels, Tags, Author, Scope, Created, Updated
- Fix `SummarizeComponents` pluralization: "conditions" not "condition(s)"
- Add `Created`/`Updated` typed fields to automation API types
- Preserve `--show-components` in both default and extended paths
- Use `Emit` helpers consistently instead of manual `Render`+`Fprint`

## Test plan
- [ ] `jtk automation list` shows ID|STATE|NAME columns
- [ ] `jtk automation list --id` shows one UUID per line
- [ ] `jtk automation list --extended` shows LABELS, TAGS, AUTHOR columns
- [ ] `jtk automation get <id>` shows header line format
- [ ] `jtk automation get <id> --id` shows UUID only
- [ ] `jtk automation get <id> --extended` shows Labels, Tags, Author, Scope, Created, Updated
- [ ] `jtk automation get <id> --show-components` still works
- [ ] `make test` passes
- [ ] `make lint` passes (jtk clean)