### PR TITLE
feat(jtk): fix dashboards list/gadgets output and wire --id/--extended flags

### DIFF
--- a/tools/jtk/api/dashboards.go
+++ b/tools/jtk/api/dashboards.go
@@ -23,7 +23,19 @@ type Dashboard struct {
 
 // SharePerm represents a dashboard sharing permission
 type SharePerm struct {
-	Type string `json:"type"` // "global", "project", "group", etc.
+	Type    string            `json:"type"`
+	Group   *SharePermGroup   `json:"group,omitempty"`
+	Project *SharePermProject `json:"project,omitempty"`
+}
+
+// SharePermGroup identifies a group in a sharing permission.
+type SharePermGroup struct {
+	Name string `json:"name"`
+}
+
+// SharePermProject identifies a project in a sharing permission.
+type SharePermProject struct {
+	Key string `json:"key"`
 }
 
 // DashboardGadget represents a gadget on a dashboard

--- a/tools/jtk/internal/cmd/dashboards/dashboards.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards.go
@@ -70,7 +70,7 @@ Use --extended for additional fields (rank, permissions).`,
 	return cmd
 }
 
-func runList(ctx context.Context, opts *root.Options, search string, maxResults int) error {
+func runList(_ context.Context, opts *root.Options, search string, maxResults int) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -110,8 +110,7 @@ func runList(ctx context.Context, opts *root.Options, search string, maxResults 
 		return v.JSON(dashboards)
 	}
 
-	// Fetch gadget counts — sequential because dashboard API methods use internal context.
-	gadgetCounts := fetchGadgetCounts(ctx, client, dashboards)
+	gadgetCounts := fetchGadgetCounts(client, dashboards)
 
 	presenter := jtkpresent.DashboardPresenter{}
 	if opts.IsExtended() {
@@ -121,9 +120,11 @@ func runList(ctx context.Context, opts *root.Options, search string, maxResults 
 	return jtkpresent.Emit(opts, presenter.PresentList(dashboards, gadgetCounts))
 }
 
-// fetchGadgetCounts fetches gadget counts for each dashboard. Errors on individual
-// fetches are silently skipped (missing key renders as "-" in the presenter).
-func fetchGadgetCounts(_ context.Context, client *api.Client, dashboards []api.Dashboard) map[string]int {
+// fetchGadgetCounts fetches gadget counts for each dashboard sequentially.
+// Dashboard API methods use internal context.Background(); cancellation support
+// deferred until those methods accept context.Context.
+// Errors on individual fetches are silently skipped (missing key renders as "-").
+func fetchGadgetCounts(client *api.Client, dashboards []api.Dashboard) map[string]int {
 	counts := make(map[string]int, len(dashboards))
 	for _, d := range dashboards {
 		resp, err := client.GetDashboardGadgets(d.ID)

--- a/tools/jtk/internal/cmd/dashboards/dashboards.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -54,10 +53,12 @@ func newListCmd(opts *root.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List dashboards",
-		Long:  "List accessible dashboards. Use --search to filter by name.",
+		Long: `List accessible dashboards. Use --search to filter by name.
+Use --extended for additional fields (rank, permissions).`,
 		Example: `  jtk dashboards list
   jtk dashboards list --search "Sprint"
-  jtk dashboards list --max 10`,
+  jtk dashboards list --max 10
+  jtk dashboards list --extended`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runList(cmd.Context(), opts, search, maxResults)
 		},
@@ -69,7 +70,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
 	return cmd
 }
 
-func runList(_ context.Context, opts *root.Options, search string, maxResults int) error {
+func runList(ctx context.Context, opts *root.Options, search string, maxResults int) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -93,23 +94,45 @@ func runList(_ context.Context, opts *root.Options, search string, maxResults in
 		dashboards = result.Dashboards
 	}
 
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(dashboards))
+		for i, d := range dashboards {
+			ids[i] = d.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
 	if len(dashboards) == 0 {
-		model := jtkpresent.DashboardPresenter{}.PresentEmpty()
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.DashboardPresenter{}.PresentEmpty())
 	}
 
 	if v.Format == view.FormatJSON {
 		return v.JSON(dashboards)
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.DashboardPresenter{}.PresentList(dashboards)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	// Fetch gadget counts — sequential because dashboard API methods use internal context.
+	gadgetCounts := fetchGadgetCounts(ctx, client, dashboards)
+
+	presenter := jtkpresent.DashboardPresenter{}
+	if opts.IsExtended() {
+		return jtkpresent.Emit(opts, presenter.PresentListExtended(dashboards, gadgetCounts))
+	}
+
+	return jtkpresent.Emit(opts, presenter.PresentList(dashboards, gadgetCounts))
+}
+
+// fetchGadgetCounts fetches gadget counts for each dashboard. Errors on individual
+// fetches are silently skipped (missing key renders as "-" in the presenter).
+func fetchGadgetCounts(_ context.Context, client *api.Client, dashboards []api.Dashboard) map[string]int {
+	counts := make(map[string]int, len(dashboards))
+	for _, d := range dashboards {
+		resp, err := client.GetDashboardGadgets(d.ID)
+		if err != nil {
+			continue
+		}
+		counts[d.ID] = len(resp.Gadgets)
+	}
+	return counts
 }
 
 func newGetCmd(opts *root.Options) *cobra.Command {
@@ -140,7 +163,6 @@ func runGet(_ context.Context, opts *root.Options, dashboardID string) error {
 		return err
 	}
 
-	// Also get gadgets
 	gadgetsResp, err := client.GetDashboardGadgets(dashboardID)
 	if err != nil {
 		return fmt.Errorf("failed to get gadgets: %w", err)
@@ -153,12 +175,8 @@ func runGet(_ context.Context, opts *root.Options, dashboardID string) error {
 		})
 	}
 
