### PR TITLE
feat(jtk): fix automation list crash and automation get empty output

### DIFF
--- a/tools/jtk/api/automation.go
+++ b/tools/jtk/api/automation.go
@@ -77,27 +77,25 @@ func (c *Client) GetAutomationRule(ctx context.Context, ruleID string) (*Automat
 		return nil, fmt.Errorf("getting automation rule %s: %w", ruleID, err)
 	}
 
-	// Newer Cloud response shape is an envelope: {"rule": {...}, "connections": [...]}
-	var env struct {
-		Rule *AutomationRule `json:"rule"`
-	}
-	if err := json.Unmarshal(body, &env); err == nil && env.Rule != nil {
-		// Normalize legacy identifier field name for callers.
-		if env.Rule.UUID == "" && env.Rule.RuleKey != "" {
-			env.Rule.UUID = env.Rule.RuleKey
-		}
-		return env.Rule, nil
-	}
-
-	// Fallback to legacy/plain shape where the rule is the top-level object.
-	var rule AutomationRule
-	if err := json.Unmarshal(body, &rule); err != nil {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(body, &probe); err != nil {
 		return nil, fmt.Errorf("parsing automation rule: %w", err)
 	}
+
+	var rule AutomationRule
+	if ruleJSON, ok := probe["rule"]; ok {
+		if err := json.Unmarshal(ruleJSON, &rule); err != nil {
+			return nil, fmt.Errorf("parsing automation rule: %w", err)
+		}
+	} else {
+		if err := json.Unmarshal(body, &rule); err != nil {
+			return nil, fmt.Errorf("parsing automation rule: %w", err)
+		}
+	}
+
 	if rule.UUID == "" && rule.RuleKey != "" {
 		rule.UUID = rule.RuleKey
 	}
-
 	return &rule, nil
 }
 

--- a/tools/jtk/api/automation.go
+++ b/tools/jtk/api/automation.go
@@ -83,7 +83,7 @@ func (c *Client) GetAutomationRule(ctx context.Context, ruleID string) (*Automat
 	}
 
 	var rule AutomationRule
