### PR TITLE
feat(jtk): fix links list --extended column order

### DIFF
--- a/tools/jtk/internal/present/link.go
+++ b/tools/jtk/internal/present/link.go
@@ -14,15 +14,16 @@ import (
 type LinkPresenter struct{}
 
 // LinkListSpec declares the columns emitted by PresentList. Default:
-// LINK_ID|TYPE|DIRECTION|ISSUE|SUMMARY. Extended adds TYPE_ID and STATUS.
+// LINK_ID|TYPE|DIRECTION|ISSUE|SUMMARY. Extended:
+// LINK_ID|TYPE_ID|TYPE|DIRECTION|ISSUE|STATUS|SUMMARY.
 var LinkListSpec = projection.Registry{
 	{Header: "LINK_ID", Identity: true},
+	{Header: "TYPE_ID", Extended: true},
 	{Header: "TYPE"},
 	{Header: "DIRECTION"},
 	{Header: "ISSUE"},
-	{Header: "SUMMARY"},
-	{Header: "TYPE_ID", Extended: true},
 	{Header: "STATUS", Extended: true},
+	{Header: "SUMMARY"},
 }
 
 // LinkTypesSpec declares the columns for link types. All default.
@@ -33,12 +34,12 @@ var LinkTypesSpec = projection.Registry{
 	{Header: "OUTWARD"},
 }
 
-// PresentList creates a table presentation of issue links. Extended
-// adds TYPE_ID and the linked issue's current STATUS.
+// PresentList creates a table presentation of issue links. Extended:
+// LINK_ID|TYPE_ID|TYPE|DIRECTION|ISSUE|STATUS|SUMMARY.
 func (LinkPresenter) PresentList(links []api.IssueLink, extended bool) *present.OutputModel {
 	var headers []string
 	if extended {
-		headers = []string{"LINK_ID", "TYPE", "DIRECTION", "ISSUE", "SUMMARY", "TYPE_ID", "STATUS"}
+		headers = []string{"LINK_ID", "TYPE_ID", "TYPE", "DIRECTION", "ISSUE", "STATUS", "SUMMARY"}
 	} else {
 		headers = []string{"LINK_ID", "TYPE", "DIRECTION", "ISSUE", "SUMMARY"}
 	}
@@ -65,7 +66,7 @@ func (LinkPresenter) PresentList(links []api.IssueLink, extended bool) *present.
 
 		if extended {
 			rows[i] = present.Row{
-				Cells: []string{l.ID, l.Type.Name, direction, key, summary, OrDash(l.Type.ID), OrDash(status)},
+				Cells: []string{l.ID, OrDash(l.Type.ID), l.Type.Name, direction, key, OrDash(status), summary},
 			}
 		} else {
 			rows[i] = present.Row{

--- a/tools/jtk/internal/present/link_test.go
+++ b/tools/jtk/internal/present/link_test.go
@@ -65,18 +65,32 @@ func TestLinkTypesSpec_MatchesPresentTypesHeaders(t *testing.T) {
 
 func TestLinkPresenter_PresentList_Extended(t *testing.T) {
 	t.Parallel()
-	links := []api.IssueLink{{
-		ID:   "17844",
-		Type: api.IssueLinkType{ID: "10100", Name: "Blocker", Inward: "is blocked by", Outward: "blocks"},
-		OutwardIssue: &api.LinkedIssue{
-			Key: "MON-4819",
-			Fields: struct {
-				Summary   string         `json:"summary"`
-				Status    *api.Status    `json:"status,omitempty"`
-				IssueType *api.IssueType `json:"issuetype,omitempty"`
-			}{Summary: "Linked issue B", Status: &api.Status{Name: "Backlog"}},
+	links := []api.IssueLink{
+		{
+			ID:   "17844",
+			Type: api.IssueLinkType{ID: "10100", Name: "Blocker", Inward: "is blocked by", Outward: "blocks"},
+			OutwardIssue: &api.LinkedIssue{
+				Key: "MON-4819",
+				Fields: struct {
+					Summary   string         `json:"summary"`
+					Status    *api.Status    `json:"status,omitempty"`
+					IssueType *api.IssueType `json:"issuetype,omitempty"`
+				}{Summary: "Linked issue B", Status: &api.Status{Name: "Backlog"}},
+			},
 		},
-	}}
+		{
+			ID:   "17845",
+			Type: api.IssueLinkType{ID: "10200", Name: "Relates", Inward: "relates to", Outward: "relates to"},
+			InwardIssue: &api.LinkedIssue{
+				Key: "MON-4700",
+				Fields: struct {
+					Summary   string         `json:"summary"`
+					Status    *api.Status    `json:"status,omitempty"`
+					IssueType *api.IssueType `json:"issuetype,omitempty"`
+				}{Summary: "Fix ghost row"},
+			},
+		},
+	}
 
 	model := LinkPresenter{}.PresentList(links, true)
 	table := model.Sections[0].(*present.TableSection)
@@ -91,21 +105,58 @@ func TestLinkPresenter_PresentList_Extended(t *testing.T) {
 		}
 	}
 
-	row := table.Rows[0]
-	if len(row.Cells) != len(expectedHeaders) {
-		t.Fatalf("expected %d cells, got %d", len(expectedHeaders), len(row.Cells))
+	for i, row := range table.Rows {
+		if len(row.Cells) != len(expectedHeaders) {
+			t.Fatalf("row %d: expected %d cells, got %d", i, len(expectedHeaders), len(row.Cells))
+		}
 	}
-	if row.Cells[0] != "17844" {
-		t.Errorf("LINK_ID: expected '17844', got %q", row.Cells[0])
+
+	// Row 0: OutwardIssue with status
+	r0 := table.Rows[0].Cells
+	wantR0 := []string{"17844", "10100", "Blocker", "is blocked by", "MON-4819", "Backlog", "Linked issue B"}
+	for i, w := range wantR0 {
+		if r0[i] != w {
+			t.Errorf("row0[%d] (%s): expected %q, got %q", i, expectedHeaders[i], w, r0[i])
+		}
 	}
-	if row.Cells[1] != "10100" {
-		t.Errorf("TYPE_ID: expected '10100', got %q", row.Cells[1])
+
+	// Row 1: InwardIssue with nil status
+	r1 := table.Rows[1].Cells
+	wantR1 := []string{"17845", "10200", "Relates", "relates to", "MON-4700", "-", "Fix ghost row"}
+	for i, w := range wantR1 {
+		if r1[i] != w {
+			t.Errorf("row1[%d] (%s): expected %q, got %q", i, expectedHeaders[i], w, r1[i])
+		}
 	}
-	if row.Cells[5] != "Backlog" {
-		t.Errorf("STATUS: expected 'Backlog', got %q", row.Cells[5])
+}
+
+func TestLinkPresenter_PresentList_Default_CellOrder(t *testing.T) {
+	t.Parallel()
+	links := []api.IssueLink{{
+		ID:   "17844",
+		Type: api.IssueLinkType{ID: "10100", Name: "Blocker", Inward: "is blocked by", Outward: "blocks"},
+		OutwardIssue: &api.LinkedIssue{
+			Key: "MON-4819",
+			Fields: struct {
+				Summary   string         `json:"summary"`
+				Status    *api.Status    `json:"status,omitempty"`
+				IssueType *api.IssueType `json:"issuetype,omitempty"`
+			}{Summary: "Linked issue B", Status: &api.Status{Name: "Backlog"}},
+		},
+	}}
+
+	model := LinkPresenter{}.PresentList(links, false)
+	table := model.Sections[0].(*present.TableSection)
+
+	want := []string{"17844", "Blocker", "is blocked by", "MON-4819", "Linked issue B"}
+	row := table.Rows[0].Cells
+	if len(row) != len(want) {
+		t.Fatalf("expected %d cells, got %d", len(want), len(row))
 	}
-	if row.Cells[6] != "Linked issue B" {
-		t.Errorf("SUMMARY: expected 'Linked issue B', got %q", row.Cells[6])
+	for i, w := range want {
+		if row[i] != w {
+			t.Errorf("cell[%d]: expected %q, got %q", i, w, row[i])
+		}
 	}
 }
 

--- a/tools/jtk/internal/present/link_test.go
+++ b/tools/jtk/internal/present/link_test.go
@@ -81,11 +81,31 @@ func TestLinkPresenter_PresentList_Extended(t *testing.T) {
 	model := LinkPresenter{}.PresentList(links, true)
 	table := model.Sections[0].(*present.TableSection)
 
-	if table.Rows[0].Cells[5] != "10100" {
-		t.Errorf("TYPE_ID: expected '10100', got %q", table.Rows[0].Cells[5])
+	expectedHeaders := []string{"LINK_ID", "TYPE_ID", "TYPE", "DIRECTION", "ISSUE", "STATUS", "SUMMARY"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
 	}
-	if table.Rows[0].Cells[6] != "Backlog" {
-		t.Errorf("STATUS: expected 'Backlog', got %q", table.Rows[0].Cells[6])
+	for i, h := range expectedHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+
+	row := table.Rows[0]
+	if len(row.Cells) != len(expectedHeaders) {
+		t.Fatalf("expected %d cells, got %d", len(expectedHeaders), len(row.Cells))
+	}
+	if row.Cells[0] != "17844" {
+		t.Errorf("LINK_ID: expected '17844', got %q", row.Cells[0])
+	}
+	if row.Cells[1] != "10100" {
+		t.Errorf("TYPE_ID: expected '10100', got %q", row.Cells[1])
+	}
+	if row.Cells[5] != "Backlog" {
+		t.Errorf("STATUS: expected 'Backlog', got %q", row.Cells[5])
+	}
+	if row.Cells[6] != "Linked issue B" {
+		t.Errorf("SUMMARY: expected 'Linked issue B', got %q", row.Cells[6])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reorders `jtk links list --extended` columns to match #230 spec
- Before: `LINK_ID | TYPE | DIRECTION | ISSUE | SUMMARY | TYPE_ID | STATUS`
- After: `LINK_ID | TYPE_ID | TYPE | DIRECTION | ISSUE | STATUS | SUMMARY`

Closes #289

## Test plan
- [x] Spec-lock test verifies header order for both default and extended modes
- [x] Extended test asserts exact header order and cell positions for TYPE_ID, STATUS, SUMMARY
- [x] `make build && make test && make lint` all pass