### PR TITLE
feat(jtk): fix attachments list --extended column order and get output format

### DIFF
--- a/tools/jtk/internal/cmd/attachments/attachments.go
+++ b/tools/jtk/internal/cmd/attachments/attachments.go
@@ -251,7 +251,7 @@ func runGet(ctx context.Context, opts *root.Options, attachmentID, outputPath st
 		actualPath = filepath.Join(outputPath, attachment.Filename)
 	}
 
-	return jtkpresent.Emit(opts, jtkpresent.AttachmentPresenter{}.PresentDownloaded(actualPath, attachment.Size))
+	return jtkpresent.Emit(opts, jtkpresent.AttachmentPresenter{}.PresentDownloaded(attachment.ID.String(), actualPath, attachment.Size))
 }
 
 func newDeleteCmd(opts *root.Options) *cobra.Command {

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -438,11 +438,10 @@ func TestRunGet_Success(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, string(content), fileContent)
 
-	// Verify success message includes ID, arrow, path, and size
+	// Verify exact success message format
 	output := stdout.String()
-	testutil.Contains(t, output, "Downloaded 10001")
-	testutil.Contains(t, output, "→")
-	testutil.Contains(t, output, "downloaded.txt")
+	wantMsg := fmt.Sprintf("Downloaded 10001 → %s (36 B)", outputPath)
+	testutil.Contains(t, output, wantMsg)
 }
 
 // --- delete tests ---

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -438,9 +438,10 @@ func TestRunGet_Success(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, string(content), fileContent)
 
-	// Verify success message
+	// Verify success message includes ID, arrow, path, and size
 	output := stdout.String()
-	testutil.Contains(t, output, "Downloaded")
+	testutil.Contains(t, output, "Downloaded 10001")
+	testutil.Contains(t, output, "→")
 	testutil.Contains(t, output, "downloaded.txt")
 }
 

--- a/tools/jtk/internal/present/attachment.go
+++ b/tools/jtk/internal/present/attachment.go
@@ -14,23 +14,24 @@ import (
 type AttachmentPresenter struct{}
 
 // AttachmentListSpec declares the columns emitted by PresentList. Default:
-// ID|FILENAME|SIZE|AUTHOR|CREATED. Extended adds BYTES and MIME_TYPE.
+// ID|FILENAME|SIZE|AUTHOR|CREATED. Extended:
+// ID|FILENAME|SIZE|BYTES|MIME_TYPE|AUTHOR|CREATED.
 var AttachmentListSpec = projection.Registry{
 	{Header: "ID", Identity: true},
 	{Header: "FILENAME"},
 	{Header: "SIZE"},
-	{Header: "AUTHOR"},
-	{Header: "CREATED"},
 	{Header: "BYTES", Extended: true},
 	{Header: "MIME_TYPE", Extended: true},
+	{Header: "AUTHOR"},
+	{Header: "CREATED"},
 }
 
-// PresentList creates a table presentation of attachments. Extended
-// adds BYTES (raw size) and MIME_TYPE columns, uses full timestamps.
+// PresentList creates a table presentation of attachments. Extended:
+// ID|FILENAME|SIZE|BYTES|MIME_TYPE|AUTHOR|CREATED.
 func (AttachmentPresenter) PresentList(attachments []api.Attachment, extended bool) *present.OutputModel {
 	var headers []string
 	if extended {
-		headers = []string{"ID", "FILENAME", "SIZE", "AUTHOR", "CREATED", "BYTES", "MIME_TYPE"}
+		headers = []string{"ID", "FILENAME", "SIZE", "BYTES", "MIME_TYPE", "AUTHOR", "CREATED"}
 	} else {
 		headers = []string{"ID", "FILENAME", "SIZE", "AUTHOR", "CREATED"}
 	}
@@ -43,10 +44,10 @@ func (AttachmentPresenter) PresentList(attachments []api.Attachment, extended bo
 					a.ID.String(),
 					a.Filename,
 					FormatSize(a.Size),
-					a.Author.DisplayName,
-					OrDash(a.Created),
 					FormatInt(int(a.Size)),
 					OrDash(a.MimeType),
+					a.Author.DisplayName,
+					OrDash(a.Created),
 				},
 			}
 		} else {
@@ -76,13 +77,12 @@ func (AttachmentPresenter) PresentUploaded(filename, id, size string) *present.O
 }
 
 // PresentDownloaded creates a success message for attachment download.
