### PR TITLE
feat(jtk): fix boards get --extended filter name rendering

### DIFF
--- a/tools/jtk/api/boards.go
+++ b/tools/jtk/api/boards.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 )
 
@@ -49,6 +50,28 @@ func (c *Client) GetBoardConfiguration(ctx context.Context, boardID int) (*Board
 	}
 
 	return &config, nil
+}
+
+// Filter represents a Jira saved filter.
+type Filter struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// GetFilter retrieves a saved filter by ID.
+func (c *Client) GetFilter(ctx context.Context, filterID string) (*Filter, error) {
+	urlStr := fmt.Sprintf("%s/filter/%s", c.BaseURL, url.PathEscape(filterID))
+	body, err := c.Get(ctx, urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("getting filter %s: %w", filterID, err)
+	}
+
+	var f Filter
+	if err := json.Unmarshal(body, &f); err != nil {
+		return nil, fmt.Errorf("parsing filter: %w", err)
+	}
+
+	return &f, nil
 }
 
 // GetBoard retrieves a board by ID

--- a/tools/jtk/api/boards_test.go
+++ b/tools/jtk/api/boards_test.go
@@ -1,0 +1,39 @@
+package api //nolint:revive // package name is intentional
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestGetFilter(t *testing.T) {
+	t.Parallel()
+	var receivedPath string
+
+	client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"10026","name":"MON Aggregate"}`))
+	}))
+	defer server.Close()
+
+	f, err := client.GetFilter(context.Background(), "10026")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, f.ID, "10026")
+	testutil.Equal(t, f.Name, "MON Aggregate")
+	testutil.Equal(t, receivedPath, "/rest/api/3/filter/10026")
+}
+
+func TestGetFilter_NotFound(t *testing.T) {
+	t.Parallel()
+	client, server := newTestClientWithServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errorMessages":["The selected filter is not available to you"]}`))
+	}))
+	defer server.Close()
+
+	_, err := client.GetFilter(context.Background(), "99999")
+	testutil.Error(t, err)
+}

--- a/tools/jtk/internal/cmd/boards/boards.go
+++ b/tools/jtk/internal/cmd/boards/boards.go
@@ -233,6 +233,11 @@ func runGet(ctx context.Context, opts *root.Options, client *api.Client, resolve
 		if configErr != nil {
 			_ = jtkpresent.Emit(opts, jtkpresent.BoardPresenter{}.PresentConfigFetchWarning(configErr))
 		}
+		if config != nil && config.Filter.ID != "" && config.Filter.Name == "" {
+			if f, err := client.GetFilter(ctx, config.Filter.ID); err == nil && f.Name != "" {
+				config.Filter.Name = f.Name
+			}
+		}
 	}
 
 	if v.Format == view.FormatJSON {

--- a/tools/jtk/internal/cmd/boards/boards_test.go
+++ b/tools/jtk/internal/cmd/boards/boards_test.go
@@ -589,6 +589,46 @@ func TestRunGet_MissingArg(t *testing.T) {
 	testutil.NotNil(t, err)
 }
 
+func TestRunGet_Extended_FilterNameAlreadyPresent_NoExtraFetch(t *testing.T) {
+	t.Parallel()
+	var filterFetched bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/filter/"):
+			filterFetched = true
+			w.WriteHeader(http.StatusInternalServerError)
+		case strings.Contains(r.URL.Path, "/configuration"):
+			_ = json.NewEncoder(w).Encode(api.BoardConfiguration{
+				Filter: api.BoardFilter{ID: "100", Name: "already set"},
+				ColumnConfig: api.BoardColumnConfig{
+					Columns: []api.BoardColumn{{Name: "Done"}},
+				},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(api.Board{
+				ID: 23, Name: "B", Type: "scrum",
+				Location: api.BoardLocation{ProjectKey: "MON"},
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, client, &api.Board{ID: 23, Name: "B"}, "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Filter: already set (id: 100)")
+	if filterFetched {
+		t.Error("filter endpoint should not be called when name is already present")
+	}
+}
+
 func TestRunGet_Extended_FilterNameResolved(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/jtk/internal/cmd/boards/boards_test.go
+++ b/tools/jtk/internal/cmd/boards/boards_test.go
@@ -588,3 +588,84 @@ func TestRunGet_MissingArg(t *testing.T) {
 	err = rootCmd.Execute()
 	testutil.NotNil(t, err)
 }
+
+func TestRunGet_Extended_FilterNameResolved(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/configuration"):
+			_ = json.NewEncoder(w).Encode(api.BoardConfiguration{
+				ID:     23,
+				Name:   "MON board",
+				Filter: api.BoardFilter{ID: "10026", Name: ""},
+				ColumnConfig: api.BoardColumnConfig{
+					Columns: []api.BoardColumn{{Name: "Ready"}, {Name: "Done"}},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/filter/"):
+			_, _ = w.Write([]byte(`{"id":"10026","name":"MON Aggregate"}`))
+		default:
+			_ = json.NewEncoder(w).Encode(api.Board{
+				ID: 23, Name: "MON board", Type: "scrum",
+				Location: api.BoardLocation{ProjectKey: "MON", ProjectName: "Platform Development"},
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	resolvedBoard := &api.Board{ID: 23, Name: "MON board"}
+	err = runGet(context.Background(), opts, client, resolvedBoard, "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Filter: MON Aggregate (id: 10026)")
+}
+
+func TestRunGet_Extended_FilterNameFallback(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/configuration"):
+			_ = json.NewEncoder(w).Encode(api.BoardConfiguration{
+				ID:     23,
+				Name:   "MON board",
+				Filter: api.BoardFilter{ID: "10026", Name: ""},
+				ColumnConfig: api.BoardColumnConfig{
+					Columns: []api.BoardColumn{{Name: "Ready"}},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/filter/"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"errorMessages":["You do not have permission"]}`))
+		default:
+			_ = json.NewEncoder(w).Encode(api.Board{
+				ID: 23, Name: "MON board", Type: "scrum",
+				Location: api.BoardLocation{ProjectKey: "MON", ProjectName: "Platform Development"},
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(client)
+
+	resolvedBoard := &api.Board{ID: 23, Name: "MON board"}
+	err = runGet(context.Background(), opts, client, resolvedBoard, "")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Filter: id: 10026")
+}


### PR DESCRIPTION
## Summary
- Adds `GetFilter` API method to fetch saved filter details from `/rest/api/3/filter/{id}`
- Resolves filter name in `boards get --extended` when the board configuration response has the filter ID but no name
- Gracefully degrades to ID-only display if the filter fetch fails (permissions, 404, etc.)

Closes #304