### PR TITLE
feat(jtk): normalize --extended on issues get; add --custom-fields flag

### DIFF
--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -92,6 +92,10 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 
 	presenter := jtkpresent.IssuePresenter{}
 
+	if opts.IsExtended() {
+		noTruncate = true
+	}
+
 	if projected {
 		model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate)
 		jtkpresent.AppendDynamicDetailFields(model, issue, projection.DynamicSpecs(selected))
@@ -100,10 +104,6 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 			appendCustomFields(ctx, client, issue, model)
 		}
 		return jtkpresent.Emit(opts, model)
-	}
-
-	if opts.IsExtended() {
-		noTruncate = true
 	}
 	model := presenter.PresentDetail(issue, client.IssueURL(issue.Key), opts.IsExtended(), noTruncate)
 	if customFields {

--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
@@ -17,6 +19,7 @@ import (
 func newGetCmd(opts *root.Options) *cobra.Command {
 	var noTruncate bool
 	var fieldsFlag string
+	var customFields bool
 
 	cmd := &cobra.Command{
 		Use:   "get <issue-key>",
@@ -26,21 +29,23 @@ func newGetCmd(opts *root.Options) *cobra.Command {
   jtk issues get PROJ-123 --fulltext
   jtk issues get PROJ-123 --id
   jtk issues get PROJ-123 --fields Status,Assignee
-  jtk issues get PROJ-123 --fields "Issue Type"`,
+  jtk issues get PROJ-123 --fields "Issue Type"
+  jtk issues get PROJ-123 --custom-fields`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGet(cmd.Context(), opts, args[0], noTruncate || opts.IsFullText(), fieldsFlag)
+			return runGet(cmd.Context(), opts, args[0], noTruncate || opts.IsFullText(), fieldsFlag, customFields)
 		},
 	}
 
 	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Show full description without truncation")
 	_ = cmd.Flags().MarkDeprecated("no-truncate", "use --fulltext instead")
 	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display fields (labels, Jira field IDs, or human names)")
+	cmd.Flags().BoolVar(&customFields, "custom-fields", false, "Append custom fields section to output")
 
 	return cmd
 }
 
-func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate bool, fieldsFlag string) error {
+func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate bool, fieldsFlag string, customFields bool) error {
 	v := opts.View()
 
 	client, err := opts.APIClient()
@@ -57,6 +62,10 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	}
 
 	if fieldsFlag != "" && v.Format == view.FormatJSON {
+		return jtkpresent.ErrFieldsWithJSON
+	}
+
+	if customFields && v.Format == view.FormatJSON {
 		return jtkpresent.ErrFieldsWithJSON
 	}
 
@@ -83,35 +92,31 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 
 	presenter := jtkpresent.IssuePresenter{}
 
-	if opts.IsExtended() {
-		noTruncate = true
-		transitions, transErr := client.GetTransitions(ctx, issueKey)
-		watchers, _ := client.GetWatchers(ctx, issueKey)
-		fields, _ := cache.GetFieldsCacheFirst(ctx, client)
-		dctx := &jtkpresent.DetailContext{
-			Transitions:       transitions,
-			TransitionsFailed: transErr != nil,
-			Watchers:          watchers,
-			Fields:            fields,
-		}
-
-		if projected {
-			model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate, dctx)
-			jtkpresent.AppendDynamicDetailFields(model, issue, projection.DynamicSpecs(selected))
-			projection.ApplyToDetailInModel(model, selected)
-			return jtkpresent.Emit(opts, model)
-		}
-		model := presenter.PresentDetailExtended(issue, client.IssueURL(issue.Key), dctx)
-		return jtkpresent.Emit(opts, model)
-	}
-
 	if projected {
-		model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate, nil)
+		model := presenter.PresentDetailProjection(issue, client.IssueURL(issue.Key), noTruncate)
 		jtkpresent.AppendDynamicDetailFields(model, issue, projection.DynamicSpecs(selected))
 		projection.ApplyToDetailInModel(model, selected)
+		if customFields {
+			appendCustomFields(ctx, client, issue, model)
+		}
 		return jtkpresent.Emit(opts, model)
 	}
 
-	model := presenter.PresentDetail(issue, client.IssueURL(issue.Key), false, noTruncate)
+	if opts.IsExtended() {
+		noTruncate = true
+	}
+	model := presenter.PresentDetail(issue, client.IssueURL(issue.Key), opts.IsExtended(), noTruncate)
+	if customFields {
+		appendCustomFields(ctx, client, issue, model)
+	}
 	return jtkpresent.Emit(opts, model)
+}
+
+func appendCustomFields(ctx context.Context, client *api.Client, issue *api.Issue, model *present.OutputModel) {
+	fields, err := cache.GetFieldsCacheFirst(ctx, client)
+	if err != nil {
+		return
+	}
+	entries := api.ExtractIssueFieldValues(issue, fields)
+	jtkpresent.AppendCustomFieldsSection(model, entries)
 }

