### PR TITLE
feat(jtk): add HAS_SCREEN and CONDITIONAL columns to transitions list --extended

### DIFF
--- a/tools/jtk/api/transitions_test.go
+++ b/tools/jtk/api/transitions_test.go
@@ -82,8 +82,8 @@ func TestClient_GetTransitions(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{
 			"transitions": [
-				{"id": "11", "name": "To Do", "to": {"id": "1", "name": "To Do"}},
-				{"id": "21", "name": "In Progress", "to": {"id": "2", "name": "In Progress"}}
+				{"id": "11", "name": "To Do", "hasScreen": true, "isConditional": false, "to": {"id": "1", "name": "To Do"}},
+				{"id": "21", "name": "In Progress", "hasScreen": false, "isConditional": true, "to": {"id": "2", "name": "In Progress"}}
 			]
 		}`))
 	}))
@@ -101,6 +101,10 @@ func TestClient_GetTransitions(t *testing.T) {
 	testutil.Len(t, transitions, 2)
 	testutil.Equal(t, transitions[0].ID, "11")
 	testutil.Equal(t, transitions[0].Name, "To Do")
+	testutil.True(t, transitions[0].HasScreen)
+	testutil.False(t, transitions[0].IsConditional)
+	testutil.False(t, transitions[1].HasScreen)
+	testutil.True(t, transitions[1].IsConditional)
 }
 
 func TestClient_GetTransitionsWithFields(t *testing.T) {

--- a/tools/jtk/api/types.go
+++ b/tools/jtk/api/types.go
@@ -328,10 +328,12 @@ type BoardColumn struct {
 
 // Transition represents a workflow transition
 type Transition struct {
-	ID     string                     `json:"id"`
-	Name   string                     `json:"name"`
-	To     Status                     `json:"to"`
-	Fields map[string]TransitionField `json:"fields,omitempty"`
+	ID            string                     `json:"id"`
+	Name          string                     `json:"name"`
+	HasScreen     bool                       `json:"hasScreen"`
+	IsConditional bool                       `json:"isConditional"`
+	To            Status                     `json:"to"`
+	Fields        map[string]TransitionField `json:"fields,omitempty"`
 }
 
 // TransitionField represents field metadata for a transition

--- a/tools/jtk/internal/cmd/transitions/transitions.go
+++ b/tools/jtk/internal/cmd/transitions/transitions.go
@@ -41,7 +41,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
 		Example: `  # List transitions
   jtk transitions list PROJ-123
 
-  # Extended output with status category and required fields
+  # Extended output with status category, screen/conditional info, and required fields
   jtk transitions list PROJ-123 --extended
 
   # Emit only transition IDs

--- a/tools/jtk/internal/cmd/transitions/transitions_test.go
+++ b/tools/jtk/internal/cmd/transitions/transitions_test.go
@@ -206,8 +206,8 @@ func transitionsServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := api.TransitionsResponse{
 			Transitions: []api.Transition{
-				{ID: "11", Name: "Backlog", To: api.Status{Name: "Backlog", StatusCategory: api.StatusCategory{Name: "To Do"}}},
-				{ID: "31", Name: "In Development", To: api.Status{Name: "In Development", StatusCategory: api.StatusCategory{Name: "In Progress"}}},
+				{ID: "11", Name: "Backlog", HasScreen: true, IsConditional: false, To: api.Status{Name: "Backlog", StatusCategory: api.StatusCategory{Name: "To Do"}}},
+				{ID: "31", Name: "In Development", HasScreen: false, IsConditional: true, To: api.Status{Name: "In Development", StatusCategory: api.StatusCategory{Name: "In Progress"}}},
 			},
 		}
 		w.WriteHeader(http.StatusOK)
@@ -253,8 +253,12 @@ func TestRunList_Extended(t *testing.T) {
 
 	out := stdout.String()
 	testutil.Contains(t, out, "STATUS_CATEGORY")
+	testutil.Contains(t, out, "HAS_SCREEN")
+	testutil.Contains(t, out, "CONDITIONAL")
 	testutil.Contains(t, out, "To Do")
 	testutil.Contains(t, out, "In Progress")
+	testutil.Contains(t, out, "yes")
+	testutil.Contains(t, out, "no")
 }
 
 func TestRunList_IDOnly(t *testing.T) {

--- a/tools/jtk/internal/present/transition.go
+++ b/tools/jtk/internal/present/transition.go
@@ -15,23 +15,25 @@ import (
 type TransitionPresenter struct{}
 
 // TransitionListSpec declares the columns emitted by PresentList. Default
-// order per #230 is ID|NAME|TO_STATUS; extended adds STATUS_CATEGORY and
-// REQUIRED_FIELDS.
+// order per #230 is ID|NAME|TO_STATUS; extended adds STATUS_CATEGORY,
+// HAS_SCREEN, CONDITIONAL, and REQUIRED_FIELDS.
 var TransitionListSpec = projection.Registry{
 	{Header: "ID", Identity: true},
 	{Header: "NAME"},
 	{Header: "TO_STATUS"},
 	{Header: "STATUS_CATEGORY", Extended: true},
+	{Header: "HAS_SCREEN", Extended: true},
+	{Header: "CONDITIONAL", Extended: true},
 	{Header: "REQUIRED_FIELDS", Extended: true},
 }
 
 // PresentList creates a table view for a list of transitions. Default
-// order is ID|NAME|TO_STATUS; --extended adds STATUS_CATEGORY and
-// REQUIRED_FIELDS.
+// order is ID|NAME|TO_STATUS; --extended adds STATUS_CATEGORY, HAS_SCREEN,
+// CONDITIONAL, and REQUIRED_FIELDS.
 func (TransitionPresenter) PresentList(transitions []api.Transition, extended bool) *present.OutputModel {
 	var headers []string
 	if extended {
-		headers = []string{"ID", "NAME", "TO_STATUS", "STATUS_CATEGORY", "REQUIRED_FIELDS"}
+		headers = []string{"ID", "NAME", "TO_STATUS", "STATUS_CATEGORY", "HAS_SCREEN", "CONDITIONAL", "REQUIRED_FIELDS"}
 	} else {
 		headers = []string{"ID", "NAME", "TO_STATUS"}
 	}
@@ -46,6 +48,8 @@ func (TransitionPresenter) PresentList(transitions []api.Transition, extended bo
 					t.Name,
 					toStatus,
 					OrDash(t.To.StatusCategory.Name),
+					BoolString(t.HasScreen),
+					BoolString(t.IsConditional),
 					GetRequiredFieldsForTransition(t),
 				},
 			}

--- a/tools/jtk/internal/present/transition_test.go
+++ b/tools/jtk/internal/present/transition_test.go
@@ -43,8 +43,9 @@ func TestTransitionPresenter_PresentList_Extended(t *testing.T) {
 	t.Parallel()
 	transitions := []api.Transition{
 		{
-			ID:   "71",
-			Name: "Deployed",
+			ID:        "71",
+			Name:      "Deployed",
+			HasScreen: true,
 			To: api.Status{
 				Name:           "Deployed",
 				StatusCategory: api.StatusCategory{Name: "Done"},
@@ -54,8 +55,9 @@ func TestTransitionPresenter_PresentList_Extended(t *testing.T) {
 			},
 		},
 		{
-			ID:   "11",
-			Name: "Backlog",
+			ID:            "11",
+			Name:          "Backlog",
+			IsConditional: true,
 			To: api.Status{
 				Name:           "Backlog",
 				StatusCategory: api.StatusCategory{Name: "To Do"},
@@ -66,7 +68,7 @@ func TestTransitionPresenter_PresentList_Extended(t *testing.T) {
 	model := TransitionPresenter{}.PresentList(transitions, true)
 	table := model.Sections[0].(*present.TableSection)
 
-	expectedHeaders := []string{"ID", "NAME", "TO_STATUS", "STATUS_CATEGORY", "REQUIRED_FIELDS"}
+	expectedHeaders := []string{"ID", "NAME", "TO_STATUS", "STATUS_CATEGORY", "HAS_SCREEN", "CONDITIONAL", "REQUIRED_FIELDS"}
 	if len(table.Headers) != len(expectedHeaders) {
 		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
 	}
@@ -79,11 +81,23 @@ func TestTransitionPresenter_PresentList_Extended(t *testing.T) {
 	if table.Rows[0].Cells[3] != "Done" {
 		t.Errorf("row 0 STATUS_CATEGORY: expected 'Done', got %q", table.Rows[0].Cells[3])
 	}
-	if table.Rows[0].Cells[4] != "Resolution" {
-		t.Errorf("row 0 REQUIRED_FIELDS: expected 'Resolution', got %q", table.Rows[0].Cells[4])
+	if table.Rows[0].Cells[4] != "yes" {
+		t.Errorf("row 0 HAS_SCREEN: expected 'yes', got %q", table.Rows[0].Cells[4])
 	}
-	if table.Rows[1].Cells[4] != "-" {
-		t.Errorf("row 1 REQUIRED_FIELDS: expected '-', got %q", table.Rows[1].Cells[4])
+	if table.Rows[0].Cells[5] != "no" {
+		t.Errorf("row 0 CONDITIONAL: expected 'no', got %q", table.Rows[0].Cells[5])
+	}
+	if table.Rows[0].Cells[6] != "Resolution" {
+		t.Errorf("row 0 REQUIRED_FIELDS: expected 'Resolution', got %q", table.Rows[0].Cells[6])
+	}
+	if table.Rows[1].Cells[4] != "no" {
+		t.Errorf("row 1 HAS_SCREEN: expected 'no', got %q", table.Rows[1].Cells[4])
+	}
+	if table.Rows[1].Cells[5] != "yes" {
+		t.Errorf("row 1 CONDITIONAL: expected 'yes', got %q", table.Rows[1].Cells[5])
+	}
+	if table.Rows[1].Cells[6] != "-" {
+		t.Errorf("row 1 REQUIRED_FIELDS: expected '-', got %q", table.Rows[1].Cells[6])
 	}
 }
 

--- a/tools/jtk/internal/present/transition_test.go
+++ b/tools/jtk/internal/present/transition_test.go
@@ -63,6 +63,16 @@ func TestTransitionPresenter_PresentList_Extended(t *testing.T) {
 				StatusCategory: api.StatusCategory{Name: "To Do"},
 			},
 		},
+		{
+			ID:            "41",
+			Name:          "In Review",
+			HasScreen:     true,
+			IsConditional: true,
+			To: api.Status{
+				Name:           "In Review",
+				StatusCategory: api.StatusCategory{Name: "In Progress"},
+			},
+		},
 	}
 
 	model := TransitionPresenter{}.PresentList(transitions, true)
@@ -75,6 +85,12 @@ func TestTransitionPresenter_PresentList_Extended(t *testing.T) {
 	for i, h := range expectedHeaders {
 		if table.Headers[i] != h {
 			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+
+	for i, row := range table.Rows {
+		if len(row.Cells) != len(expectedHeaders) {
+			t.Fatalf("row %d: expected %d cells, got %d", i, len(expectedHeaders), len(row.Cells))
 		}
 	}
 
@@ -98,6 +114,12 @@ func TestTransitionPresenter_PresentList_Extended(t *testing.T) {
 	}
 	if table.Rows[1].Cells[6] != "-" {
 		t.Errorf("row 1 REQUIRED_FIELDS: expected '-', got %q", table.Rows[1].Cells[6])
+	}
+	if table.Rows[2].Cells[4] != "yes" {
+		t.Errorf("row 2 HAS_SCREEN: expected 'yes', got %q", table.Rows[2].Cells[4])
+	}
+	if table.Rows[2].Cells[5] != "yes" {
+		t.Errorf("row 2 CONDITIONAL: expected 'yes', got %q", table.Rows[2].Cells[5])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `HAS_SCREEN` and `CONDITIONAL` columns to `jtk transitions list --extended` output
- Maps to `hasScreen` and `isConditional` boolean fields from the Jira transitions API
- Extended column order: `ID | NAME | TO_STATUS | STATUS_CATEGORY | HAS_SCREEN | CONDITIONAL | REQUIRED_FIELDS`

Closes #287

## Test plan
- [x] Presenter spec-lock test validates exact header order for both default and extended modes
- [x] API deserialization test verifies `hasScreen`/`isConditional` round-trip
- [x] Command-level extended test checks new columns appear in output
- [x] `make build && make test && make lint` all pass