### PR TITLE
feat(jtk): fix fields list column order, rename --custom flag, and add fields show

### DIFF
--- a/tools/jtk/api/field_management.go
+++ b/tools/jtk/api/field_management.go
@@ -260,6 +260,101 @@ func (c *Client) UpdateFieldContextOptions(ctx context.Context, fieldID, context
 	return result.Options, nil
 }
 
+// FieldContextProjectMapping represents a mapping from a context to a project.
+type FieldContextProjectMapping struct {
+	ContextID string `json:"contextId"`
+	ProjectID string `json:"projectId,omitempty"`
+	IsGlobal  bool   `json:"isGlobalContext"`
+}
+
+// fieldContextProjectMappingsResponse is the paginated response from the project mapping endpoint.
+type fieldContextProjectMappingsResponse struct {
+	MaxResults int                          `json:"maxResults"`
+	StartAt    int                          `json:"startAt"`
+	Total      int                          `json:"total"`
+	IsLast     bool                         `json:"isLast"`
+	Values     []FieldContextProjectMapping `json:"values"`
+}
+
+// GetAllFieldContexts returns all contexts for a field, paginating through all pages.
+func (c *Client) GetAllFieldContexts(ctx context.Context, fieldID string) ([]FieldContext, error) {
+	if fieldID == "" {
+		return nil, ErrFieldIDRequired
+	}
+	var all []FieldContext
+	startAt := 0
+	for {
+		urlStr := fmt.Sprintf("%s/field/%s/context?startAt=%d", c.BaseURL, url.PathEscape(fieldID), startAt)
+		body, err := c.Get(ctx, urlStr)
+		if err != nil {
+			return nil, fmt.Errorf("fetching field contexts: %w", err)
+		}
+		var page FieldContextsResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("parsing field contexts: %w", err)
+		}
+		all = append(all, page.Values...)
+		if page.IsLast || len(page.Values) == 0 {
+			break
+		}
+		startAt += len(page.Values)
+	}
+	return all, nil
+}
+
+// GetAllFieldContextProjectMappings returns all context-to-project mappings for a field.
+func (c *Client) GetAllFieldContextProjectMappings(ctx context.Context, fieldID string) ([]FieldContextProjectMapping, error) {
+	if fieldID == "" {
+		return nil, ErrFieldIDRequired
+	}
+	var all []FieldContextProjectMapping
+	startAt := 0
+	for {
+		urlStr := fmt.Sprintf("%s/field/%s/context/projectmapping?startAt=%d", c.BaseURL, url.PathEscape(fieldID), startAt)
+		body, err := c.Get(ctx, urlStr)
+		if err != nil {
+			return nil, fmt.Errorf("fetching field context project mappings: %w", err)
+		}
+		var page fieldContextProjectMappingsResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("parsing field context project mappings: %w", err)
+		}
+		all = append(all, page.Values...)
+		if page.IsLast || len(page.Values) == 0 {
+			break
+		}
+		startAt += len(page.Values)
+	}
+	return all, nil
+}
+
+// GetAllFieldContextOptions returns all options for a field context, paginating through all pages.
+func (c *Client) GetAllFieldContextOptions(ctx context.Context, fieldID, contextID string) ([]FieldContextOption, error) {
+	if fieldID == "" {
+		return nil, ErrFieldIDRequired
+	}
+	var all []FieldContextOption
+	startAt := 0
+	for {
+		urlStr := fmt.Sprintf("%s/field/%s/context/%s/option?startAt=%d",
+			c.BaseURL, url.PathEscape(fieldID), url.PathEscape(contextID), startAt)
+		body, err := c.Get(ctx, urlStr)
+		if err != nil {
+			return nil, err
+		}
+		var page FieldContextOptionsResponse
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, err
+		}
+		all = append(all, page.Values...)
+		if page.IsLast || len(page.Values) == 0 {
+			break
+		}
+		startAt += len(page.Values)
+	}
+	return all, nil
+}
+
 // DeleteFieldContextOption deletes an option from a field context
 func (c *Client) DeleteFieldContextOption(ctx context.Context, fieldID, contextID, optionID string) error {
 	if fieldID == "" {

--- a/tools/jtk/api/field_management_test.go
+++ b/tools/jtk/api/field_management_test.go
@@ -359,3 +359,97 @@ func TestDeleteFieldContextOption_EmptyID(t *testing.T) {
 	err := client.DeleteFieldContextOption(context.Background(), "", "10001", "3")
 	testutil.True(t, errors.Is(err, ErrFieldIDRequired))
 }
+
+func TestGetAllFieldContexts_MultiPage(t *testing.T) {
+	t.Parallel()
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			testutil.Contains(t, r.URL.RawQuery, "startAt=0")
+			_ = json.NewEncoder(w).Encode(FieldContextsResponse{
+				Values: []FieldContext{{ID: "10100", Name: "Context A"}},
+				IsLast: false,
+			})
+		} else {
+			testutil.Contains(t, r.URL.RawQuery, "startAt=1")
+			_ = json.NewEncoder(w).Encode(FieldContextsResponse{
+				Values: []FieldContext{{ID: "10101", Name: "Context B"}},
+				IsLast: true,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	contexts, err := client.GetAllFieldContexts(context.Background(), "customfield_10100")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(contexts), 2)
+	testutil.Equal(t, contexts[0].ID, "10100")
+	testutil.Equal(t, contexts[1].ID, "10101")
+	testutil.Equal(t, callCount, 2)
+}
+
+func TestGetAllFieldContextProjectMappings_MultiPage(t *testing.T) {
+	t.Parallel()
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			testutil.Contains(t, r.URL.RawQuery, "startAt=0")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"contextId": "10100", "projectId": "1001", "isGlobalContext": false},
+				},
+				"isLast": false,
+			})
+		} else {
+			testutil.Contains(t, r.URL.RawQuery, "startAt=1")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"contextId": "10101", "isGlobalContext": true},
+				},
+				"isLast": true,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	mappings, err := client.GetAllFieldContextProjectMappings(context.Background(), "customfield_10100")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(mappings), 2)
+	testutil.Equal(t, mappings[0].ProjectID, "1001")
+	testutil.Equal(t, mappings[1].IsGlobal, true)
+	testutil.Equal(t, callCount, 2)
+}
+
+func TestGetAllFieldContextOptions_MultiPage(t *testing.T) {
+	t.Parallel()
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			testutil.Contains(t, r.URL.RawQuery, "startAt=0")
+			_ = json.NewEncoder(w).Encode(FieldContextOptionsResponse{
+				Values: []FieldContextOption{{ID: "20001", Value: "Option A"}},
+				IsLast: false,
+			})
+		} else {
+			testutil.Contains(t, r.URL.RawQuery, "startAt=1")
+			_ = json.NewEncoder(w).Encode(FieldContextOptionsResponse{
+				Values: []FieldContextOption{{ID: "20002", Value: "Option B"}},
+				IsLast: true,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	options, err := client.GetAllFieldContextOptions(context.Background(), "customfield_10100", "10001")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(options), 2)
+	testutil.Equal(t, options[0].Value, "Option A")
+	testutil.Equal(t, options[1].Value, "Option B")
+	testutil.Equal(t, callCount, 2)
+}

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
 	"strings"
 )
