### PR TITLE
feat(issues): add `check` subcommand to audit field values

### DIFF
--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `issues check <issue-key>` subcommand to audit an issue for populated/missing field values, with `--require` (hard-fail) and `--warn` (advisory) flags. A curated default warn-list (Summary, Description, Assignee, Priority, Labels, Story Points, Sprint, Components, Fix Version/s) applies when no flags are passed. Useful as a transition guardrail or CI step.
 - `users get <account-id>` subcommand to look up a user by account ID ([#189](https://github.com/open-cli-collective/atlassian-cli/pull/189))
 - `--assignee none` on `issues update` and `--field assignee=null` to unassign issues ([#187](https://github.com/open-cli-collective/atlassian-cli/pull/187))
 - `--field` flag accumulates repeated values for the same key, enabling multi-checkbox and multi-select custom fields ([#186](https://github.com/open-cli-collective/atlassian-cli/pull/186))

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -406,6 +406,38 @@ jtk issues delete PROJ-123 --force
 
 ---
 
+### `jtk issues check <issue-key>`
+
+Check whether an issue has values for expected fields. Useful as a guardrail
+before transitions or as a CI step. Each field can be named by its display name
+(e.g. `Story Points`), Jira field ID (e.g. `customfield_10035`), or property
+key (e.g. `assignee`).
+
+```bash
+# Default warn list (Summary, Description, Assignee, Priority, Labels,
+# Story Points, Sprint, Components, Fix Version/s) — fields not on the
+# project's schema are silently skipped.
+jtk issues check PROJ-123
+
+# Hard-fail (non-zero exit) if Story Points or Sprint are missing.
+jtk issues check PROJ-123 --require "Story Points" --require Sprint
+
+# Mix required and warning fields, comma-separated.
+jtk issues check PROJ-123 --require "Story Points,Sprint" --warn "Description,Assignee"
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--require` | (none) | Field must be populated; missing → non-zero exit (repeatable) |
+| `--warn` | (default list) | Field flagged if missing; never fails the check (repeatable) |
+
+**Exit codes:** `0` if all `--require` fields populated; `1` if any are missing.
+
+**Arguments:**
+- `<issue-key>` - The issue key (**required**)
+
+---
+
 ### `jtk issues fields [issue-key]`
 
 List available fields for issues.

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -433,7 +433,9 @@ jtk issues check PROJ-123 --require Sprint --id
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--require` | (none) | Field must be populated; missing → non-zero exit (repeatable) |
-| `--warn` | (default list) | Field flagged if missing; never fails the check (repeatable) |
+| `--warn` | (curated list, only when neither flag is provided) | Field flagged if missing; never fails the check (repeatable) |
+
+When `--require` is provided alone, the curated default warn-list is **not** applied — only the explicitly-named fields are checked.
 
 Output respects the standard global flags: `--output table\|json\|plain`, and `--id` to emit only the IDs of fields whose status is `MISSING`.
 

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -424,12 +424,18 @@ jtk issues check PROJ-123 --require "Story Points" --require Sprint
 
 # Mix required and warning fields, comma-separated.
 jtk issues check PROJ-123 --require "Story Points,Sprint" --warn "Description,Assignee"
+
+# JSON output, or emit only the IDs of MISSING fields.
+jtk issues check PROJ-123 --output json
+jtk issues check PROJ-123 --require Sprint --id
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--require` | (none) | Field must be populated; missing → non-zero exit (repeatable) |
 | `--warn` | (default list) | Field flagged if missing; never fails the check (repeatable) |
+
+Output respects the standard global flags: `--output table\|json\|plain`, and `--id` to emit only the IDs of fields whose status is `MISSING`.
 
 **Exit codes:** `0` if all `--require` fields populated; `1` if any are missing.
 

--- a/tools/jtk/internal/cmd/issues/check.go
+++ b/tools/jtk/internal/cmd/issues/check.go
@@ -133,7 +133,7 @@ func buildCheckResults(required, warn []string, fields []api.Field, populated ma
 	var results []checkResult
 	missingRequired := 0
 
-	add := func(requested, level string, hardFail bool) {
+	evaluateField := func(requested, level string, hardFail bool) {
 		id, display, ok := resolver.resolve(requested)
 		if !ok {
 			if useDefaults {
@@ -178,10 +178,10 @@ func buildCheckResults(required, warn []string, fields []api.Field, populated ma
 	}
 
 	for _, f := range required {
-		add(f, "REQUIRED", true)
+		evaluateField(f, "REQUIRED", true)
 	}
 	for _, f := range warn {
-		add(f, "WARN", false)
+		evaluateField(f, "WARN", false)
 	}
 
 	sort.SliceStable(results, func(i, j int) bool {

--- a/tools/jtk/internal/cmd/issues/check.go
+++ b/tools/jtk/internal/cmd/issues/check.go
@@ -75,14 +75,22 @@ Fields not present on the issue's project schema are silently skipped.`,
 	return cmd
 }
 
-// checkResult is one row in the check output.
+// Levels and statuses used in checkResult and surfaced verbatim in the
+// LEVEL / STATUS columns of the command output.
+const (
+	levelRequired = "REQUIRED"
+	levelWarn     = "WARN"
+	statusOK      = "OK"
+	statusMissing = "MISSING"
+)
+
 type checkResult struct {
 	requested string // user's spelling of the field name
 	resolved  string // field ID after resolution (e.g. "customfield_10035")
 	display   string // human-friendly name (e.g. "Story Points")
-	level     string // "REQUIRED" or "WARN"
-	status    string // "OK" or "MISSING"
-	value     string // populated value (truncated for display)
+	level     string
+	status    string
+	value     string
 }
 
 func runCheck(ctx context.Context, opts *root.Options, issueKey string, required, warn []string) error {
@@ -133,7 +141,11 @@ func buildCheckResults(required, warn []string, fields []api.Field, populated ma
 	var results []checkResult
 	missingRequired := 0
 
-	evaluateField := func(requested, level string, hardFail bool) {
+	evaluateField := func(requested string, isRequired bool) {
+		level := levelWarn
+		if isRequired {
+			level = levelRequired
+		}
 		id, display, ok := resolver.resolve(requested)
 		if !ok {
 			if useDefaults {
@@ -144,10 +156,10 @@ func buildCheckResults(required, warn []string, fields []api.Field, populated ma
 				resolved:  "",
 				display:   requested,
 				level:     level,
-				status:    "MISSING",
+				status:    statusMissing,
 				value:     "(unknown field on this instance)",
 			})
-			if hardFail {
+			if isRequired {
 				missingRequired++
 			}
 			return
@@ -159,7 +171,7 @@ func buildCheckResults(required, warn []string, fields []api.Field, populated ma
 				resolved:  id,
 				display:   display,
 				level:     level,
-				status:    "OK",
+				status:    statusOK,
 				value:     entry.Value,
 			})
 			return
@@ -169,24 +181,24 @@ func buildCheckResults(required, warn []string, fields []api.Field, populated ma
 			resolved:  id,
 			display:   display,
 			level:     level,
-			status:    "MISSING",
+			status:    statusMissing,
 			value:     "",
 		})
-		if hardFail {
+		if isRequired {
 			missingRequired++
 		}
 	}
 
 	for _, f := range required {
-		evaluateField(f, "REQUIRED", true)
+		evaluateField(f, true)
 	}
 	for _, f := range warn {
-		evaluateField(f, "WARN", false)
+		evaluateField(f, false)
 	}
 
 	sort.SliceStable(results, func(i, j int) bool {
 		if results[i].level != results[j].level {
-			return results[i].level == "REQUIRED"
+			return results[i].level == levelRequired
 		}
 		return results[i].display < results[j].display
 	})
@@ -198,7 +210,7 @@ func emitCheckResults(opts *root.Options, results []checkResult) error {
 	if opts.EmitIDOnly() {
 		var ids []string
 		for _, r := range results {
-			if r.status == "MISSING" {
+			if r.status == statusMissing {
 				ids = append(ids, idForEmit(r))
 			}
 		}

--- a/tools/jtk/internal/cmd/issues/check.go
+++ b/tools/jtk/internal/cmd/issues/check.go
@@ -1,0 +1,266 @@
+package issues
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+)
+
+// defaultWarnFields are commonly-important fields that are not enforced by Jira's
+// own required-field machinery but tend to matter for workflow hygiene. Each is
+// resolved against the project's field metadata at runtime — fields that don't
+// exist on the issue's project (e.g., Sprint on a non-Agile project) are
+// silently skipped, so no false warnings.
+var defaultWarnFields = []string{
+	"Summary",
+	"Description",
+	"Assignee",
+	"Priority",
+	"Labels",
+	"Story Points",
+	"Sprint",
+	"Components",
+	"Fix Version/s",
+}
+
+func newCheckCmd(opts *root.Options) *cobra.Command {
+	var requireFields []string
+	var warnFields []string
+
+	cmd := &cobra.Command{
+		Use:   "check <issue-key>",
+		Short: "Check that an issue has values for expected fields",
+		Long: `Audit an issue for populated/missing field values.
+
+Useful as a guardrail before transitions or as a CI step. Each field can be
+named by its display name (e.g. "Story Points"), its Jira field ID
+(e.g. "customfield_10035"), or its property key (e.g. "assignee").
+
+` + "`--require`" + ` fields fail the check (non-zero exit) if missing.
+` + "`--warn`" + `    fields are reported but do not change the exit code.
+
+When neither flag is provided, a curated default warn-list is used:
+` + strings.Join(defaultWarnFields, ", ") + `.
+Fields not present on the issue's project schema are silently skipped.`,
+		Example: `  # Default warn list (Story Points, Sprint, Description, Assignee, …)
+  jtk issues check PROJ-123
+
+  # Hard-fail if Story Points or Sprint are missing
+  jtk issues check PROJ-123 --require "Story Points" --require Sprint
+
+  # Mix required and warning fields, comma-separated
+  jtk issues check PROJ-123 --require "Story Points,Sprint" --warn "Description,Assignee"
+
+  # By field ID (instance-specific) or property key
+  jtk issues check PROJ-123 --require customfield_10035 --warn assignee`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCheck(cmd.Context(), opts, args[0], requireFields, warnFields)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&requireFields, "require", nil, "Field name/ID that must be populated (repeatable; comma-separated accepted)")
+	cmd.Flags().StringSliceVar(&warnFields, "warn", nil, "Field name/ID to warn on if missing (repeatable; comma-separated accepted)")
+
+	return cmd
+}
+
+// checkResult is one row in the check output.
+type checkResult struct {
+	requested string // user's spelling of the field name
+	resolved  string // field ID after resolution (e.g. "customfield_10035")
+	display   string // human-friendly name (e.g. "Story Points")
+	level     string // "REQUIRED" or "WARN"
+	status    string // "OK" or "MISSING"
+	value     string // populated value (truncated for display)
+}
+
+func runCheck(ctx context.Context, opts *root.Options, issueKey string, required, warn []string) error {
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	useDefaults := len(required) == 0 && len(warn) == 0
+	if useDefaults {
+		warn = append([]string{}, defaultWarnFields...)
+	}
+
+	issue, err := client.GetIssue(ctx, issueKey)
+	if err != nil {
+		return err
+	}
+
+	fields, err := cache.GetFieldsCacheFirst(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	populated := make(map[string]api.IssueFieldEntry)
+	for _, e := range api.ExtractIssueFieldValues(issue, fields) {
+		populated[e.ID] = e
+	}
+
+	results, missingRequired := buildCheckResults(required, warn, fields, populated, useDefaults)
+
+	if err := emitCheckResults(opts, results); err != nil {
+		return err
+	}
+
+	if missingRequired > 0 {
+		return fmt.Errorf("%s: %d required field(s) missing", issueKey, missingRequired)
+	}
+	return nil
+}
+
+// buildCheckResults resolves every requested field name to a field ID and
+// records OK/MISSING. When useDefaults is true, fields that don't resolve to a
+// known schema entry are silently dropped (so a non-Agile project doesn't get
+// "Sprint MISSING"). When the user named the fields explicitly, unresolved
+// names are surfaced as MISSING — typos shouldn't pass silently.
+func buildCheckResults(required, warn []string, fields []api.Field, populated map[string]api.IssueFieldEntry, useDefaults bool) ([]checkResult, int) {
+	resolver := newFieldResolver(fields)
+	var results []checkResult
+	missingRequired := 0
+
+	add := func(requested, level string, hardFail bool) {
+		id, display, ok := resolver.resolve(requested)
+		if !ok {
+			if useDefaults {
+				return
+			}
+			results = append(results, checkResult{
+				requested: requested,
+				resolved:  "",
+				display:   requested,
+				level:     level,
+				status:    "MISSING",
+				value:     "(unknown field on this instance)",
+			})
+			if hardFail {
+				missingRequired++
+			}
+			return
+		}
+		entry, populatedHit := populated[id]
+		if populatedHit {
+			results = append(results, checkResult{
+				requested: requested,
+				resolved:  id,
+				display:   display,
+				level:     level,
+				status:    "OK",
+				value:     entry.Value,
+			})
+			return
+		}
+		results = append(results, checkResult{
+			requested: requested,
+			resolved:  id,
+			display:   display,
+			level:     level,
+			status:    "MISSING",
+			value:     "",
+		})
+		if hardFail {
+			missingRequired++
+		}
+	}
+
+	for _, f := range required {
+		add(f, "REQUIRED", true)
+	}
+	for _, f := range warn {
+		add(f, "WARN", false)
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].level != results[j].level {
+			return results[i].level == "REQUIRED"
+		}
+		return results[i].display < results[j].display
+	})
+
+	return results, missingRequired
+}
+
+func emitCheckResults(opts *root.Options, results []checkResult) error {
+	if opts.EmitIDOnly() {
+		var ids []string
+		for _, r := range results {
+			if r.status == "MISSING" {
+				ids = append(ids, idForEmit(r))
+			}
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	rows := make([]present.Row, len(results))
+	for i, r := range results {
+		rows[i] = present.Row{Cells: []string{r.display, r.level, r.status, r.value}}
+	}
+
+	model := &present.OutputModel{
+		Sections: []present.Section{
+			&present.TableSection{
+				Headers: []string{"FIELD", "LEVEL", "STATUS", "VALUE"},
+				Rows:    rows,
+			},
+		},
+	}
+
+	return jtkpresent.Emit(opts, model)
+}
+
+func idForEmit(r checkResult) string {
+	if r.resolved != "" {
+		return r.resolved
+	}
+	return r.requested
+}
+
+// fieldResolver maps user-supplied field references (display name, field ID,
+// or property key like "assignee") to the canonical field ID + display name.
+type fieldResolver struct {
+	byID   map[string]api.Field
+	byName map[string]api.Field // lower-cased name → field
+}
+
+func newFieldResolver(fields []api.Field) *fieldResolver {
+	r := &fieldResolver{
+		byID:   make(map[string]api.Field, len(fields)),
+		byName: make(map[string]api.Field, len(fields)),
+	}
+	for _, f := range fields {
+		r.byID[f.ID] = f
+		r.byName[strings.ToLower(f.Name)] = f
+	}
+	return r
+}
+
+func (r *fieldResolver) resolve(input string) (id string, display string, ok bool) {
+	if f, hit := r.byID[input]; hit {
+		return f.ID, f.Name, true
+	}
+	if f, hit := r.byName[strings.ToLower(input)]; hit {
+		return f.ID, f.Name, true
+	}
+	// Fall back to the literal input as both ID and display, so users can
+	// pass an arbitrary customfield_NNNNN even if it's not in the cached
+	// field metadata. The ExtractIssueFieldValues map will still answer
+	// hit/miss correctly.
+	if strings.HasPrefix(input, "customfield_") {
+		return input, input, true
+	}
+	return "", "", false
+}

--- a/tools/jtk/internal/cmd/issues/check_test.go
+++ b/tools/jtk/internal/cmd/issues/check_test.go
@@ -16,9 +16,6 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
-// Tests are non-parallel: cache.SetRootForTest / SetInstanceKeyForTest are
-// process-globals (same as fields_test.go).
-
 func TestNewCheckCmd(t *testing.T) {
 	t.Parallel()
 	opts := &root.Options{}
@@ -197,6 +194,10 @@ func TestBuildCheckResults_OrdersRequiredFirstThenAlphabetical(t *testing.T) {
 }
 
 // --- end-to-end runCheck tests through an httptest server ---
+// These tests are non-parallel: cache.SetRootForTest /
+// SetInstanceKeyForTest (called via seedCacheForIssues) are process-globals
+// that race with t.Parallel() tests writing them. Same convention as
+// fields_test.go.
 
 func newCheckTestServer(t *testing.T, issue api.Issue) *httptest.Server {
 	t.Helper()

--- a/tools/jtk/internal/cmd/issues/check_test.go
+++ b/tools/jtk/internal/cmd/issues/check_test.go
@@ -107,9 +107,9 @@ func TestBuildCheckResults_RequiredMissingTriggersFailure(t *testing.T) {
 	for _, r := range results {
 		byField[r.display] = r
 	}
-	testutil.Equal(t, byField["Summary"].status, "OK")
-	testutil.Equal(t, byField["Story Points"].status, "MISSING")
-	testutil.Equal(t, byField["Story Points"].level, "REQUIRED")
+	testutil.Equal(t, byField["Summary"].status, statusOK)
+	testutil.Equal(t, byField["Story Points"].status, statusMissing)
+	testutil.Equal(t, byField["Story Points"].level, levelRequired)
 }
 
 func TestBuildCheckResults_WarnMissingDoesNotFail(t *testing.T) {
@@ -124,8 +124,8 @@ func TestBuildCheckResults_WarnMissingDoesNotFail(t *testing.T) {
 	)
 	testutil.Equal(t, missing, 0) // warn-only never fails
 	testutil.Equal(t, len(results), 1)
-	testutil.Equal(t, results[0].level, "WARN")
-	testutil.Equal(t, results[0].status, "MISSING")
+	testutil.Equal(t, results[0].level, levelWarn)
+	testutil.Equal(t, results[0].status, statusMissing)
 }
 
 func TestBuildCheckResults_DefaultsSilentlySkipUnknownFields(t *testing.T) {
@@ -171,7 +171,7 @@ func TestBuildCheckResults_ExplicitUnknownFieldSurfacesAsMissing(t *testing.T) {
 	)
 	testutil.Equal(t, missing, 1)
 	testutil.Equal(t, len(results), 1)
-	testutil.Equal(t, results[0].status, "MISSING")
+	testutil.Equal(t, results[0].status, statusMissing)
 	testutil.Contains(t, results[0].value, "unknown field")
 }
 
@@ -188,7 +188,7 @@ func TestBuildCheckResults_OrdersRequiredFirstThenAlphabetical(t *testing.T) {
 	// Expected order: REQUIRED Summary, WARN Assignee, WARN Story Points.
 	testutil.Equal(t, len(results), 3)
 	testutil.Equal(t, results[0].display, "Summary")
-	testutil.Equal(t, results[0].level, "REQUIRED")
+	testutil.Equal(t, results[0].level, levelRequired)
 	testutil.Equal(t, results[1].display, "Assignee")
 	testutil.Equal(t, results[2].display, "Story Points")
 }
@@ -240,7 +240,7 @@ func TestRunCheck_RequiredMissingReturnsError(t *testing.T) {
 		t.Fatalf("error should describe missing required field count, got: %v", err)
 	}
 	testutil.Contains(t, stdout.String(), "Story Points")
-	testutil.Contains(t, stdout.String(), "MISSING")
+	testutil.Contains(t, stdout.String(), statusMissing)
 }
 
 func TestRunCheck_DefaultWarnListNeverErrors(t *testing.T) {
@@ -268,5 +268,5 @@ func TestRunCheck_DefaultWarnListNeverErrors(t *testing.T) {
 	testutil.RequireNoError(t, err) // default-mode is warn-only; no required → no error
 	testutil.Contains(t, stdout.String(), "Story Points")
 	testutil.Contains(t, stdout.String(), "Sprint")
-	testutil.Contains(t, stdout.String(), "WARN")
+	testutil.Contains(t, stdout.String(), levelWarn)
 }

--- a/tools/jtk/internal/cmd/issues/check_test.go
+++ b/tools/jtk/internal/cmd/issues/check_test.go
@@ -1,0 +1,271 @@
+package issues
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+// Tests are non-parallel: cache.SetRootForTest / SetInstanceKeyForTest are
+// process-globals (same as fields_test.go).
+
+func TestNewCheckCmd(t *testing.T) {
+	t.Parallel()
+	opts := &root.Options{}
+	cmd := newCheckCmd(opts)
+
+	testutil.Equal(t, cmd.Use, "check <issue-key>")
+	testutil.NotNil(t, cmd.Flags().Lookup("require"))
+	testutil.NotNil(t, cmd.Flags().Lookup("warn"))
+}
+
+func TestFieldResolver_ResolvesByID(t *testing.T) {
+	t.Parallel()
+	r := newFieldResolver([]api.Field{
+		{ID: "summary", Name: "Summary"},
+		{ID: "customfield_10035", Name: "Story Points", Custom: true},
+	})
+
+	id, display, ok := r.resolve("customfield_10035")
+	testutil.Equal(t, ok, true)
+	testutil.Equal(t, id, "customfield_10035")
+	testutil.Equal(t, display, "Story Points")
+}
+
+func TestFieldResolver_ResolvesByDisplayNameCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	r := newFieldResolver([]api.Field{
+		{ID: "customfield_10035", Name: "Story Points", Custom: true},
+	})
+
+	id, display, ok := r.resolve("story points")
+	testutil.Equal(t, ok, true)
+	testutil.Equal(t, id, "customfield_10035")
+	testutil.Equal(t, display, "Story Points")
+
+	id, display, ok = r.resolve("STORY POINTS")
+	testutil.Equal(t, ok, true)
+	testutil.Equal(t, id, "customfield_10035")
+	testutil.Equal(t, display, "Story Points")
+}
+
+func TestFieldResolver_FallsBackToLiteralCustomfieldID(t *testing.T) {
+	t.Parallel()
+	r := newFieldResolver(nil) // empty schema
+
+	id, display, ok := r.resolve("customfield_99999")
+	testutil.Equal(t, ok, true)
+	testutil.Equal(t, id, "customfield_99999")
+	testutil.Equal(t, display, "customfield_99999")
+}
+
+func TestFieldResolver_UnknownNameDoesNotResolve(t *testing.T) {
+	t.Parallel()
+	r := newFieldResolver([]api.Field{
+		{ID: "summary", Name: "Summary"},
+	})
+
+	_, _, ok := r.resolve("totally-unknown")
+	testutil.Equal(t, ok, false)
+}
+
+func standardFields() []api.Field {
+	return []api.Field{
+		{ID: "summary", Name: "Summary"},
+		{ID: "description", Name: "Description"},
+		{ID: "assignee", Name: "Assignee"},
+		{ID: "priority", Name: "Priority"},
+		{ID: "labels", Name: "Labels"},
+		{ID: "customfield_10035", Name: "Story Points", Custom: true},
+		{ID: "customfield_10020", Name: "Sprint", Custom: true},
+	}
+}
+
+func TestBuildCheckResults_RequiredMissingTriggersFailure(t *testing.T) {
+	t.Parallel()
+	populated := map[string]api.IssueFieldEntry{
+		"summary": {ID: "summary", Name: "Summary", Value: "ok"},
+	}
+	results, missing := buildCheckResults(
+		[]string{"Story Points", "Summary"},
+		nil,
+		standardFields(),
+		populated,
+		false,
+	)
+	testutil.Equal(t, missing, 1)
+	testutil.Equal(t, len(results), 2)
+
+	byField := map[string]checkResult{}
+	for _, r := range results {
+		byField[r.display] = r
+	}
+	testutil.Equal(t, byField["Summary"].status, "OK")
+	testutil.Equal(t, byField["Story Points"].status, "MISSING")
+	testutil.Equal(t, byField["Story Points"].level, "REQUIRED")
+}
+
+func TestBuildCheckResults_WarnMissingDoesNotFail(t *testing.T) {
+	t.Parallel()
+	populated := map[string]api.IssueFieldEntry{}
+	results, missing := buildCheckResults(
+		nil,
+		[]string{"Story Points"},
+		standardFields(),
+		populated,
+		false,
+	)
+	testutil.Equal(t, missing, 0) // warn-only never fails
+	testutil.Equal(t, len(results), 1)
+	testutil.Equal(t, results[0].level, "WARN")
+	testutil.Equal(t, results[0].status, "MISSING")
+}
+
+func TestBuildCheckResults_DefaultsSilentlySkipUnknownFields(t *testing.T) {
+	t.Parallel()
+	// Schema lacks Sprint + Story Points (e.g., a non-Agile project).
+	fields := []api.Field{
+		{ID: "summary", Name: "Summary"},
+		{ID: "assignee", Name: "Assignee"},
+	}
+	populated := map[string]api.IssueFieldEntry{
+		"summary": {ID: "summary", Name: "Summary", Value: "ok"},
+	}
+
+	results, missing := buildCheckResults(
+		nil,
+		defaultWarnFields,
+		fields,
+		populated,
+		true, // useDefaults — fields not on schema get dropped, not flagged
+	)
+	testutil.Equal(t, missing, 0)
+	for _, r := range results {
+		// Only Summary + Assignee from the default list should resolve here.
+		if r.display != "Summary" && r.display != "Assignee" {
+			t.Errorf("unexpected default field surfaced when not on schema: %q", r.display)
+		}
+	}
+}
+
+func TestBuildCheckResults_ExplicitUnknownFieldSurfacesAsMissing(t *testing.T) {
+	t.Parallel()
+	// User explicitly named "Story Points" but schema doesn't have it. With
+	// useDefaults=false, we surface this so a typo isn't silent.
+	fields := []api.Field{
+		{ID: "summary", Name: "Summary"},
+	}
+	results, missing := buildCheckResults(
+		[]string{"Story Points"},
+		nil,
+		fields,
+		map[string]api.IssueFieldEntry{},
+		false,
+	)
+	testutil.Equal(t, missing, 1)
+	testutil.Equal(t, len(results), 1)
+	testutil.Equal(t, results[0].status, "MISSING")
+	testutil.Contains(t, results[0].value, "unknown field")
+}
+
+func TestBuildCheckResults_OrdersRequiredFirstThenAlphabetical(t *testing.T) {
+	t.Parallel()
+	populated := map[string]api.IssueFieldEntry{}
+	results, _ := buildCheckResults(
+		[]string{"Summary"},
+		[]string{"Assignee", "Story Points"},
+		standardFields(),
+		populated,
+		false,
+	)
+	// Expected order: REQUIRED Summary, WARN Assignee, WARN Story Points.
+	testutil.Equal(t, len(results), 3)
+	testutil.Equal(t, results[0].display, "Summary")
+	testutil.Equal(t, results[0].level, "REQUIRED")
+	testutil.Equal(t, results[1].display, "Assignee")
+	testutil.Equal(t, results[2].display, "Story Points")
+}
+
+// --- end-to-end runCheck tests through an httptest server ---
+
+func newCheckTestServer(t *testing.T, issue api.Issue) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/field" {
+			t.Fatal("live /field must not be called when cache is fresh")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issue)
+	}))
+}
+
+func TestRunCheck_RequiredMissingReturnsError(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", standardFields()))
+
+	issue := api.Issue{
+		Key: "TEST-1",
+		Fields: api.IssueFields{
+			Summary: "has summary",
+			// no Story Points
+		},
+	}
+
+	server := newCheckTestServer(t, issue)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runCheck(context.Background(), opts, "TEST-1", []string{"Story Points"}, nil)
+	if err == nil {
+		t.Fatal("expected runCheck to return an error when a required field is missing")
+	}
+	if !strings.Contains(err.Error(), "1 required field") {
+		t.Fatalf("error should describe missing required field count, got: %v", err)
+	}
+	testutil.Contains(t, stdout.String(), "Story Points")
+	testutil.Contains(t, stdout.String(), "MISSING")
+}
+
+func TestRunCheck_DefaultWarnListNeverErrors(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("fields", "24h", standardFields()))
+
+	issue := api.Issue{
+		Key: "TEST-2",
+		Fields: api.IssueFields{
+			Summary: "has summary",
+		},
+	}
+
+	server := newCheckTestServer(t, issue)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runCheck(context.Background(), opts, "TEST-2", nil, nil)
+	testutil.RequireNoError(t, err) // default-mode is warn-only; no required → no error
+	testutil.Contains(t, stdout.String(), "Story Points")
+	testutil.Contains(t, stdout.String(), "Sprint")
+	testutil.Contains(t, stdout.String(), "WARN")
+}

--- a/tools/jtk/internal/cmd/issues/issues.go
+++ b/tools/jtk/internal/cmd/issues/issues.go
@@ -16,6 +16,7 @@ func Register(parent *cobra.Command, opts *root.Options) {
 	}
 
 	cmd.AddCommand(newArchiveCmd(opts))
+	cmd.AddCommand(newCheckCmd(opts))
 	cmd.AddCommand(newGetCmd(opts))
 	cmd.AddCommand(newListCmd(opts))
 	cmd.AddCommand(newSearchCmd(opts))


### PR DESCRIPTION
## Summary

Adds `jtk issues check <issue-key>` to verify that an issue has values for expected fields. Useful as a guardrail before transitions or as a CI step.

```bash
# Default warn list (Summary, Description, Assignee, Priority, Labels,
# Story Points, Sprint, Components, Fix Version/s) — fields not on the
# project's schema are silently skipped.
jtk issues check PROJ-123

# Hard-fail (non-zero exit) if Story Points or Sprint are missing.
jtk issues check PROJ-123 --require "Story Points" --require Sprint

# Mix required and warning fields, comma-separated.
jtk issues check PROJ-123 --require "Story Points,Sprint" --warn "Description,Assignee"
```

## Why

Story Points, Sprint, and other workflow-hygiene fields are commonly *socially* required but not enforced by Jira's own required-field machinery. It's easy to create or transition a ticket without them and only notice later. A standalone audit command is a low-friction way to:

- gate a CI step (`jtk issues check $TICKET --require "Story Points,Sprint" || exit 1`)
- inspect a ticket interactively before moving it forward
- back a project's "what's missing on this ticket?" workflow without each consumer having to roll their own field-extraction logic

## Behavior

- `--require <field>` (repeatable, comma-separated): missing → non-zero exit (`1`)
- `--warn <field>` (repeatable, comma-separated): reported but never fails the check
- No flags → curated default warn-list applies (warn-only, never fails)
- Field names resolve case-insensitively against cached field metadata. Display name (`Story Points`), property key (`assignee`), or instance-specific custom field ID (`customfield_10035`) all work.
- Unknown explicit field names surface as `MISSING` (typos aren't silent). Unknown default-list fields are dropped (so non-Agile projects don't get false `Sprint MISSING` warnings).
- Output respects the standard text-first model: table by default, JSON via `--output json`, IDs of missing fields via `--id`.

## Example output

```
$ jtk issues check PROJ-123 --require "Story Points" --require Sprint --warn Description --warn Assignee
FIELD          | LEVEL    | STATUS  | VALUE
Sprint         | REQUIRED | OK      | Sprint 70
Story Points   | REQUIRED | OK      | 1
Assignee       | WARN     | OK      | Caleb Piekstra
Description    | WARN     | OK      | Follow-up to ABC-123. ...

$ jtk issues check PROJ-123 --require components ; echo $?
FIELD       | LEVEL    | STATUS  | VALUE
Components  | REQUIRED | MISSING |
PROJ-123: 1 required field(s) missing
1
```

## Test plan

- [x] Unit tests for field-name resolution (display name / property key / customfield ID / unknown)
- [x] Unit tests for required-vs-warn semantics, exit-code mapping, default-list silent-skip
- [x] End-to-end tests via `httptest` server covering populated + missing flows
- [x] `make build` clean
- [x] `make lint` clean for new code (two pre-existing gosec false positives in `internal/present/sprint_test.go` remain — not introduced here)
- [x] Smoke-tested against a real ticket