-	if ruleJSON, ok := probe["rule"]; ok {
+	if ruleJSON, ok := probe["rule"]; ok && string(ruleJSON) != "null" {
 		if err := json.Unmarshal(ruleJSON, &rule); err != nil {
 			return nil, fmt.Errorf("parsing automation rule: %w", err)
 		}

--- a/tools/jtk/api/automation_test.go
+++ b/tools/jtk/api/automation_test.go
@@ -609,6 +609,77 @@ func TestListAutomationRulesPagination(t *testing.T) {
 	testutil.Equal(t, atomic.LoadInt32(&page), int32(2)) // Verify two pages were fetched
 }
 
+func TestTimestamp_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    Timestamp
+		wantErr bool
+	}{
+		{"string ISO", `"2023-12-04T10:00:00.000+0000"`, Timestamp("2023-12-04T10:00:00.000+0000"), false},
+		{"epoch millis", `1701680400000`, Timestamp("2023-12-04T09:00:00Z"), false},
+		{"null", `null`, Timestamp(""), false},
+		{"invalid", `true`, Timestamp(""), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var ts Timestamp
+			err := ts.UnmarshalJSON([]byte(tt.input))
+			if tt.wantErr {
+				testutil.Error(t, err)
+				return
+			}
+			testutil.RequireNoError(t, err)
+			testutil.Equal(t, string(ts), string(tt.want))
+		})
+	}
+}
+
+func TestGetAutomationRule_EnvelopeWithNumericTimestamp(t *testing.T) {
+	t.Parallel()
+	client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"cloudId":"cloud-1"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"rule":{"uuid":"uuid-99","name":"Numeric TS","state":"ENABLED","created":1701680400000,"updated":1701766800000,"components":[{"component":"ACTION","type":"assign"}]}}`))
+	}))
+	defer server.Close()
+
+	rule, err := client.GetAutomationRule(context.Background(), "uuid-99")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, rule.UUID, "uuid-99")
+	testutil.Equal(t, rule.Name, "Numeric TS")
+	testutil.Equal(t, rule.State, "ENABLED")
+	testutil.Equal(t, string(rule.Created), "2023-12-04T09:00:00Z")
+	testutil.Equal(t, string(rule.Updated), "2023-12-05T09:00:00Z")
+	testutil.Len(t, rule.Components, 1)
+}
+
+func TestListAutomationRules_NumericTimestamp(t *testing.T) {
+	t.Parallel()
+	client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"cloudId":"cloud-1"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[{"uuid":"uuid-1","name":"Rule One","state":"ENABLED","created":1701680400000}]}`))
+	}))
+	defer server.Close()
+
+	rules, err := client.ListAutomationRules(context.Background())
+	testutil.RequireNoError(t, err)
+	testutil.Len(t, rules, 1)
+	testutil.Equal(t, rules[0].Name, "Rule One")
+	testutil.Equal(t, string(rules[0].Created), "2023-12-04T09:00:00Z")
+}
+
 func TestDeleteAutomationRule(t *testing.T) {
 	t.Parallel()
 

--- a/tools/jtk/api/automation_test.go
+++ b/tools/jtk/api/automation_test.go
@@ -681,6 +681,44 @@ func TestListAutomationRules_NumericTimestamp(t *testing.T) {
 	testutil.Equal(t, string(rules[0].Created), "2023-12-04T09:00:00Z")
 }
 
+func TestGetAutomationRule_LegacyWithNumericTimestamp(t *testing.T) {
+	t.Parallel()
+	client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"cloudId":"cloud-1"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":42,"name":"Legacy TS","state":"ENABLED","created":1701680400000}`))
+	}))
+	defer server.Close()
+
+	rule, err := client.GetAutomationRule(context.Background(), "42")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, rule.Name, "Legacy TS")
+	testutil.Equal(t, rule.State, "ENABLED")
+	testutil.Equal(t, string(rule.Created), "2023-12-04T09:00:00Z")
+}
+
+func TestGetAutomationRule_EnvelopeWithNullRule(t *testing.T) {
+	t.Parallel()
+	client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"cloudId":"cloud-1"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"rule":null}`))
+	}))
+	defer server.Close()
+
+	rule, err := client.GetAutomationRule(context.Background(), "null-rule")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, rule.Identifier(), "")
+}
+
 func TestGetAutomationRule_MalformedJSON(t *testing.T) {
 	t.Parallel()
 	client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/jtk/api/automation_test.go
+++ b/tools/jtk/api/automation_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -678,6 +679,53 @@ func TestListAutomationRules_NumericTimestamp(t *testing.T) {
 	testutil.Len(t, rules, 1)
 	testutil.Equal(t, rules[0].Name, "Rule One")
 	testutil.Equal(t, string(rules[0].Created), "2023-12-04T09:00:00Z")
+}
+
+func TestGetAutomationRule_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"cloudId":"cloud-1"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer server.Close()
+
+	_, err := client.GetAutomationRule(context.Background(), "bad")
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "parsing automation rule")
+}
+
+func TestGetAutomationRule_EnvelopeWithInvalidRule(t *testing.T) {
+	t.Parallel()
+	client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"cloudId":"cloud-1"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"rule":"not-an-object"}`))
+	}))
+	defer server.Close()
+
+	_, err := client.GetAutomationRule(context.Background(), "bad")
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "parsing automation rule")
+}
+
+func TestTimestamp_OmitEmpty(t *testing.T) {
+	t.Parallel()
+	rule := AutomationRuleSummary{UUID: "uuid-1", Name: "Test", State: "ENABLED"}
+	data, err := json.Marshal(rule)
+	testutil.RequireNoError(t, err)
+	s := string(data)
+	if strings.Contains(s, `"created"`) {
+		t.Errorf("empty Timestamp should be omitted, got: %s", s)
+	}
 }
 
 func TestDeleteAutomationRule(t *testing.T) {

--- a/tools/jtk/api/automation_types.go
+++ b/tools/jtk/api/automation_types.go
@@ -25,7 +25,7 @@ func (t *Timestamp) UnmarshalJSON(data []byte) error {
 	}
 	var n int64
 	if err := json.Unmarshal(data, &n); err != nil {
-		return fmt.Errorf("Timestamp: cannot unmarshal %s", string(data))
+		return fmt.Errorf("Timestamp: cannot unmarshal %q: %w", data, err)
 	}
 	*t = Timestamp(time.UnixMilli(n).UTC().Format(time.RFC3339))
 	return nil

--- a/tools/jtk/api/automation_types.go
+++ b/tools/jtk/api/automation_types.go
@@ -1,6 +1,37 @@
 package api //nolint:revive // package name is intentional
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Timestamp accepts both JSON strings (ISO 8601) and numbers (epoch millis).
+// The Jira Automation API returns timestamps as epoch-millisecond numbers in
+// some endpoints and ISO 8601 strings in others.
+type Timestamp string
+
+func (t *Timestamp) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		*t = Timestamp(s)
+		return nil
+	}
+	var n int64
+	if err := json.Unmarshal(data, &n); err != nil {
+		return fmt.Errorf("Timestamp: cannot unmarshal %s", string(data))
+	}
+	*t = Timestamp(time.UnixMilli(n).UTC().Format(time.RFC3339))
+	return nil
+}
+
+func (t Timestamp) String() string { return string(t) }
 
 // AutomationRule represents a full automation rule.
 //