@@ -291,26 +290,13 @@ func ResolveFieldOptions(ctx context.Context, c *Client, issueKey, fieldID strin
 var ErrFieldNotInEditMeta = errors.New("field not found in edit metadata")
 
 func getAllContextOptions(ctx context.Context, c *Client, fieldID, contextID string) ([]FieldOptionValue, error) {
-	var all []FieldOptionValue
-	startAt := 0
-	for {
-		urlStr := fmt.Sprintf("%s/field/%s/context/%s/option?startAt=%d",
-			c.BaseURL, url.PathEscape(fieldID), url.PathEscape(contextID), startAt)
-		body, err := c.Get(ctx, urlStr)
-		if err != nil {
-			return nil, err
-		}
-		var page FieldContextOptionsResponse
-		if err := json.Unmarshal(body, &page); err != nil {
-			return nil, err
-		}
-		for _, o := range page.Values {
-			all = append(all, FieldOptionValue{ID: o.ID, Value: o.Value, Disabled: o.Disabled})
-		}
-		if page.IsLast || len(page.Values) == 0 {
-			break
-		}
-		startAt += len(page.Values)
+	opts, err := c.GetAllFieldContextOptions(ctx, fieldID, contextID)
+	if err != nil {
+		return nil, err
 	}
-	return all, nil
+	result := make([]FieldOptionValue, len(opts))
+	for i, o := range opts {
+		result[i] = FieldOptionValue{ID: o.ID, Value: o.Value, Disabled: o.Disabled}
+	}
+	return result, nil
 }

--- a/tools/jtk/internal/cmd/fields/fields.go
+++ b/tools/jtk/internal/cmd/fields/fields.go
@@ -28,6 +28,7 @@ func Register(parent *cobra.Command, opts *root.Options) {
 	}
 
 	cmd.AddCommand(newListCmd(opts))
+	cmd.AddCommand(newShowCmd(opts))
 	cmd.AddCommand(newCreateCmd(opts))
 	cmd.AddCommand(newDeleteCmd(opts))
 	cmd.AddCommand(newRestoreCmd(opts))
@@ -49,24 +50,27 @@ func newListCmd(opts *root.Options) *cobra.Command {
   jtk fields list
 
   # List only custom fields
-  jtk fields list --custom
+  jtk fields list --custom-fields
 
   # Search for fields by name
-  jtk fields list --name "story point"`,
+  jtk fields list --name "story point"
+
+  # Emit only field IDs
+  jtk fields list --id`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runList(cmd.Context(), opts, customOnly, nameFilter)
 		},
 	}
 
+	cmd.Flags().BoolVar(&customOnly, "custom-fields", false, "Show only custom fields")
 	cmd.Flags().BoolVar(&customOnly, "custom", false, "Show only custom fields")
+	_ = cmd.Flags().MarkHidden("custom")
 	cmd.Flags().StringVar(&nameFilter, "name", "", "Filter fields by name (case-insensitive substring match)")
 
 	return cmd
 }
 
 func runList(ctx context.Context, opts *root.Options, customOnly bool, nameFilter string) error {
-	v := opts.View()
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -97,23 +101,24 @@ func runList(ctx context.Context, opts *root.Options, customOnly bool, nameFilte
 		fields = filtered
 	}
 
-	if len(fields) == 0 {
-		model := jtkpresent.FieldPresenter{}.PresentEmpty()
-		out := present.Render(model, opts.RenderStyle())
-		fmt.Fprint(opts.Stdout, out.Stdout)
-		fmt.Fprint(opts.Stderr, out.Stderr)
-		return nil
+	if opts.EmitIDOnly() {
+		ids := make([]string, len(fields))
+		for i, f := range fields {
+			ids[i] = f.ID
+		}
+		return jtkpresent.EmitIDs(opts, ids)
 	}
 
+	if len(fields) == 0 {
+		return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentEmpty())
+	}
+
+	v := opts.View()
 	if v.Format == view.FormatJSON {
 		return v.JSON(fields)
 	}
 
-	model := jtkpresent.FieldPresenter{}.PresentList(fields, opts.IsExtended())
-	out := present.Render(model, opts.RenderStyle())
-	fmt.Fprint(opts.Stdout, out.Stdout)
-	fmt.Fprint(opts.Stderr, out.Stderr)
-	return nil
+	return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentList(fields, opts.IsExtended()))
 }
 
 func newCreateCmd(opts *root.Options) *cobra.Command {

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -1310,6 +1310,141 @@ func TestRunShow_OptionFetchError4xx(t *testing.T) {
 	testutil.Equal(t, cols[4], "-")
 }
 
+func TestRunShow_OptionFetchError5xx(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/context/projectmapping"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"contextId": "10100", "isGlobalContext": true},
+				},
+				"isLast": true,
+			})
+		case strings.Contains(r.URL.Path, "/context/10100/option"):
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"errorMessage": "server error"})
+		case strings.Contains(r.URL.Path, "/context"):
+			_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+				Values: []api.FieldContext{
+					{ID: "10100", Name: "Default Context", IsGlobalContext: true},
+				},
+				IsLast: true,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runShow(context.Background(), opts, "customfield_10100")
+	testutil.True(t, err != nil, "expected 5xx error to propagate")
+	testutil.Contains(t, err.Error(), "server error")
+}
+
+func TestRunShow_EmptyJSON(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+			Values: []api.FieldContext{},
+			IsLast: true,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runShow(context.Background(), opts, "customfield_10100")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, strings.TrimSpace(stdout.String()), "[]")
+}
+
+func TestRunShow_EmptyIDOnly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+			Values: []api.FieldContext{},
+			IsLast: true,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runShow(context.Background(), opts, "customfield_10100")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "")
+}
+
+func TestRunShow_MultiPageContexts(t *testing.T) {
+	t.Parallel()
+	contextCallCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/context/projectmapping"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"contextId": "10100", "isGlobalContext": true},
+					{"contextId": "10101", "isGlobalContext": true},
+				},
+				"isLast": true,
+			})
+		case strings.Contains(r.URL.Path, "/option"):
+			_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
+				Values: []api.FieldContextOption{},
+				IsLast: true,
+			})
+		case strings.Contains(r.URL.Path, "/context"):
+			contextCallCount++
+			if contextCallCount == 1 {
+				_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+					Values: []api.FieldContext{
+						{ID: "10100", Name: "Page 1 Context", IsGlobalContext: true},
+					},
+					IsLast: false,
+				})
+			} else {
+				_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+					Values: []api.FieldContext{
+						{ID: "10101", Name: "Page 2 Context", IsGlobalContext: true},
+					},
+					IsLast: true,
+				})
+			}
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runShow(context.Background(), opts, "customfield_10100")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "Page 1 Context")
+	testutil.Contains(t, out, "Page 2 Context")
+}
+
 func TestNewShowCmd(t *testing.T) {
 	t.Parallel()
 	rootCmd, opts := root.NewCmd()

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -35,9 +35,16 @@ func TestNewListCmd(t *testing.T) {
 	testutil.Equal(t, cmd.Use, "list")
 	testutil.NotEmpty(t, cmd.Short)
 
+	customFieldsFlag := cmd.Flags().Lookup("custom-fields")
+	testutil.NotNil(t, customFieldsFlag)
+	testutil.Equal(t, customFieldsFlag.DefValue, "false")
+
 	customFlag := cmd.Flags().Lookup("custom")
 	testutil.NotNil(t, customFlag)
 	testutil.Equal(t, customFlag.DefValue, "false")
+	if customFlag.Hidden != true {
+		t.Error("--custom flag should be hidden")
+	}
 
 	nameFlag := cmd.Flags().Lookup("name")
 	testutil.NotNil(t, nameFlag)
@@ -66,6 +73,113 @@ func TestRunList_Table(t *testing.T) {
 	testutil.Contains(t, stdout.String(), "summary")
 	testutil.Contains(t, stdout.String(), "customfield_10100")
 	testutil.Contains(t, stdout.String(), "Environment")
+}
+
+func TestRunList_ColumnOrder(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.Field{
+			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, false, "")
+	testutil.RequireNoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	cols := strings.Split(lines[1], " | ")
+	testutil.Equal(t, cols[0], "summary")
+	testutil.Equal(t, cols[1], "string")
+	testutil.Equal(t, cols[2], "Summary")
+}
+
+func TestRunList_IDOnly(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.Field{
+			{ID: "summary", Name: "Summary", Schema: api.FieldSchema{Type: "string"}},
+			{ID: "customfield_10100", Name: "Environment", Custom: true, Schema: api.FieldSchema{Type: "option"}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, false, "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "summary\ncustomfield_10100\n")
+}
+
+func TestRunList_IDOnly_Empty(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.Field{})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, false, "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "")
+}
+
+func TestRunList_Extended_ColumnOrder(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.Field{
+			{
+				ID:          "summary",
+				Name:        "Summary",
+				Schema:      api.FieldSchema{Type: "string"},
+				Searchable:  true,
+				Navigable:   true,
+				Orderable:   true,
+				ClauseNames: []string{"summary"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, false, "")
+	testutil.RequireNoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	cols := strings.Split(lines[1], " | ")
+	testutil.Equal(t, cols[0], "summary")
+	testutil.Equal(t, cols[1], "string")
+	testutil.Equal(t, cols[2], "yes")
+	testutil.Equal(t, cols[3], "yes")
+	testutil.Equal(t, cols[4], "yes")
+	testutil.Equal(t, cols[5], "summary")
+	testutil.Equal(t, cols[6], "Summary")
 }
 
 func TestRunList_JSON(t *testing.T) {
@@ -1004,4 +1118,204 @@ func TestRunList_CacheHit_CustomFilter_SkipsLiveCall(t *testing.T) {
 	testutil.Contains(t, stdout.String(), "Story Points")
 	testutil.Contains(t, stdout.String(), "Sprint")
 	testutil.NotContains(t, stdout.String(), "Summary")
+}
+
+// --- Show command tests ---
+
+func newShowTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/context/projectmapping"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"contextId": "10100", "isGlobalContext": true},
+					{"contextId": "10101", "projectId": "10001", "isGlobalContext": false},
+					{"contextId": "10102", "projectId": "10002", "isGlobalContext": false},
+				},
+				"isLast": true,
+			})
+		case strings.Contains(r.URL.Path, "/context/10100/option"):
+			_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
+				Values: []api.FieldContextOption{
+					{ID: "20001", Value: "Platform"},
+					{ID: "20002", Value: "Integration"},
+				},
+				IsLast: true,
+			})
+		case strings.Contains(r.URL.Path, "/context/10101/option"):
+			_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
+				Values: []api.FieldContextOption{
+					{ID: "20010", Value: "CapOne"},
+				},
+				IsLast: true,
+			})
+		case strings.Contains(r.URL.Path, "/context/10102/option"):
+			_ = json.NewEncoder(w).Encode(api.FieldContextOptionsResponse{
+				Values: []api.FieldContextOption{},
+				IsLast: true,
+			})
+		case strings.Contains(r.URL.Path, "/context"):
+			_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+				Values: []api.FieldContext{
+					{ID: "10100", Name: "Default Context", IsGlobalContext: true},
+					{ID: "10101", Name: "MON Project Context"},
+					{ID: "10102", Name: "ON Project Context"},
+				},
+				IsLast: true,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func TestRunShow_Table(t *testing.T) {
+	t.Parallel()
+	server := newShowTestServer(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runShow(context.Background(), opts, "customfield_10100")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	testutil.True(t, len(lines) >= 5, "expected header + 4 data rows")
+
+	// Header
+	testutil.Contains(t, lines[0], "CONTEXT_ID")
+	testutil.Contains(t, lines[0], "OPTION_VALUE")
+
+	// Global context with options
+	testutil.Contains(t, out, "(global)")
+	testutil.Contains(t, out, "Platform")
+	testutil.Contains(t, out, "Integration")
+
+	// Project context with options
+	testutil.Contains(t, out, "CapOne")
+
+	// Empty context renders - | -
+	cols := strings.Split(lines[4], " | ")
+	testutil.Equal(t, cols[0], "10102")
+	testutil.Equal(t, cols[3], "-")
+	testutil.Equal(t, cols[4], "-")
+}
+
+func TestRunShow_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := newShowTestServer(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runShow(context.Background(), opts, "customfield_10100")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "10100\n10101\n10102\n")
+}
+
+func TestRunShow_JSON(t *testing.T) {
+	t.Parallel()
+	server := newShowTestServer(t)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runShow(context.Background(), opts, "customfield_10100")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, `"context_id"`)
+	testutil.Contains(t, out, `"option_value"`)
+	testutil.Contains(t, out, "Platform")
+}
+
+func TestRunShow_Empty(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+			Values: []api.FieldContext{},
+			IsLast: true,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runShow(context.Background(), opts, "customfield_10100")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "No contexts found")
+}
+
+func TestRunShow_OptionFetchError4xx(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/context/projectmapping"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"contextId": "10100", "isGlobalContext": true},
+				},
+				"isLast": true,
+			})
+		case strings.Contains(r.URL.Path, "/context/10100/option"):
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"errorMessage": "not a select field"})
+		case strings.Contains(r.URL.Path, "/context"):
+			_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+				Values: []api.FieldContext{
+					{ID: "10100", Name: "Default Context", IsGlobalContext: true},
+				},
+				IsLast: true,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runShow(context.Background(), opts, "customfield_10100")
+	testutil.RequireNoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	cols := strings.Split(lines[1], " | ")
+	testutil.Equal(t, cols[3], "-")
+	testutil.Equal(t, cols[4], "-")
+}
+
+func TestNewShowCmd(t *testing.T) {
+	t.Parallel()
+	rootCmd, opts := root.NewCmd()
+	Register(rootCmd, opts)
+
+	cmd, _, err := rootCmd.Find([]string{"fields", "show"})
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, cmd.Name(), "show")
 }

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -51,6 +51,36 @@ func TestNewListCmd(t *testing.T) {
 	testutil.Equal(t, nameFlag.DefValue, "")
 }
 
