### PR TITLE
feat(jtk): fix sprints list sort order and current board name format

### DIFF
--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -144,42 +144,73 @@ func runList(ctx context.Context, opts *root.Options, client *api.Client, boardI
 		}
 	}
 
-	result, err := client.ListSprints(ctx, boardID, state, startAt, maxResults)
+	allSprints, err := fetchAllSprints(ctx, client, boardID, state)
 	if err != nil {
 		return err
 	}
 
-	hasMore := !result.IsLast
-	if hasMore && len(result.Values) == 0 {
-		return fmt.Errorf("unexpected paginated response: IsLast=false with empty values (startAt=%d)", startAt)
+	jtkpresent.SortSprintsForDisplay(allSprints)
+
+	// Client-side pagination window over the sorted slice.
+	total := len(allSprints)
+	if startAt > total {
+		startAt = total
 	}
+	end := startAt + maxResults
+	if end > total {
+		end = total
+	}
+	page := allSprints[startAt:end]
+	hasMore := end < total
 	nextToken := ""
 	if hasMore {
-		nextToken = strconv.Itoa(startAt + len(result.Values))
+		nextToken = strconv.Itoa(end)
 	}
 
 	if idOnly {
-		ids := make([]string, len(result.Values))
-		for i, s := range result.Values {
+		ids := make([]string, len(page))
+		for i, s := range page {
 			ids[i] = strconv.Itoa(s.ID)
 		}
 		return jtkpresent.EmitIDsWithPaginationToken(opts, ids, hasMore, nextToken)
 	}
 
-	if len(result.Values) == 0 {
+	if len(page) == 0 {
 		return jtkpresent.Emit(opts, jtkpresent.SprintPresenter{}.PresentEmpty())
 	}
 
 	if v.Format == view.FormatJSON {
-		arts := jtkartifact.ProjectSprints(result.Values, opts.ArtifactMode())
+		arts := jtkartifact.ProjectSprints(page, opts.ArtifactMode())
 		return v.RenderArtifactList(artifact.NewListResult(arts, hasMore))
 	}
 
-	model := jtkpresent.SprintPresenter{}.PresentListWithPagination(result.Values, opts.IsExtended(), hasMore, nextToken)
+	model := jtkpresent.SprintPresenter{}.PresentListWithPagination(page, opts.IsExtended(), hasMore, nextToken)
 	if projected {
 		projection.ApplyToTableInModel(model, selected)
 	}
 	return jtkpresent.Emit(opts, model)
+}
+
+const fetchPageSize = 50
+
+func fetchAllSprints(ctx context.Context, client *api.Client, boardID int, state string) ([]api.Sprint, error) {
+	var all []api.Sprint
+	startAt := 0
+	for {
+		result, err := client.ListSprints(ctx, boardID, state, startAt, fetchPageSize)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, result.Values...)
+		if result.IsLast || len(result.Values) == 0 {
+			break
+		}
+		startAt += len(result.Values)
+		if len(all) > 10000 {
+			break
+		}
+	}
+	return all, nil
 }
 
 func newCurrentCmd(opts *root.Options) *cobra.Command {
@@ -250,6 +281,13 @@ func runCurrent(ctx context.Context, opts *root.Options, client *api.Client, boa
 
 	if v.Format == view.FormatJSON {
 		return v.RenderArtifact(jtkartifact.ProjectSprint(sprint, opts.ArtifactMode()))
+	}
+
+	// Enrich synthetic board (no name) for table output paths.
+	if board.Name == "" {
+		if enriched, err := client.GetBoard(ctx, board.ID); err == nil && enriched.ID == board.ID && enriched.Name != "" {
+			board = enriched
+		}
 	}
 
 	presenter := jtkpresent.SprintPresenter{}

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -152,6 +152,9 @@ func runList(ctx context.Context, opts *root.Options, client *api.Client, boardI
 	jtkpresent.SortSprintsForDisplay(allSprints)
 
 	// Client-side pagination window over the sorted slice.
+	if maxResults <= 0 {
+		maxResults = 50
+	}
 	total := len(allSprints)
 	if startAt > total {
 		startAt = total
@@ -201,14 +204,14 @@ func fetchAllSprints(ctx context.Context, client *api.Client, boardID int, state
 		if err != nil {
 			return nil, err
 		}
+		if !result.IsLast && len(result.Values) == 0 {
+			return nil, fmt.Errorf("unexpected paginated response: IsLast=false with empty values (startAt=%d)", startAt)
+		}
 		all = append(all, result.Values...)
-		if result.IsLast || len(result.Values) == 0 {
+		if result.IsLast {
 			break
 		}
 		startAt += len(result.Values)
-		if len(all) > 10000 {
-			break
-		}
 	}
 	return all, nil
 }

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -234,10 +235,26 @@ func TestRunList_InvalidNextPageToken(t *testing.T) {
 
 func TestRunList_Pagination(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+
+	// Server returns 3 sprints across 2 pages.
+	allSprints := []api.Sprint{
+		{ID: 10, Name: "S1", State: "active"},
+		{ID: 11, Name: "S2", State: "future"},
+		{ID: 12, Name: "S3", State: "closed"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startAt := 0
+		if v := r.URL.Query().Get("startAt"); v != "" {
+			startAt, _ = strconv.Atoi(v)
+		}
+		end := startAt + 2
+		if end > len(allSprints) {
+			end = len(allSprints)
+		}
+		page := allSprints[startAt:end]
 		_ = json.NewEncoder(w).Encode(api.SprintsResponse{
-			Values: []api.Sprint{{ID: 10, Name: "S1", State: "active"}},
-			IsLast: false,
+			Values: page,
+			IsLast: end >= len(allSprints),
 		})
 	}))
 	defer server.Close()
@@ -245,13 +262,14 @@ func TestRunList_Pagination(t *testing.T) {
 	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
 	testutil.RequireNoError(t, err)
 
+	// Request max=2: client-side pagination over 3 sorted sprints.
 	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
 	opts.SetAPIClient(client)
 
-	err = runList(context.Background(), opts, client, 123, "", 1, "", "")
+	err = runList(context.Background(), opts, client, 123, "", 2, "", "")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "More results available (next: 1)")
+	testutil.Contains(t, stdout.String(), "More results available (next: 2)")
 }
 
 // --- current subcommand ---
@@ -841,6 +859,259 @@ func TestAddCmd_NumericSprintPassThrough(t *testing.T) {
 	err := rootCmd.Execute()
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, capturedPath, "/rest/agile/1.0/sprint/999/issue")
+}
+
+func TestRunList_SortOrder(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		tt := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &tt
+	}
+
+	sprints := []api.Sprint{
+		{ID: 1, Name: "Old Closed", State: "closed", StartDate: d(2025, 1, 1), EndDate: d(2025, 1, 14), CompleteDate: d(2025, 1, 14)},
+		{ID: 2, Name: "Future", State: "future"},
+		{ID: 3, Name: "Active", State: "active", StartDate: d(2025, 4, 1), EndDate: d(2025, 4, 14)},
+		{ID: 4, Name: "Recent Closed", State: "closed", StartDate: d(2025, 3, 1), EndDate: d(2025, 3, 14), CompleteDate: d(2025, 3, 14)},
+	}
+
+	server := newTestSprintsServer(t, sprints)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 123, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	// lines[0] is the header; data rows start at lines[1]
+	if len(lines) < 5 {
+		t.Fatalf("expected header + 4 data rows, got %d lines:\n%s", len(lines), output)
+	}
+	testutil.True(t, strings.Contains(lines[1], "Active"))
+	testutil.True(t, strings.Contains(lines[2], "Future"))
+	testutil.True(t, strings.Contains(lines[3], "Recent Closed"))
+	testutil.True(t, strings.Contains(lines[4], "Old Closed"))
+}
+
+func TestRunList_SortOrder_IDOnly(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		tt := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &tt
+	}
+
+	sprints := []api.Sprint{
+		{ID: 1, Name: "Closed", State: "closed", CompleteDate: d(2025, 1, 14)},
+		{ID: 2, Name: "Future", State: "future"},
+		{ID: 3, Name: "Active", State: "active", StartDate: d(2025, 4, 1)},
+	}
+
+	server := newTestSprintsServer(t, sprints)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 123, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+
+	testutil.Equal(t, stdout.String(), "3\n2\n1\n")
+}
+
+func TestRunList_SortOrder_JSON(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		tt := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &tt
+	}
+
+	sprints := []api.Sprint{
+		{ID: 1, Name: "Closed", State: "closed", CompleteDate: d(2025, 1, 14)},
+		{ID: 2, Name: "Future", State: "future"},
+		{ID: 3, Name: "Active", State: "active", StartDate: d(2025, 4, 1)},
+	}
+
+	server := newTestSprintsServer(t, sprints)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 123, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+
+	// Verify sort order: Active (ID=3) before Future (ID=2) before Closed (ID=1)
+	output := stdout.String()
+	posActive := strings.Index(output, "Active")
+	posFuture := strings.Index(output, "Future")
+	posClosed := strings.Index(output, "Closed")
+	if posActive < 0 || posFuture < 0 || posClosed < 0 {
+		t.Fatalf("expected all three sprints in JSON output:\n%s", output)
+	}
+	if posActive >= posFuture || posFuture >= posClosed {
+		t.Errorf("expected Active before Future before Closed in JSON, got positions %d, %d, %d", posActive, posFuture, posClosed)
+	}
+}
+
+func TestRunList_Extended_GoalColumn(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		tt := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &tt
+	}
+
+	sprints := []api.Sprint{
+		{ID: 1, Name: "Closed Sprint", State: "closed", StartDate: d(2025, 1, 1), EndDate: d(2025, 1, 14), CompleteDate: d(2025, 1, 14), Goal: "Complete Q1 milestone"},
+		{ID: 2, Name: "Active Sprint", State: "active", StartDate: d(2025, 4, 1), EndDate: d(2025, 4, 14), Goal: "Ship CapOne a11y fixes", OriginBoardID: 23},
+	}
+
+	server := newTestSprintsServer(t, sprints)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 123, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	// lines[0] is the header; data rows start at lines[1]
+	if len(lines) < 3 {
+		t.Fatalf("expected header + 2 data rows, got %d lines:\n%s", len(lines), output)
+	}
+	testutil.True(t, strings.Contains(lines[1], "Ship CapOne a11y fixes"))
+	testutil.True(t, strings.Contains(lines[2], "Complete Q1 milestone"))
+}
+
+func TestRunList_ClientSidePagination(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		tt := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &tt
+	}
+
+	sprints := []api.Sprint{
+		{ID: 1, Name: "Closed A", State: "closed", CompleteDate: d(2025, 1, 14)},
+		{ID: 2, Name: "Closed B", State: "closed", CompleteDate: d(2025, 2, 14)},
+		{ID: 3, Name: "Active", State: "active", StartDate: d(2025, 4, 1)},
+	}
+
+	server := newTestSprintsServer(t, sprints)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	// Page 1: max=2, sorted order is Active(3), Closed B(2), Closed A(1)
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 123, "", 2, "", "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "3\n2\n")
+	testutil.Contains(t, output, "More results available (next: 2)")
+
+	// Page 2: startAt=2, max=2
+	stdout.Reset()
+	err = runList(context.Background(), opts, client, 123, "", 2, "2", "")
+	testutil.RequireNoError(t, err)
+
+	output = stdout.String()
+	testutil.Equal(t, output, "1\n")
+}
+
+func TestRunCurrent_BoardEnrichment(t *testing.T) {
+	t.Parallel()
+
+	seedBoardsAndSprints(t, nil, nil) // empty cache — board resolves synthetic
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/board/23/sprint"):
+			_ = json.NewEncoder(w).Encode(api.SprintsResponse{
+				IsLast: true,
+				Values: []api.Sprint{{ID: 125, Name: "MON Sprint 70", State: "active"}},
+			})
+		case strings.Contains(r.URL.Path, "/board/23"):
+			_ = json.NewEncoder(w).Encode(api.Board{ID: 23, Name: "MON board", Type: "scrum"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := newAgileClient(t, server)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	board := &api.Board{ID: 23} // synthetic — no name
+	err := runCurrent(context.Background(), opts, client, board, "")
+	testutil.RequireNoError(t, err)
+
+	testutil.Contains(t, stdout.String(), "Board: 23 (MON board)")
+}
+
+func TestRunCurrent_BoardEnrichmentFailsGracefully(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/board/23/sprint"):
+			_ = json.NewEncoder(w).Encode(api.SprintsResponse{
+				IsLast: true,
+				Values: []api.Sprint{{ID: 125, Name: "MON Sprint 70", State: "active"}},
+			})
+		case strings.Contains(r.URL.Path, "/board/23"):
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := newAgileClient(t, server)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	board := &api.Board{ID: 23} // synthetic — no name
+	err := runCurrent(context.Background(), opts, client, board, "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Board: 23")
+	testutil.NotContains(t, output, "Board: 23 (")
 }
 
 func TestRunAdd_AgentOutput(t *testing.T) {

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -1048,6 +1048,36 @@ func TestRunList_ClientSidePagination(t *testing.T) {
 	testutil.Equal(t, output, "1\n")
 }
 
+func TestRunList_ClientSidePagination_Table(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		tt := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &tt
+	}
+
+	sprints := []api.Sprint{
+		{ID: 1, Name: "Closed", State: "closed", CompleteDate: d(2025, 1, 14)},
+		{ID: 2, Name: "Future", State: "future"},
+		{ID: 3, Name: "Active", State: "active", StartDate: d(2025, 4, 1)},
+	}
+
+	server := newTestSprintsServer(t, sprints)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 123, "", 2, "", "")
+	testutil.RequireNoError(t, err)
+
+	testutil.Contains(t, stdout.String(), "More results available (next: 2)")
+}
+
 func TestRunCurrent_BoardEnrichment(t *testing.T) {
 	t.Parallel()
 
@@ -1189,6 +1219,7 @@ func TestRunList_StartAtBeyondTotal(t *testing.T) {
 }
 
 func TestCurrentCmd_BoardEnrichmentCobraLevel(t *testing.T) {
+	t.Parallel()
 	seedBoardsAndSprints(t, nil, nil) // empty cache — numeric board resolves synthetic
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -1114,6 +1114,113 @@ func TestRunCurrent_BoardEnrichmentFailsGracefully(t *testing.T) {
 	testutil.NotContains(t, output, "Board: 23 (")
 }
 
+func TestFetchAllSprints_Error(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	_, err = fetchAllSprints(context.Background(), client, 123, "")
+	testutil.NotNil(t, err)
+}
+
+func TestFetchAllSprints_EmptyWithNotLast(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.SprintsResponse{
+			Values: []api.Sprint{},
+			IsLast: false,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	_, err = fetchAllSprints(context.Background(), client, 123, "")
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "unexpected paginated response")
+}
+
+func TestFetchAllSprints_StatePassthrough(t *testing.T) {
+	t.Parallel()
+	var capturedStates []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedStates = append(capturedStates, r.URL.Query().Get("state"))
+		_ = json.NewEncoder(w).Encode(api.SprintsResponse{
+			Values: []api.Sprint{{ID: 1, State: "active"}},
+			IsLast: true,
+		})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	_, err = fetchAllSprints(context.Background(), client, 123, "active")
+	testutil.RequireNoError(t, err)
+	if len(capturedStates) != 1 || capturedStates[0] != "active" {
+		t.Errorf("expected state=active to be passed through, got %v", capturedStates)
+	}
+}
+
+func TestRunList_StartAtBeyondTotal(t *testing.T) {
+	t.Parallel()
+	sprints := []api.Sprint{{ID: 1, Name: "S1", State: "active"}}
+
+	server := newTestSprintsServer(t, sprints)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	// startAt=100 is beyond the 1-sprint total
+	err = runList(context.Background(), opts, client, 123, "", 50, "100", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "")
+}
+
+func TestCurrentCmd_BoardEnrichmentCobraLevel(t *testing.T) {
+	seedBoardsAndSprints(t, nil, nil) // empty cache — numeric board resolves synthetic
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/board/23/sprint"):
+			_ = json.NewEncoder(w).Encode(api.SprintsResponse{
+				IsLast: true,
+				Values: []api.Sprint{{ID: 125, Name: "MON Sprint 70", State: "active"}},
+			})
+		case r.URL.Path == "/rest/agile/1.0/board/23":
+			_ = json.NewEncoder(w).Encode(api.Board{ID: 23, Name: "MON board", Type: "scrum"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := newAgileClient(t, server)
+
+	rootCmd, opts := root.NewCmd()
+	opts.SetAPIClient(client)
+	var stdout bytes.Buffer
+	opts.Stdout = &stdout
+	opts.Stderr = &bytes.Buffer{}
+	Register(rootCmd, opts)
+
+	rootCmd.SetArgs([]string{"sprints", "current", "--board", "23"})
+	err := rootCmd.Execute()
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Board: 23 (MON board)")
+}
+
 func TestRunAdd_AgentOutput(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/tools/jtk/internal/present/sprint.go
+++ b/tools/jtk/internal/present/sprint.go
@@ -2,12 +2,81 @@ package present
 
 import (
 	"fmt"
+	"sort"
+	"time"
 
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
+
+// SortSprintsForDisplay sorts sprints for display: active first, then future,
+// then closed by recency. Within closed, sort by CompleteDate → EndDate →
+// StartDate descending. Deterministic tie-breaker: ID descending.
+func SortSprintsForDisplay(sprints []api.Sprint) {
+	sort.SliceStable(sprints, func(i, j int) bool {
+		pi, pj := statePriority(sprints[i].State), statePriority(sprints[j].State)
+		if pi != pj {
+			return pi < pj
+		}
+		if pi == 2 { // closed
+			return closedLess(sprints[i], sprints[j])
+		}
+		return dateDescThenID(sprints[i].StartDate, sprints[j].StartDate, sprints[i].ID, sprints[j].ID)
+	})
+}
+
+func statePriority(state string) int {
+	switch state {
+	case "active":
+		return 0
+	case "future":
+		return 1
+	default:
+		return 2
+	}
+}
+
+func closedLess(a, b api.Sprint) bool {
+	if cmp := compareDatesDesc(a.CompleteDate, b.CompleteDate); cmp != 0 {
+		return cmp < 0
+	}
+	if cmp := compareDatesDesc(a.EndDate, b.EndDate); cmp != 0 {
+		return cmp < 0
+	}
+	return dateDescThenID(a.StartDate, b.StartDate, a.ID, b.ID)
+}
+
+func dateDescThenID(a, b *time.Time, idA, idB int) bool {
+	if cmp := compareDatesDesc(a, b); cmp != 0 {
+		return cmp < 0
+	}
+	return idA > idB
+}
+
+// compareDatesDesc returns -1 if a should sort before b (descending),
+// +1 if after, 0 if equal. Nil sorts after non-nil.
+func compareDatesDesc(a, b *time.Time) int {
+	aNil := a == nil || a.IsZero()
+	bNil := b == nil || b.IsZero()
+	if aNil && bNil {
+		return 0
+	}
+	if aNil {
+		return 1
+	}
+	if bNil {
+		return -1
+	}
+	if a.After(*b) {
+		return -1
+	}
+	if a.Before(*b) {
+		return 1
+	}
+	return 0
+}
 
 // SprintPresenter creates presentation models for sprint data.
 type SprintPresenter struct{}

--- a/tools/jtk/internal/present/sprint.go
+++ b/tools/jtk/internal/present/sprint.go
@@ -20,9 +20,13 @@ func SortSprintsForDisplay(sprints []api.Sprint) {
 		if pi != pj {
 			return pi < pj
 		}
-		if pi == 2 { // closed
+		if pi == 2 { // closed: most recently completed first
 			return closedLess(sprints[i], sprints[j])
 		}
+		if pi == 1 { // future: nearest upcoming first (ascending)
+			return dateAscThenID(sprints[i].StartDate, sprints[j].StartDate, sprints[i].ID, sprints[j].ID)
+		}
+		// active: most recent first (descending)
 		return dateDescThenID(sprints[i].StartDate, sprints[j].StartDate, sprints[i].ID, sprints[j].ID)
 	})
 }
@@ -53,6 +57,36 @@ func dateDescThenID(a, b *time.Time, idA, idB int) bool {
 		return cmp < 0
 	}
 	return idA > idB
+}
+
+func dateAscThenID(a, b *time.Time, idA, idB int) bool {
+	if cmp := compareDatesAsc(a, b); cmp != 0 {
+		return cmp < 0
+	}
+	return idA < idB
+}
+
+// compareDatesAsc returns -1 if a should sort before b (ascending),
+// +1 if after, 0 if equal. Nil sorts after non-nil (unknown = last).
+func compareDatesAsc(a, b *time.Time) int {
+	aNil := a == nil || a.IsZero()
+	bNil := b == nil || b.IsZero()
+	if aNil && bNil {
+		return 0
+	}
+	if aNil {
+		return 1
+	}
+	if bNil {
+		return -1
+	}
+	if a.Before(*b) {
+		return -1
+	}
+	if a.After(*b) {
+		return 1
+	}
+	return 0
 }
 
 // compareDatesDesc returns -1 if a should sort before b (descending),

--- a/tools/jtk/internal/present/sprint_test.go
+++ b/tools/jtk/internal/present/sprint_test.go
@@ -428,6 +428,79 @@ func TestSortSprintsForDisplay_DeterministicTieBreaker(t *testing.T) {
 	}
 }
 
+func TestSortSprintsForDisplay_ClosedFallbackToEndDate(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &t
+	}
+
+	sprints := []api.Sprint{
+		{ID: 1, State: "closed", EndDate: d(2025, 1, 14)},
+		{ID: 2, State: "closed", EndDate: d(2025, 3, 14)},
+		{ID: 3, State: "closed", EndDate: d(2025, 2, 14)},
+	}
+
+	SortSprintsForDisplay(sprints)
+
+	wantIDs := []int{2, 3, 1}
+	for i, want := range wantIDs {
+		if sprints[i].ID != want {
+			t.Errorf("position %d: got ID=%d, want ID=%d", i, sprints[i].ID, want)
+		}
+	}
+}
+
+func TestSortSprintsForDisplay_ClosedFallbackToStartDate(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &t
+	}
+
+	sprints := []api.Sprint{
+		{ID: 1, State: "closed", StartDate: d(2025, 1, 1)},
+		{ID: 2, State: "closed", StartDate: d(2025, 3, 1)},
+	}
+
+	SortSprintsForDisplay(sprints)
+
+	wantIDs := []int{2, 1}
+	for i, want := range wantIDs {
+		if sprints[i].ID != want {
+			t.Errorf("position %d: got ID=%d, want ID=%d", i, sprints[i].ID, want)
+		}
+	}
+}
+
+func TestSortSprintsForDisplay_MultipleActiveFuture(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &t
+	}
+
+	sprints := []api.Sprint{
+		{ID: 1, State: "active", StartDate: d(2025, 3, 1)},
+		{ID: 2, State: "active", StartDate: d(2025, 4, 1)},
+		{ID: 3, State: "future", StartDate: d(2025, 5, 1)},
+		{ID: 4, State: "future", StartDate: d(2025, 6, 1)},
+		{ID: 5, State: "future"},
+	}
+
+	SortSprintsForDisplay(sprints)
+
+	wantIDs := []int{2, 1, 4, 3, 5}
+	for i, want := range wantIDs {
+		if sprints[i].ID != want {
+			t.Errorf("position %d: got ID=%d, want ID=%d", i, sprints[i].ID, want)
+		}
+	}
+}
+
 func TestSprintPresenter_PresentDetailProjection(t *testing.T) {
 	t.Parallel()
 

--- a/tools/jtk/internal/present/sprint_test.go
+++ b/tools/jtk/internal/present/sprint_test.go
@@ -493,7 +493,8 @@ func TestSortSprintsForDisplay_MultipleActiveFuture(t *testing.T) {
 
 	SortSprintsForDisplay(sprints)
 
-	wantIDs := []int{2, 1, 4, 3, 5}
+	// Active: descending (most recent first). Future: ascending (nearest first), nil last.
+	wantIDs := []int{2, 1, 3, 4, 5}
 	for i, want := range wantIDs {
 		if sprints[i].ID != want {
 			t.Errorf("position %d: got ID=%d, want ID=%d", i, sprints[i].ID, want)

--- a/tools/jtk/internal/present/sprint_test.go
+++ b/tools/jtk/internal/present/sprint_test.go
@@ -355,3 +355,106 @@ func TestSprintPresenter_PresentResolutionSynthetic(t *testing.T) {
 		t.Errorf("want warning: prefix, got %q", msg.Message)
 	}
 }
+
+func TestSortSprintsForDisplay(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &t
+	}
+
+	sprints := []api.Sprint{
+		{ID: 1, Name: "Old Closed", State: "closed", StartDate: d(2025, 1, 1), EndDate: d(2025, 1, 14), CompleteDate: d(2025, 1, 14)},
+		{ID: 2, Name: "Future B", State: "future"},
+		{ID: 3, Name: "Active", State: "active", StartDate: d(2025, 4, 1), EndDate: d(2025, 4, 14)},
+		{ID: 4, Name: "Recent Closed", State: "closed", StartDate: d(2025, 3, 1), EndDate: d(2025, 3, 14), CompleteDate: d(2025, 3, 14)},
+		{ID: 5, Name: "Future A", State: "future", StartDate: d(2025, 5, 1)},
+	}
+
+	SortSprintsForDisplay(sprints)
+
+	wantIDs := []int{3, 5, 2, 4, 1}
+	for i, want := range wantIDs {
+		if sprints[i].ID != want {
+			t.Errorf("position %d: got ID=%d (%s), want ID=%d", i, sprints[i].ID, sprints[i].Name, want)
+		}
+	}
+}
+
+func TestSortSprintsForDisplay_ClosedByCompleteDate(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &t
+	}
+
+	sprints := []api.Sprint{
+		{ID: 10, State: "closed", CompleteDate: d(2025, 1, 10)},
+		{ID: 11, State: "closed", CompleteDate: d(2025, 3, 10)},
+		{ID: 12, State: "closed", CompleteDate: d(2025, 2, 10)},
+		{ID: 13, State: "closed"}, // nil dates → last, higher ID first
+		{ID: 14, State: "closed"},
+	}
+
+	SortSprintsForDisplay(sprints)
+
+	wantIDs := []int{11, 12, 10, 14, 13}
+	for i, want := range wantIDs {
+		if sprints[i].ID != want {
+			t.Errorf("position %d: got ID=%d, want ID=%d", i, sprints[i].ID, want)
+		}
+	}
+}
+
+func TestSortSprintsForDisplay_DeterministicTieBreaker(t *testing.T) {
+	t.Parallel()
+
+	d := func(year, month, day int) *time.Time {
+		t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+		return &t
+	}
+
+	sprints := []api.Sprint{
+		{ID: 100, State: "active", StartDate: d(2025, 4, 1)},
+		{ID: 200, State: "active", StartDate: d(2025, 4, 1)},
+	}
+
+	SortSprintsForDisplay(sprints)
+
+	if sprints[0].ID != 200 || sprints[1].ID != 100 {
+		t.Errorf("expected higher ID first on tie: got %d, %d", sprints[0].ID, sprints[1].ID)
+	}
+}
+
+func TestSprintPresenter_PresentDetailProjection(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 14, 0, 0, 0, 0, time.UTC)
+
+	sprint := &api.Sprint{
+		ID:            42,
+		Name:          "Sprint 1",
+		State:         "active",
+		Goal:          "Complete MVP",
+		StartDate:     &start,
+		EndDate:       &end,
+		OriginBoardID: 23,
+	}
+	board := &api.Board{ID: 23, Name: "MON board"}
+
+	model := SprintPresenter{}.PresentDetailProjection(sprint, board)
+	detail := model.Sections[0].(*present.DetailSection)
+
+	wantLabels := []string{"ID", "NAME", "STATE", "START", "END", "BOARD", "GOAL", "ORIGIN_BOARD"}
+	for i, l := range wantLabels {
+		if detail.Fields[i].Label != l {
+			t.Errorf("field %d: got label %q, want %q", i, detail.Fields[i].Label, l)
+		}
+	}
+	if detail.Fields[6].Value != "Complete MVP" {
+		t.Errorf("GOAL value: got %q, want %q", detail.Fields[6].Value, "Complete MVP")
+	}
+}


### PR DESCRIPTION
## Summary
- Sort `sprints list` output: active → future → closed by recency (CompleteDate → EndDate → StartDate, deterministic ID tie-breaker)
- Fetch all pages before sorting for correct global ordering with client-side `--max`/`--next-page-token` pagination
- Enrich synthetic board in `sprints current` when cache is cold via single `GetBoard` API call (graceful fallback)

Closes #286

## Test plan
- [x] `TestSortSprintsForDisplay` — mixed states, dates, nil dates, deterministic tie-breaking
- [x] `TestSortSprintsForDisplay_ClosedByCompleteDate` — closed sort by CompleteDate
- [x] `TestSortSprintsForDisplay_DeterministicTieBreaker` — ID-based tie-breaking
- [x] `TestRunList_SortOrder` — table output in state-priority order
- [x] `TestRunList_SortOrder_IDOnly` — --id respects sort order
- [x] `TestRunList_SortOrder_JSON` — JSON respects sort order
- [x] `TestRunList_Extended_GoalColumn` — goal text rendered correctly after sort
- [x] `TestRunList_ClientSidePagination` — --max and --next-page-token window
- [x] `TestRunCurrent_BoardEnrichment` — synthetic board gets name from API
- [x] `TestRunCurrent_BoardEnrichmentFailsGracefully` — 404 → shows ID only
- [x] All 38 sprint command tests pass
- [x] All 225 presenter tests pass
- [x] `make build`, `make test`, `make lint` clean (jtk)