@@ -25,8 +56,8 @@ type AutomationRule struct {
 	Labels          []string        `json:"labels,omitempty"`
 	Tags            []string        `json:"tags,omitempty"`
 	Projects        []RuleProject   `json:"projects,omitempty"`
-	Created         string          `json:"created,omitempty"`
-	Updated         string          `json:"updated,omitempty"`
+	Created         Timestamp       `json:"created,omitempty"`
+	Updated         Timestamp       `json:"updated,omitempty"`
 	Trigger         *RuleComponent  `json:"trigger,omitempty"`
 	Components      []RuleComponent `json:"components,omitempty"`
 
@@ -91,8 +122,8 @@ type AutomationRuleSummary struct {
 	Labels          []string      `json:"labels,omitempty"`
 	Tags            []string      `json:"tags,omitempty"`
 	Projects        []RuleProject `json:"projects,omitempty"`
-	Created         string        `json:"created,omitempty"`
-	Updated         string        `json:"updated,omitempty"`
+	Created         Timestamp     `json:"created,omitempty"`
+	Updated         Timestamp     `json:"updated,omitempty"`
 	RuleScopeARIs   []string      `json:"ruleScopeARIs,omitempty"`
 }
 

--- a/tools/jtk/internal/cmd/automation/get_test.go
+++ b/tools/jtk/internal/cmd/automation/get_test.go
@@ -292,6 +292,7 @@ func TestRunGet_EnvelopeWithNumericTimestamps(t *testing.T) {
 	testutil.Contains(t, out, "2 total")
 	testutil.Contains(t, out, "Created: 2023-12-04")
 	testutil.Contains(t, out, "Updated: 2023-12-05")
+	testutil.Contains(t, out, "Author: Test Author")
 }
 
 func TestRunGet_ShowComponents(t *testing.T) {

--- a/tools/jtk/internal/cmd/automation/get_test.go
+++ b/tools/jtk/internal/cmd/automation/get_test.go
@@ -260,6 +260,40 @@ func TestRunGet_Extended_NoAuthor(t *testing.T) {
 	testutil.Contains(t, out, "Author: -")
 }
 
+func TestRunGet_EnvelopeWithNumericTimestamps(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+			return
+		}
+		if r.URL.Path == "/rest/api/3/user" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"accountId":"acct-1","displayName":"Test Author"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"rule":{"uuid":"uuid-env","name":"Envelope Rule","state":"ENABLED","authorAccountId":"acct-1","created":1701680400000,"updated":1701766800000,"components":[{"component":"TRIGGER","type":"issue.created"},{"component":"ACTION","type":"assign.issue"}]}}`))
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "uuid-env", false)
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "uuid-env  Envelope Rule")
+	testutil.Contains(t, out, "State: ENABLED")
+	testutil.Contains(t, out, "2 total")
+	testutil.Contains(t, out, "Created: 2023-12-04")
+	testutil.Contains(t, out, "Updated: 2023-12-05")
+}
+
 func TestRunGet_ShowComponents(t *testing.T) {
 	rule := api.AutomationRule{
 		UUID:  "uuid-123",

--- a/tools/jtk/internal/cmd/automation/get_test.go
+++ b/tools/jtk/internal/cmd/automation/get_test.go
@@ -261,6 +261,7 @@ func TestRunGet_Extended_NoAuthor(t *testing.T) {
 }
 
 func TestRunGet_EnvelopeWithNumericTimestamps(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/_edge/tenant_info" {
 			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))

--- a/tools/jtk/internal/cmd/automation/list_test.go
+++ b/tools/jtk/internal/cmd/automation/list_test.go
@@ -183,6 +183,7 @@ func TestRunList_IDOnly_Empty(t *testing.T) {
 }
 
 func TestRunList_NumericTimestamps(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/_edge/tenant_info" {
 			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))

--- a/tools/jtk/internal/cmd/automation/list_test.go
+++ b/tools/jtk/internal/cmd/automation/list_test.go
@@ -182,6 +182,33 @@ func TestRunList_IDOnly_Empty(t *testing.T) {
 	}
 }
 
+func TestRunList_NumericTimestamps(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"uuid":"uuid-ts","name":"Timestamp Rule","state":"ENABLED","created":1701680400000,"updated":1701766800000}]}`))
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "")
+	testutil.RequireNoError(t, err)
+
+	out := stdout.String()
+	testutil.Contains(t, out, "uuid-ts")
+	testutil.Contains(t, out, "ENABLED")
+	testutil.Contains(t, out, "Timestamp Rule")
+}
+
 func TestRunList_Empty(t *testing.T) {
 	server := newListTestServer(t, nil)
 	defer server.Close()

--- a/tools/jtk/internal/present/automation.go
+++ b/tools/jtk/internal/present/automation.go
@@ -296,7 +296,7 @@ func (AutomationPresenter) PresentGetDetailExtended(rule *api.AutomationRule, sh
 	sections = append(sections, msg(fmt.Sprintf("Tags: %s", OrDash(strings.Join(rule.Tags, ", ")))))
 	sections = append(sections, msg(fmt.Sprintf("Author: %s", OrDash(authorName))))
 	sections = append(sections, msg(fmt.Sprintf("Scope: %s", automationScope(rule))))
-	sections = append(sections, msg(fmt.Sprintf("Created: %s   Updated: %s", OrDash(FormatTime(rule.Created)), OrDash(FormatTime(rule.Updated)))))
+	sections = append(sections, msg(fmt.Sprintf("Created: %s   Updated: %s", OrDash(FormatTime(string(rule.Created))), OrDash(FormatTime(string(rule.Updated))))))
 
 	if showComponents && len(rule.Components) > 0 {
 		sections = append(sections, componentTable(rule.Components))


### PR DESCRIPTION
## Summary
- Adds `Timestamp` type to handle both JSON string (ISO 8601) and number (epoch millis) timestamps from Jira Automation API
- Changes `Created`/`Updated` fields on `AutomationRule` and `AutomationRuleSummary` from `string` to `Timestamp`
- Hardens `GetAutomationRule` envelope detection: probes for `"rule"` key before parsing instead of silently falling back to legacy shape on any error

Closes #302