### PR TITLE
feat(jtk): fix issues get --extended sprint resolution and transitions format

### DIFF
--- a/tools/jtk/api/types.go
+++ b/tools/jtk/api/types.go
@@ -79,6 +79,30 @@ func (f *IssueFields) UnmarshalJSON(data []byte) error {
 		}
 	}
 
+	if f.Sprint == nil {
+		if sprintRaw, ok := raw["customfield_10020"]; ok {
+			f.Sprint = resolveSprintFromCustomField(sprintRaw)
+		}
+	}
+
+	return nil
+}
+
+func resolveSprintFromCustomField(raw json.RawMessage) *Sprint {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var arr []Sprint
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		if len(arr) == 0 {
+			return nil
+		}
+		return &arr[len(arr)-1]
+	}
+	var s Sprint
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return &s
+	}
 	return nil
 }
 

--- a/tools/jtk/api/types_test.go
+++ b/tools/jtk/api/types_test.go
@@ -722,3 +722,59 @@ func TestIssue_RoundTrip_WithCustomFields(t *testing.T) {
 	testutil.Equal(t, fields["customfield_10001"], float64(8))
 	testutil.Equal(t, fields["customfield_10002"].(map[string]any)["value"], "Bug Fix")
 }
+
+func TestIssueFields_SprintFromCustomField10020_Array(t *testing.T) {
+	t.Parallel()
+	input := `{
+		"summary": "Test",
+		"customfield_10020": [
+			{"id": 100, "name": "Sprint 69", "state": "closed"},
+			{"id": 125, "name": "MON Sprint 70", "state": "active", "startDate": "2026-04-10T00:00:00.000Z", "endDate": "2026-04-24T00:00:00.000Z"}
+		]
+	}`
+	var f IssueFields
+	err := json.Unmarshal([]byte(input), &f)
+	testutil.RequireNoError(t, err)
+	if f.Sprint == nil {
+		t.Fatal("Sprint should be resolved from customfield_10020")
+	}
+	testutil.Equal(t, f.Sprint.ID, 125)
+	testutil.Equal(t, f.Sprint.Name, "MON Sprint 70")
+	testutil.Equal(t, f.Sprint.State, "active")
+}
+
+func TestIssueFields_SprintFromCustomField10020_TypedFieldWins(t *testing.T) {
+	t.Parallel()
+	input := `{
+		"summary": "Test",
+		"sprint": {"id": 99, "name": "Typed Sprint", "state": "active"},
+		"customfield_10020": [{"id": 125, "name": "Custom Sprint", "state": "active"}]
+	}`
+	var f IssueFields
+	err := json.Unmarshal([]byte(input), &f)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, f.Sprint.ID, 99)
+	testutil.Equal(t, f.Sprint.Name, "Typed Sprint")
+}
+
+func TestIssueFields_SprintFromCustomField10020_EmptyArray(t *testing.T) {
+	t.Parallel()
+	input := `{"summary": "Test", "customfield_10020": []}`
+	var f IssueFields
+	err := json.Unmarshal([]byte(input), &f)
+	testutil.RequireNoError(t, err)
+	if f.Sprint != nil {
+		t.Error("Sprint should be nil for empty array")
+	}
+}
+
+func TestIssueFields_SprintFromCustomField10020_Null(t *testing.T) {
+	t.Parallel()
+	input := `{"summary": "Test", "customfield_10020": null}`
+	var f IssueFields
+	err := json.Unmarshal([]byte(input), &f)
+	testutil.RequireNoError(t, err)
+	if f.Sprint != nil {
+		t.Error("Sprint should be nil for null")
+	}
+}

--- a/tools/jtk/api/types_test.go
+++ b/tools/jtk/api/types_test.go
@@ -743,6 +743,22 @@ func TestIssueFields_SprintFromCustomField10020_Array(t *testing.T) {
 	testutil.Equal(t, f.Sprint.State, "active")
 }
 
