### PR TITLE
feat(jtk): add VISIBILITY column to comments list --extended

### DIFF
--- a/tools/jtk/api/types.go
+++ b/tools/jtk/api/types.go
@@ -351,13 +351,20 @@ type FieldOption struct {
 	Value string `json:"value,omitempty"`
 }
 
+// CommentVisibility represents the visibility restriction on a comment.
+type CommentVisibility struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
 // Comment represents an issue comment
 type Comment struct {
-	ID      string       `json:"id"`
-	Author  User         `json:"author"`
-	Body    *ADFDocument `json:"body"`
-	Created string       `json:"created"`
-	Updated string       `json:"updated"`
+	ID         string             `json:"id"`
+	Author     User               `json:"author"`
+	Body       *ADFDocument       `json:"body"`
+	Created    string             `json:"created"`
+	Updated    string             `json:"updated"`
+	Visibility *CommentVisibility `json:"visibility,omitempty"`
 }
 
 // Field represents a Jira field definition

--- a/tools/jtk/internal/cmd/comments/comments_fields_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_fields_test.go
@@ -142,6 +142,40 @@ func TestRunList_Fields_BlockMode_PreservesPaginationHint(t *testing.T) {
 	testutil.Contains(t, output, "More results available")
 }
 
+// --fields VISIBILITY selects the extended-only column without requiring
+// --extended on the command. Guards that projection handles extended columns
+// requested explicitly via --fields.
+func TestRunList_Fields_TableMode_VisibilityColumn(t *testing.T) {
+	t.Parallel()
+	comments := []api.Comment{
+		plainComment("1", "Alice", "public"),
+		{
+			ID:     "2",
+			Author: api.User{DisplayName: "Bob"},
+			Body: &api.ADFDocument{
+				Type: "doc", Version: 1,
+				Content: []*api.ADFNode{{Type: "paragraph", Content: []*api.ADFNode{{Type: "text", Text: "restricted"}}}},
+			},
+			Created:    "2024-01-15T11:00:00.000Z",
+			Visibility: &api.CommentVisibility{Type: "role", Value: "Administrators"},
+		},
+	}
+	server := newTestCommentsServer(t, comments)
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	opts.Extended = true
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "ID,VISIBILITY")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "VISIBILITY")
+	testutil.Contains(t, output, "Administrators")
+	if strings.Contains(output, "BODY") {
+		t.Errorf("BODY header should be absent when not selected: %q", output)
+	}
+}
+
 // Unknown --fields token must surface as UnknownFieldError. The no-op
 // fetcher prevents UnrenderedFieldError or a real /field call.
 func TestRunList_Fields_UnknownToken_Errors(t *testing.T) {

--- a/tools/jtk/internal/cmd/comments/comments_fields_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_fields_test.go
@@ -142,9 +142,8 @@ func TestRunList_Fields_BlockMode_PreservesPaginationHint(t *testing.T) {
 	testutil.Contains(t, output, "More results available")
 }
 
-// --fields VISIBILITY selects the extended-only column without requiring
-// --extended on the command. Guards that projection handles extended columns
-// requested explicitly via --fields.
+// --fields VISIBILITY with --extended selects the visibility column and
+// drops unselected columns. Guards that projection handles extended columns.
 func TestRunList_Fields_TableMode_VisibilityColumn(t *testing.T) {
 	t.Parallel()
 	comments := []api.Comment{

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -363,10 +363,11 @@ func TestRunList_Extended_VisibilityColumn(t *testing.T) {
 	output := stdout.String()
 	testutil.Contains(t, output, "VISIBILITY")
 	testutil.Contains(t, output, "Administrators")
-	// Nil visibility should render as "-"
+	// Table mode: verify the VISIBILITY column contains "-" for the nil-visibility row.
+	// We check for "| - |" which only matches a dash cell, not date hyphens.
 	lines := strings.Split(strings.TrimSpace(output), "\n")
-	if len(lines) >= 2 && !strings.Contains(lines[1], "-") {
-		t.Errorf("expected nil visibility to render as '-' in first data row, got %q", lines[1])
+	if len(lines) >= 2 && !strings.Contains(lines[1], "| - |") {
+		t.Errorf("expected nil visibility to render as '- ' cell in first data row, got %q", lines[1])
 	}
 }
 
@@ -396,7 +397,7 @@ func TestRunList_FullTextExtended_VisibilityField(t *testing.T) {
 	output := stdout.String()
 	testutil.Contains(t, output, "Visibility:")
 	testutil.Contains(t, output, "Administrators")
-	testutil.Contains(t, output, "-")
+	testutil.Contains(t, output, "Visibility: -")
 }
 
 // commentsServerWithTotal is like newTestCommentsServer but lets the caller

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -363,6 +363,40 @@ func TestRunList_Extended_VisibilityColumn(t *testing.T) {
 	output := stdout.String()
 	testutil.Contains(t, output, "VISIBILITY")
 	testutil.Contains(t, output, "Administrators")
+	// Nil visibility should render as "-"
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) >= 2 && !strings.Contains(lines[1], "-") {
+		t.Errorf("expected nil visibility to render as '-' in first data row, got %q", lines[1])
+	}
+}
+
+func TestRunList_FullTextExtended_VisibilityField(t *testing.T) {
+	t.Parallel()
+	comments := []api.Comment{
+		plainComment("1", "Alice", "public comment"),
+		{
+			ID:     "2",
+			Author: api.User{DisplayName: "Bob"},
+			Body: &api.ADFDocument{
+				Type: "doc", Version: 1,
+				Content: []*api.ADFNode{{Type: "paragraph", Content: []*api.ADFNode{{Type: "text", Text: "restricted"}}}},
+			},
+			Created:    "2024-01-15T11:00:00.000Z",
+			Visibility: &api.CommentVisibility{Type: "role", Value: "Administrators"},
+		},
+	}
+	server := newTestCommentsServer(t, comments)
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	opts.Extended = true
+	err := runList(context.Background(), opts, "TEST-1", 50, true, "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Visibility:")
+	testutil.Contains(t, output, "Administrators")
+	testutil.Contains(t, output, "-")
 }
 
 // commentsServerWithTotal is like newTestCommentsServer but lets the caller

--- a/tools/jtk/internal/cmd/comments/comments_test.go
+++ b/tools/jtk/internal/cmd/comments/comments_test.go
@@ -337,6 +337,34 @@ func TestRunList_NoComments(t *testing.T) {
 	testutil.Contains(t, combined, "No comments")
 }
 
+func TestRunList_Extended_VisibilityColumn(t *testing.T) {
+	t.Parallel()
+	comments := []api.Comment{
+		plainComment("1", "Alice", "public comment"),
+		{
+			ID:     "2",
+			Author: api.User{DisplayName: "Bob"},
+			Body: &api.ADFDocument{
+				Type: "doc", Version: 1,
+				Content: []*api.ADFNode{{Type: "paragraph", Content: []*api.ADFNode{{Type: "text", Text: "restricted"}}}},
+			},
+			Created:    "2024-01-15T11:00:00.000Z",
+			Visibility: &api.CommentVisibility{Type: "role", Value: "Administrators"},
+		},
+	}
+	server := newTestCommentsServer(t, comments)
+	defer server.Close()
+
+	opts, stdout, _ := newCommentsOpts(t, server)
+	opts.Extended = true
+	err := runList(context.Background(), opts, "TEST-1", 50, false, "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "VISIBILITY")
+	testutil.Contains(t, output, "Administrators")
+}
+
 // commentsServerWithTotal is like newTestCommentsServer but lets the caller
 // set Total independently from len(comments), so pagination hasMore can be
 // exercised explicitly.

--- a/tools/jtk/internal/present/comment.go
+++ b/tools/jtk/internal/present/comment.go
@@ -24,6 +24,7 @@ var CommentListSpec = projection.Registry{
 	{Header: "AUTHOR"},
 	{Header: "CREATED"},
 	{Header: "UPDATED", Extended: true},
+	{Header: "VISIBILITY", Extended: true},
 	{Header: "BODY"},
 }
 
@@ -35,6 +36,7 @@ var CommentDetailSpec = projection.Registry{
 	{Header: "Author"},
 	{Header: "Created"},
 	{Header: "Updated", Extended: true},
+	{Header: "Visibility", Extended: true},
 	{Header: "Body"},
 }
 
@@ -43,7 +45,7 @@ var CommentDetailSpec = projection.Registry{
 func (CommentPresenter) PresentList(comments []api.Comment, extended bool) *present.OutputModel {
 	var headers []string
 	if extended {
-		headers = []string{"ID", "AUTHOR", "CREATED", "UPDATED", "BODY"}
+		headers = []string{"ID", "AUTHOR", "CREATED", "UPDATED", "VISIBILITY", "BODY"}
 	} else {
 		headers = []string{"ID", "AUTHOR", "CREATED", "BODY"}
 	}
@@ -63,7 +65,7 @@ func (CommentPresenter) PresentList(comments []api.Comment, extended bool) *pres
 		}
 		if extended {
 			rows[i] = present.Row{
-				Cells: []string{c.ID, author, OrDash(c.Created), OrDash(c.Updated), body},
+				Cells: []string{c.ID, author, OrDash(c.Created), OrDash(c.Updated), formatVisibility(c.Visibility), body},
 			}
 		} else {
 			rows[i] = present.Row{
@@ -97,7 +99,10 @@ func (CommentPresenter) PresentListFull(comments []api.Comment, extended bool) *
 			{Label: "Created", Value: FormatTime(c.Created)},
 		}
 		if extended {
-			fields = append(fields, present.Field{Label: "Updated", Value: OrDash(c.Updated)})
+			fields = append(fields,
+				present.Field{Label: "Updated", Value: OrDash(c.Updated)},
+				present.Field{Label: "Visibility", Value: formatVisibility(c.Visibility)},
+			)
 		}
 		fields = append(fields, present.Field{Label: "Body", Value: body})
 		sections[i] = &present.DetailSection{Fields: fields}
@@ -174,6 +179,13 @@ func (CommentPresenter) PresentDeleted(commentID, issueKey string) *present.Outp
 			},
 		},
 	}
+}
+
+func formatVisibility(v *api.CommentVisibility) string {
+	if v == nil {
+		return "-"
+	}
+	return OrDash(v.Value)
 }
 
 // PresentEmpty creates an info message when no comments are found.

--- a/tools/jtk/internal/present/comment_test.go
+++ b/tools/jtk/internal/present/comment_test.go
@@ -142,6 +142,70 @@ func TestCommentDetailSpec_MatchesPresentDetailLabels(t *testing.T) {
 	}
 }
 
+func TestCommentPresenter_PresentList_ExtendedVisibility(t *testing.T) {
+	t.Parallel()
+	comments := []api.Comment{
+		{
+			ID:     "100",
+			Author: api.User{DisplayName: "Alice"},
+			Body: &api.ADFDocument{
+				Type: "doc", Version: 1,
+				Content: []*api.ADFNode{{Type: "paragraph", Content: []*api.ADFNode{{Type: "text", Text: "public"}}}},
+			},
+			Created: "2024-01-15T10:00:00.000Z",
+		},
+		{
+			ID:     "101",
+			Author: api.User{DisplayName: "Bob"},
+			Body: &api.ADFDocument{
+				Type: "doc", Version: 1,
+				Content: []*api.ADFNode{{Type: "paragraph", Content: []*api.ADFNode{{Type: "text", Text: "restricted"}}}},
+			},
+			Created:    "2024-01-15T11:00:00.000Z",
+			Visibility: &api.CommentVisibility{Type: "role", Value: "Administrators"},
+		},
+		{
+			ID:     "102",
+			Author: api.User{DisplayName: "Carol"},
+			Body: &api.ADFDocument{
+				Type: "doc", Version: 1,
+				Content: []*api.ADFNode{{Type: "paragraph", Content: []*api.ADFNode{{Type: "text", Text: "empty vis"}}}},
+			},
+			Created:    "2024-01-15T12:00:00.000Z",
+			Visibility: &api.CommentVisibility{Type: "role", Value: ""},
+		},
+	}
+
+	model := CommentPresenter{}.PresentList(comments, true)
+	table := model.Sections[0].(*present.TableSection)
+
+	expectedHeaders := []string{"ID", "AUTHOR", "CREATED", "UPDATED", "VISIBILITY", "BODY"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
+	}
+	for i, h := range expectedHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+
+	for i, row := range table.Rows {
+		if len(row.Cells) != len(expectedHeaders) {
+			t.Fatalf("row %d: expected %d cells, got %d", i, len(expectedHeaders), len(row.Cells))
+		}
+	}
+
+	if table.Rows[0].Cells[4] != "-" {
+		t.Errorf("row 0 VISIBILITY: expected '-' (nil), got %q", table.Rows[0].Cells[4])
+	}
+	if table.Rows[1].Cells[4] != "Administrators" {
+		t.Errorf("row 1 VISIBILITY: expected 'Administrators', got %q", table.Rows[1].Cells[4])
+	}
+	if table.Rows[2].Cells[4] != "-" {
+		t.Errorf("row 2 VISIBILITY: expected '-' (empty value), got %q", table.Rows[2].Cells[4])
+	}
+}
+
 func TestCommentListSpec_ExtendedMatchesPresentListHeaders(t *testing.T) {
 	t.Parallel()
 	comments := singleComment()

--- a/tools/jtk/internal/present/comment_test.go
+++ b/tools/jtk/internal/present/comment_test.go
@@ -206,6 +206,54 @@ func TestCommentPresenter_PresentList_ExtendedVisibility(t *testing.T) {
 	}
 }
 
+func TestCommentPresenter_PresentListFull_ExtendedVisibility(t *testing.T) {
+	t.Parallel()
+	comments := []api.Comment{
+		{
+			ID:     "100",
+			Author: api.User{DisplayName: "Alice"},
+			Body: &api.ADFDocument{
+				Type: "doc", Version: 1,
+				Content: []*api.ADFNode{{Type: "paragraph", Content: []*api.ADFNode{{Type: "text", Text: "public"}}}},
+			},
+			Created: "2024-01-15T10:00:00.000Z",
+		},
+		{
+			ID:     "101",
+			Author: api.User{DisplayName: "Bob"},
+			Body: &api.ADFDocument{
+				Type: "doc", Version: 1,
+				Content: []*api.ADFNode{{Type: "paragraph", Content: []*api.ADFNode{{Type: "text", Text: "restricted"}}}},
+			},
+			Created:    "2024-01-15T11:00:00.000Z",
+			Visibility: &api.CommentVisibility{Type: "role", Value: "Administrators"},
+		},
+	}
+
+	model := CommentPresenter{}.PresentListFull(comments, true)
+
+	ds0 := model.Sections[0].(*present.DetailSection)
+	ds1 := model.Sections[1].(*present.DetailSection)
+
+	var vis0, vis1 string
+	for _, f := range ds0.Fields {
+		if f.Label == "Visibility" {
+			vis0 = f.Value
+		}
+	}
+	for _, f := range ds1.Fields {
+		if f.Label == "Visibility" {
+			vis1 = f.Value
+		}
+	}
+	if vis0 != "-" {
+		t.Errorf("comment 0 Visibility: expected '-', got %q", vis0)
+	}
+	if vis1 != "Administrators" {
+		t.Errorf("comment 1 Visibility: expected 'Administrators', got %q", vis1)
+	}
+}
+
 func TestCommentListSpec_ExtendedMatchesPresentListHeaders(t *testing.T) {
 	t.Parallel()
 	comments := singleComment()


### PR DESCRIPTION
## Summary
- Adds `VISIBILITY` column to `jtk comments list --extended` (table and detail modes)
- Maps to Jira API `visibility` object (`type` + `value` fields) on comments
- Shows `-` when unrestricted, restriction group/role name otherwise
- Handles edge case of empty visibility value via `OrDash`

Closes #288

## Test plan
- [x] Presenter spec-lock tests verify exact header order for both default and extended modes (table + detail)
- [x] Dedicated visibility test covers nil, non-nil, and empty-value cases
- [x] Command-level extended test verifies VISIBILITY header and values in output
- [x] `--fields VISIBILITY` projection test verifies column selection works
- [x] `make build && make test && make lint` all pass