### PR TITLE
feat(jtk): make --fields accept any Jira field via cache-backed resolution

### DIFF
--- a/tools/jtk/api/issues.go
+++ b/tools/jtk/api/issues.go
@@ -390,6 +390,21 @@ func versionNames(vs []Version) string {
 	return strings.Join(names, ", ")
 }
 
+// ExtractFieldValue returns a display-ready string for any Jira field on an issue.
+// Typed struct fields (status, assignee, etc.) use knownFieldExtractors;
+// everything else falls back to FormatCustomFieldValue on the CustomFields map.
+func ExtractFieldValue(issue *Issue, fieldID string) string {
+	if extract, ok := knownFieldExtractors[fieldID]; ok {
+		return extract(issue)
+	}
+	if issue.Fields.CustomFields != nil {
+		if raw, ok := issue.Fields.CustomFields[fieldID]; ok {
+			return FormatCustomFieldValue(raw)
+		}
+	}
+	return ""
+}
+
 // FormatCustomFieldValue formats an arbitrary custom field value as a display string.
 func FormatCustomFieldValue(v any) string {
 	if v == nil {

--- a/tools/jtk/api/sprints.go
+++ b/tools/jtk/api/sprints.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // ListSprints returns sprints for a board
@@ -51,8 +52,10 @@ func (c *Client) GetSprint(ctx context.Context, sprintID int) (*Sprint, error) {
 	return &sprint, nil
 }
 
-// GetSprintIssues returns issues in a sprint
-func (c *Client) GetSprintIssues(ctx context.Context, sprintID int, startAt, maxResults int) (*SearchResult, error) {
+// GetSprintIssues returns issues in a sprint. When fields is non-empty,
+// only those Jira field IDs are returned; otherwise the Agile default
+// (navigable + Agile fields) is used.
+func (c *Client) GetSprintIssues(ctx context.Context, sprintID int, startAt, maxResults int, fields []string) (*SearchResult, error) {
 	params := map[string]string{}
 
 	if startAt > 0 {
@@ -60,6 +63,9 @@ func (c *Client) GetSprintIssues(ctx context.Context, sprintID int, startAt, max
 	}
 	if maxResults > 0 {
 		params["maxResults"] = strconv.Itoa(maxResults)
+	}
+	if len(fields) > 0 {
+		params["fields"] = strings.Join(fields, ",")
 	}
 
 	urlStr := buildURL(fmt.Sprintf("%s/sprint/%d/issue", c.AgileURL, sprintID), params)

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -97,6 +97,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 
 		if projected {
 			model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate, dctx)
+			jtkpresent.AppendDynamicDetailFields(model, issue, projection.DynamicSpecs(selected))
 			projection.ApplyToDetailInModel(model, selected)
 			return jtkpresent.Emit(opts, model)
 		}
@@ -106,6 +107,7 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 
 	if projected {
 		model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate, nil)
+		jtkpresent.AppendDynamicDetailFields(model, issue, projection.DynamicSpecs(selected))
 		projection.ApplyToDetailInModel(model, selected)
 		return jtkpresent.Emit(opts, model)
 	}

--- a/tools/jtk/internal/cmd/issues/get_fields_test.go
+++ b/tools/jtk/internal/cmd/issues/get_fields_test.go
@@ -141,22 +141,22 @@ func TestRunGet_Fields_UnknownToken_Errors(t *testing.T) {
 	}
 }
 
-func TestRunGet_Fields_UnrenderedField_ByFieldID_Errors(t *testing.T) {
+func TestRunGet_Fields_DynamicField_ByFieldID_Succeeds(t *testing.T) {
 	// Non-parallel: cache isolation uses process-global SetRootForTest.
 	t.Cleanup(cache.SetRootForTest(t.TempDir()))
-	cs := newCapturingGetServer(t, fullIssue(), []api.Field{
+	issue := fullIssue()
+	issue.Fields.CustomFields = map[string]any{
+		"customfield_99999": "phantom-value",
+	}
+	cs := newCapturingGetServer(t, issue, []api.Field{
 		{ID: "customfield_99999", Name: "Phantom"},
 	})
 	defer cs.server.Close()
 
-	opts, _, _ := newGetOpts(t, cs)
+	opts, stdout, _ := newGetOpts(t, cs)
 	err := runGet(context.Background(), opts, "TEST-1", false, "customfield_99999")
-	var ure *projection.UnrenderedFieldError
-	if !errors.As(err, &ure) {
-		t.Fatalf("expected UnrenderedFieldError, got %v", err)
-	}
-	testutil.Equal(t, "Phantom", ure.JiraName)
-	testutil.Equal(t, "issues get", ure.Command)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "phantom-value")
 }
 
 func TestRunGet_Fields_WithJSON_Errors(t *testing.T) {

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -172,6 +172,7 @@ func runList(ctx context.Context, opts *root.Options, project, sprint string, ma
 
 	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, opts.IsExtended(), hasMore, nextToken)
 	if projected {
+		jtkpresent.AppendDynamicTableColumns(model, result.Issues, projection.DynamicSpecs(selected))
 		projection.ApplyToTableInModel(model, selected)
 	}
 	return jtkpresent.Emit(opts, model)

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -315,23 +314,31 @@ func newCapturingServerWithCustomFields(t *testing.T, keys []string, isLast bool
 		if strings.Contains(r.URL.Path, "/search") {
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, cs.searchCaptured)
-			// Build raw JSON with custom fields embedded so UnmarshalJSON captures them
-			var issueJSONs []string
-			for _, k := range keys {
-				parts := []string{
-					fmt.Sprintf(`"key":%q`, k),
-					fmt.Sprintf(`"fields":{"summary":"summary for %s","status":{"name":"Open"},"issuetype":{"name":"Task"},"assignee":{"displayName":"Alice"}`, k),
-				}
-				for fid, fv := range customFields {
-					fvJSON, _ := json.Marshal(fv)
-					parts[1] += fmt.Sprintf(`,%q:%s`, fid, string(fvJSON))
-				}
-				parts[1] += "}"
-				issueJSONs = append(issueJSONs, "{"+strings.Join(parts, ",")+","+fmt.Sprintf(`"id":%q`, k)+"}")
+
+			issueFields := map[string]any{
+				"summary":   "summary for fixture",
+				"status":    map[string]any{"name": "Open"},
+				"issuetype": map[string]any{"name": "Task"},
+				"assignee":  map[string]any{"displayName": "Alice"},
 			}
-			resp := fmt.Sprintf(`{"issues":[%s],"isLast":%t}`, strings.Join(issueJSONs, ","), isLast)
+			for fid, fv := range customFields {
+				issueFields[fid] = fv
+			}
+
+			var issues []map[string]any
+			for _, k := range keys {
+				issues = append(issues, map[string]any{
+					"id":     k,
+					"key":    k,
+					"fields": issueFields,
+				})
+			}
+			resp := map[string]any{"issues": issues, "isLast": isLast}
+			if !isLast {
+				resp["nextPageToken"] = "next-token"
+			}
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(resp))
+			_ = json.NewEncoder(w).Encode(resp)
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -469,6 +476,7 @@ func TestRunList_Fields_DynamicField_ByFieldID_Succeeds(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Phantom")
 	testutil.Contains(t, stdout.String(), "phantom-val")
+	testutil.Contains(t, strings.Join(cs.searchCaptured.Fields, ","), "customfield_99999")
 }
 
 func TestRunList_Fields_WithJSON_Errors(t *testing.T) {

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -400,7 +400,7 @@ func TestRunList_Fields_UnknownToken_Errors(t *testing.T) {
 	}
 }
 
-func TestRunList_Fields_UnrenderedField_ByHumanName_Errors(t *testing.T) {
+func TestRunList_Fields_DynamicField_ByHumanName_Succeeds(t *testing.T) {
 	// Non-parallel: cache isolation uses process-global SetRootForTest.
 	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
@@ -408,17 +408,13 @@ func TestRunList_Fields_UnrenderedField_ByHumanName_Errors(t *testing.T) {
 	})
 	defer cs.server.Close()
 
-	opts, _, _ := newOptsFor(t, cs)
+	opts, stdout, _ := newOptsFor(t, cs)
 	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "Phantom")
-	var ure *projection.UnrenderedFieldError
-	if !errors.As(err, &ure) {
-		t.Fatalf("expected UnrenderedFieldError, got %v", err)
-	}
-	testutil.Equal(t, "Phantom", ure.JiraName)
-	testutil.Equal(t, "issues list", ure.Command)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Phantom")
 }
 
-func TestRunList_Fields_UnrenderedField_ByFieldID_Errors(t *testing.T) {
+func TestRunList_Fields_DynamicField_ByFieldID_Succeeds(t *testing.T) {
 	// Non-parallel: cache isolation uses process-global SetRootForTest.
 	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
@@ -426,14 +422,10 @@ func TestRunList_Fields_UnrenderedField_ByFieldID_Errors(t *testing.T) {
 	})
 	defer cs.server.Close()
 
-	opts, _, _ := newOptsFor(t, cs)
+	opts, stdout, _ := newOptsFor(t, cs)
 	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "customfield_99999")
-	var ure *projection.UnrenderedFieldError
-	if !errors.As(err, &ure) {
-		t.Fatalf("expected UnrenderedFieldError, got %v", err)
-	}
-	testutil.Equal(t, "Phantom", ure.JiraName)
-	testutil.Contains(t, err.Error(), "Phantom")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Phantom")
 }
 
 func TestRunList_Fields_WithJSON_Errors(t *testing.T) {

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -301,6 +302,43 @@ func newCapturingServer(t *testing.T, keys []string, isLast bool, fieldsResp []a
 	return cs
 }
 
+func newCapturingServerWithCustomFields(t *testing.T, keys []string, isLast bool, fieldsResp []api.Field, customFields map[string]any) *capturingServer {
+	t.Helper()
+	cs := &capturingServer{searchCaptured: &api.SearchRequest{}}
+	cs.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/field") {
+			cs.fieldsCalls++
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(fieldsResp)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/search") {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, cs.searchCaptured)
+			// Build raw JSON with custom fields embedded so UnmarshalJSON captures them
+			var issueJSONs []string
+			for _, k := range keys {
+				parts := []string{
+					fmt.Sprintf(`"key":%q`, k),
+					fmt.Sprintf(`"fields":{"summary":"summary for %s","status":{"name":"Open"},"issuetype":{"name":"Task"},"assignee":{"displayName":"Alice"}`, k),
+				}
+				for fid, fv := range customFields {
+					fvJSON, _ := json.Marshal(fv)
+					parts[1] += fmt.Sprintf(`,%q:%s`, fid, string(fvJSON))
+				}
+				parts[1] += "}"
+				issueJSONs = append(issueJSONs, "{"+strings.Join(parts, ",")+","+fmt.Sprintf(`"id":%q`, k)+"}")
+			}
+			resp := fmt.Sprintf(`{"issues":[%s],"isLast":%t}`, strings.Join(issueJSONs, ","), isLast)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(resp))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	return cs
+}
+
 func newOptsFor(t *testing.T, cs *capturingServer) (*root.Options, *bytes.Buffer, *bytes.Buffer) {
 	return newListOpts(t, cs.server)
 }
@@ -403,29 +441,34 @@ func TestRunList_Fields_UnknownToken_Errors(t *testing.T) {
 func TestRunList_Fields_DynamicField_ByHumanName_Succeeds(t *testing.T) {
 	// Non-parallel: cache isolation uses process-global SetRootForTest.
 	t.Cleanup(cache.SetRootForTest(t.TempDir()))
-	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
-		{ID: "customfield_99999", Name: "Phantom"},
-	})
+	cs := newCapturingServerWithCustomFields(t, []string{"TEST-1"}, true,
+		[]api.Field{{ID: "customfield_99999", Name: "Phantom"}},
+		map[string]any{"customfield_99999": "phantom-val"},
+	)
 	defer cs.server.Close()
 
 	opts, stdout, _ := newOptsFor(t, cs)
 	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "Phantom")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Phantom")
+	testutil.Contains(t, stdout.String(), "phantom-val")
+	testutil.Contains(t, strings.Join(cs.searchCaptured.Fields, ","), "customfield_99999")
 }
 
 func TestRunList_Fields_DynamicField_ByFieldID_Succeeds(t *testing.T) {
 	// Non-parallel: cache isolation uses process-global SetRootForTest.
 	t.Cleanup(cache.SetRootForTest(t.TempDir()))
-	cs := newCapturingServer(t, []string{"TEST-1"}, true, []api.Field{
-		{ID: "customfield_99999", Name: "Phantom"},
-	})
+	cs := newCapturingServerWithCustomFields(t, []string{"TEST-1"}, true,
+		[]api.Field{{ID: "customfield_99999", Name: "Phantom"}},
+		map[string]any{"customfield_99999": "phantom-val"},
+	)
 	defer cs.server.Close()
 
 	opts, stdout, _ := newOptsFor(t, cs)
 	err := runList(context.Background(), opts, "TEST", "", 25, "", false, "customfield_99999")
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "Phantom")
+	testutil.Contains(t, stdout.String(), "phantom-val")
 }
 
 func TestRunList_Fields_WithJSON_Errors(t *testing.T) {

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -129,6 +129,7 @@ func runSearch(ctx context.Context, opts *root.Options, jql string, maxResults i
 
 	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, opts.IsExtended(), hasMore, nextToken)
 	if projected {
+		jtkpresent.AppendDynamicTableColumns(model, result.Issues, projection.DynamicSpecs(selected))
 		projection.ApplyToTableInModel(model, selected)
 	}
 	return jtkpresent.Emit(opts, model)

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -325,6 +325,9 @@ func newIssuesCmd(opts *root.Options) *cobra.Command {
   jtk sprints issues 456 --fields KEY,STATUS,customfield_10005`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if fieldsFlag != "" && opts.View().Format == view.FormatJSON {
+				return jtkpresent.ErrFieldsWithJSON
+			}
 			client, err := opts.APIClient()
 			if err != nil {
 				return err

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
@@ -22,6 +23,12 @@ import (
 )
 
 func noFieldFetch(_ context.Context) ([]api.Field, error) { return nil, nil }
+
+func issueFieldsFetcher(client *api.Client) func(context.Context) ([]api.Field, error) {
+	return func(ctx context.Context) ([]api.Field, error) {
+		return cache.GetFieldsCacheFirst(ctx, client)
+	}
+}
 
 // validateBoardRef rejects inputs that would parse as numeric but produce a
 // synthetic Board{ID: n} with n <= 0, which the downstream Agile endpoints
@@ -307,13 +314,15 @@ func runCurrent(ctx context.Context, opts *root.Options, client *api.Client, boa
 func newIssuesCmd(opts *root.Options) *cobra.Command {
 	var maxResults int
 	var nextPageToken string
+	var fieldsFlag string
 
 	cmd := &cobra.Command{
 		Use:   "issues <sprint>",
 		Short: "List issues in a sprint",
 		Long:  "List all issues in a specific sprint. Accepts a sprint ID or name (resolved via cache).",
 		Example: `  jtk sprints issues 456
-  jtk sprints issues "MON Sprint 70"`,
+  jtk sprints issues "MON Sprint 70"
+  jtk sprints issues 456 --fields KEY,STATUS,customfield_10005`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := opts.APIClient()
@@ -324,22 +333,45 @@ func newIssuesCmd(opts *root.Options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runIssues(cmd.Context(), opts, resolvedSprint.ID, maxResults, nextPageToken)
+			return runIssues(cmd.Context(), opts, resolvedSprint.ID, maxResults, nextPageToken, fieldsFlag)
 		},
 	}
 
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of results")
 	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Decimal startAt for the next page")
+	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns (headers, Jira field IDs, or human names)")
 
 	return cmd
 }
 
-func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults int, nextPageToken string) error {
+func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults int, nextPageToken string, fieldsFlag string) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
+	}
+
+	idOnly := opts.EmitIDOnly()
+
+	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
+		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	var selected []projection.ColumnSpec
+	var projected bool
+	if !idOnly {
+		selected, projected, err = projection.Resolve(
+			ctx,
+			jtkpresent.IssueListSpec,
+			opts.IsExtended(),
+			fieldsFlag,
+			issueFieldsFetcher(client),
+			"sprints issues",
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	startAt, err := jtkpresent.ParseStartAtToken(nextPageToken)
@@ -363,7 +395,7 @@ func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults
 		nextToken = strconv.Itoa(startAt + len(result.Issues))
 	}
 
-	if opts.EmitIDOnly() {
+	if idOnly {
 		ids := make([]string, len(result.Issues))
 		for i, issue := range result.Issues {
 			ids[i] = issue.Key
@@ -381,6 +413,10 @@ func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults
 	}
 
 	model := jtkpresent.IssuePresenter{}.PresentListWithPagination(result.Issues, opts.IsExtended(), hasMore, nextToken)
+	if projected {
+		jtkpresent.AppendDynamicTableColumns(model, result.Issues, projection.DynamicSpecs(selected))
+		projection.ApplyToTableInModel(model, selected)
+	}
 	return jtkpresent.Emit(opts, model)
 }
 

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -379,7 +379,12 @@ func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults
 		return err
 	}
 
-	result, err := client.GetSprintIssues(ctx, sprintID, startAt, maxResults)
+	var fetchFields []string
+	if projected {
+		fetchFields = projection.DeriveFetchFields(selected)
+	}
+
+	result, err := client.GetSprintIssues(ctx, sprintID, startAt, maxResults, fetchFields)
 	if err != nil {
 		return err
 	}
@@ -479,7 +484,7 @@ func runAdd(ctx context.Context, opts *root.Options, client *api.Client, sprintI
 		found := make(map[string]bool)
 		startAt := 0
 		for {
-			result, err := client.GetSprintIssues(ctx, sprintID, startAt, 50)
+			result, err := client.GetSprintIssues(ctx, sprintID, startAt, 50, nil)
 			if err != nil {
 				break
 			}

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -325,7 +325,7 @@ func newIssuesCmd(opts *root.Options) *cobra.Command {
   jtk sprints issues 456 --fields KEY,STATUS,customfield_10005`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if fieldsFlag != "" && opts.View().Format == view.FormatJSON {
+			if !opts.EmitIDOnly() && fieldsFlag != "" && opts.View().Format == view.FormatJSON {
 				return jtkpresent.ErrFieldsWithJSON
 			}
 			client, err := opts.APIClient()
@@ -356,10 +356,6 @@ func runIssues(ctx context.Context, opts *root.Options, sprintID int, maxResults
 	}
 
 	idOnly := opts.EmitIDOnly()
-
-	if !idOnly && fieldsFlag != "" && v.Format == view.FormatJSON {
-		return jtkpresent.ErrFieldsWithJSON
-	}
 
 	var selected []projection.ColumnSpec
 	var projected bool

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -577,6 +577,57 @@ func TestRunIssues_Empty(t *testing.T) {
 	testutil.Contains(t, stdout.String(), "No issues in sprint")
 }
 
+func TestRunIssues_Fields_DynamicCustomField(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/field") {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]api.Field{
+				{ID: "customfield_99999", Name: "Phantom"},
+			})
+			return
+		}
+		if strings.Contains(r.URL.Path, "/sprint/") && strings.Contains(r.URL.Path, "/issue") {
+			resp := map[string]any{
+				"startAt":    0,
+				"maxResults": 50,
+				"total":      1,
+				"issues": []map[string]any{{
+					"id":  "1",
+					"key": "PROJ-101",
+					"fields": map[string]any{
+						"summary":           "Fix bug",
+						"status":            map[string]any{"name": "Open"},
+						"issuetype":         map[string]any{"name": "Task"},
+						"customfield_99999": "phantom-val",
+					},
+				}},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runIssues(context.Background(), opts, 456, 50, "", "KEY,STATUS,customfield_99999")
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "PROJ-101")
+	testutil.Contains(t, output, "Phantom")
+	testutil.Contains(t, output, "phantom-val")
+}
+
 // --- add subcommand ---
 
 func TestNewAddCmd(t *testing.T) {

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -495,7 +495,7 @@ func TestRunIssues_Table(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runIssues(context.Background(), opts, 456, 50, "")
+	err = runIssues(context.Background(), opts, 456, 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -525,7 +525,7 @@ func TestRunIssues_IDOnly(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
 	opts.SetAPIClient(client)
 
-	err = runIssues(context.Background(), opts, 456, 50, "")
+	err = runIssues(context.Background(), opts, 456, 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	testutil.Equal(t, stdout.String(), "PROJ-101\nPROJ-102\n")
@@ -552,7 +552,7 @@ func TestRunIssues_JSON(t *testing.T) {
 	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runIssues(context.Background(), opts, 456, 50, "")
+	err = runIssues(context.Background(), opts, 456, 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -571,7 +571,7 @@ func TestRunIssues_Empty(t *testing.T) {
 	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runIssues(context.Background(), opts, 456, 50, "")
+	err = runIssues(context.Background(), opts, 456, 50, "", "")
 	testutil.RequireNoError(t, err)
 
 	testutil.Contains(t, stdout.String(), "No issues in sprint")

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -696,6 +696,61 @@ func (IssuePresenter) PresentList(issues []api.Issue, extended bool) *present.Ou
 	}
 }
 
+// AppendDynamicTableColumns adds columns for dynamic (cache-resolved) field
+// specs to the first TableSection in model. Each spec becomes a new column
+// with values extracted via api.ExtractFieldValue. Must be called BEFORE
+// ProjectTable so the projection slice can find the headers.
+func AppendDynamicTableColumns(model *present.OutputModel, issues []api.Issue, specs []projection.ColumnSpec) {
+	if model == nil || len(specs) == 0 {
+		return
+	}
+	for i, s := range model.Sections {
+		ts, ok := s.(*present.TableSection)
+		if !ok {
+			continue
+		}
+		for _, spec := range specs {
+			ts.Headers = append(ts.Headers, spec.Header)
+		}
+		for j, r := range ts.Rows {
+			if j >= len(issues) {
+				break
+			}
+			for _, spec := range specs {
+				val := api.ExtractFieldValue(&issues[j], spec.FieldID)
+				r.Cells = append(r.Cells, OrDash(val))
+			}
+			ts.Rows[j] = r
+		}
+		model.Sections[i] = ts
+		return
+	}
+}
+
+// AppendDynamicDetailFields adds fields for dynamic (cache-resolved) field
+// specs to the first DetailSection in model. Must be called BEFORE
+// ProjectDetail so the projection slice can find the labels.
+func AppendDynamicDetailFields(model *present.OutputModel, issue *api.Issue, specs []projection.ColumnSpec) {
+	if model == nil || issue == nil || len(specs) == 0 {
+		return
+	}
+	for i, s := range model.Sections {
+		ds, ok := s.(*present.DetailSection)
+		if !ok {
+			continue
+		}
+		for _, spec := range specs {
+			val := api.ExtractFieldValue(issue, spec.FieldID)
+			ds.Fields = append(ds.Fields, present.Field{
+				Label: spec.Header,
+				Value: OrDash(val),
+			})
+		}
+		model.Sections[i] = ds
+		return
+	}
+}
+
 // PresentTypes creates a table view for issue types.
 func (IssuePresenter) PresentTypes(types []api.IssueType) *present.OutputModel {
 	rows := make([]present.Row, len(types))

--- a/tools/jtk/internal/present/projection/project.go
+++ b/tools/jtk/internal/present/projection/project.go
@@ -121,6 +121,18 @@ func HasExtendedFields(selected []ColumnSpec, registry Registry) bool {
 	return false
 }
 
+// DynamicSpecs returns only the Dynamic specs from selected. Commands use
+// this to identify columns/fields that need runtime value extraction.
+func DynamicSpecs(selected []ColumnSpec) []ColumnSpec {
+	var out []ColumnSpec
+	for _, c := range selected {
+		if c.Dynamic {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 // DeriveFetchFields returns the minimum Jira field-ID set needed to render
 // the selected specs. Output is sorted and deduplicated so API requests are
 // stable across runs. Synthetic specs (empty FieldID, empty Fetch) are

--- a/tools/jtk/internal/present/projection/resolve.go
+++ b/tools/jtk/internal/present/projection/resolve.go
@@ -27,26 +27,22 @@ func (e *UnknownFieldError) Error() string {
 		quoteAll(e.Unknown), strings.Join(e.Suggestions, ", "))
 }
 
-// UnrenderedFieldError reports a --fields token that resolves to a real
-// Jira field but is not rendered by the current command. The error
-// message uses the Jira human-readable name (from api.Field.Name) even
-// when the user passed a field ID, so the UX is consistent.
-//
-// This is distinct from UnknownFieldError; callers (commands) print both
-// as prose on stderr, but tests assert on the specific type to verify
-// the projection-scope contract.
-type UnrenderedFieldError struct {
-	Token       string // What the user typed.
-	JiraName    string // api.Field.Name.
-	JiraID      string // api.Field.ID.
-	Command     string // e.g. "issues list" — used in the error message.
-	Suggestions []string
+// AmbiguousFieldNameError reports a --fields token that matches multiple
+// Jira fields by human name. The user must disambiguate with an exact
+// field ID.
+type AmbiguousFieldNameError struct {
+	Token   string
+	Matches []api.Field
 }
 
-func (e *UnrenderedFieldError) Error() string {
+func (e *AmbiguousFieldNameError) Error() string {
+	parts := make([]string, len(e.Matches))
+	for i, f := range e.Matches {
+		parts[i] = fmt.Sprintf("%s (%s)", f.Name, f.ID)
+	}
 	return fmt.Sprintf(
-		"field %q (%s) exists but is not rendered by %q; supported fields: %s",
-		e.JiraName, e.JiraID, e.Command, strings.Join(e.Suggestions, ", "),
+		"field name %q is ambiguous — matches: %s; use the field ID to disambiguate",
+		e.Token, strings.Join(parts, ", "),
 	)
 }
 
@@ -86,22 +82,20 @@ func (e *ExtendedOnlyError) Error() string {
 //   - Identity specs are prepended if the user omitted them; dedup preserved.
 //   - If a token matches an Extended-only spec with extended==false, return
 //     ExtendedOnlyError.
-//   - If a token resolves to a real api.Field but no registry entry, return
-//     UnrenderedFieldError using the Jira human-readable name — even when
-//     the user passed the field ID.
+//   - If a token resolves to a real api.Field but no registry entry, a
+//     dynamic ColumnSpec is created (Dynamic: true) so the command can
+//     render it from the issue's raw field data.
+//   - If a human name matches multiple Jira fields, return
+//     AmbiguousFieldNameError so the user can disambiguate with a field ID.
 //   - Otherwise, unresolved tokens → UnknownFieldError with registry-based
 //     suggestions.
-//
-// cmdName is the user-visible command label (e.g., "issues list") used in
-// UnrenderedFieldError for clarity; commands pass cmd.CommandPath() or a
-// hardcoded label.
 func Resolve(
 	ctx context.Context,
 	r Registry,
 	extended bool,
 	fieldsFlag string,
 	fetchFields func(context.Context) ([]api.Field, error),
-	cmdName string,
+	_ string,
 ) (selected []ColumnSpec, projectionApplied bool, err error) {
 	modeRegistry := r.ForMode(extended)
 
@@ -173,12 +167,28 @@ func Resolve(
 			return nil, false, ferr
 		}
 
+		// Collect all resolved headers so we can detect collisions when
+		// creating dynamic specs. Pre-seed with fast-path resolved specs
+		// and identity specs.
+		resolvedHeaders := make(map[string]struct{})
+		for _, c := range modeRegistry {
+			if c.Identity {
+				resolvedHeaders[strings.ToLower(c.Header)] = struct{}{}
+			}
+		}
+		for _, spec := range resolved {
+			if spec != nil {
+				resolvedHeaders[strings.ToLower(spec.Header)] = struct{}{}
+			}
+		}
+
 		var unknown []string
 		for _, i := range deferred {
 			tok := tokens[i]
 			if spec, ok := modeRegistry.Match(tok, fields); ok {
 				s := spec
 				resolved[i] = &s
+				resolvedHeaders[strings.ToLower(s.Header)] = struct{}{}
 				continue
 			}
 
@@ -189,13 +199,27 @@ func Resolve(
 			}
 
 			if jf := findJiraField(fields, tok); jf != nil {
-				return nil, false, &UnrenderedFieldError{
-					Token:       tok,
-					JiraName:    jf.Name,
-					JiraID:      jf.ID,
-					Command:     cmdName,
-					Suggestions: registryHeaders(modeRegistry),
+				// Check for ambiguous human-name matches (only when
+				// the token is NOT an exact field ID match).
+				if api.FindFieldByID(fields, tok) == nil {
+					if matches := findAllJiraFieldsByName(fields, tok); len(matches) > 1 {
+						return nil, false, &AmbiguousFieldNameError{Token: tok, Matches: matches}
+					}
 				}
+
+				header := jf.Name
+				if _, collision := resolvedHeaders[strings.ToLower(header)]; collision {
+					header = fmt.Sprintf("%s (%s)", jf.Name, jf.ID)
+				}
+				resolvedHeaders[strings.ToLower(header)] = struct{}{}
+
+				resolved[i] = &ColumnSpec{
+					Header:  header,
+					FieldID: jf.ID,
+					Fetch:   []string{jf.ID},
+					Dynamic: true,
+				}
+				continue
 			}
 
 			unknown = append(unknown, tok)
@@ -228,6 +252,19 @@ func findJiraField(fields []api.Field, token string) *api.Field {
 		return f
 	}
 	return nil
+}
+
+// findAllJiraFieldsByName returns all fields whose Name matches token
+// (case-insensitive). Used to detect ambiguous human-name references.
+func findAllJiraFieldsByName(fields []api.Field, token string) []api.Field {
+	lower := strings.ToLower(token)
+	var matches []api.Field
+	for _, f := range fields {
+		if strings.ToLower(f.Name) == lower {
+			matches = append(matches, f)
+		}
+	}
+	return matches
 }
 
 // parseTokens splits a --fields CSV, trims whitespace, drops empty segments.

--- a/tools/jtk/internal/present/projection/resolve.go
+++ b/tools/jtk/internal/present/projection/resolve.go
@@ -167,19 +167,13 @@ func Resolve(
 			return nil, false, ferr
 		}
 
-		// Collect all resolved headers so we can detect collisions when
-		// creating dynamic specs. Pre-seed with fast-path resolved specs
-		// and identity specs.
+		// Collect all known headers to detect collisions when creating
+		// dynamic specs. Seed with the full registry (not just selected
+		// or mode-filtered) so dynamic fields named like built-ins always
+		// get disambiguated.
 		resolvedHeaders := make(map[string]struct{})
-		for _, c := range modeRegistry {
-			if c.Identity {
-				resolvedHeaders[strings.ToLower(c.Header)] = struct{}{}
-			}
-		}
-		for _, spec := range resolved {
-			if spec != nil {
-				resolvedHeaders[strings.ToLower(spec.Header)] = struct{}{}
-			}
+		for _, c := range r {
+			resolvedHeaders[strings.ToLower(c.Header)] = struct{}{}
 		}
 
 		var unknown []string

--- a/tools/jtk/internal/present/projection/resolve_test.go
+++ b/tools/jtk/internal/present/projection/resolve_test.go
@@ -154,32 +154,69 @@ func TestResolve_UnknownToken_FallbackAttemptedButFails(t *testing.T) {
 	testutil.Equal(t, 1, stub.calls)
 }
 
-func TestResolve_UnrenderedField_ByHumanName(t *testing.T) {
+func TestResolve_DynamicSpec_ByHumanName(t *testing.T) {
 	t.Parallel()
 	stub := &fetchStub{fields: []api.Field{
 		{ID: "customfield_99999", Name: "Phantom"},
 	}}
-	_, _, err := Resolve(context.Background(), testRegistry, false, "Phantom", stub.fetch, "issues list")
-	var ure *UnrenderedFieldError
-	testutil.True(t, errors.As(err, &ure))
-	testutil.Equal(t, "Phantom", ure.JiraName)
-	testutil.Equal(t, "customfield_99999", ure.JiraID)
-	testutil.Equal(t, "issues list", ure.Command)
+	selected, projected, err := Resolve(context.Background(), testRegistry, false, "Phantom", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.True(t, projected)
+	// Should contain identity (KEY) + dynamic spec
+	var found bool
+	for _, s := range selected {
+		if s.FieldID == "customfield_99999" && s.Dynamic && s.Header == "Phantom" {
+			found = true
+		}
+	}
+	testutil.True(t, found)
 }
 
-func TestResolve_UnrenderedField_ByFieldID_UsesHumanNameInMessage(t *testing.T) {
+func TestResolve_DynamicSpec_ByFieldID(t *testing.T) {
 	t.Parallel()
 	stub := &fetchStub{fields: []api.Field{
 		{ID: "customfield_99999", Name: "Phantom"},
 	}}
-	_, _, err := Resolve(context.Background(), testRegistry, false, "customfield_99999", stub.fetch, "issues list")
-	var ure *UnrenderedFieldError
-	testutil.True(t, errors.As(err, &ure))
-	testutil.Equal(t, "Phantom", ure.JiraName)
-	testutil.Equal(t, "customfield_99999", ure.JiraID)
-	// Error message must resolve the ID to the human-readable name.
-	testutil.Contains(t, err.Error(), "Phantom")
-	testutil.Contains(t, err.Error(), "customfield_99999")
+	selected, projected, err := Resolve(context.Background(), testRegistry, false, "customfield_99999", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	testutil.True(t, projected)
+	var found bool
+	for _, s := range selected {
+		if s.FieldID == "customfield_99999" && s.Dynamic && s.Header == "Phantom" {
+			found = true
+		}
+	}
+	testutil.True(t, found)
+}
+
+func TestResolve_AmbiguousFieldName_Errors(t *testing.T) {
+	t.Parallel()
+	stub := &fetchStub{fields: []api.Field{
+		{ID: "customfield_10001", Name: "Duplicate"},
+		{ID: "customfield_10002", Name: "Duplicate"},
+	}}
+	_, _, err := Resolve(context.Background(), testRegistry, false, "Duplicate", stub.fetch, "issues list")
+	var afe *AmbiguousFieldNameError
+	testutil.True(t, errors.As(err, &afe))
+	testutil.Equal(t, 2, len(afe.Matches))
+}
+
+func TestResolve_DynamicSpec_HeaderCollision(t *testing.T) {
+	t.Parallel()
+	// "STATUS" is a registered header. A custom field also named "STATUS"
+	// should get a disambiguated header.
+	stub := &fetchStub{fields: []api.Field{
+		{ID: "customfield_99999", Name: "STATUS"},
+	}}
+	selected, _, err := Resolve(context.Background(), testRegistry, false, "STATUS,customfield_99999", stub.fetch, "issues list")
+	testutil.RequireNoError(t, err)
+	var dynamicHeader string
+	for _, s := range selected {
+		if s.Dynamic {
+			dynamicHeader = s.Header
+		}
+	}
+	testutil.Equal(t, "STATUS (customfield_99999)", dynamicHeader)
 }
 
 func TestResolve_ExtendedOnlyToken_WithoutFlag_Errors(t *testing.T) {

--- a/tools/jtk/internal/present/projection/spec.go
+++ b/tools/jtk/internal/present/projection/spec.go
@@ -37,6 +37,10 @@ type ColumnSpec struct {
 	// When empty and FieldID is empty, the column contributes nothing
 	// to the fetch set (synthetic columns like a constructed URL).
 	Fetch []string
+	// Dynamic is true for specs created at runtime from Jira field
+	// metadata (cache-backed). Commands use this to append values
+	// that the hardcoded presenter doesn't know about.
+	Dynamic bool
 }
 
 // fetchFields returns the Jira field IDs required to render this spec.

--- a/tools/jtk/internal/present/projection/spec.go
+++ b/tools/jtk/internal/present/projection/spec.go
@@ -105,8 +105,10 @@ func (r Registry) Match(token string, fields []api.Field) (ColumnSpec, bool) {
 	if len(fields) == 0 {
 		return ColumnSpec{}, false
 	}
-	// Human-name fallback: find the Jira field whose Name matches the token,
-	// then map its ID back to a ColumnSpec via FieldID.
+	// Human-name fallback: scan ALL Jira fields whose Name matches the token
+	// and return the first whose ID maps to a ColumnSpec. This avoids
+	// cache-order dependency when multiple fields share a name but only
+	// one is registered.
 	for i := range fields {
 		if strings.EqualFold(fields[i].Name, token) {
 			fieldID := fields[i].ID
@@ -115,9 +117,6 @@ func (r Registry) Match(token string, fields []api.Field) (ColumnSpec, bool) {
 					return c, true
 				}
 			}
-			// Found in Jira but not in the registry — caller distinguishes
-			// this case via findJiraField in resolve.go.
-			return ColumnSpec{}, false
 		}
 	}
 	return ColumnSpec{}, false


### PR DESCRIPTION
## Summary
- **Dynamic field resolution**: `--fields` now accepts any Jira field by human name or `customfield_XXXXX` ID, backed by the field cache. Previously errored with `UnrenderedFieldError` for unregistered fields.
- **`sprints issues --fields`**: New flag added with full projection support, matching `issues list`/`issues search` semantics.
- **Ambiguity detection**: Human names matching multiple Jira fields return an `AmbiguousFieldNameError` with IDs for disambiguation.
- **Header collision handling**: Dynamic fields whose names collide with registered headers are disambiguated with `(fieldID)` suffix.

## Test plan
- [x] Unit tests updated: `UnrenderedFieldError` tests → dynamic spec creation tests
- [x] New tests: ambiguous field names, header collision, sprints issues --fields
- [x] `make test` — all 832+ tests passing
- [x] `make lint` — clean
- [x] Before/after verification against live Jira (posted as [issue comment](https://github.com/open-cli-collective/atlassian-cli/issues/316#issuecomment-4338802461))

Closes #316