### PR TITLE
feat(jtk): fix remaining output compliance gaps

### DIFF
--- a/tools/jtk/api/automation_test.go
+++ b/tools/jtk/api/automation_test.go
@@ -775,3 +775,38 @@ func TestDeleteAutomationRule(t *testing.T) {
 	testutil.Equal(t, receivedMethod, http.MethodDelete)
 	testutil.Contains(t, receivedPath, "/rule/rule-uuid-123")
 }
+
+func TestRuleComponent_DecodedChildren(t *testing.T) {
+	t.Parallel()
+	c := RuleComponent{
+		Component: "CONDITION",
+		Type:      "container",
+		Children:  json.RawMessage(`[{"component":"ACTION","type":"create"}]`),
+	}
+	children := c.DecodedChildren()
+	testutil.Len(t, children, 1)
+	testutil.Equal(t, children[0].Component, "ACTION")
+	testutil.Equal(t, children[0].Type, "create")
+}
+
+func TestRuleComponent_DecodedConditions(t *testing.T) {
+	t.Parallel()
+	c := RuleComponent{
+		Component:  "TRIGGER",
+		Type:       "issue.created",
+		Conditions: json.RawMessage(`[{"component":"CONDITION","type":"jql"}]`),
+	}
+	conditions := c.DecodedConditions()
+	testutil.Len(t, conditions, 1)
+	testutil.Equal(t, conditions[0].Component, "CONDITION")
+}
+
+func TestRuleComponent_DecodedChildren_NilAndMalformed(t *testing.T) {
+	t.Parallel()
+	empty := RuleComponent{Component: "ACTION", Type: "assign"}
+	testutil.Len(t, empty.DecodedChildren(), 0)
+	testutil.Len(t, empty.DecodedConditions(), 0)
+
+	malformed := RuleComponent{Children: json.RawMessage(`{invalid`)}
+	testutil.Len(t, malformed.DecodedChildren(), 0)
+}

--- a/tools/jtk/api/automation_types.go
+++ b/tools/jtk/api/automation_types.go
@@ -76,6 +76,30 @@ type RuleComponent struct {
 	ConnectionID  string          `json:"connectionId,omitempty"`
 }
 