+func TestIssueFields_SprintFromCustomField10020_SingleObject(t *testing.T) {
+	t.Parallel()
+	input := `{
+		"summary": "Test",
+		"customfield_10020": {"id": 125, "name": "Single Sprint", "state": "active"}
+	}`
+	var f IssueFields
+	err := json.Unmarshal([]byte(input), &f)
+	testutil.RequireNoError(t, err)
+	if f.Sprint == nil {
+		t.Fatal("Sprint should be resolved from single-object customfield_10020")
+	}
+	testutil.Equal(t, f.Sprint.ID, 125)
+	testutil.Equal(t, f.Sprint.Name, "Single Sprint")
+}
+
 func TestIssueFields_SprintFromCustomField10020_TypedFieldWins(t *testing.T) {
 	t.Parallel()
 	input := `{
@@ -765,6 +781,17 @@ func TestIssueFields_SprintFromCustomField10020_EmptyArray(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	if f.Sprint != nil {
 		t.Error("Sprint should be nil for empty array")
+	}
+}
+
+func TestIssueFields_SprintFromCustomField10020_BareString(t *testing.T) {
+	t.Parallel()
+	input := `{"summary": "Test", "customfield_10020": "not a sprint"}`
+	var f IssueFields
+	err := json.Unmarshal([]byte(input), &f)
+	testutil.RequireNoError(t, err)
+	if f.Sprint != nil {
+		t.Error("Sprint should be nil for bare string value")
 	}
 }
 

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -353,8 +353,8 @@ func TestRunGet_Extended_ShowsNewSections(t *testing.T) {
 		case strings.HasSuffix(r.URL.Path, "/transitions"):
 			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{
 				Transitions: []api.Transition{
-					{ID: "11", Name: "Backlog"},
-					{ID: "21", Name: "In Progress"},
+					{ID: "11", Name: "Backlog", To: api.Status{Name: "Backlog"}},
+					{ID: "21", Name: "In Progress", To: api.Status{Name: "In Development"}},
 				},
 			})
 		case strings.HasSuffix(r.URL.Path, "/watchers"):
@@ -382,8 +382,9 @@ func TestRunGet_Extended_ShowsNewSections(t *testing.T) {
 	testutil.Contains(t, output, "Watchers: 3 (watching: yes)")
 	testutil.Contains(t, output, "Resolution: Done")
 	testutil.Contains(t, output, "Transitions:")
-	testutil.Contains(t, output, "Backlog")
-	testutil.Contains(t, output, "In Progress")
+	testutil.Contains(t, output, "  11 | Backlog | Backlog")
+	testutil.Contains(t, output, "  21 | In Progress | In Development")
+	testutil.NotContains(t, output, "ID | NAME")
 	// Extended implies fulltext — full description present
 	testutil.NotContains(t, output, "[truncated")
 }
@@ -432,7 +433,62 @@ func TestRunGet_ExtendedFields_ProjectionUsesDetailContext(t *testing.T) {
 
 	output := stdout.String()
 	testutil.Contains(t, output, "5 (watching: no)")
-	testutil.Contains(t, output, "11:Backlog")
+	testutil.Contains(t, output, "11:Backlog:-")
 	testutil.Contains(t, output, longDesc)
 	testutil.NotContains(t, output, "[truncated")
+}
+
+func TestRunGet_Extended_SprintFromCustomField(t *testing.T) {
+	t.Parallel()
+	issueJSON := `{
+		"key": "MON-4970",
+		"fields": {
+			"summary": "Sprint test issue",
+			"status": {"name": "In Development", "statusCategory": {"name": "In Progress"}},
+			"issuetype": {"name": "Task"},
+			"customfield_10020": [
+				{"id": 100, "name": "Sprint 69", "state": "closed"},
+				{"id": 125, "name": "MON Sprint 70", "state": "active", "startDate": "2026-04-10T00:00:00.000Z", "endDate": "2026-04-24T00:00:00.000Z"}
+			],
+			"customfield_10035": 5
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/transitions"):
+			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{
+				Transitions: []api.Transition{
+					{ID: "91", Name: "Ready", To: api.Status{Name: "Ready for Development"}},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/watchers"):
+			_ = json.NewEncoder(w).Encode(api.WatchersInfo{WatchCount: 1, IsWatching: false})
+		case strings.Contains(r.URL.Path, "/field"):
+			_ = json.NewEncoder(w).Encode([]api.Field{
+				{ID: "customfield_10020", Name: "Sprint"},
+				{ID: "customfield_10035", Name: "Story Points"},
+			})
+		default:
+			_, _ = w.Write([]byte(issueJSON))
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "MON-4970", false, "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Sprint: MON Sprint 70 (id: 125, active, 2026-04-10 → 2026-04-24)")
+	testutil.NotContains(t, output, "customfield_10020")
+	testutil.Contains(t, output, "customfield_10035")
+	testutil.Contains(t, output, "  91 | Ready | Ready for Development")
 }

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -381,14 +381,9 @@ func (IssuePresenter) PresentDetailExtended(issue *api.Issue, _ string, dctx *De
 	if dctx != nil && dctx.TransitionsFailed {
 		sections = append(sections, msg("  (unavailable)"))
 	} else if dctx != nil && len(dctx.Transitions) > 0 {
-		rows := make([]present.Row, len(dctx.Transitions))
-		for i, t := range dctx.Transitions {
-			rows[i] = present.Row{Cells: []string{t.ID, t.Name}}
+		for _, t := range dctx.Transitions {
+			sections = append(sections, msg(fmt.Sprintf("  %s | %s | %s", t.ID, t.Name, OrDash(t.To.Name))))
 		}
-		sections = append(sections, &present.TableSection{
-			Headers: []string{"ID", "NAME"},
-			Rows:    rows,
-		})
 	} else {
 		sections = append(sections, msg("  (none)"))
 	}
@@ -414,6 +409,9 @@ func issueExtendedCustomFields(issue *api.Issue, dctx *DetailContext) []present.
 	var entries []entry
 	for id, raw := range issue.Fields.CustomFields {
 		if !strings.HasPrefix(id, "customfield_") || raw == nil {
+			continue
+		}
+		if id == "customfield_10020" && issue.Fields.Sprint != nil {
 			continue
 		}
 		val := api.FormatCustomFieldValue(raw)
@@ -461,6 +459,9 @@ func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fullte
 			if !strings.HasPrefix(id, "customfield_") || raw == nil {
 				continue
 			}
+			if id == "customfield_10020" && issue.Fields.Sprint != nil {
+				continue
+			}
 			val := api.FormatCustomFieldValue(raw)
 			if val != "" {
 				parts = append(parts, fmt.Sprintf("%s=%s", id, val))
@@ -476,7 +477,7 @@ func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fullte
 	if dctx != nil && len(dctx.Transitions) > 0 {
 		var parts []string
 		for _, t := range dctx.Transitions {
-			parts = append(parts, fmt.Sprintf("%s:%s", t.ID, t.Name))
+			parts = append(parts, fmt.Sprintf("%s:%s:%s", t.ID, t.Name, OrDash(t.To.Name)))
 		}
 		transitionsVal = strings.Join(parts, ", ")
 	}

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -537,6 +537,38 @@ func TestIssuePresenter_PresentDetailProjection_TransitionsIncludeToStatus(t *te
 	t.Error("Transitions field not found")
 }
 
+func TestIssuePresenter_PresentDetailProjection_CustomFieldSuppression(t *testing.T) {
+	t.Parallel()
+	issue := &api.Issue{
+		Key: "MON-123",
+		Fields: api.IssueFields{
+			Summary: "Test",
+			Sprint:  &api.Sprint{ID: 125, Name: "MON Sprint 70", State: "active"},
+			CustomFields: map[string]any{
+				"customfield_10020": "MON Sprint 70",
+				"customfield_10035": float64(5),
+			},
+		},
+	}
+	dctx := &DetailContext{}
+
+	model := IssuePresenter{}.PresentDetailProjection(issue, "", false, dctx)
+	detail := model.Sections[0].(*present.DetailSection)
+
+	for _, f := range detail.Fields {
+		if f.Label == "Custom_Fields" {
+			if strings.Contains(f.Value, "customfield_10020") {
+				t.Error("customfield_10020 should be suppressed in projection when Sprint is populated")
+			}
+			if !strings.Contains(f.Value, "customfield_10035") {
+				t.Error("other custom fields should be present")
+			}
+			return
+		}
+	}
+	t.Error("Custom_Fields field not found")
+}
+
 func TestIssuePresenter_PresentTypeFallbackWarning(t *testing.T) {
 	t.Parallel()
 	model := IssuePresenter{}.PresentTypeFallbackWarning("Bug", "MON", "Task")

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -449,6 +449,94 @@ func TestIssuePresenter_PresentTypeAlreadyCurrent(t *testing.T) {
 	}
 }
 
+func TestIssuePresenter_PresentDetailExtended_TransitionsFormat(t *testing.T) {
+	t.Parallel()
+	issue := &api.Issue{
+		Key: "MON-123",
+		Fields: api.IssueFields{
+			Summary:   "Test",
+			Status:    &api.Status{Name: "Open"},
+			IssueType: &api.IssueType{Name: "Task"},
+		},
+	}
+	dctx := &DetailContext{
+		Transitions: []api.Transition{
+			{ID: "11", Name: "Backlog", To: api.Status{Name: "Backlog"}},
+			{ID: "21", Name: "Ready for Development", To: api.Status{Name: "Ready for Development"}},
+		},
+	}
+
+	model := IssuePresenter{}.PresentDetailExtended(issue, "", dctx)
+	rendered := renderMsgSections(model)
+
+	if strings.Contains(rendered, "ID | NAME\n") {
+		t.Error("transitions should not have a header row")
+	}
+	if !strings.Contains(rendered, "  11 | Backlog | Backlog") {
+		t.Errorf("expected indented transition line, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "  21 | Ready for Development | Ready for Development") {
+		t.Errorf("expected second transition line, got:\n%s", rendered)
+	}
+}
+
+func TestIssuePresenter_PresentDetailExtended_SprintResolved(t *testing.T) {
+	t.Parallel()
+	issue := &api.Issue{
+		Key: "MON-123",
+		Fields: api.IssueFields{
+			Summary:   "Test",
+			Status:    &api.Status{Name: "Open"},
+			IssueType: &api.IssueType{Name: "Task"},
+			Sprint:    &api.Sprint{ID: 125, Name: "MON Sprint 70", State: "active"},
+			CustomFields: map[string]any{
+				"customfield_10020": "MON Sprint 70",
+				"customfield_10035": float64(5),
+			},
+		},
+	}
+	dctx := &DetailContext{}
+
+	model := IssuePresenter{}.PresentDetailExtended(issue, "", dctx)
+	rendered := renderMsgSections(model)
+
+	if !strings.Contains(rendered, "Sprint: MON Sprint 70 (id: 125, active)") {
+		t.Errorf("expected sprint line, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "customfield_10020") {
+		t.Error("customfield_10020 should be suppressed when Sprint is populated")
+	}
+	if !strings.Contains(rendered, "customfield_10035") {
+		t.Error("other custom fields should still appear")
+	}
+}
+
+func TestIssuePresenter_PresentDetailProjection_TransitionsIncludeToStatus(t *testing.T) {
+	t.Parallel()
+	issue := &api.Issue{
+		Key:    "MON-123",
+		Fields: api.IssueFields{Summary: "Test"},
+	}
+	dctx := &DetailContext{
+		Transitions: []api.Transition{
+			{ID: "11", Name: "Backlog", To: api.Status{Name: "Backlog"}},
+		},
+	}
+
+	model := IssuePresenter{}.PresentDetailProjection(issue, "", false, dctx)
+	detail := model.Sections[0].(*present.DetailSection)
+
+	for _, f := range detail.Fields {
+		if f.Label == "Transitions" {
+			if !strings.Contains(f.Value, "11:Backlog:Backlog") {
+				t.Errorf("expected transitions to include To.Name, got %q", f.Value)
+			}
+			return
+		}
+	}
+	t.Error("Transitions field not found")
+}
+
 func TestIssuePresenter_PresentTypeFallbackWarning(t *testing.T) {
 	t.Parallel()
 	model := IssuePresenter{}.PresentTypeFallbackWarning("Bug", "MON", "Task")


### PR DESCRIPTION
## Summary
- Resolves sprint from `customfield_10020` when the typed `sprint` field is nil (Jira returns sprint as a custom field in the REST API)
- Suppresses `customfield_10020` from the custom fields block when Sprint is populated (both extended and projection paths)
- Replaces transitions table (with header row) with indented pipe-delimited lines: `ID | NAME | TO_STATUS`
- Updates projection `Transitions` format to include `To.Name`

Closes #303