### PR TITLE
feat(jtk): fix boards get --extended filter name rendering

### DIFF
--- a/tools/jtk/internal/cmd/boards/boards_test.go
+++ b/tools/jtk/internal/cmd/boards/boards_test.go
@@ -448,6 +448,50 @@ func TestRunGet_Extended(t *testing.T) {
 	}
 }
 
+func TestRunGet_Extended_EmptyFilterName(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/configuration") {
+			_ = json.NewEncoder(w).Encode(api.BoardConfiguration{
+				ID:     42,
+				Name:   "Sprint Board",
+				Filter: api.BoardFilter{ID: "10084", Name: ""},
+				ColumnConfig: api.BoardColumnConfig{
+					Columns: []api.BoardColumn{
+						{Name: "Backlog"},
+						{Name: "Ready for Development"},
+						{Name: "In Development"},
+					},
+				},
+			})
+		} else {
+			_ = json.NewEncoder(w).Encode(api.Board{
+				ID: 42, Name: "Sprint Board", Type: "scrum",
+				Location: api.BoardLocation{ProjectKey: "PROJ", ProjectName: "My Project"},
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	resolvedBoard := &api.Board{ID: 42, Name: "Sprint Board"}
+	err = runGet(context.Background(), opts, client, resolvedBoard, "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Filter: id: 10084")
+	if strings.Contains(output, "Filter:  (id:") {
+		t.Errorf("filter should not have leading space before (id:): %q", output)
+	}
+	testutil.Contains(t, output, "Column config: Backlog, Ready for Development, In Development")
+}
+
 func TestRunGet_NameFallback(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/tools/jtk/internal/present/board.go
+++ b/tools/jtk/internal/present/board.go
@@ -99,7 +99,7 @@ func (BoardPresenter) PresentDetail(board *api.Board, config *api.BoardConfigura
 		filterVal := "-"
 		columnVal := "-"
 		if config != nil {
-			filterVal = fmt.Sprintf("%s (id: %s)", config.Filter.Name, config.Filter.ID)
+			filterVal = formatFilterRef(config.Filter)
 			colNames := make([]string, len(config.ColumnConfig.Columns))
 			for i, c := range config.ColumnConfig.Columns {
 				colNames[i] = c.Name
@@ -118,7 +118,7 @@ func (BoardPresenter) PresentDetailProjection(board *api.Board, config *api.Boar
 	filterName := "-"
 	columnConfig := "-"
 	if config != nil {
-		filterName = fmt.Sprintf("%s (id: %s)", config.Filter.Name, config.Filter.ID)
+		filterName = formatFilterRef(config.Filter)
 		colNames := make([]string, len(config.ColumnConfig.Columns))
 		for i, c := range config.ColumnConfig.Columns {
 			colNames[i] = c.Name
@@ -138,6 +138,16 @@ func (BoardPresenter) PresentDetailProjection(board *api.Board, config *api.Boar
 	return &present.OutputModel{
 		Sections: []present.Section{&present.DetailSection{Fields: fields}},
 	}
+}
+
+func formatFilterRef(f api.BoardFilter) string {
+	if f.ID == "" {
+		return "-"
+	}
+	if f.Name != "" {
+		return fmt.Sprintf("%s (id: %s)", f.Name, f.ID)
+	}
+	return fmt.Sprintf("id: %s", f.ID)
 }
 
 // PresentConfigFetchWarning creates a warning when board configuration

--- a/tools/jtk/internal/present/board_test.go
+++ b/tools/jtk/internal/present/board_test.go
@@ -116,6 +116,28 @@ func TestPresentBoardDetail_Extended(t *testing.T) {
 	}
 }
 
+func TestFormatFilterRef(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		filter api.BoardFilter
+		want   string
+	}{
+		{"name and id", api.BoardFilter{ID: "100", Name: "my filter"}, "my filter (id: 100)"},
+		{"empty name", api.BoardFilter{ID: "10084", Name: ""}, "id: 10084"},
+		{"empty id", api.BoardFilter{ID: "", Name: "orphan"}, "-"},
+		{"both empty", api.BoardFilter{ID: "", Name: ""}, "-"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatFilterRef(tt.filter)
+			if got != tt.want {
+				t.Errorf("formatFilterRef(%+v) = %q, want %q", tt.filter, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPresentBoardDetail_Extended_EmptyFilterName(t *testing.T) {
 	t.Parallel()
 	board := &api.Board{
@@ -196,6 +218,32 @@ func TestPresentBoardDetailProjection_ContainsAllSpecHeaders(t *testing.T) {
 			t.Errorf("spec header %q not found in projection detail fields", h)
 		}
 	}
+}
+
+func TestPresentBoardDetailProjection_EmptyFilterName(t *testing.T) {
+	t.Parallel()
+	board := &api.Board{
+		ID: 23, Name: "MON board", Type: "scrum",
+		Location: api.BoardLocation{ProjectKey: "MON", ProjectName: "Platform Development"},
+	}
+	config := &api.BoardConfiguration{
+		Filter: api.BoardFilter{ID: "10084", Name: ""},
+		ColumnConfig: api.BoardColumnConfig{
+			Columns: []api.BoardColumn{{Name: "Backlog"}},
+		},
+	}
+	model := BoardPresenter{}.PresentDetailProjection(board, config)
+	detail := model.Sections[0].(*present.DetailSection)
+
+	for _, f := range detail.Fields {
+		if f.Label == "FILTER" {
+			if f.Value != "id: 10084" {
+				t.Errorf("FILTER: expected 'id: 10084', got %q", f.Value)
+			}
+			return
+		}
+	}
+	t.Error("FILTER field not found in projection output")
 }
 
 func TestSprintListSpec_HeaderParityWithPresenter(t *testing.T) {

--- a/tools/jtk/internal/present/board_test.go
+++ b/tools/jtk/internal/present/board_test.go
@@ -116,6 +116,34 @@ func TestPresentBoardDetail_Extended(t *testing.T) {
 	}
 }
 
+func TestPresentBoardDetail_Extended_EmptyFilterName(t *testing.T) {
+	t.Parallel()
+	board := &api.Board{
+		ID: 23, Name: "MON board", Type: "scrum",
+		Location: api.BoardLocation{ProjectKey: "MON", ProjectName: "Platform Development"},
+	}
+	config := &api.BoardConfiguration{
+		Filter: api.BoardFilter{ID: "10084", Name: ""},
+		ColumnConfig: api.BoardColumnConfig{
+			Columns: []api.BoardColumn{
+				{Name: "Backlog"},
+				{Name: "Ready for Development"},
+				{Name: "In Development"},
+			},
+		},
+	}
+	model := BoardPresenter{}.PresentDetail(board, config, true)
+
+	filterLine := model.Sections[2].(*present.MessageSection)
+	if filterLine.Message != "Filter: id: 10084" {
+		t.Errorf("empty filter name: expected 'Filter: id: 10084', got %q", filterLine.Message)
+	}
+	colLine := model.Sections[3].(*present.MessageSection)
+	if colLine.Message != "Column config: Backlog, Ready for Development, In Development" {
+		t.Errorf("columns: got %q", colLine.Message)
+	}
+}
+
 func TestPresentBoardDetail_ExtendedStableRows_NilConfig(t *testing.T) {
 	t.Parallel()
 	board := &api.Board{


### PR DESCRIPTION
## Summary
- Fixes blank filter name in `jtk boards get --extended` output
- Before: `Filter:  (id: 10084)` (leading space when name is empty)
- After: `Filter: id: 10084` (clean fallback when name is empty)
- When name is present: `Filter: board filter for MON board (id: 10084)` (unchanged)
- Column config rendering verified correct — uses API column names directly

Closes #291

## Test plan
- [x] Presenter test for empty filter name → `id: 10084` format
- [x] Presenter test for named filter → `name (id: N)` format (existing, unchanged)
- [x] Presenter test for nil config → `-` (existing, unchanged)
- [x] Command-level test for empty filter name with exact output assertion
- [x] Command-level test verifies column names render exactly from API fixture
- [x] `make build && make test && make lint` all pass