+// DecodedChildren decodes the Children json.RawMessage into a slice of RuleComponent.
+func (c *RuleComponent) DecodedChildren() []RuleComponent {
+	if len(c.Children) == 0 {
+		return nil
+	}
+	var children []RuleComponent
+	if json.Unmarshal(c.Children, &children) != nil {
+		return nil
+	}
+	return children
+}
+
+// DecodedConditions decodes the Conditions json.RawMessage into a slice of RuleComponent.
+func (c *RuleComponent) DecodedConditions() []RuleComponent {
+	if len(c.Conditions) == 0 {
+		return nil
+	}
+	var conditions []RuleComponent
+	if json.Unmarshal(c.Conditions, &conditions) != nil {
+		return nil
+	}
+	return conditions
+}
+
 // AutomationRuleSummary is the lighter representation returned by the list/summary endpoint.
 type AutomationRuleSummary struct {
 	// Legacy numeric ID (may be absent).

--- a/tools/jtk/api/issues.go
+++ b/tools/jtk/api/issues.go
@@ -397,6 +397,9 @@ func FormatCustomFieldValue(v any) string {
 	}
 	switch val := v.(type) {
 	case string:
+		if strings.Contains(val, "={") {
+			return ""
+		}
 		return val
 	case float64:
 		if val == float64(int64(val)) {

--- a/tools/jtk/api/issues.go
+++ b/tools/jtk/api/issues.go
@@ -413,7 +413,7 @@ func FormatCustomFieldValue(v any) string {
 		if s, ok := val["displayName"].(string); ok {
 			return s
 		}
-		return fmt.Sprintf("%v", val)
+		return ""
 	case []any:
 		parts := make([]string, 0, len(val))
 		for _, item := range val {
@@ -435,7 +435,7 @@ func FormatCustomFieldValue(v any) string {
 		}
 		return "no"
 	default:
-		return fmt.Sprintf("%v", v)
+		return ""
 	}
 }
 

--- a/tools/jtk/api/issues_extract_test.go
+++ b/tools/jtk/api/issues_extract_test.go
@@ -107,6 +107,8 @@ func TestFormatCustomFieldValue_Types(t *testing.T) {
 		{"nil", nil, ""},
 		{"unhandled_map", map[string]any{"progress": float64(0), "total": float64(0)}, ""},
 		{"unhandled_type", struct{ X int }{42}, ""},
+		{"serialized_java_object", "{pullrequest={dataType=pullrequest, state=MERGED}}", ""},
+		{"normal_string_with_equals", "key=value", "key=value"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/jtk/api/issues_extract_test.go
+++ b/tools/jtk/api/issues_extract_test.go
@@ -105,6 +105,8 @@ func TestFormatCustomFieldValue_Types(t *testing.T) {
 		{"bool_true", true, "yes"},
 		{"bool_false", false, "no"},
 		{"nil", nil, ""},
+		{"unhandled_map", map[string]any{"progress": float64(0), "total": float64(0)}, ""},
+		{"unhandled_type", struct{ X int }{42}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tools/jtk/api/search.go
+++ b/tools/jtk/api/search.go
@@ -37,6 +37,7 @@ var DefaultSearchFields = []string{
 	"components",
 	"reporter",
 	"parent",
+	"customfield_10020",
 	"customfield_10035",
 }
 

--- a/tools/jtk/internal/cmd/automation/get_test.go
+++ b/tools/jtk/internal/cmd/automation/get_test.go
@@ -323,7 +323,6 @@ func TestRunGet_ShowComponents(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	out := stdout.String()
-	testutil.Contains(t, out, "COMPONENT")
-	testutil.Contains(t, out, "TRIGGER")
-	testutil.Contains(t, out, "ACTION")
+	testutil.Contains(t, out, "TRIGGER  issue.created")
+	testutil.Contains(t, out, "  ACTION  assign.issue")
 }

--- a/tools/jtk/internal/present/automation.go
+++ b/tools/jtk/internal/present/automation.go
@@ -273,8 +273,8 @@ func (AutomationPresenter) PresentGetDetail(rule *api.AutomationRule, showCompon
 		sections = append(sections, msg(fmt.Sprintf("Description: %s", rule.Description)))
 	}
 
-	if showComponents && len(rule.Components) > 0 {
-		sections = append(sections, componentTable(rule.Components))
+	if showComponents && (rule.Trigger != nil || len(rule.Components) > 0) {
+		sections = append(sections, componentTree(rule.Trigger, rule.Components))
 	}
 
 	return &present.OutputModel{Sections: sections}
@@ -299,23 +299,42 @@ func (AutomationPresenter) PresentGetDetailExtended(rule *api.AutomationRule, sh
 	sections = append(sections, msg(fmt.Sprintf("Scope: %s", automationScope(rule))))
 	sections = append(sections, msg(fmt.Sprintf("Created: %s   Updated: %s", formatAtlassianTimeOrDash(rule.Created), formatAtlassianTimeOrDash(rule.Updated))))
 
-	if showComponents && len(rule.Components) > 0 {
-		sections = append(sections, componentTable(rule.Components))
+	if showComponents && (rule.Trigger != nil || len(rule.Components) > 0) {
+		sections = append(sections, componentTree(rule.Trigger, rule.Components))
 	}
 
 	return &present.OutputModel{Sections: sections}
 }
 
-func componentTable(components []api.RuleComponent) *present.TableSection {
-	rows := make([]present.Row, len(components))
-	for i, c := range components {
-		rows[i] = present.Row{
-			Cells: []string{fmt.Sprintf("%d", i+1), c.Component, c.Type},
-		}
+func componentTree(trigger *api.RuleComponent, components []api.RuleComponent) *present.MessageSection {
+	var lines []string
+	if trigger != nil {
+		renderComponent(&lines, trigger, 0)
 	}
-	return &present.TableSection{
-		Headers: []string{"#", "COMPONENT", "TYPE"},
-		Rows:    rows,
+	for i := range components {
+		c := &components[i]
+		if c.Component == "TRIGGER" {
+			if trigger == nil {
+				renderComponent(&lines, c, 0)
+			}
+			continue
+		}
+		renderComponent(&lines, c, 1)
+	}
+	return &present.MessageSection{
+		Message: strings.Join(lines, "\n"),
+		Stream:  present.StreamStdout,
+	}
+}
+
+func renderComponent(lines *[]string, c *api.RuleComponent, depth int) {
+	indent := strings.Repeat("  ", depth)
+	*lines = append(*lines, fmt.Sprintf("%s%s  %s", indent, c.Component, c.Type))
+	for _, cond := range c.DecodedConditions() {
+		renderComponent(lines, &cond, depth+1)
+	}
+	for _, child := range c.DecodedChildren() {
+		renderComponent(lines, &child, depth+1)
 	}
 }
 

--- a/tools/jtk/internal/present/automation_test.go
+++ b/tools/jtk/internal/present/automation_test.go
@@ -301,6 +301,71 @@ func TestAutomationPresenter_PresentGetDetail_ShowComponents(t *testing.T) {
 	}
 }
 
+func TestComponentTree_NestedChildren(t *testing.T) {
+	t.Parallel()
+	trigger := &api.RuleComponent{Component: "TRIGGER", Type: "issue.created"}
+	components := []api.RuleComponent{
+		{
+			Component: "CONDITION",
+			Type:      "jira.condition.container.block",
+			Children:  json.RawMessage(`[{"component":"CONDITION_BLOCK","type":"jira.condition.if.block","children":[{"component":"ACTION","type":"jira.issue.create"}]}]`),
+		},
+		{Component: "ACTION", Type: "assign.issue"},
+	}
+
+	rule := &api.AutomationRule{
+		UUID:       "uuid-nested",
+		Name:       "Nested",
+		State:      "ENABLED",
+		Trigger:    trigger,
+		Components: components,
+	}
+
+	model := AutomationPresenter{}.PresentGetDetail(rule, true)
+	tree := model.Sections[3].(*present.MessageSection)
+
+	if !strings.Contains(tree.Message, "TRIGGER  issue.created") {
+		t.Errorf("missing trigger, got %q", tree.Message)
+	}
+	if !strings.Contains(tree.Message, "  CONDITION  jira.condition.container.block") {
+		t.Errorf("missing condition, got %q", tree.Message)
+	}
+	if !strings.Contains(tree.Message, "    CONDITION_BLOCK  jira.condition.if.block") {
+		t.Errorf("missing nested condition block, got %q", tree.Message)
+	}
+	if !strings.Contains(tree.Message, "      ACTION  jira.issue.create") {
+		t.Errorf("missing deeply nested action, got %q", tree.Message)
+	}
+	if !strings.Contains(tree.Message, "  ACTION  assign.issue") {
+		t.Errorf("missing top-level action, got %q", tree.Message)
+	}
+}
+
+func TestComponentTree_TriggerDeduplication(t *testing.T) {
+	t.Parallel()
+	trigger := &api.RuleComponent{Component: "TRIGGER", Type: "issue.created"}
+	components := []api.RuleComponent{
+		{Component: "TRIGGER", Type: "issue.created"},
+		{Component: "ACTION", Type: "assign.issue"},
+	}
+
+	rule := &api.AutomationRule{
+		UUID:       "uuid-dedup",
+		Name:       "Dedup",
+		State:      "ENABLED",
+		Trigger:    trigger,
+		Components: components,
+	}
+
+	model := AutomationPresenter{}.PresentGetDetail(rule, true)
+	tree := model.Sections[3].(*present.MessageSection)
+
+	count := strings.Count(tree.Message, "TRIGGER  issue.created")
+	if count != 1 {
+		t.Errorf("expected 1 TRIGGER line (deduplication), got %d in %q", count, tree.Message)
+	}
+}
+
 func TestAutomationPresenter_PresentGetDetailExtended(t *testing.T) {
 	t.Parallel()
 	rule := &api.AutomationRule{

--- a/tools/jtk/internal/present/automation_test.go
+++ b/tools/jtk/internal/present/automation_test.go
@@ -2,6 +2,7 @@ package present
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -283,18 +284,20 @@ func TestAutomationPresenter_PresentGetDetail_ShowComponents(t *testing.T) {
 
 	model := AutomationPresenter{}.PresentGetDetail(rule, true)
 
-	// Header + State + Components + component table = 4
-	// (no description, so 3 msg sections + 1 table)
+	// Header + State + Components + component tree = 4
 	if len(model.Sections) != 4 {
-		t.Fatalf("expected 4 sections (3 msg + table), got %d", len(model.Sections))
+		t.Fatalf("expected 4 sections (3 msg + tree), got %d", len(model.Sections))
 	}
 
-	table, ok := model.Sections[3].(*present.TableSection)
+	tree, ok := model.Sections[3].(*present.MessageSection)
 	if !ok {
-		t.Fatalf("expected TableSection at [3], got %T", model.Sections[3])
+		t.Fatalf("expected MessageSection at [3], got %T", model.Sections[3])
 	}
-	if len(table.Rows) != 2 {
-		t.Errorf("expected 2 component rows, got %d", len(table.Rows))
+	if !strings.Contains(tree.Message, "TRIGGER  issue.created") {
+		t.Errorf("expected trigger line, got %q", tree.Message)
+	}
+	if !strings.Contains(tree.Message, "  ACTION  assign.issue") {
+		t.Errorf("expected indented action line, got %q", tree.Message)
 	}
 }
 

--- a/tools/jtk/internal/present/dashboard.go
+++ b/tools/jtk/internal/present/dashboard.go
@@ -104,8 +104,12 @@ func (DashboardPresenter) PresentGadgets(gadgets []api.DashboardGadget) *present
 	rows := make([]present.Row, len(gadgets))
 	for i, g := range gadgets {
 		pos := fmt.Sprintf("%d,%d", g.Position.Row, g.Position.Column)
+		typ := g.ModuleID
+		if typ == "" {
+			typ = gadgetTypeFromURI(g.URI)
+		}
 		rows[i] = present.Row{
-			Cells: []string{FormatInt(g.ID), pos, g.Title, g.ModuleID},
+			Cells: []string{FormatInt(g.ID), pos, g.Title, typ},
 		}
 	}
 	return &present.OutputModel{
@@ -238,4 +242,19 @@ func formatPermissions(perms []api.SharePerm) string {
 		}
 	}
 	return strings.Join(parts, ", ")
+}
+
+// gadgetTypeFromURI extracts the short gadget type from a Jira gadget URI.
+// URI format: rest/gadgets/1.0/g/com.atlassian.jira.gadgets:assigned-to-me-gadget/gadgets/...
+func gadgetTypeFromURI(uri string) string {
+	colonIdx := strings.LastIndex(uri, ":")
+	if colonIdx < 0 {
+		return ""
+	}
+	rest := uri[colonIdx+1:]
+	slashIdx := strings.Index(rest, "/")
+	if slashIdx < 0 {
+		return rest
+	}
+	return rest[:slashIdx]
 }

--- a/tools/jtk/internal/present/dashboard_test.go
+++ b/tools/jtk/internal/present/dashboard_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 )
@@ -196,4 +197,37 @@ func TestFormatPermissions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGadgetTypeFromURI(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{"standard", "rest/gadgets/1.0/g/com.atlassian.jira.gadgets:assigned-to-me-gadget/gadgets/assigned-to-me-gadget.xml", "assigned-to-me-gadget"},
+		{"project", "rest/gadgets/1.0/g/com.atlassian.jira.gadgets:project-gadget/gadgets/project-gadget.xml", "project-gadget"},
+		{"no_slash", "com.atlassian.jira.gadgets:filter-results-gadget", "filter-results-gadget"},
+		{"empty", "", ""},
+		{"no_colon", "rest/gadgets/1.0/g/no-colon", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			testutil.Equal(t, gadgetTypeFromURI(tt.uri), tt.want)
+		})
+	}
+}
+
+func TestPresentGadgets_URIFallback(t *testing.T) {
+	t.Parallel()
+	gadgets := []api.DashboardGadget{
+		{ID: 1, Title: "Spaces", URI: "rest/gadgets/1.0/g/com.atlassian.jira.gadgets:project-gadget/gadgets/project-gadget.xml"},
+		{ID: 2, Title: "Filter", ModuleID: "explicit-type"},
+	}
+	model := DashboardPresenter{}.PresentGadgets(gadgets)
+	table := model.Sections[0].(*present.TableSection)
+	testutil.Equal(t, table.Rows[0].Cells[3], "project-gadget")
+	testutil.Equal(t, table.Rows[1].Cells[3], "explicit-type")
 }

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -34,7 +34,7 @@ var IssueListSpec = projection.Registry{
 	{Header: "PTS", FieldID: "customfield_10035", Fetch: []string{"customfield_10035"}},
 	{Header: "ASSIGNEE", FieldID: "assignee"},
 	{Header: "REPORTER", FieldID: "reporter", Extended: true},
-	{Header: "SPRINT", FieldID: "sprint", Extended: true},
+	{Header: "SPRINT", FieldID: "sprint", Aliases: []string{"customfield_10020"}, Fetch: []string{"customfield_10020"}, Extended: true},
 	{Header: "PARENT", FieldID: "parent", Extended: true},
 	{Header: "UPDATED", FieldID: "updated", Extended: true},
 	{Header: "LABELS", FieldID: "labels", Extended: true},


### PR DESCRIPTION
## Summary

- **Sprint column**: Add `customfield_10020` to `DefaultSearchFields` and SPRINT column spec `Fetch` so `issues list --extended` resolves sprint names
- **Complex field values**: Return empty string for unrenderable complex types in `FormatCustomFieldValue()` — fields are omitted from output instead of showing raw `map[...]`
- **Gadgets TYPE**: Extract gadget type from URI field as fallback when `ModuleID` is empty
- **Show-components tree**: Replace flat `# | COMPONENT | TYPE` table with indented tree that recursively renders trigger, conditions, and children

## Test plan

- [x] `make build` — compiles
- [x] `make test` — all tests pass
- [x] `make lint` — zero issues
- [ ] Live: `bin/jtk issues search --jql "issue = MON-1918" --extended` — SPRINT shows `MON Sprint 70`
- [ ] Live: `bin/jtk issues fields MON-4970` — no `map[...]` values
- [ ] Live: `bin/jtk dashboards gadgets list 10000` — TYPE column populated
- [ ] Live: `bin/jtk automation get 018c2840-57c1-7869-9393-11205cc87ce4 --show-components` — indented tree

Closes #312