+func TestRunList_CustomFieldsFlag_CobraExecute(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]api.Field{
+			{ID: "summary", Name: "Summary", Custom: false, Schema: api.FieldSchema{Type: "string"}},
+			{ID: "customfield_10100", Name: "Environment", Custom: true, Schema: api.FieldSchema{Type: "option"}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	rootCmd, opts := root.NewCmd()
+	opts.Output = "table"
+	opts.Stdout = &stdout
+	opts.Stderr = &bytes.Buffer{}
+	opts.SetAPIClient(client)
+	Register(rootCmd, opts)
+
+	rootCmd.SetArgs([]string{"fields", "list", "--custom-fields"})
+	err = rootCmd.Execute()
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "customfield_10100")
+	testutil.NotContains(t, out, "summary")
+}
+
 func TestRunList_Table(t *testing.T) {
 	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1282,6 +1312,48 @@ func TestRunShow_OptionFetchError4xx(t *testing.T) {
 		case strings.Contains(r.URL.Path, "/context/10100/option"):
 			w.WriteHeader(http.StatusBadRequest)
 			_ = json.NewEncoder(w).Encode(map[string]string{"errorMessage": "not a select field"})
+		case strings.Contains(r.URL.Path, "/context"):
+			_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
+				Values: []api.FieldContext{
+					{ID: "10100", Name: "Default Context", IsGlobalContext: true},
+				},
+				IsLast: true,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runShow(context.Background(), opts, "customfield_10100")
+	testutil.RequireNoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	testutil.True(t, len(lines) >= 2, "expected header + data row")
+	cols := strings.Split(lines[1], " | ")
+	testutil.Equal(t, cols[3], "-")
+	testutil.Equal(t, cols[4], "-")
+}
+
+func TestRunShow_OptionFetchError404(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/context/projectmapping"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"values": []map[string]any{
+					{"contextId": "10100", "isGlobalContext": true},
+				},
+				"isLast": true,
+			})
+		case strings.Contains(r.URL.Path, "/context/10100/option"):
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"errorMessage": "not found"})
 		case strings.Contains(r.URL.Path, "/context"):
 			_ = json.NewEncoder(w).Encode(api.FieldContextsResponse{
 				Values: []api.FieldContext{

--- a/tools/jtk/internal/cmd/fields/show.go
+++ b/tools/jtk/internal/cmd/fields/show.go
@@ -44,10 +44,6 @@ func runShow(ctx context.Context, opts *root.Options, fieldID string) error {
 		return err
 	}
 
-	if len(contexts) == 0 {
-		return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentFieldShowEmpty(fieldID))
-	}
-
 	if opts.EmitIDOnly() {
 		seen := make(map[string]bool, len(contexts))
 		var ids []string
@@ -58,6 +54,14 @@ func runShow(ctx context.Context, opts *root.Options, fieldID string) error {
 			}
 		}
 		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	if len(contexts) == 0 {
+		v := opts.View()
+		if v.Format == view.FormatJSON {
+			return v.JSON([]jtkpresent.FieldShowRow{})
+		}
+		return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentFieldShowEmpty(fieldID))
 	}
 
 	mappings, err := client.GetAllFieldContextProjectMappings(ctx, fieldID)

--- a/tools/jtk/internal/cmd/fields/show.go
+++ b/tools/jtk/internal/cmd/fields/show.go
@@ -1,0 +1,159 @@
+package fields
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	sharederrors "github.com/open-cli-collective/atlassian-go/errors"
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+)
+
+func newShowCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <field-id>",
+		Short: "Show field contexts and options",
+		Long:  "Show a flat denormalized view of a field's contexts, project mappings, and options.",
+		Example: `  # Show contexts and options for a custom field
+  jtk fields show customfield_10100
+
+  # Emit only context IDs
+  jtk fields show customfield_10100 --id`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runShow(cmd.Context(), opts, args[0])
+		},
+	}
+}
+
+func runShow(ctx context.Context, opts *root.Options, fieldID string) error {
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	contexts, err := client.GetAllFieldContexts(ctx, fieldID)
+	if err != nil {
+		return err
+	}
+
+	if len(contexts) == 0 {
+		return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentFieldShowEmpty(fieldID))
+	}
+
+	if opts.EmitIDOnly() {
+		seen := make(map[string]bool, len(contexts))
+		var ids []string
+		for _, c := range contexts {
+			if !seen[c.ID] {
+				seen[c.ID] = true
+				ids = append(ids, c.ID)
+			}
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	mappings, err := client.GetAllFieldContextProjectMappings(ctx, fieldID)
+	if err != nil {
+		return err
+	}
+
+	projectsByContext := buildProjectMap(mappings)
+
+	rows, err := buildShowRows(ctx, client, fieldID, contexts, projectsByContext)
+	if err != nil {
+		return err
+	}
+
+	v := opts.View()
+	if v.Format == view.FormatJSON {
+		return v.JSON(rows)
+	}
+
+	return jtkpresent.Emit(opts, jtkpresent.FieldPresenter{}.PresentFieldShow(rows))
+}
+
+func buildProjectMap(mappings []api.FieldContextProjectMapping) map[string]string {
+	grouped := make(map[string][]string)
+	globals := make(map[string]bool)
+	for _, m := range mappings {
+		if m.IsGlobal {
+			globals[m.ContextID] = true
+			continue
+		}
+		if m.ProjectID != "" {
+			grouped[m.ContextID] = append(grouped[m.ContextID], m.ProjectID)
+		}
+	}
+
+	result := make(map[string]string, len(grouped)+len(globals))
+	for ctxID := range globals {
+		result[ctxID] = "(global)"
+	}
+	for ctxID, ids := range grouped {
+		if _, isGlobal := result[ctxID]; isGlobal {
+			continue
+		}
+		sort.Strings(ids)
+		result[ctxID] = strings.Join(ids, ", ")
+	}
+	return result
+}
+
+func buildShowRows(ctx context.Context, client *api.Client, fieldID string, contexts []api.FieldContext, projectsByContext map[string]string) ([]jtkpresent.FieldShowRow, error) {
+	var rows []jtkpresent.FieldShowRow
+	for _, fc := range contexts {
+		projects := projectsByContext[fc.ID]
+		if projects == "" {
+			if fc.IsGlobalContext {
+				projects = "(global)"
+			} else {
+				projects = "-"
+			}
+		}
+
+		emptyRow := jtkpresent.FieldShowRow{
+			ContextID:   fc.ID,
+			Context:     fc.Name,
+			Projects:    projects,
+			OptionID:    "-",
+			OptionValue: "-",
+		}
+
+		options, err := client.GetAllFieldContextOptions(ctx, fieldID, fc.ID)
+		if err != nil {
+			if isOptionFetchTolerable(err) {
+				rows = append(rows, emptyRow)
+				continue
+			}
+			return nil, err
+		}
+
+		if len(options) == 0 {
+			rows = append(rows, emptyRow)
+			continue
+		}
+
+		for _, opt := range options {
+			rows = append(rows, jtkpresent.FieldShowRow{
+				ContextID:   fc.ID,
+				Context:     fc.Name,
+				Projects:    projects,
+				OptionID:    opt.ID,
+				OptionValue: opt.Value,
+			})
+		}
+	}
+	return rows, nil
+}
+
+func isOptionFetchTolerable(err error) bool {
+	return errors.Is(err, sharederrors.ErrBadRequest) || errors.Is(err, sharederrors.ErrNotFound)
+}

--- a/tools/jtk/internal/present/field.go
+++ b/tools/jtk/internal/present/field.go
@@ -13,21 +13,17 @@ import (
 type FieldPresenter struct{}
 
 // PresentList creates a table view for a list of fields. Default: ID|TYPE|NAME.
-// Extended adds SEARCHABLE, NAVIGABLE, ORDERABLE, CLAUSE_NAMES per #230.
+// Extended: ID|TYPE|SEARCHABLE|NAVIGABLE|ORDERABLE|CLAUSE_NAMES|NAME per #230.
 func (FieldPresenter) PresentList(fields []api.Field, extended bool) *present.OutputModel {
 	var headers []string
 	if extended {
-		headers = []string{"ID", "NAME", "TYPE", "CUSTOM", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES"}
+		headers = []string{"ID", "TYPE", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES", "NAME"}
 	} else {
-		headers = []string{"ID", "NAME", "TYPE", "CUSTOM"}
+		headers = []string{"ID", "TYPE", "NAME"}
 	}
 
 	rows := make([]present.Row, len(fields))
 	for i, f := range fields {
-		custom := "no"
-		if f.Custom {
-			custom = "yes"
-		}
 		if extended {
 			clauseNames := "-"
 			if len(f.ClauseNames) > 0 {
@@ -36,18 +32,17 @@ func (FieldPresenter) PresentList(fields []api.Field, extended bool) *present.Ou
 			rows[i] = present.Row{
 				Cells: []string{
 					f.ID,
-					f.Name,
 					OrDash(f.Schema.Type),
-					custom,
 					BoolString(f.Searchable),
 					BoolString(f.Navigable),
 					BoolString(f.Orderable),
 					clauseNames,
+					f.Name,
 				},
 			}
 		} else {
 			rows[i] = present.Row{
-				Cells: []string{f.ID, f.Name, OrDash(f.Schema.Type), custom},
+				Cells: []string{f.ID, OrDash(f.Schema.Type), f.Name},
 			}
 		}
 	}
@@ -332,6 +327,46 @@ func (FieldPresenter) PresentOptionDeleted(optionID, contextID string) *present.
 			&present.MessageSection{
 				Kind:    present.MessageSuccess,
 				Message: fmt.Sprintf("Deleted option %s from context %s", optionID, contextID),
+				Stream:  present.StreamStdout,
+			},
+		},
+	}
+}
+
+// FieldShowRow represents a single row in the fields show denormalized view.
+type FieldShowRow struct {
+	ContextID   string `json:"context_id"`
+	Context     string `json:"context"`
+	Projects    string `json:"projects"`
+	OptionID    string `json:"option_id"`
+	OptionValue string `json:"option_value"`
+}
+
+// PresentFieldShow creates a table view for a field's denormalized context/option data.
+func (FieldPresenter) PresentFieldShow(rows []FieldShowRow) *present.OutputModel {
+	tableRows := make([]present.Row, len(rows))
+	for i, r := range rows {
+		tableRows[i] = present.Row{
+			Cells: []string{r.ContextID, r.Context, r.Projects, r.OptionID, r.OptionValue},
+		}
+	}
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"CONTEXT_ID", "CONTEXT", "PROJECTS", "OPTION_ID", "OPTION_VALUE"},
+				Rows:    tableRows,
+			},
+		},
+	}
+}
+
+// PresentFieldShowEmpty creates an info message when a field has no contexts.
+func (FieldPresenter) PresentFieldShowEmpty(fieldID string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("No contexts found for field %s", fieldID),
 				Stream:  present.StreamStdout,
 			},
 		},