-// Size formatting is handled internally.
-func (AttachmentPresenter) PresentDownloaded(filename string, sizeBytes int64) *present.OutputModel {
+func (AttachmentPresenter) PresentDownloaded(attachmentID, filename string, sizeBytes int64) *present.OutputModel {
 	return &present.OutputModel{
 		Sections: []present.Section{
 			&present.MessageSection{
 				Kind:    present.MessageSuccess,
-				Message: fmt.Sprintf("Downloaded %s (%s)", filename, FormatSize(sizeBytes)),
+				Message: fmt.Sprintf("Downloaded %s → %s (%s)", attachmentID, filename, FormatSize(sizeBytes)),
 				Stream:  present.StreamStdout,
 			},
 		},

--- a/tools/jtk/internal/present/attachment_test.go
+++ b/tools/jtk/internal/present/attachment_test.go
@@ -43,14 +43,24 @@ func TestAttachmentListSpec_MatchesPresentListHeaders(t *testing.T) {
 
 func TestAttachmentPresenter_PresentList_Extended(t *testing.T) {
 	t.Parallel()
-	attachments := []api.Attachment{{
-		ID:       "10234",
-		Filename: "audit-notes.md",
-		Size:     4301,
-		MimeType: "text/markdown",
-		Created:  "2026-04-16T09:00:00+0000",
-		Author:   api.User{DisplayName: "Alice"},
-	}}
+	attachments := []api.Attachment{
+		{
+			ID:       "10234",
+			Filename: "audit-notes.md",
+			Size:     4301,
+			MimeType: "text/markdown",
+			Created:  "2026-04-16T09:00:00+0000",
+			Author:   api.User{DisplayName: "Alice"},
+		},
+		{
+			ID:       "10235",
+			Filename: "mystery.bin",
+			Size:     100,
+			MimeType: "",
+			Created:  "2026-04-16T10:00:00+0000",
+			Author:   api.User{DisplayName: "Bob"},
+		},
+	}
 
 	model := AttachmentPresenter{}.PresentList(attachments, true)
 	table := model.Sections[0].(*present.TableSection)
@@ -65,15 +75,51 @@ func TestAttachmentPresenter_PresentList_Extended(t *testing.T) {
 		}
 	}
 
-	row := table.Rows[0]
-	if len(row.Cells) != len(expectedHeaders) {
-		t.Fatalf("expected %d cells, got %d", len(expectedHeaders), len(row.Cells))
-	}
-	want := []string{"10234", "audit-notes.md", "4.2 KB", "4301", "text/markdown", "Alice", "2026-04-16T09:00:00+0000"}
-	for i, w := range want {
-		if row.Cells[i] != w {
-			t.Errorf("cell[%d] (%s): expected %q, got %q", i, expectedHeaders[i], w, row.Cells[i])
+	for i, row := range table.Rows {
+		if len(row.Cells) != len(expectedHeaders) {
+			t.Fatalf("row %d: expected %d cells, got %d", i, len(expectedHeaders), len(row.Cells))
 		}
+	}
+
+	want0 := []string{"10234", "audit-notes.md", "4.2 KB", "4301", "text/markdown", "Alice", "2026-04-16T09:00:00+0000"}
+	for i, w := range want0 {
+		if table.Rows[0].Cells[i] != w {
+			t.Errorf("row0[%d] (%s): expected %q, got %q", i, expectedHeaders[i], w, table.Rows[0].Cells[i])
+		}
+	}
+
+	// Row 1: empty MimeType renders as "-"
+	if table.Rows[1].Cells[4] != "-" {
+		t.Errorf("row1 MIME_TYPE: expected '-' for empty, got %q", table.Rows[1].Cells[4])
+	}
+}
+
+func TestAttachmentPresenter_PresentList_Default_CellOrder(t *testing.T) {
+	t.Parallel()
+	attachments := []api.Attachment{{
+		ID:       "10234",
+		Filename: "audit-notes.md",
+		Size:     4301,
+		MimeType: "text/markdown",
+		Created:  "2026-04-16T09:00:00+0000",
+		Author:   api.User{DisplayName: "Alice"},
+	}}
+
+	model := AttachmentPresenter{}.PresentList(attachments, false)
+	table := model.Sections[0].(*present.TableSection)
+
+	row := table.Rows[0]
+	if len(row.Cells) != 5 {
+		t.Fatalf("expected 5 cells, got %d", len(row.Cells))
+	}
+	if row.Cells[0] != "10234" {
+		t.Errorf("ID: expected '10234', got %q", row.Cells[0])
+	}
+	if row.Cells[1] != "audit-notes.md" {
+		t.Errorf("FILENAME: expected 'audit-notes.md', got %q", row.Cells[1])
+	}
+	if row.Cells[3] != "Alice" {
+		t.Errorf("AUTHOR: expected 'Alice', got %q", row.Cells[3])
 	}
 }
 

--- a/tools/jtk/internal/present/attachment_test.go
+++ b/tools/jtk/internal/present/attachment_test.go
@@ -55,17 +55,31 @@ func TestAttachmentPresenter_PresentList_Extended(t *testing.T) {
 	model := AttachmentPresenter{}.PresentList(attachments, true)
 	table := model.Sections[0].(*present.TableSection)
 
-	if table.Rows[0].Cells[5] != "4301" {
-		t.Errorf("BYTES: expected '4301', got %q", table.Rows[0].Cells[5])
+	expectedHeaders := []string{"ID", "FILENAME", "SIZE", "BYTES", "MIME_TYPE", "AUTHOR", "CREATED"}
+	if len(table.Headers) != len(expectedHeaders) {
+		t.Fatalf("expected %d headers, got %d", len(expectedHeaders), len(table.Headers))
 	}
-	if table.Rows[0].Cells[6] != "text/markdown" {
-		t.Errorf("MIME_TYPE: expected 'text/markdown', got %q", table.Rows[0].Cells[6])
+	for i, h := range expectedHeaders {
+		if table.Headers[i] != h {
+			t.Errorf("header[%d]: expected %q, got %q", i, h, table.Headers[i])
+		}
+	}
+
+	row := table.Rows[0]
+	if len(row.Cells) != len(expectedHeaders) {
+		t.Fatalf("expected %d cells, got %d", len(expectedHeaders), len(row.Cells))
+	}
+	want := []string{"10234", "audit-notes.md", "4.2 KB", "4301", "text/markdown", "Alice", "2026-04-16T09:00:00+0000"}
+	for i, w := range want {
+		if row.Cells[i] != w {
+			t.Errorf("cell[%d] (%s): expected %q, got %q", i, expectedHeaders[i], w, row.Cells[i])
+		}
 	}
 }
 
 func TestAttachmentPresenter_PresentDownloaded(t *testing.T) {
 	t.Parallel()
-	model := AttachmentPresenter{}.PresentDownloaded("./audit.md", 4301)
+	model := AttachmentPresenter{}.PresentDownloaded("10234", "./audit.md", 4301)
 	msg := model.Sections[0].(*present.MessageSection)
 	if msg.Kind != present.MessageSuccess {
 		t.Errorf("want MessageSuccess, got %v", msg.Kind)
@@ -73,7 +87,7 @@ func TestAttachmentPresenter_PresentDownloaded(t *testing.T) {
 	if msg.Stream != present.StreamStdout {
 		t.Errorf("want StreamStdout, got %v", msg.Stream)
 	}
-	if msg.Message != "Downloaded ./audit.md (4.2 KB)" {
+	if msg.Message != "Downloaded 10234 → ./audit.md (4.2 KB)" {
 		t.Errorf("unexpected message: %q", msg.Message)
 	}
 }


### PR DESCRIPTION
## Summary
- Reorders `jtk attachments list --extended` columns: BYTES and MIME_TYPE now follow SIZE (before AUTHOR/CREATED)
- Before: `ID | FILENAME | SIZE | AUTHOR | CREATED | BYTES | MIME_TYPE`
- After: `ID | FILENAME | SIZE | BYTES | MIME_TYPE | AUTHOR | CREATED`
- Updates `attachments get` output to include attachment ID and arrow: `Downloaded 10234 → ./file.md (4.2 KB)`

Closes #290

## Test plan
- [x] Spec-lock test verifies header order for both default and extended modes
- [x] Extended test asserts exact header order and all cell positions
- [x] PresentDownloaded test verifies new 3-arg signature and `→` format
- [x] Command-level TestRunGet_Success asserts exact output format
- [x] `make build && make test && make lint` all pass