-	// Text path: presenter → render → write
 	model := jtkpresent.DashboardPresenter{}.PresentDetail(dash, gadgetsResp.Gadgets)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, model)
 }
 
 func newCreateCmd(opts *root.Options) *cobra.Command {
@@ -211,7 +229,8 @@ func runCreate(opts *root.Options, name, description string) error {
 		return v.JSON(dash)
 	}
 
-	return jtkpresent.Emit(opts, jtkpresent.DashboardPresenter{}.PresentList([]api.Dashboard{*dash}))
+	counts := map[string]int{dash.ID: 0}
+	return jtkpresent.Emit(opts, jtkpresent.DashboardPresenter{}.PresentList([]api.Dashboard{*dash}, counts))
 }
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {
@@ -239,10 +258,7 @@ func runDelete(opts *root.Options, dashboardID string) error {
 		return err
 	}
 
-	model := jtkpresent.DashboardPresenter{}.PresentDeleted(dashboardID)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.DashboardPresenter{}.PresentDeleted(dashboardID))
 }
 
 func newGadgetsCmd(opts *root.Options) *cobra.Command {
@@ -287,23 +303,23 @@ func runGadgetsList(_ context.Context, opts *root.Options, dashboardID string) e
 		return err
 	}
 
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(result.Gadgets))
+		for i, g := range result.Gadgets {
+			ids[i] = strconv.Itoa(g.ID)
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
 	if len(result.Gadgets) == 0 {
-		model := jtkpresent.DashboardPresenter{}.PresentNoGadgets(dashboardID)
-		out := present.Render(model, opts.RenderStyle())
-		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-		return nil
+		return jtkpresent.Emit(opts, jtkpresent.DashboardPresenter{}.PresentNoGadgets(dashboardID))
 	}
 
 	if v.Format == view.FormatJSON {
 		return v.JSON(result.Gadgets)
 	}
 
-	// Text path: presenter → render → write
-	model := jtkpresent.DashboardPresenter{}.PresentGadgets(result.Gadgets)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.DashboardPresenter{}.PresentGadgets(result.Gadgets))
 }
 
 func newGadgetsAddCmd(opts *root.Options) *cobra.Command {
@@ -412,8 +428,5 @@ func runGadgetsRemove(opts *root.Options, dashboardID string, gadgetID int) erro
 		return err
 	}
 