--- a/tools/jtk/internal/present/field_test.go
+++ b/tools/jtk/internal/present/field_test.go
@@ -18,29 +18,26 @@ func TestFieldPresenter_PresentList_Default(t *testing.T) {
 	model := FieldPresenter{}.PresentList(fields, false)
 
 	table := model.Sections[0].(*present.TableSection)
-	expectedHeaders := []string{"ID", "NAME", "TYPE", "CUSTOM"}
-	if len(table.Headers) != len(expectedHeaders) {
-		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	wantHeaders := []string{"ID", "TYPE", "NAME"}
+	if len(table.Headers) != len(wantHeaders) {
+		t.Fatalf("expected %d headers, got %d", len(wantHeaders), len(table.Headers))
 	}
-	for i, h := range expectedHeaders {
+	for i, h := range wantHeaders {
 		if table.Headers[i] != h {
-			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+			t.Errorf("header[%d] = %q, want %q", i, table.Headers[i], h)
 		}
 	}
 	if len(table.Rows) != 2 {
 		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
 	}
 	if table.Rows[0].Cells[0] != "summary" {
-		t.Errorf("row 0 ID: expected 'summary', got %q", table.Rows[0].Cells[0])
+		t.Errorf("row 0 cell 0 (ID) = %q, want %q", table.Rows[0].Cells[0], "summary")
 	}
-	if table.Rows[0].Cells[1] != "Summary" {
-		t.Errorf("row 0 Name: expected 'Summary', got %q", table.Rows[0].Cells[1])
+	if table.Rows[0].Cells[1] != "string" {
+		t.Errorf("row 0 cell 1 (TYPE) = %q, want %q", table.Rows[0].Cells[1], "string")
 	}
-	if table.Rows[0].Cells[3] != "no" {
-		t.Errorf("row 0 Custom: expected 'no', got %q", table.Rows[0].Cells[3])
-	}
-	if table.Rows[1].Cells[3] != "yes" {
-		t.Errorf("row 1 Custom: expected 'yes', got %q", table.Rows[1].Cells[3])
+	if table.Rows[0].Cells[2] != "Summary" {
+		t.Errorf("row 0 cell 2 (NAME) = %q, want %q", table.Rows[0].Cells[2], "Summary")
 	}
 }
 
@@ -67,26 +64,74 @@ func TestFieldPresenter_PresentList_Extended(t *testing.T) {
 	model := FieldPresenter{}.PresentList(fields, true)
 
 	table := model.Sections[0].(*present.TableSection)
-	expectedHeaders := []string{"ID", "NAME", "TYPE", "CUSTOM", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES"}
-	if len(table.Headers) != len(expectedHeaders) {
-		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	wantHeaders := []string{"ID", "TYPE", "SEARCHABLE", "NAVIGABLE", "ORDERABLE", "CLAUSE_NAMES", "NAME"}
+	if len(table.Headers) != len(wantHeaders) {
+		t.Fatalf("expected %d headers, got %d", len(wantHeaders), len(table.Headers))
 	}
-	for i, h := range expectedHeaders {
+	for i, h := range wantHeaders {
 		if table.Headers[i] != h {
-			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+			t.Errorf("header[%d] = %q, want %q", i, table.Headers[i], h)
 		}
 	}
 
-	if table.Rows[0].Cells[3] != "no" {
-		t.Errorf("row 0 custom: expected 'no', got %q", table.Rows[0].Cells[3])
+	// Row 0: summary
+	if table.Rows[0].Cells[0] != "summary" {
+		t.Errorf("row 0 cell 0 (ID) = %q, want %q", table.Rows[0].Cells[0], "summary")
+	}
+	if table.Rows[0].Cells[1] != "string" {
+		t.Errorf("row 0 cell 1 (TYPE) = %q, want %q", table.Rows[0].Cells[1], "string")
+	}
+	if table.Rows[0].Cells[2] != "yes" {
+		t.Errorf("row 0 cell 2 (SEARCHABLE) = %q, want %q", table.Rows[0].Cells[2], "yes")
+	}
+	if table.Rows[0].Cells[3] != "yes" {
+		t.Errorf("row 0 cell 3 (NAVIGABLE) = %q, want %q", table.Rows[0].Cells[3], "yes")
 	}
 	if table.Rows[0].Cells[4] != "yes" {
-		t.Errorf("row 0 searchable: expected 'yes', got %q", table.Rows[0].Cells[4])
+		t.Errorf("row 0 cell 4 (ORDERABLE) = %q, want %q", table.Rows[0].Cells[4], "yes")
 	}
-	if table.Rows[0].Cells[7] != "summary" {
-		t.Errorf("row 0 clause_names: expected 'summary', got %q", table.Rows[0].Cells[7])
+	if table.Rows[0].Cells[5] != "summary" {
+		t.Errorf("row 0 cell 5 (CLAUSE_NAMES) = %q, want %q", table.Rows[0].Cells[5], "summary")
 	}
-	if table.Rows[1].Cells[7] != "-" {
-		t.Errorf("row 1 clause_names: expected '-' for no clauses, got %q", table.Rows[1].Cells[7])
+	if table.Rows[0].Cells[6] != "Summary" {
+		t.Errorf("row 0 cell 6 (NAME) = %q, want %q", table.Rows[0].Cells[6], "Summary")
+	}
+
+	// Row 1: Story Points (no clause names → dash)
+	if table.Rows[1].Cells[5] != "-" {
+		t.Errorf("row 1 cell 5 (CLAUSE_NAMES) = %q, want %q", table.Rows[1].Cells[5], "-")
+	}
+}
+
+func TestFieldPresenter_PresentFieldShow(t *testing.T) {
+	t.Parallel()
+	rows := []FieldShowRow{
+		{ContextID: "10100", Context: "Default Context", Projects: "(global)", OptionID: "20001", OptionValue: "Platform"},
+		{ContextID: "10100", Context: "Default Context", Projects: "(global)", OptionID: "20002", OptionValue: "Integration"},
+		{ContextID: "10101", Context: "MON Project Context", Projects: "10001", OptionID: "20010", OptionValue: "CapOne"},
+		{ContextID: "10102", Context: "ON Project Context", Projects: "10002", OptionID: "-", OptionValue: "-"},
+	}
+
+	model := FieldPresenter{}.PresentFieldShow(rows)
+
+	table := model.Sections[0].(*present.TableSection)
+	wantHeaders := []string{"CONTEXT_ID", "CONTEXT", "PROJECTS", "OPTION_ID", "OPTION_VALUE"}
+	for i, h := range wantHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d] = %q, want %q", i, table.Headers[i], h)
+		}
+	}
+
+	if len(table.Rows) != 4 {
+		t.Fatalf("expected 4 rows, got %d", len(table.Rows))
+	}
+	if table.Rows[0].Cells[2] != "(global)" {
+		t.Errorf("row 0 PROJECTS = %q, want %q", table.Rows[0].Cells[2], "(global)")
+	}
+	if table.Rows[3].Cells[3] != "-" {
+		t.Errorf("row 3 OPTION_ID = %q, want %q", table.Rows[3].Cells[3], "-")
+	}
+	if table.Rows[3].Cells[4] != "-" {
+		t.Errorf("row 3 OPTION_VALUE = %q, want %q", table.Rows[3].Cells[4], "-")
 	}
 }


### PR DESCRIPTION
## Summary
- Fix `fields list` default column order to `ID|TYPE|NAME` (removes extra CUSTOM column)
- Fix `fields list --extended` to `ID|TYPE|SEARCHABLE|NAVIGABLE|ORDERABLE|CLAUSE_NAMES|NAME`
- Wire `--id` flag for `fields list` (was not wired)
- Rename `--custom` to `--custom-fields` (hidden `--custom` alias for backwards compat)
- Add `fields show <field-id>` — flat denormalized context/option view: `CONTEXT_ID|CONTEXT|PROJECTS|OPTION_ID|OPTION_VALUE`
- Add paginated API methods: `GetAllFieldContexts`, `GetAllFieldContextProjectMappings`, `GetAllFieldContextOptions`

Closes #285

## Test plan
- [x] Presenter tests: PresentList default/extended column order, PresentFieldShow
- [x] Command tests: --id, --custom-fields, --custom hidden alias, column order assertions
- [x] Show command: table, JSON, --id, empty contexts, 4xx error tolerance for non-select fields
- [x] `make build` / `make test` / `make lint` pass