--- a/tools/jtk/internal/cmd/issues/get_fields_test.go
+++ b/tools/jtk/internal/cmd/issues/get_fields_test.go
@@ -78,7 +78,7 @@ func TestRunGet_Fields_ProjectsDetailToSelected(t *testing.T) {
 	defer cs.server.Close()
 
 	opts, stdout, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", false, "Status")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Status", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -100,7 +100,7 @@ func TestRunGet_Fields_Points_Column(t *testing.T) {
 	defer cs.server.Close()
 
 	opts, stdout, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", false, "Points")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Points", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -117,7 +117,7 @@ func TestRunGet_Fields_HumanName_TriggersFieldsFetch(t *testing.T) {
 	defer cs.server.Close()
 
 	opts, stdout, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", false, "Issue Type")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Issue Type", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -134,7 +134,7 @@ func TestRunGet_Fields_UnknownToken_Errors(t *testing.T) {
 	defer cs.server.Close()
 
 	opts, _, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", false, "bogus")
+	err := runGet(context.Background(), opts, "TEST-1", false, "bogus", false)
 	var ufe *projection.UnknownFieldError
 	if !errors.As(err, &ufe) {
 		t.Fatalf("expected UnknownFieldError, got %v", err)
@@ -154,7 +154,7 @@ func TestRunGet_Fields_DynamicField_ByFieldID_Succeeds(t *testing.T) {
 	defer cs.server.Close()
 
 	opts, stdout, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", false, "customfield_99999")
+	err := runGet(context.Background(), opts, "TEST-1", false, "customfield_99999", false)
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "phantom-value")
 }
@@ -166,7 +166,7 @@ func TestRunGet_Fields_WithJSON_Errors(t *testing.T) {
 
 	opts, _, _ := newGetOpts(t, cs)
 	opts.Output = "json"
-	err := runGet(context.Background(), opts, "TEST-1", false, "Status")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Status", false)
 	if err == nil {
 		t.Fatalf("expected error when --fields combined with --output json")
 	}
@@ -180,7 +180,7 @@ func TestRunGet_FieldsWithIDOnly_IDWins(t *testing.T) {
 
 	opts, stdout, _ := newGetOpts(t, cs)
 	opts.IDOnly = true
-	err := runGet(context.Background(), opts, "TEST-1", false, "Status")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Status", false)
 	testutil.RequireNoError(t, err)
 
 	// Bare key on stdout; nothing else.
@@ -200,7 +200,7 @@ func TestRunGet_IDOnly_SkipsFieldsResolution(t *testing.T) {
 
 	opts, _, _ := newGetOpts(t, cs)
 	opts.IDOnly = true
-	err := runGet(context.Background(), opts, "TEST-1", false, "Issue Type")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Issue Type", false)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, 0, cs.fieldsCalls)
 }
@@ -212,7 +212,7 @@ func TestRunGet_IDOnly_BypassesFieldsValidation(t *testing.T) {
 
 	opts, stdout, _ := newGetOpts(t, cs)
 	opts.IDOnly = true
-	err := runGet(context.Background(), opts, "TEST-1", false, "bogus")
+	err := runGet(context.Background(), opts, "TEST-1", false, "bogus", false)
 	testutil.RequireNoError(t, err)
 	if stdout.String() != "TEST-1\n" {
 		t.Errorf("expected bare key, got %q", stdout.String())
@@ -227,7 +227,7 @@ func TestRunGet_IDOnly_BypassesJSONFieldsRejection(t *testing.T) {
 	opts, stdout, _ := newGetOpts(t, cs)
 	opts.IDOnly = true
 	opts.Output = "json"
-	err := runGet(context.Background(), opts, "TEST-1", false, "Status")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Status", false)
 	testutil.RequireNoError(t, err)
 	if stdout.String() != "TEST-1\n" {
 		t.Errorf("expected bare key, got %q", stdout.String())
@@ -251,7 +251,7 @@ func TestRunGet_Fields_SuppressesDescription_WhenNotSelected(t *testing.T) {
 	defer cs.server.Close()
 
 	opts, stdout, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", false, "Summary,Status")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Summary,Status", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -272,7 +272,7 @@ func TestRunGet_Fields_Description_TruncatedWithoutFullText(t *testing.T) {
 	defer cs.server.Close()
 
 	opts, stdout, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", false, "Description")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Description", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -288,7 +288,7 @@ func TestRunGet_Fields_Description_FullTextWhenSelected(t *testing.T) {
 	defer cs.server.Close()
 
 	opts, stdout, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", true, "Description")
+	err := runGet(context.Background(), opts, "TEST-1", true, "Description", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -305,7 +305,7 @@ func TestRunGet_Fields_FullTextNoOp_WhenDescriptionNotSelected(t *testing.T) {
 	defer cs.server.Close()
 
 	opts, stdout, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", true, "Summary")
+	err := runGet(context.Background(), opts, "TEST-1", true, "Summary", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -332,7 +332,7 @@ func TestRunGet_Fields_HumanName_CacheHit_SkipsFieldsFetch(t *testing.T) {
 	defer cs.server.Close()
 
 	opts, stdout, _ := newGetOpts(t, cs)
-	err := runGet(context.Background(), opts, "TEST-1", false, "Issue Type")
+	err := runGet(context.Background(), opts, "TEST-1", false, "Issue Type", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -67,7 +67,7 @@ func TestRunGet_TruncatesDescription(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "TEST-1", false, "")
+	err = runGet(context.Background(), opts, "TEST-1", false, "", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -107,7 +107,7 @@ func TestRunGet_FullDescription(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "TEST-1", true, "")
+	err = runGet(context.Background(), opts, "TEST-1", true, "", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -224,7 +224,7 @@ func TestRunGet_IDOnly(t *testing.T) {
 	opts := &root.Options{Output: "table", IDOnly: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	testutil.RequireNoError(t, runGet(context.Background(), opts, "TEST-1", false, ""))
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TEST-1", false, "", false))
 	testutil.Equal(t, stdout.String(), "TEST-1\n")
 }
 
@@ -252,7 +252,7 @@ func TestRunGet_IDOnlyPrecedenceOverExtendedFullText(t *testing.T) {
 
 	// runGet receives noTruncate derived from RunE; when --id is set, the truncation
 	// value doesn't matter because EmitIDOnly collapses output before presenter runs.
-	testutil.RequireNoError(t, runGet(context.Background(), opts, "TEST-1", true, ""))
+	testutil.RequireNoError(t, runGet(context.Background(), opts, "TEST-1", true, "", false))
 	testutil.Equal(t, stdout.String(), "TEST-1\n")
 }
 
@@ -286,7 +286,7 @@ func TestRunGet_ShortDescriptionNotTruncated(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "TEST-1", false, "")
+	err = runGet(context.Background(), opts, "TEST-1", false, "", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -323,7 +323,7 @@ func TestRunGet_JSONOutputIgnoresFullFlag(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "TEST-1", true, "")
+	err = runGet(context.Background(), opts, "TEST-1", true, "", false)
 	testutil.RequireNoError(t, err)
 
 	// Should be valid JSON
@@ -333,7 +333,7 @@ func TestRunGet_JSONOutputIgnoresFullFlag(t *testing.T) {
 	testutil.Equal(t, result.Key, "TEST-1")
 }
 
-func TestRunGet_Extended_ShowsNewSections(t *testing.T) {
+func TestRunGet_Extended_ShowsNormalizedSections(t *testing.T) {
 	t.Parallel()
 	issue := api.Issue{
 		Key: "TEST-1",
@@ -341,29 +341,16 @@ func TestRunGet_Extended_ShowsNewSections(t *testing.T) {
 			Summary:     "Test issue",
 			Status:      &api.Status{Name: "Open", StatusCategory: api.StatusCategory{Name: "To Do"}},
 			IssueType:   &api.IssueType{Name: "Task"},
+			Reporter:    &api.User{DisplayName: "Bob"},
 			Resolution:  &api.Resolution{Name: "Done"},
 			FixVersions: []api.Version{{ID: "1", Name: "v1.0"}},
+			Created:     "2026-04-01T12:00:00.000+0000",
 			Description: &api.Description{Text: strings.Repeat("A", 300)},
 		},
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case strings.HasSuffix(r.URL.Path, "/transitions"):
-			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{
-				Transitions: []api.Transition{
-					{ID: "11", Name: "Backlog", To: api.Status{Name: "Backlog"}},
-					{ID: "21", Name: "In Progress", To: api.Status{Name: "In Development"}},
-				},
-			})
-		case strings.HasSuffix(r.URL.Path, "/watchers"):
-			_ = json.NewEncoder(w).Encode(api.WatchersInfo{WatchCount: 3, IsWatching: true})
-		case strings.Contains(r.URL.Path, "/field"):
-			_ = json.NewEncoder(w).Encode([]api.Field{})
-		default:
-			_ = json.NewEncoder(w).Encode(issue)
-		}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(issue)
 	}))
 	defer server.Close()
 
@@ -374,68 +361,19 @@ func TestRunGet_Extended_ShowsNewSections(t *testing.T) {
 	opts := &root.Options{Output: "table", Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "TEST-1", false, "")
+	err = runGet(context.Background(), opts, "TEST-1", false, "", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
+	testutil.Contains(t, output, "Reporter: Bob")
 	testutil.Contains(t, output, "Fix Versions: v1.0")
-	testutil.Contains(t, output, "Watchers: 3 (watching: yes)")
 	testutil.Contains(t, output, "Resolution: Done")
-	testutil.Contains(t, output, "Transitions:")
-	testutil.Contains(t, output, "  11 | Backlog | Backlog")
-	testutil.Contains(t, output, "  21 | In Progress | In Development")
-	testutil.NotContains(t, output, "ID | NAME")
 	// Extended implies fulltext — full description present
 	testutil.NotContains(t, output, "[truncated")
-}
-
-func TestRunGet_ExtendedFields_ProjectionUsesDetailContext(t *testing.T) {
-	t.Parallel()
-	longDesc := strings.Repeat("B", 300)
-	issue := api.Issue{
-		Key: "TEST-1",
-		Fields: api.IssueFields{
-			Summary:     "Test issue",
-			Status:      &api.Status{Name: "Open"},
-			IssueType:   &api.IssueType{Name: "Task"},
-			Description: &api.Description{Text: longDesc},
-		},
-	}
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case strings.HasSuffix(r.URL.Path, "/transitions"):
-			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{
-				Transitions: []api.Transition{
-					{ID: "11", Name: "Backlog"},
-				},
-			})
-		case strings.HasSuffix(r.URL.Path, "/watchers"):
-			_ = json.NewEncoder(w).Encode(api.WatchersInfo{WatchCount: 5, IsWatching: false})
-		case strings.HasSuffix(r.URL.Path, "/field"):
-			_ = json.NewEncoder(w).Encode([]api.Field{})
-		default:
-			_ = json.NewEncoder(w).Encode(issue)
-		}
-	}))
-	defer server.Close()
-
-	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
-	testutil.RequireNoError(t, err)
-
-	var stdout bytes.Buffer
-	opts := &root.Options{Output: "table", Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
-	opts.SetAPIClient(client)
-
-	err = runGet(context.Background(), opts, "TEST-1", false, "Watchers,Transitions,Description")
-	testutil.RequireNoError(t, err)
-
-	output := stdout.String()
-	testutil.Contains(t, output, "5 (watching: no)")
-	testutil.Contains(t, output, "11:Backlog:-")
-	testutil.Contains(t, output, longDesc)
-	testutil.NotContains(t, output, "[truncated")
+	// Kitchen-sink items no longer present
+	testutil.NotContains(t, output, "Transitions:")
+	testutil.NotContains(t, output, "Watchers:")
+	testutil.NotContains(t, output, "category:")
 }
 
 func TestRunGet_Extended_SprintFromCustomField(t *testing.T) {
@@ -444,35 +382,17 @@ func TestRunGet_Extended_SprintFromCustomField(t *testing.T) {
 		"key": "MON-4970",
 		"fields": {
 			"summary": "Sprint test issue",
-			"status": {"name": "In Development", "statusCategory": {"name": "In Progress"}},
+			"status": {"name": "In Development"},
 			"issuetype": {"name": "Task"},
 			"customfield_10020": [
 				{"id": 100, "name": "Sprint 69", "state": "closed"},
 				{"id": 125, "name": "MON Sprint 70", "state": "active", "startDate": "2026-04-10T00:00:00.000Z", "endDate": "2026-04-24T00:00:00.000Z"}
-			],
-			"customfield_10035": 5
+			]
 		}
 	}`
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case strings.HasSuffix(r.URL.Path, "/transitions"):
-			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{
-				Transitions: []api.Transition{
-					{ID: "91", Name: "Ready", To: api.Status{Name: "Ready for Development"}},
-				},
-			})
-		case strings.HasSuffix(r.URL.Path, "/watchers"):
-			_ = json.NewEncoder(w).Encode(api.WatchersInfo{WatchCount: 1, IsWatching: false})
-		case strings.Contains(r.URL.Path, "/field"):
-			_ = json.NewEncoder(w).Encode([]api.Field{
-				{ID: "customfield_10020", Name: "Sprint"},
-				{ID: "customfield_10035", Name: "Story Points"},
-			})
-		default:
-			_, _ = w.Write([]byte(issueJSON))
-		}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(issueJSON))
 	}))
 	defer server.Close()
 
@@ -483,12 +403,9 @@ func TestRunGet_Extended_SprintFromCustomField(t *testing.T) {
 	opts := &root.Options{Output: "table", Extended: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runGet(context.Background(), opts, "MON-4970", false, "")
+	err = runGet(context.Background(), opts, "MON-4970", false, "", false)
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
-	testutil.Contains(t, output, "Sprint: MON Sprint 70 (id: 125, active, 2026-04-10 → 2026-04-24)")
-	testutil.NotContains(t, output, "customfield_10020")
-	testutil.Contains(t, output, "customfield_10035")
-	testutil.Contains(t, output, "  91 | Ready | Ready for Development")
+	testutil.Contains(t, output, "Sprint: MON Sprint 70 (active)")
 }

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -408,4 +409,62 @@ func TestRunGet_Extended_SprintFromCustomField(t *testing.T) {
 
 	output := stdout.String()
 	testutil.Contains(t, output, "Sprint: MON Sprint 70 (active)")
+}
+
+func TestRunGet_CustomFields_AppendsSection(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+
+	issueJSON := `{
+		"key": "TEST-1",
+		"fields": {
+			"summary": "Test issue",
+			"status": {"name": "Open"},
+			"issuetype": {"name": "Task"},
+			"customfield_10005": {"value": "Bug"}
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/field") {
+			_ = json.NewEncoder(w).Encode([]api.Field{
+				{ID: "customfield_10005", Name: "Change type", Custom: true, Schema: api.FieldSchema{Type: "option"}},
+			})
+			return
+		}
+		_, _ = w.Write([]byte(issueJSON))
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "TEST-1", false, "", true)
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "Custom Fields:")
+	testutil.Contains(t, output, "Change type: Bug")
+}
+
+func TestRunGet_CustomFields_WithJSON_Errors(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.Issue{Key: "TEST-1"})
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	opts := &root.Options{Output: "json", Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGet(context.Background(), opts, "TEST-1", false, "", true)
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "not supported")
 }

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -60,6 +60,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 25, "Maximum number of results to return")
 	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Token for next page of results")
 	cmd.Flags().BoolVar(&allFields, "all-fields", false, "Include all fields (e.g. description)")
+	_ = cmd.Flags().MarkDeprecated("all-fields", "use --fields description instead")
 	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns (headers, Jira field IDs, or human names)")
 
 	return cmd

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -53,6 +53,7 @@ func newSearchCmd(opts *root.Options) *cobra.Command {
 	cmd.Flags().IntVarP(&maxResults, "max", "m", 25, "Maximum number of results to return")
 	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Token for next page of results")
 	cmd.Flags().BoolVar(&allFields, "all-fields", false, "Include all fields (e.g. description)")
+	_ = cmd.Flags().MarkDeprecated("all-fields", "use --fields description instead")
 	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns (headers, Jira field IDs, or human names)")
 	_ = cmd.MarkFlagRequired("jql")
 

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -11,14 +11,6 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
-// DetailContext carries extended-only data fetched by the command layer.
-type DetailContext struct {
-	Transitions       []api.Transition
-	TransitionsFailed bool              // true when the API call failed
-	Watchers          *api.WatchersInfo // nil = unavailable
-	Fields            []api.Field       // nil = degrade to raw field IDs
-}
-
 // IssuePresenter creates presentation models for issue data.
 type IssuePresenter struct{}
 
@@ -45,7 +37,8 @@ var IssueListSpec = projection.Registry{
 // IssueDetailSpec declares the fields emitted by PresentDetail /
 // PresentDetailProjection and the metadata for --fields projection.
 // Default fields are those an agent needs daily; extended adds
-// admin/schema/audit detail per #230.
+// Reporter, Created, Fix Versions, Resolution — matching the
+// "add more built-in context" semantics of --extended on list/search.
 var IssueDetailSpec = projection.Registry{
 	{Header: "Key", Identity: true},
 	{Header: "Summary", FieldID: "summary"},
@@ -62,14 +55,8 @@ var IssueDetailSpec = projection.Registry{
 	{Header: "Description", FieldID: "description"},
 	{Header: "Reporter", FieldID: "reporter", Extended: true},
 	{Header: "Created", FieldID: "created", Extended: true},
-	{Header: "Status_Category", Extended: true},
-	{Header: "Sprint_Dates", Extended: true},
-	{Header: "Component_IDs", Extended: true},
 	{Header: "Fix_Versions", FieldID: "fixVersions", Extended: true},
-	{Header: "Watchers", Extended: true},
 	{Header: "Resolution", FieldID: "resolution", Extended: true},
-	{Header: "Custom_Fields", Extended: true},
-	{Header: "Transitions", Extended: true},
 }
 
 // PresentDetail creates a spec-shaped detail view for a single issue.
@@ -143,61 +130,29 @@ func issueDetailDefaultSections(issue *api.Issue, fulltext bool) []present.Secti
 
 func issueDetailExtendedSections(issue *api.Issue, fulltext bool) []present.Section {
 	status := issueStatusName(issue)
-	statusCategory := ""
-	if issue.Fields.Status != nil {
-		statusCategory = issue.Fields.Status.StatusCategory.Name
-	}
 	issueType := issueTypeName(issue)
 	priority := issuePriorityName(issue)
 	points := formatStoryPoints(issue)
-
-	assignee := "Unassigned"
-	assigneeID := ""
-	if issue.Fields.Assignee != nil {
-		assignee = issue.Fields.Assignee.DisplayName
-		assigneeID = issue.Fields.Assignee.AccountID
-	}
-
-	reporter := "-"
-	reporterID := ""
-	if issue.Fields.Reporter != nil {
-		reporter = issue.Fields.Reporter.DisplayName
-		reporterID = issue.Fields.Reporter.AccountID
-	}
-
-	statusLine := fmt.Sprintf("Status: %s", OrDash(status))
-	if statusCategory != "" {
-		statusLine += fmt.Sprintf(" (category: %s)", statusCategory)
-	}
-	statusLine += fmt.Sprintf("   Type: %s   Priority: %s   Points: %s",
-		OrDash(issueType), OrDash(priority), points)
-
-	assigneeLine := fmt.Sprintf("Assignee: %s", assignee)
-	if assigneeID != "" {
-		assigneeLine += fmt.Sprintf(" (%s)", assigneeID)
-	}
-	assigneeLine += fmt.Sprintf("   Reporter: %s", reporter)
-	if reporterID != "" {
-		assigneeLine += fmt.Sprintf(" (%s)", reporterID)
-	}
+	assignee := issueAssigneeName(issue)
+	updated := FormatTime(issue.Fields.Updated)
+	reporter := issueReporterName(issue)
+	created := FormatTime(issue.Fields.Created)
 
 	sections := []present.Section{
-		msg(statusLine),
-		msg(assigneeLine),
+		msg(fmt.Sprintf("Status: %s   Type: %s   Priority: %s   Points: %s",
+			OrDash(status), OrDash(issueType), OrDash(priority), points)),
+		msg(fmt.Sprintf("Assignee: %s   Reporter: %s",
+			assignee, reporter)),
 		msg(fmt.Sprintf("Updated: %s   Created: %s",
-			OrDash(issue.Fields.Updated), OrDash(issue.Fields.Created))),
+			OrDash(updated), OrDash(created))),
 	}
 
 	if issue.Fields.Sprint != nil {
-		s := issue.Fields.Sprint
-		sprintRef := s.Name
-		sprintMeta := fmt.Sprintf("id: %d, %s", s.ID, OrDash(s.State))
-		if s.StartDate != nil {
-			sprintMeta += ", " + FormatDateOrDash(s.StartDate) + " → " + FormatDateOrDash(s.EndDate)
+		sprintRef := issue.Fields.Sprint.Name
+		if issue.Fields.Sprint.State != "" {
+			sprintRef += " (" + issue.Fields.Sprint.State + ")"
 		}
-		sections = append(sections, msg(fmt.Sprintf("Sprint: %s (%s)", sprintRef, sprintMeta)))
-	} else {
-		sections = append(sections, msg("Sprint: -"))
+		sections = append(sections, msg("Sprint: "+sprintRef))
 	}
 
 	if issue.Fields.Parent != nil {
@@ -209,24 +164,30 @@ func issueDetailExtendedSections(issue *api.Issue, fulltext bool) []present.Sect
 			parentRef += " (" + issue.Fields.Parent.Fields.IssueType.Name + ")"
 		}
 		sections = append(sections, msg("Parent: "+parentRef))
-	} else {
-		sections = append(sections, msg("Parent: -"))
 	}
 
-	labels := "-"
 	if len(issue.Fields.Labels) > 0 {
-		labels = strings.Join(issue.Fields.Labels, ", ")
+		sections = append(sections, msg("Labels: "+strings.Join(issue.Fields.Labels, ", ")))
 	}
-	sections = append(sections, msg("Labels: "+labels))
 
 	if len(issue.Fields.Components) > 0 {
 		names := make([]string, len(issue.Fields.Components))
 		for i, c := range issue.Fields.Components {
-			names[i] = fmt.Sprintf("%s (%s)", c.Name, c.ID)
+			names[i] = c.Name
 		}
 		sections = append(sections, msg("Components: "+strings.Join(names, ", ")))
-	} else {
-		sections = append(sections, msg("Components: -"))
+	}
+
+	if len(issue.Fields.FixVersions) > 0 {
+		names := make([]string, len(issue.Fields.FixVersions))
+		for i, v := range issue.Fields.FixVersions {
+			names[i] = v.Name
+		}
+		sections = append(sections, msg("Fix Versions: "+strings.Join(names, ", ")))
+	}
+
+	if issue.Fields.Resolution != nil {
+		sections = append(sections, msg("Resolution: "+issue.Fields.Resolution.Name))
 	}
 
 	sections = append(sections, issueDescriptionSection(issue, fulltext)...)
@@ -252,236 +213,40 @@ func issueDescriptionSection(issue *api.Issue, fulltext bool) []present.Section 
 	}
 }
 
-// PresentDetailExtended builds the full extended detail view with additional
-// context data (transitions, watchers, custom fields). Extended always implies
-// fulltext — description is never truncated.
-func (IssuePresenter) PresentDetailExtended(issue *api.Issue, _ string, dctx *DetailContext) *present.OutputModel {
-	sections := []present.Section{
-		msg(fmt.Sprintf("%s  %s", issue.Key, issue.Fields.Summary)),
+// AppendCustomFieldsSection appends a "Custom Fields:" section to the model
+// using pre-extracted IssueFieldEntry values (from api.ExtractIssueFieldValues).
+// Only custom fields (customfield_*) are included; entries are sorted by ID.
+func AppendCustomFieldsSection(model *present.OutputModel, entries []api.IssueFieldEntry) {
+	if model == nil || len(entries) == 0 {
+		return
 	}
 
-	status := issueStatusName(issue)
-	statusCategory := ""
-	if issue.Fields.Status != nil {
-		statusCategory = issue.Fields.Status.StatusCategory.Name
-	}
-	issueType := issueTypeName(issue)
-	priority := issuePriorityName(issue)
-	points := formatStoryPoints(issue)
-
-	assignee := "Unassigned"
-	assigneeID := ""
-	if issue.Fields.Assignee != nil {
-		assignee = issue.Fields.Assignee.DisplayName
-		assigneeID = issue.Fields.Assignee.AccountID
-	}
-
-	reporter := "-"
-	reporterID := ""
-	if issue.Fields.Reporter != nil {
-		reporter = issue.Fields.Reporter.DisplayName
-		reporterID = issue.Fields.Reporter.AccountID
-	}
-
-	statusLine := fmt.Sprintf("Status: %s", OrDash(status))
-	if statusCategory != "" {
-		statusLine += fmt.Sprintf(" (category: %s)", statusCategory)
-	}
-	statusLine += fmt.Sprintf("   Type: %s   Priority: %s   Points: %s",
-		OrDash(issueType), OrDash(priority), points)
-
-	assigneeLine := fmt.Sprintf("Assignee: %s", assignee)
-	if assigneeID != "" {
-		assigneeLine += fmt.Sprintf(" (%s)", assigneeID)
-	}
-	assigneeLine += fmt.Sprintf("   Reporter: %s", reporter)
-	if reporterID != "" {
-		assigneeLine += fmt.Sprintf(" (%s)", reporterID)
-	}
-
-	sections = append(sections,
-		msg(statusLine),
-		msg(assigneeLine),
-		msg(fmt.Sprintf("Updated: %s   Created: %s",
-			OrDash(issue.Fields.Updated), OrDash(issue.Fields.Created))),
-	)
-
-	if issue.Fields.Sprint != nil {
-		s := issue.Fields.Sprint
-		sprintRef := s.Name
-		sprintMeta := fmt.Sprintf("id: %d, %s", s.ID, OrDash(s.State))
-		if s.StartDate != nil {
-			sprintMeta += ", " + FormatDateOrDash(s.StartDate) + " → " + FormatDateOrDash(s.EndDate)
-		}
-		sections = append(sections, msg(fmt.Sprintf("Sprint: %s (%s)", sprintRef, sprintMeta)))
-	} else {
-		sections = append(sections, msg("Sprint: -"))
-	}
-
-	if issue.Fields.Parent != nil {
-		parentRef := issue.Fields.Parent.Key
-		if issue.Fields.Parent.Fields.Summary != "" {
-			parentRef += " — " + issue.Fields.Parent.Fields.Summary
-		}
-		if issue.Fields.Parent.Fields.IssueType != nil {
-			parentRef += " (" + issue.Fields.Parent.Fields.IssueType.Name + ")"
-		}
-		sections = append(sections, msg("Parent: "+parentRef))
-	} else {
-		sections = append(sections, msg("Parent: -"))
-	}
-
-	labels := "-"
-	if len(issue.Fields.Labels) > 0 {
-		labels = strings.Join(issue.Fields.Labels, ", ")
-	}
-	sections = append(sections, msg("Labels: "+labels))
-
-	if len(issue.Fields.Components) > 0 {
-		names := make([]string, len(issue.Fields.Components))
-		for i, c := range issue.Fields.Components {
-			names[i] = fmt.Sprintf("%s (%s)", c.Name, c.ID)
-		}
-		sections = append(sections, msg("Components: "+strings.Join(names, ", ")))
-	} else {
-		sections = append(sections, msg("Components: -"))
-	}
-
-	fixVersions := "-"
-	if len(issue.Fields.FixVersions) > 0 {
-		names := make([]string, len(issue.Fields.FixVersions))
-		for i, v := range issue.Fields.FixVersions {
-			names[i] = v.Name
-		}
-		fixVersions = strings.Join(names, ", ")
-	}
-	sections = append(sections, msg("Fix Versions: "+fixVersions))
-
-	if dctx != nil && dctx.Watchers != nil {
-		watching := "no"
-		if dctx.Watchers.IsWatching {
-			watching = "yes"
-		}
-		sections = append(sections, msg(fmt.Sprintf("Watchers: %d (watching: %s)", dctx.Watchers.WatchCount, watching)))
-	} else {
-		sections = append(sections, msg("Watchers: -"))
-	}
-
-	resolution := "-"
-	if issue.Fields.Resolution != nil {
-		resolution = issue.Fields.Resolution.Name
-	}
-	sections = append(sections, msg("Resolution: "+resolution))
-
-	sections = append(sections, issueExtendedCustomFields(issue, dctx)...)
-
-	sections = append(sections, issueDescriptionSection(issue, true)...)
-
-	sections = append(sections, msg(""), msg("Transitions:"))
-	if dctx != nil && dctx.TransitionsFailed {
-		sections = append(sections, msg("  (unavailable)"))
-	} else if dctx != nil && len(dctx.Transitions) > 0 {
-		for _, t := range dctx.Transitions {
-			sections = append(sections, msg(fmt.Sprintf("  %s | %s | %s", t.ID, t.Name, OrDash(t.To.Name))))
-		}
-	} else {
-		sections = append(sections, msg("  (none)"))
-	}
-
-	return &present.OutputModel{Sections: sections}
-}
-
-func issueExtendedCustomFields(issue *api.Issue, dctx *DetailContext) []present.Section {
-	if issue.Fields.CustomFields == nil {
-		return nil
-	}
-
-	fieldIndex := make(map[string]string)
-	if dctx != nil && dctx.Fields != nil {
-		for _, f := range dctx.Fields {
-			fieldIndex[f.ID] = f.Name
-		}
-	}
-
-	type entry struct {
-		id, value, name string
-	}
-	var entries []entry
-	for id, raw := range issue.Fields.CustomFields {
-		if !strings.HasPrefix(id, "customfield_") || raw == nil {
-			continue
-		}
-		if id == "customfield_10020" && issue.Fields.Sprint != nil {
-			continue
-		}
-		val := api.FormatCustomFieldValue(raw)
-		if val == "" {
-			continue
-		}
-		name := fieldIndex[id]
-		entries = append(entries, entry{id: id, value: val, name: name})
-	}
-
-	if len(entries) == 0 {
-		return nil
-	}
-
-	sort.Slice(entries, func(i, j int) bool { return entries[i].id < entries[j].id })
-
-	var sections []present.Section
+	var custom []api.IssueFieldEntry
 	for _, e := range entries {
-		line := fmt.Sprintf("%s: %s", e.id, e.value)
-		if e.name != "" {
-			line += fmt.Sprintf("   (%s)", e.name)
+		if strings.HasPrefix(e.ID, "customfield_") {
+			custom = append(custom, e)
 		}
-		sections = append(sections, msg(line))
 	}
-	return sections
+	if len(custom) == 0 {
+		return
+	}
+
+	sort.Slice(custom, func(i, j int) bool { return custom[i].ID < custom[j].ID })
+
+	model.Sections = append(model.Sections, msg(""), msg("Custom Fields:"))
+	for _, e := range custom {
+		line := fmt.Sprintf("  %s: %s", e.Name, e.Value)
+		if e.Name == e.ID {
+			line = fmt.Sprintf("  %s: %s", e.ID, e.Value)
+		}
+		model.Sections = append(model.Sections, msg(line))
+	}
 }
 
 // PresentDetailProjection builds a DetailSection view for `issues get --fields`.
-// When dctx is non-nil, extended fields (Watchers, Custom_Fields, Transitions)
-// are populated from it; otherwise they render as "-".
-func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fulltext bool, dctx *DetailContext) *present.OutputModel {
-	watchersVal := "-"
-	if dctx != nil && dctx.Watchers != nil {
-		watching := "no"
-		if dctx.Watchers.IsWatching {
-			watching = "yes"
-		}
-		watchersVal = fmt.Sprintf("%d (watching: %s)", dctx.Watchers.WatchCount, watching)
-	}
-
-	customFieldsVal := "-"
-	if dctx != nil && issue.Fields.CustomFields != nil {
-		var parts []string
-		for id, raw := range issue.Fields.CustomFields {
-			if !strings.HasPrefix(id, "customfield_") || raw == nil {
-				continue
-			}
-			if id == "customfield_10020" && issue.Fields.Sprint != nil {
-				continue
-			}
-			val := api.FormatCustomFieldValue(raw)
-			if val != "" {
-				parts = append(parts, fmt.Sprintf("%s=%s", id, val))
-			}
-		}
-		if len(parts) > 0 {
-			sort.Strings(parts)
-			customFieldsVal = strings.Join(parts, "; ")
-		}
-	}
-
-	transitionsVal := "-"
-	if dctx != nil && len(dctx.Transitions) > 0 {
-		var parts []string
-		for _, t := range dctx.Transitions {
-			parts = append(parts, fmt.Sprintf("%s:%s:%s", t.ID, t.Name, OrDash(t.To.Name)))
-		}
-		transitionsVal = strings.Join(parts, ", ")
-	}
-
+// Only fields in the IssueDetailSpec registry are included; ProjectDetail
+// slices the result to the user's selected subset.
+func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fulltext bool) *present.OutputModel {
 	fields := []present.Field{
 		{Label: "Key", Value: issue.Key},
 		{Label: "Summary", Value: issue.Fields.Summary},
@@ -498,14 +263,8 @@ func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fullte
 		{Label: "Description", Value: issueDescriptionText(issue, fulltext)},
 		{Label: "Reporter", Value: issueReporterName(issue)},
 		{Label: "Created", Value: OrDash(issue.Fields.Created)},
-		{Label: "Status_Category", Value: issueStatusCategory(issue)},
-		{Label: "Sprint_Dates", Value: issueSprintDates(issue)},
-		{Label: "Component_IDs", Value: issueComponentIDs(issue)},
 		{Label: "Fix_Versions", Value: issueFixVersions(issue)},
-		{Label: "Watchers", Value: watchersVal},
 		{Label: "Resolution", Value: issueResolution(issue)},
-		{Label: "Custom_Fields", Value: customFieldsVal},
-		{Label: "Transitions", Value: transitionsVal},
 	}
 	return &present.OutputModel{
 		Sections: []present.Section{&present.DetailSection{Fields: fields}},
@@ -574,32 +333,6 @@ func issueComponentNames(issue *api.Issue) string {
 		names[i] = c.Name
 	}
 	return strings.Join(names, ", ")
-}
-
-func issueComponentIDs(issue *api.Issue) string {
-	if len(issue.Fields.Components) == 0 {
-		return "-"
-	}
-	ids := make([]string, len(issue.Fields.Components))
-	for i, c := range issue.Fields.Components {
-		ids[i] = fmt.Sprintf("%s (%s)", c.Name, c.ID)
-	}
-	return strings.Join(ids, ", ")
-}
-
-func issueStatusCategory(issue *api.Issue) string {
-	if issue.Fields.Status != nil && issue.Fields.Status.StatusCategory.Name != "" {
-		return issue.Fields.Status.StatusCategory.Name
-	}
-	return "-"
-}
-
-func issueSprintDates(issue *api.Issue) string {
-	if issue.Fields.Sprint == nil {
-		return "-"
-	}
-	s := issue.Fields.Sprint
-	return fmt.Sprintf("%s → %s", FormatDateOrDash(s.StartDate), FormatDateOrDash(s.EndDate))
 }
 
 func issueFixVersions(issue *api.Issue) string {

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -235,11 +235,11 @@ func AppendCustomFieldsSection(model *present.OutputModel, entries []api.IssueFi
 
 	model.Sections = append(model.Sections, msg(""), msg("Custom Fields:"))
 	for _, e := range custom {
-		line := fmt.Sprintf("  %s: %s", e.Name, e.Value)
-		if e.Name == e.ID {
-			line = fmt.Sprintf("  %s: %s", e.ID, e.Value)
+		label := e.Name
+		if label == "" || label == e.ID {
+			label = e.ID
 		}
-		model.Sections = append(model.Sections, msg(line))
+		model.Sections = append(model.Sections, msg(fmt.Sprintf("  %s: %s", label, e.Value)))
 	}
 }
 
@@ -262,7 +262,7 @@ func (IssuePresenter) PresentDetailProjection(issue *api.Issue, _ string, fullte
 		{Label: "Components", Value: OrDash(issueComponentNames(issue))},
 		{Label: "Description", Value: issueDescriptionText(issue, fulltext)},
 		{Label: "Reporter", Value: issueReporterName(issue)},
-		{Label: "Created", Value: OrDash(issue.Fields.Created)},
+		{Label: "Created", Value: OrDash(FormatTime(issue.Fields.Created))},
 		{Label: "Fix_Versions", Value: issueFixVersions(issue)},
 		{Label: "Resolution", Value: issueResolution(issue)},
 	}

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -285,7 +285,7 @@ func TestIssueDetailSpec_MatchesPresentDetailProjectionLabels(t *testing.T) {
 			Description: &api.Description{},
 		},
 	}
-	model := IssuePresenter{}.PresentDetailProjection(issue, "https://example.com/PROJ-1", true, nil)
+	model := IssuePresenter{}.PresentDetailProjection(issue, "https://example.com/PROJ-1", true)
 	detail := model.Sections[0].(*present.DetailSection)
 
 	renderedLabels := make(map[string]bool, len(detail.Fields))
@@ -447,126 +447,6 @@ func TestIssuePresenter_PresentTypeAlreadyCurrent(t *testing.T) {
 	if msg.Message != "type is already SDLC" {
 		t.Errorf("want exact original wording, got %q", msg.Message)
 	}
-}
-
-func TestIssuePresenter_PresentDetailExtended_TransitionsFormat(t *testing.T) {
-	t.Parallel()
-	issue := &api.Issue{
-		Key: "MON-123",
-		Fields: api.IssueFields{
-			Summary:   "Test",
-			Status:    &api.Status{Name: "Open"},
-			IssueType: &api.IssueType{Name: "Task"},
-		},
-	}
-	dctx := &DetailContext{
-		Transitions: []api.Transition{
-			{ID: "11", Name: "Backlog", To: api.Status{Name: "Backlog"}},
-			{ID: "21", Name: "Ready for Development", To: api.Status{Name: "Ready for Development"}},
-		},
-	}
-
-	model := IssuePresenter{}.PresentDetailExtended(issue, "", dctx)
-	rendered := renderMsgSections(model)
-
-	if strings.Contains(rendered, "ID | NAME\n") {
-		t.Error("transitions should not have a header row")
-	}
-	if !strings.Contains(rendered, "  11 | Backlog | Backlog") {
-		t.Errorf("expected indented transition line, got:\n%s", rendered)
-	}
-	if !strings.Contains(rendered, "  21 | Ready for Development | Ready for Development") {
-		t.Errorf("expected second transition line, got:\n%s", rendered)
-	}
-}
-
-func TestIssuePresenter_PresentDetailExtended_SprintResolved(t *testing.T) {
-	t.Parallel()
-	issue := &api.Issue{
-		Key: "MON-123",
-		Fields: api.IssueFields{
-			Summary:   "Test",
-			Status:    &api.Status{Name: "Open"},
-			IssueType: &api.IssueType{Name: "Task"},
-			Sprint:    &api.Sprint{ID: 125, Name: "MON Sprint 70", State: "active"},
-			CustomFields: map[string]any{
-				"customfield_10020": "MON Sprint 70",
-				"customfield_10035": float64(5),
-			},
-		},
-	}
-	dctx := &DetailContext{}
-
-	model := IssuePresenter{}.PresentDetailExtended(issue, "", dctx)
-	rendered := renderMsgSections(model)
-
-	if !strings.Contains(rendered, "Sprint: MON Sprint 70 (id: 125, active)") {
-		t.Errorf("expected sprint line, got:\n%s", rendered)
-	}
-	if strings.Contains(rendered, "customfield_10020") {
-		t.Error("customfield_10020 should be suppressed when Sprint is populated")
-	}
-	if !strings.Contains(rendered, "customfield_10035") {
-		t.Error("other custom fields should still appear")
-	}
-}
-
-func TestIssuePresenter_PresentDetailProjection_TransitionsIncludeToStatus(t *testing.T) {
-	t.Parallel()
-	issue := &api.Issue{
-		Key:    "MON-123",
-		Fields: api.IssueFields{Summary: "Test"},
-	}
-	dctx := &DetailContext{
-		Transitions: []api.Transition{
-			{ID: "11", Name: "Backlog", To: api.Status{Name: "Backlog"}},
-		},
-	}
-
-	model := IssuePresenter{}.PresentDetailProjection(issue, "", false, dctx)
-	detail := model.Sections[0].(*present.DetailSection)
-
-	for _, f := range detail.Fields {
-		if f.Label == "Transitions" {
-			if !strings.Contains(f.Value, "11:Backlog:Backlog") {
-				t.Errorf("expected transitions to include To.Name, got %q", f.Value)
-			}
-			return
-		}
-	}
-	t.Error("Transitions field not found")
-}
-
-func TestIssuePresenter_PresentDetailProjection_CustomFieldSuppression(t *testing.T) {
-	t.Parallel()
-	issue := &api.Issue{
-		Key: "MON-123",
-		Fields: api.IssueFields{
-			Summary: "Test",
-			Sprint:  &api.Sprint{ID: 125, Name: "MON Sprint 70", State: "active"},
-			CustomFields: map[string]any{
-				"customfield_10020": "MON Sprint 70",
-				"customfield_10035": float64(5),
-			},
-		},
-	}
-	dctx := &DetailContext{}
-
-	model := IssuePresenter{}.PresentDetailProjection(issue, "", false, dctx)
-	detail := model.Sections[0].(*present.DetailSection)
-
-	for _, f := range detail.Fields {
-		if f.Label == "Custom_Fields" {
-			if strings.Contains(f.Value, "customfield_10020") {
-				t.Error("customfield_10020 should be suppressed in projection when Sprint is populated")
-			}
-			if !strings.Contains(f.Value, "customfield_10035") {
-				t.Error("other custom fields should be present")
-			}
-			return
-		}
-	}
-	t.Error("Custom_Fields field not found")
 }
 
 func TestIssuePresenter_PresentTypeFallbackWarning(t *testing.T) {


### PR DESCRIPTION
## Summary
- **Normalized `--extended`**: `issues get --extended` now adds Reporter, Created, Fix Versions, Resolution — consistent with list/search. Removes kitchen-sink dump (account IDs, sprint internals, transitions, watchers, custom fields).
- **New `--custom-fields` flag**: Appends a clean "Custom Fields:" section using cache-backed field metadata. Works standalone or combined with `--extended`.
- **Deprecated `--all-fields`**: On `issues search` and `issues list`, `--all-fields` now shows deprecation warning pointing to `--fields description`.

## Test plan
- [x] Unit tests updated for normalized --extended output
- [x] Removed tests for deleted DetailContext/PresentDetailExtended
- [x] `make test` — all tests passing
- [x] `make lint` — clean
- [x] Before/after verification against live Jira (posted as [issue comment](https://github.com/open-cli-collective/atlassian-cli/issues/317#issuecomment-4339001281))

Closes #317