-	model := jtkpresent.DashboardPresenter{}.PresentGadgetRemoved(gadgetID, dashboardID)
-	out := present.Render(model, opts.RenderStyle())
-	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.DashboardPresenter{}.PresentGadgetRemoved(gadgetID, dashboardID))
 }

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -86,11 +86,20 @@ func TestRunList_ColumnOrder(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	out := stdout.String()
-	testutil.Contains(t, out, "ID")
-	testutil.Contains(t, out, "GADGETS")
-	testutil.Contains(t, out, "OWNER")
-	testutil.Contains(t, out, "FAVOURITE")
-	testutil.Contains(t, out, "NAME")
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+
+	header := lines[0]
+	idIdx := strings.Index(header, "ID")
+	gadgetsIdx := strings.Index(header, "GADGETS")
+	ownerIdx := strings.Index(header, "OWNER")
+	favIdx := strings.Index(header, "FAVOURITE")
+	nameIdx := strings.Index(header, "NAME")
+	testutil.True(t, idIdx < gadgetsIdx, "ID before GADGETS")
+	testutil.True(t, gadgetsIdx < ownerIdx, "GADGETS before OWNER")
+	testutil.True(t, ownerIdx < favIdx, "OWNER before FAVOURITE")
+	testutil.True(t, favIdx < nameIdx, "FAVOURITE before NAME")
+
 	testutil.Contains(t, out, "10001")
 	testutil.Contains(t, out, "2")
 	testutil.Contains(t, out, "Alice")
@@ -115,11 +124,7 @@ func TestRunList_IDOnly(t *testing.T) {
 	err = runList(context.Background(), opts, "", 50)
 	testutil.RequireNoError(t, err)
 
-	out := stdout.String()
-	testutil.Contains(t, out, "10001")
-	testutil.Contains(t, out, "10002")
-	testutil.NotContains(t, out, "Sprint Board")
-	testutil.NotContains(t, out, "GADGETS")
+	testutil.Equal(t, stdout.String(), "10001\n10002\n")
 }
 
 func TestRunList_IDOnly_Empty(t *testing.T) {
@@ -433,12 +438,17 @@ func TestRunGadgetsList_ColumnOrder(t *testing.T) {
 
 	out := stdout.String()
 	lines := strings.Split(strings.TrimSpace(out), "\n")
-	testutil.True(t, len(lines) >= 1, "expected at least header")
-	testutil.Contains(t, lines[0], "ID")
-	testutil.Contains(t, lines[0], "POSITION")
-	testutil.Contains(t, lines[0], "TITLE")
-	testutil.Contains(t, lines[0], "TYPE")
-	testutil.NotContains(t, lines[0], "MODULE")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+
+	header := lines[0]
+	idIdx := strings.Index(header, "ID")
+	posIdx := strings.Index(header, "POSITION")
+	titleIdx := strings.Index(header, "TITLE")
+	typeIdx := strings.Index(header, "TYPE")
+	testutil.True(t, idIdx < posIdx, "ID before POSITION")
+	testutil.True(t, posIdx < titleIdx, "POSITION before TITLE")
+	testutil.True(t, titleIdx < typeIdx, "TITLE before TYPE")
+	testutil.NotContains(t, header, "MODULE")
 	testutil.Contains(t, out, "0,0")
 }
 
@@ -463,11 +473,7 @@ func TestRunGadgetsList_IDOnly(t *testing.T) {
 	err = runGadgetsList(context.Background(), opts, "10001")
 	testutil.RequireNoError(t, err)
 
-	out := stdout.String()
-	testutil.Contains(t, out, "1")
-	testutil.Contains(t, out, "2")
-	testutil.NotContains(t, out, "Gadget A")
-	testutil.NotContains(t, out, "TITLE")
+	testutil.Equal(t, stdout.String(), "1\n2\n")
 }
 
 func TestRunGadgetsList_IDOnly_Empty(t *testing.T) {

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -226,11 +226,49 @@ func TestRunList_GadgetFetchFails(t *testing.T) {
 
 	out := stdout.String()
 	testutil.Contains(t, out, "Board")
-	// Gadget fetch failed → should show "-" not "0"
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	if len(lines) >= 2 {
-		testutil.NotContains(t, lines[1], " 0 ")
+	// Gadget fetch failed → GADGETS column should show "-" (unknown), not "0" (empty)
+	testutil.Contains(t, out, "-")
+}
+
+func TestRunList_IDTakesPrecedenceOverExtended(t *testing.T) {
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Board", Popularity: 5},
 	}
+	server := newListTestServer(t, dashboards, nil)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "10001\n")
+}
+
+func TestRunList_ExtendedJSON(t *testing.T) {
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Board", Popularity: 5},
+	}
+	server := newListTestServer(t, dashboards, nil)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50)
+	testutil.RequireNoError(t, err)
+
+	// JSON mode returns raw data regardless of --extended
+	testutil.Contains(t, stdout.String(), `"id"`)
+	testutil.NotContains(t, stdout.String(), "RANK")
 }
 
 func TestRunList_Search(t *testing.T) {

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -16,15 +16,41 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
-func TestRunList(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(api.DashboardsResponse{
-			Total: 1,
-			Dashboards: []api.Dashboard{
-				{ID: "10001", Name: "Sprint Board", Owner: &api.User{DisplayName: "Alice"}},
-			},
-		})
+func newListTestServer(t *testing.T, dashboards []api.Dashboard, gadgets map[string][]api.DashboardGadget) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/rest/api/3/dashboard" && r.URL.Query().Get("dashboardName") == "" {
+			_ = json.NewEncoder(w).Encode(api.DashboardsResponse{
+				Total:      len(dashboards),
+				Dashboards: dashboards,
+			})
+			return
+		}
+
+		for id, gs := range gadgets {
+			if r.URL.Path == "/rest/api/3/dashboard/"+id+"/gadget" {
+				_ = json.NewEncoder(w).Encode(api.DashboardGadgetsResponse{Gadgets: gs})
+				return
+			}
+		}
+
+		// Default: empty gadgets for any dashboard gadget request
+		if strings.Contains(r.URL.Path, "/gadget") {
+			_ = json.NewEncoder(w).Encode(api.DashboardGadgetsResponse{})
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
 	}))
+}
+
+func TestRunList(t *testing.T) {
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Sprint Board", Owner: &api.User{DisplayName: "Alice"}},
+	}
+	server := newListTestServer(t, dashboards, nil)
 	defer server.Close()
 
 	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
@@ -39,15 +65,187 @@ func TestRunList(t *testing.T) {
 	testutil.Contains(t, stdout.String(), "Sprint Board")
 }
 
+func TestRunList_ColumnOrder(t *testing.T) {
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Sprint Board", Owner: &api.User{DisplayName: "Alice"}, IsFavourite: true},
+	}
+	gadgets := map[string][]api.DashboardGadget{
+		"10001": {{ID: 1, Title: "G1"}, {ID: 2, Title: "G2"}},
+	}
+	server := newListTestServer(t, dashboards, gadgets)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "ID")
+	testutil.Contains(t, out, "GADGETS")
+	testutil.Contains(t, out, "OWNER")
+	testutil.Contains(t, out, "FAVOURITE")
+	testutil.Contains(t, out, "NAME")
+	testutil.Contains(t, out, "10001")
+	testutil.Contains(t, out, "2")
+	testutil.Contains(t, out, "Alice")
+	testutil.Contains(t, out, "Sprint Board")
+}
+
+func TestRunList_IDOnly(t *testing.T) {
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Sprint Board"},
+		{ID: "10002", Name: "Incidents"},
+	}
+	server := newListTestServer(t, dashboards, nil)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "10001")
+	testutil.Contains(t, out, "10002")
+	testutil.NotContains(t, out, "Sprint Board")
+	testutil.NotContains(t, out, "GADGETS")
+}
+
+func TestRunList_IDOnly_Empty(t *testing.T) {
+	server := newListTestServer(t, nil, nil)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50)
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "" {
+		t.Errorf("--id with empty results should emit nothing, got %q", stdout.String())
+	}
+}
+
+func TestRunList_Empty(t *testing.T) {
+	server := newListTestServer(t, nil, nil)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "No dashboards found")
+}
+
+func TestRunList_Extended(t *testing.T) {
+	dashboards := []api.Dashboard{
+		{
+			ID:          "10001",
+			Name:        "Sprint Board",
+			Owner:       &api.User{DisplayName: "Alice"},
+			IsFavourite: true,
+			Popularity:  3,
+			SharePerm:   []api.SharePerm{{Type: "group", Group: &api.SharePermGroup{Name: "developers"}}},
+		},
+	}
+	gadgets := map[string][]api.DashboardGadget{
+		"10001": {{ID: 1}, {ID: 2}, {ID: 3}},
+	}
+	server := newListTestServer(t, dashboards, gadgets)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "RANK")
+	testutil.Contains(t, out, "PERMISSIONS")
+	testutil.Contains(t, out, "group:developers")
+	testutil.Contains(t, out, "3")
+}
+
+func TestRunList_GadgetFetchFails(t *testing.T) {
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Board"},
+	}
+	// Server that returns dashboards but 500s on gadget requests
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/rest/api/3/dashboard" {
+			_ = json.NewEncoder(w).Encode(api.DashboardsResponse{Total: 1, Dashboards: dashboards})
+			return
+		}
+		if strings.Contains(r.URL.Path, "/gadget") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "Board")
+	// Gadget fetch failed → should show "-" not "0"
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) >= 2 {
+		testutil.NotContains(t, lines[1], " 0 ")
+	}
+}
+
 func TestRunList_Search(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		testutil.Equal(t, r.URL.Query().Get("dashboardName"), "Sprint")
-		_ = json.NewEncoder(w).Encode(api.DashboardSearchResponse{
-			Total: 1,
-			Values: []api.Dashboard{
-				{ID: "10002", Name: "Sprint Board"},
-			},
-		})
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/rest/api/3/dashboard/search" {
+			testutil.Equal(t, r.URL.Query().Get("dashboardName"), "Sprint")
+			_ = json.NewEncoder(w).Encode(api.DashboardSearchResponse{
+				Total: 1,
+				Values: []api.Dashboard{
+					{ID: "10002", Name: "Sprint Board"},
+				},
+			})
+			return
+		}
+		if strings.Contains(r.URL.Path, "/gadget") {
+			_ = json.NewEncoder(w).Encode(api.DashboardGadgetsResponse{})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
 
@@ -65,6 +263,7 @@ func TestRunList_Search(t *testing.T) {
 
 func TestRunGet(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/rest/api/3/dashboard/10001":
 			_ = json.NewEncoder(w).Encode(api.Dashboard{
@@ -119,7 +318,9 @@ func TestRunCreate(t *testing.T) {
 	testutil.True(t, len(lines) >= 2, "expected header + data row")
 	testutil.Contains(t, lines[0], "ID")
 	testutil.Contains(t, lines[0], "NAME")
+	testutil.Contains(t, lines[0], "GADGETS")
 	testutil.Contains(t, out, "New Board")
+	testutil.Contains(t, out, "0")
 
 	var req api.CreateDashboardRequest
 	err = json.Unmarshal(capturedBody, &req)
@@ -190,8 +391,8 @@ func TestRunGadgetsList(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(api.DashboardGadgetsResponse{
 			Gadgets: []api.DashboardGadget{
-				{ID: 1, Title: "Filter Results", ModuleID: "com.atlassian.jira.gadgets:filter-results-gadget"},
-				{ID: 2, Title: "Pie Chart", ModuleID: "com.atlassian.jira.gadgets:pie-chart-gadget"},
+				{ID: 1, Title: "Filter Results", ModuleID: "filter-results-gadget", Position: api.DashboardGadgetPos{Row: 0, Column: 0}},
+				{ID: 2, Title: "Pie Chart", ModuleID: "pie-chart-gadget", Position: api.DashboardGadgetPos{Row: 1, Column: 0}},
 			},
 		})
 	}))
@@ -208,6 +409,103 @@ func TestRunGadgetsList(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Filter Results")
 	testutil.Contains(t, stdout.String(), "Pie Chart")
+}
+
+func TestRunGadgetsList_ColumnOrder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.DashboardGadgetsResponse{
+			Gadgets: []api.DashboardGadget{
+				{ID: 1, Title: "Burndown", ModuleID: "sprint-burndown-gadget", Position: api.DashboardGadgetPos{Row: 0, Column: 0}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGadgetsList(context.Background(), opts, "10001")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 1, "expected at least header")
+	testutil.Contains(t, lines[0], "ID")
+	testutil.Contains(t, lines[0], "POSITION")
+	testutil.Contains(t, lines[0], "TITLE")
+	testutil.Contains(t, lines[0], "TYPE")
+	testutil.NotContains(t, lines[0], "MODULE")
+	testutil.Contains(t, out, "0,0")
+}
+
+func TestRunGadgetsList_IDOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.DashboardGadgetsResponse{
+			Gadgets: []api.DashboardGadget{
+				{ID: 1, Title: "Gadget A"},
+				{ID: 2, Title: "Gadget B"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runGadgetsList(context.Background(), opts, "10001")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "1")
+	testutil.Contains(t, out, "2")
+	testutil.NotContains(t, out, "Gadget A")
+	testutil.NotContains(t, out, "TITLE")
+}
+
+func TestRunGadgetsList_IDOnly_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.DashboardGadgetsResponse{})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runGadgetsList(context.Background(), opts, "10001")
+	testutil.RequireNoError(t, err)
+	if stdout.String() != "" {
+		t.Errorf("--id with empty results should emit nothing, got %q", stdout.String())
+	}
+}
+
+func TestRunGadgetsList_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.DashboardGadgetsResponse{})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGadgetsList(context.Background(), opts, "10001")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "No gadgets on dashboard 10001")
 }
 
 func TestRunGadgetsRemove(t *testing.T) {
@@ -279,8 +577,9 @@ func TestRunGadgetsAdd(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	testutil.True(t, len(lines) >= 2, "expected header + data row")
 	testutil.Contains(t, lines[0], "ID")
+	testutil.Contains(t, lines[0], "POSITION")
 	testutil.Contains(t, lines[0], "TITLE")
-	testutil.Contains(t, lines[0], "MODULE")
+	testutil.Contains(t, lines[0], "TYPE")
 	testutil.Contains(t, out, "10124")
 	testutil.Contains(t, out, "Sprint Burndown")
 	testutil.Contains(t, out, "sprint-burndown-gadget")

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -168,7 +168,7 @@ func TestRunList_Extended(t *testing.T) {
 			Name:        "Sprint Board",
 			Owner:       &api.User{DisplayName: "Alice"},
 			IsFavourite: true,
-			Popularity:  3,
+			Popularity:  7,
 			SharePerm:   []api.SharePerm{{Type: "group", Group: &api.SharePermGroup{Name: "developers"}}},
 		},
 	}
@@ -192,7 +192,7 @@ func TestRunList_Extended(t *testing.T) {
 	testutil.Contains(t, out, "RANK")
 	testutil.Contains(t, out, "PERMISSIONS")
 	testutil.Contains(t, out, "group:developers")
-	testutil.Contains(t, out, "3")
+	testutil.Contains(t, out, "7")
 }
 
 func TestRunList_GadgetFetchFails(t *testing.T) {
@@ -226,8 +226,13 @@ func TestRunList_GadgetFetchFails(t *testing.T) {
 
 	out := stdout.String()
 	testutil.Contains(t, out, "Board")
-	// Gadget fetch failed → GADGETS column should show "-" (unknown), not "0" (empty)
-	testutil.Contains(t, out, "-")
+	// Gadget fetch failed → GADGETS column (index 1) should show "-" (unknown), not "0".
+	// Agent-style table uses " | " as column separator.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	cols := strings.Split(lines[1], " | ")
+	testutil.True(t, len(cols) >= 2, "expected at least 2 columns in data row")
+	testutil.Equal(t, cols[1], "-")
 }
 
 func TestRunList_IDTakesPrecedenceOverExtended(t *testing.T) {

--- a/tools/jtk/internal/present/dashboard.go
+++ b/tools/jtk/internal/present/dashboard.go
@@ -2,6 +2,7 @@ package present
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 
@@ -45,45 +46,72 @@ func (DashboardPresenter) PresentDetail(d *api.Dashboard, gadgets []api.Dashboar
 	return &present.OutputModel{Sections: sections}
 }
 
-// PresentList creates a table view for a list of dashboards.
-func (DashboardPresenter) PresentList(dashboards []api.Dashboard) *present.OutputModel {
+// PresentList creates a table view: ID | GADGETS | OWNER | FAVOURITE | NAME.
+// gadgetCounts maps dashboard ID → gadget count; nil map or missing key renders "-".
+func (DashboardPresenter) PresentList(dashboards []api.Dashboard, gadgetCounts map[string]int) *present.OutputModel {
 	rows := make([]present.Row, len(dashboards))
 	for i, d := range dashboards {
 		owner := ""
 		if d.Owner != nil {
 			owner = d.Owner.DisplayName
 		}
-		fav := BoolString(d.IsFavourite)
 		rows[i] = present.Row{
-			Cells: []string{d.ID, d.Name, owner, fav},
+			Cells: []string{d.ID, formatGadgetCount(d.ID, gadgetCounts), owner, BoolString(d.IsFavourite), d.Name},
 		}
 	}
 	return &present.OutputModel{
 		Sections: []present.Section{
 			&present.TableSection{
-				Headers: []string{"ID", "NAME", "OWNER", "FAVOURITE"},
+				Headers: []string{"ID", "GADGETS", "OWNER", "FAVOURITE", "NAME"},
 				Rows:    rows,
 			},
 		},
 	}
 }
 
-// PresentGadgets creates a table view for a list of gadgets.
-func (DashboardPresenter) PresentGadgets(gadgets []api.DashboardGadget) *present.OutputModel {
-	rows := make([]present.Row, len(gadgets))
-	for i, g := range gadgets {
-		pos := ""
-		if g.Position.Row > 0 || g.Position.Column > 0 {
-			pos = FormatInt(g.Position.Row) + "," + FormatInt(g.Position.Column)
+// PresentListExtended creates an extended table: ID | GADGETS | OWNER | FAVOURITE | RANK | PERMISSIONS | NAME.
+func (DashboardPresenter) PresentListExtended(dashboards []api.Dashboard, gadgetCounts map[string]int) *present.OutputModel {
+	rows := make([]present.Row, len(dashboards))
+	for i, d := range dashboards {
+		owner := ""
+		if d.Owner != nil {
+			owner = d.Owner.DisplayName
 		}
 		rows[i] = present.Row{
-			Cells: []string{FormatInt(g.ID), g.Title, g.ModuleID, pos},
+			Cells: []string{
+				d.ID,
+				formatGadgetCount(d.ID, gadgetCounts),
+				owner,
+				BoolString(d.IsFavourite),
+				FormatInt(d.Popularity),
+				formatPermissions(d.SharePerm),
+				d.Name,
+			},
 		}
 	}
 	return &present.OutputModel{
 		Sections: []present.Section{
 			&present.TableSection{
-				Headers: []string{"ID", "TITLE", "MODULE", "POSITION"},
+				Headers: []string{"ID", "GADGETS", "OWNER", "FAVOURITE", "RANK", "PERMISSIONS", "NAME"},
+				Rows:    rows,
+			},
+		},
+	}
+}
+
+// PresentGadgets creates a table view: ID | POSITION | TITLE | TYPE.
+func (DashboardPresenter) PresentGadgets(gadgets []api.DashboardGadget) *present.OutputModel {
+	rows := make([]present.Row, len(gadgets))
+	for i, g := range gadgets {
+		pos := fmt.Sprintf("%d,%d", g.Position.Row, g.Position.Column)
+		rows[i] = present.Row{
+			Cells: []string{FormatInt(g.ID), pos, g.Title, g.ModuleID},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"ID", "POSITION", "TITLE", "TYPE"},
 				Rows:    rows,
 			},
 		},
@@ -171,4 +199,43 @@ func (DashboardPresenter) PresentNoGadgets(dashboardID string) *present.OutputMo
 			},
 		},
 	}
+}
+
+func formatGadgetCount(id string, counts map[string]int) string {
+	if counts == nil {
+		return "-"
+	}
+	n, ok := counts[id]
+	if !ok {
+		return "-"
+	}
+	return FormatInt(n)
+}
+
+func formatPermissions(perms []api.SharePerm) string {
+	if len(perms) == 0 {
+		return "private"
+	}
+	parts := make([]string, len(perms))
+	for i, p := range perms {
+		switch p.Type {
+		case "group":
+			if p.Group != nil && p.Group.Name != "" {
+				parts[i] = "group:" + p.Group.Name
+			} else {
+				parts[i] = "group"
+			}
+		case "project":
+			if p.Project != nil && p.Project.Key != "" {
+				parts[i] = "project:" + p.Project.Key
+			} else {
+				parts[i] = "project"
+			}
+		case "loggedin":
+			parts[i] = "logged-in"
+		default:
+			parts[i] = p.Type
+		}
+	}
+	return strings.Join(parts, ", ")
 }

--- a/tools/jtk/internal/present/dashboard_test.go
+++ b/tools/jtk/internal/present/dashboard_test.go
@@ -1,0 +1,184 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestDashboardPresenter_PresentList_ColumnOrder(t *testing.T) {
+	t.Parallel()
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Sprint Board", Owner: &api.User{DisplayName: "Alice"}, IsFavourite: true},
+		{ID: "10002", Name: "Incidents", Owner: &api.User{DisplayName: "Bob"}},
+	}
+	counts := map[string]int{"10001": 4, "10002": 2}
+
+	model := DashboardPresenter{}.PresentList(dashboards, counts)
+	table := model.Sections[0].(*present.TableSection)
+
+	wantHeaders := []string{"ID", "GADGETS", "OWNER", "FAVOURITE", "NAME"}
+	for i, h := range wantHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d] = %q, want %q", i, table.Headers[i], h)
+		}
+	}
+
+	if table.Rows[0].Cells[0] != "10001" {
+		t.Errorf("first cell should be ID, got %q", table.Rows[0].Cells[0])
+	}
+	if table.Rows[0].Cells[1] != "4" {
+		t.Errorf("gadgets cell should be '4', got %q", table.Rows[0].Cells[1])
+	}
+	if table.Rows[0].Cells[2] != "Alice" {
+		t.Errorf("owner cell should be 'Alice', got %q", table.Rows[0].Cells[2])
+	}
+	if table.Rows[0].Cells[3] != "yes" {
+		t.Errorf("favourite cell should be 'yes', got %q", table.Rows[0].Cells[3])
+	}
+	if table.Rows[0].Cells[4] != "Sprint Board" {
+		t.Errorf("name cell should be 'Sprint Board', got %q", table.Rows[0].Cells[4])
+	}
+}
+
+func TestDashboardPresenter_PresentList_NilCounts(t *testing.T) {
+	t.Parallel()
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Board"},
+	}
+
+	model := DashboardPresenter{}.PresentList(dashboards, nil)
+	table := model.Sections[0].(*present.TableSection)
+
+	if table.Rows[0].Cells[1] != "-" {
+		t.Errorf("nil counts should render '-', got %q", table.Rows[0].Cells[1])
+	}
+}
+
+func TestDashboardPresenter_PresentList_MissingKey(t *testing.T) {
+	t.Parallel()
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Board"},
+	}
+	counts := map[string]int{"other": 5}
+
+	model := DashboardPresenter{}.PresentList(dashboards, counts)
+	table := model.Sections[0].(*present.TableSection)
+
+	if table.Rows[0].Cells[1] != "-" {
+		t.Errorf("missing key should render '-', got %q", table.Rows[0].Cells[1])
+	}
+}
+
+func TestDashboardPresenter_PresentList_ZeroGadgets(t *testing.T) {
+	t.Parallel()
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Board"},
+	}
+	counts := map[string]int{"10001": 0}
+
+	model := DashboardPresenter{}.PresentList(dashboards, counts)
+	table := model.Sections[0].(*present.TableSection)
+
+	if table.Rows[0].Cells[1] != "0" {
+		t.Errorf("zero gadgets should render '0', got %q", table.Rows[0].Cells[1])
+	}
+}
+
+func TestDashboardPresenter_PresentListExtended_ColumnOrder(t *testing.T) {
+	t.Parallel()
+	dashboards := []api.Dashboard{
+		{
+			ID:          "10001",
+			Name:        "Sprint Board",
+			Owner:       &api.User{DisplayName: "Alice"},
+			IsFavourite: true,
+			Popularity:  5,
+			SharePerm:   []api.SharePerm{{Type: "group", Group: &api.SharePermGroup{Name: "developers"}}},
+		},
+	}
+	counts := map[string]int{"10001": 3}
+
+	model := DashboardPresenter{}.PresentListExtended(dashboards, counts)
+	table := model.Sections[0].(*present.TableSection)
+
+	wantHeaders := []string{"ID", "GADGETS", "OWNER", "FAVOURITE", "RANK", "PERMISSIONS", "NAME"}
+	for i, h := range wantHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d] = %q, want %q", i, table.Headers[i], h)
+		}
+	}
+
+	if table.Rows[0].Cells[4] != "5" {
+		t.Errorf("rank cell should be '5', got %q", table.Rows[0].Cells[4])
+	}
+	if table.Rows[0].Cells[5] != "group:developers" {
+		t.Errorf("permissions cell should be 'group:developers', got %q", table.Rows[0].Cells[5])
+	}
+}
+
+func TestDashboardPresenter_PresentGadgets_ColumnOrder(t *testing.T) {
+	t.Parallel()
+	gadgets := []api.DashboardGadget{
+		{ID: 100, Title: "Burndown", ModuleID: "sprint-burndown-gadget", Position: api.DashboardGadgetPos{Row: 0, Column: 0}},
+		{ID: 101, Title: "Pie Chart", ModuleID: "pie-chart-gadget", Position: api.DashboardGadgetPos{Row: 1, Column: 2}},
+	}
+
+	model := DashboardPresenter{}.PresentGadgets(gadgets)
+	table := model.Sections[0].(*present.TableSection)
+
+	wantHeaders := []string{"ID", "POSITION", "TITLE", "TYPE"}
+	for i, h := range wantHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d] = %q, want %q", i, table.Headers[i], h)
+		}
+	}
+
+	if table.Rows[0].Cells[1] != "0,0" {
+		t.Errorf("position 0,0 should be shown, got %q", table.Rows[0].Cells[1])
+	}
+	if table.Rows[1].Cells[1] != "1,2" {
+		t.Errorf("position should be '1,2', got %q", table.Rows[1].Cells[1])
+	}
+	if table.Rows[0].Cells[3] != "sprint-burndown-gadget" {
+		t.Errorf("type cell should be module ID, got %q", table.Rows[0].Cells[3])
+	}
+}
+
+func TestFormatPermissions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		perms []api.SharePerm
+		want  string
+	}{
+		{name: "empty", perms: nil, want: "private"},
+		{name: "global", perms: []api.SharePerm{{Type: "global"}}, want: "global"},
+		{name: "group with name", perms: []api.SharePerm{{Type: "group", Group: &api.SharePermGroup{Name: "devs"}}}, want: "group:devs"},
+		{name: "group without name", perms: []api.SharePerm{{Type: "group"}}, want: "group"},
+		{name: "project with key", perms: []api.SharePerm{{Type: "project", Project: &api.SharePermProject{Key: "MON"}}}, want: "project:MON"},
+		{name: "project without key", perms: []api.SharePerm{{Type: "project"}}, want: "project"},
+		{name: "loggedin", perms: []api.SharePerm{{Type: "loggedin"}}, want: "logged-in"},
+		{name: "unknown type", perms: []api.SharePerm{{Type: "projectRole"}}, want: "projectRole"},
+		{
+			name: "multiple",
+			perms: []api.SharePerm{
+				{Type: "group", Group: &api.SharePermGroup{Name: "devs"}},
+				{Type: "global"},
+			},
+			want: "group:devs, global",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatPermissions(tt.perms)
+			if got != tt.want {
+				t.Errorf("formatPermissions() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/jtk/internal/present/dashboard_test.go
+++ b/tools/jtk/internal/present/dashboard_test.go
@@ -119,6 +119,20 @@ func TestDashboardPresenter_PresentListExtended_ColumnOrder(t *testing.T) {
 	}
 }
 
+func TestDashboardPresenter_PresentListExtended_NilCounts(t *testing.T) {
+	t.Parallel()
+	dashboards := []api.Dashboard{
+		{ID: "10001", Name: "Board", Popularity: 3},
+	}
+
+	model := DashboardPresenter{}.PresentListExtended(dashboards, nil)
+	table := model.Sections[0].(*present.TableSection)
+
+	if table.Rows[0].Cells[1] != "-" {
+		t.Errorf("nil counts should render '-', got %q", table.Rows[0].Cells[1])
+	}
+}
+
 func TestDashboardPresenter_PresentGadgets_ColumnOrder(t *testing.T) {
 	t.Parallel()
 	gadgets := []api.DashboardGadget{
@@ -160,6 +174,7 @@ func TestFormatPermissions(t *testing.T) {
 		{name: "group without name", perms: []api.SharePerm{{Type: "group"}}, want: "group"},
 		{name: "project with key", perms: []api.SharePerm{{Type: "project", Project: &api.SharePermProject{Key: "MON"}}}, want: "project:MON"},
 		{name: "project without key", perms: []api.SharePerm{{Type: "project"}}, want: "project"},
+		{name: "project with empty key", perms: []api.SharePerm{{Type: "project", Project: &api.SharePermProject{Key: ""}}}, want: "project"},
 		{name: "loggedin", perms: []api.SharePerm{{Type: "loggedin"}}, want: "logged-in"},
 		{name: "unknown type", perms: []api.SharePerm{{Type: "projectRole"}}, want: "projectRole"},
 		{


### PR DESCRIPTION
## Summary
- Fix `dashboards list` column order to `ID|GADGETS|OWNER|FAVOURITE|NAME` with gadget count fetching
- Wire `--id` flag for `dashboards list` and `gadgets list` (one ID per line, empty results emit nothing)
- Wire `--extended` flag for `dashboards list` adding `RANK|PERMISSIONS` columns
- Fix `gadgets list` column order to `ID|POSITION|TITLE|TYPE` (rename MODULE→TYPE, always show position including 0,0)
- Expand `SharePerm` type with Group/Project fields for permission display formatting
- Use `Emit`/`EmitIDs` helpers and `view.FormatJSON` constant throughout

Closes #284

## Test plan
- [x] `make build` — clean
- [x] `make test` — all passing
- [x] `make lint` — no new issues (pre-existing gosec in config.go only)
- [ ] Verify `jtk dashboards list` shows GADGETS column with counts
- [ ] Verify `jtk dashboards list --id` emits one ID per line
- [ ] Verify `jtk dashboards list --extended` shows RANK and PERMISSIONS
- [ ] Verify `jtk dashboards gadgets list <id>` shows ID|POSITION|TITLE|TYPE
- [ ] Verify `jtk dashboards gadgets list <id> --id` emits one ID per line