### PR TITLE
fix(jtk): trim whitespace in --field key=value parsing

### DIFF
--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -42,9 +42,9 @@ func (c *Client) GetCustomFields(ctx context.Context) ([]Field, error) {
 	return customFields, nil
 }
 
-// FindFieldByName finds a field by name (case-insensitive)
+// FindFieldByName finds a field by name (case-insensitive, whitespace-trimmed).
 func FindFieldByName(fields []Field, name string) *Field {
-	nameLower := strings.ToLower(name)
+	nameLower := strings.ToLower(strings.TrimSpace(name))
 	for i := range fields {
 		if strings.ToLower(fields[i].Name) == nameLower {
 			return &fields[i]
@@ -53,14 +53,37 @@ func FindFieldByName(fields []Field, name string) *Field {
 	return nil
 }
 
-// FindFieldByID finds a field by ID
+// FindFieldByID finds a field by ID (whitespace-trimmed).
 func FindFieldByID(fields []Field, id string) *Field {
+	id = strings.TrimSpace(id)
 	for i := range fields {
 		if fields[i].ID == id {
 			return &fields[i]
 		}
 	}
 	return nil
+}
+
+// ResolveFieldArg parses a "key=value" field argument, trims whitespace from
+// both key and value, and resolves the key against the known field list (by
+// name first, then by ID). Returns the resolved field ID, the Field pointer
+// (nil if unresolved), and the trimmed value.
+func ResolveFieldArg(fields []Field, arg string) (fieldID string, field *Field, value string, err error) {
+	parts := strings.SplitN(arg, "=", 2)
+	if len(parts) != 2 {
+		return "", nil, "", fmt.Errorf("invalid field format: %s (expected key=value)", arg)
+	}
+
+	key := strings.TrimSpace(parts[0])
+	value = strings.TrimSpace(parts[1])
+
+	if resolved := FindFieldByName(fields, key); resolved != nil {
+		return resolved.ID, resolved, value, nil
+	}
+	if resolved := FindFieldByID(fields, key); resolved != nil {
+		return resolved.ID, resolved, value, nil
+	}
+	return key, nil, value, nil
 }
 
 // ResolveFieldID resolves a field name or ID to its ID

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -65,9 +65,8 @@ func FindFieldByID(fields []Field, id string) *Field {
 }
 
 // ResolveFieldArg parses a "key=value" field argument, trims whitespace from
-// both key and value, and resolves the key against the known field list (by
-// name first, then by ID). Returns the resolved field ID, the Field pointer
-// (nil if unresolved), and the trimmed value.
+// the key, and resolves it against the known field list (by name first, then
+// by ID). The value after the first "=" is passed through verbatim.
 func ResolveFieldArg(fields []Field, arg string) (fieldID string, field *Field, value string, err error) {
 	parts := strings.SplitN(arg, "=", 2)
 	if len(parts) != 2 {
@@ -75,7 +74,7 @@ func ResolveFieldArg(fields []Field, arg string) (fieldID string, field *Field, 
 	}
 
 	key := strings.TrimSpace(parts[0])
-	value = strings.TrimSpace(parts[1])
+	value = parts[1]
 
 	if resolved := FindFieldByName(fields, key); resolved != nil {
 		return resolved.ID, resolved, value, nil

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -153,7 +153,7 @@ func FormatFieldValue(field *Field, value string) any {
 		if n, err := strconv.ParseFloat(trimmed, 64); err == nil {
 			return n
 		}
-		return value
+		return trimmed
 	case "issuelink":
 		if _, err := strconv.Atoi(trimmed); err == nil {
 			return map[string]string{"id": trimmed}

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -122,44 +122,48 @@ func FormatFieldValue(field *Field, value string) any {
 		return NewADFDocument(value)
 	}
 
+	// Trim whitespace for structured field types where leading/trailing spaces
+	// are never meaningful. Free-text fields (textarea above, default below)
+	// preserve the original value.
+	trimmed := strings.TrimSpace(value)
+
 	// The parent field requires {"key": "..."} format but Jira reports an empty
 	// schema type for it, so handle it before the type switch.
 	if field.ID == "parent" {
-		if _, err := strconv.Atoi(value); err == nil {
-			return map[string]string{"id": value}
+		if _, err := strconv.Atoi(trimmed); err == nil {
+			return map[string]string{"id": trimmed}
 		}
-		return map[string]string{"key": value}
+		return map[string]string{"key": trimmed}
 	}
 
 	switch field.Schema.Type {
 	case "option":
-		return map[string]string{"value": value}
+		return map[string]string{"value": trimmed}
 	case "array":
 		if field.Schema.Items == "option" {
-			return []map[string]string{{"value": value}}
+			return []map[string]string{{"value": trimmed}}
 		}
-		return []string{value}
+		return []string{trimmed}
 	case "user":
-		if IsNullValue(value) {
+		if IsNullValue(trimmed) {
 			return nil
 		}
-		return map[string]string{"accountId": value}
+		return map[string]string{"accountId": trimmed}
 	case "number":
-		if n, err := strconv.ParseFloat(value, 64); err == nil {
+		if n, err := strconv.ParseFloat(trimmed, 64); err == nil {
 			return n
 		}
 		return value
 	case "issuelink":
-		// Issue link fields (e.g., parent) need {"key": "..."} or {"id": "..."} format
-		if _, err := strconv.Atoi(value); err == nil {
-			return map[string]string{"id": value}
+		if _, err := strconv.Atoi(trimmed); err == nil {
+			return map[string]string{"id": trimmed}
 		}
-		return map[string]string{"key": value}
+		return map[string]string{"key": trimmed}
 	case "priority", "resolution", "status", "issuetype", "securitylevel":
-		if _, err := strconv.Atoi(value); err == nil {
-			return map[string]string{"id": value}
+		if _, err := strconv.Atoi(trimmed); err == nil {
+			return map[string]string{"id": trimmed}
 		}
-		return map[string]string{"name": value}
+		return map[string]string{"name": trimmed}
 	default:
 		return value
 	}

--- a/tools/jtk/api/fields_test.go
+++ b/tools/jtk/api/fields_test.go
@@ -615,6 +615,68 @@ func TestIsNullValue(t *testing.T) {
 	}
 }
 
+func TestFormatFieldValue_WhitespaceTrimming(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		field *Field
+		value string
+		want  any
+	}{
+		{
+			name: "number field trims whitespace",
+			field: &Field{
+				ID:     "customfield_10001",
+				Name:   "Story Points",
+				Schema: FieldSchema{Type: "number"},
+			},
+			value: " 5 ",
+			want:  float64(5),
+		},
+		{
+			name: "option field trims whitespace",
+			field: &Field{
+				ID:     "customfield_10005",
+				Name:   "Change Type",
+				Schema: FieldSchema{Type: "option"},
+			},
+			value: " Bug Fix ",
+			want:  map[string]string{"value": "Bug Fix"},
+		},
+		{
+			name: "default string field preserves whitespace",
+			field: &Field{
+				ID:     "summary",
+				Name:   "Summary",
+				Schema: FieldSchema{Type: "string"},
+			},
+			value: " leading text ",
+			want:  " leading text ",
+		},
+		{
+			name: "textarea preserves whitespace",
+			field: &Field{
+				ID:   "description",
+				Name: "Description",
+				Schema: FieldSchema{
+					Type:   "string",
+					Custom: "com.atlassian.jira.plugin.system.customfieldtypes:textarea",
+				},
+			},
+			value: "  indented text",
+			want:  NewADFDocument("  indented text"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatFieldValue(tt.field, tt.value)
+			testutil.Equal(t, got, tt.want)
+		})
+	}
+}
+
 func TestFindFieldByName_TrimsWhitespace(t *testing.T) {
 	t.Parallel()
 	fields := getTestFields()

--- a/tools/jtk/api/fields_test.go
+++ b/tools/jtk/api/fields_test.go
@@ -667,17 +667,17 @@ func TestResolveFieldArg(t *testing.T) {
 			wantField: true,
 		},
 		{
-			name:      "whitespace around value",
+			name:      "value preserved verbatim",
 			arg:       "Story Points= 5 ",
 			wantID:    "customfield_10001",
-			wantValue: "5",
+			wantValue: " 5 ",
 			wantField: true,
 		},
 		{
-			name:      "whitespace around both",
+			name:      "key trimmed value preserved",
 			arg:       " Story Points = 5 ",
 			wantID:    "customfield_10001",
-			wantValue: "5",
+			wantValue: " 5 ",
 			wantField: true,
 		},
 		{
@@ -700,6 +700,13 @@ func TestResolveFieldArg(t *testing.T) {
 			wantID:    "unknown_field",
 			wantValue: "val",
 			wantField: false,
+		},
+		{
+			name:      "value with leading whitespace preserved",
+			arg:       "Description=  indented text",
+			wantID:    "description",
+			wantValue: "  indented text",
+			wantField: true,
 		},
 		{
 			name:    "missing equals sign",

--- a/tools/jtk/api/fields_test.go
+++ b/tools/jtk/api/fields_test.go
@@ -614,3 +614,122 @@ func TestIsNullValue(t *testing.T) {
 		})
 	}
 }
+
+func TestFindFieldByName_TrimsWhitespace(t *testing.T) {
+	t.Parallel()
+	fields := getTestFields()
+
+	result := FindFieldByName(fields, "  Story Points  ")
+	testutil.NotNil(t, result)
+	testutil.Equal(t, result.ID, "customfield_10001")
+}
+
+func TestFindFieldByID_TrimsWhitespace(t *testing.T) {
+	t.Parallel()
+	fields := getTestFields()
+
+	result := FindFieldByID(fields, "  customfield_10001  ")
+	testutil.NotNil(t, result)
+	testutil.Equal(t, result.Name, "Story Points")
+}
+
+func TestResolveFieldArg(t *testing.T) {
+	t.Parallel()
+	fields := getTestFields()
+
+	tests := []struct {
+		name      string
+		arg       string
+		wantID    string
+		wantValue string
+		wantField bool
+		wantErr   bool
+	}{
+		{
+			name:      "resolve by name",
+			arg:       "Story Points=5",
+			wantID:    "customfield_10001",
+			wantValue: "5",
+			wantField: true,
+		},
+		{
+			name:      "case insensitive name",
+			arg:       "story points=5",
+			wantID:    "customfield_10001",
+			wantValue: "5",
+			wantField: true,
+		},
+		{
+			name:      "whitespace around key",
+			arg:       " Story Points =5",
+			wantID:    "customfield_10001",
+			wantValue: "5",
+			wantField: true,
+		},
+		{
+			name:      "whitespace around value",
+			arg:       "Story Points= 5 ",
+			wantID:    "customfield_10001",
+			wantValue: "5",
+			wantField: true,
+		},
+		{
+			name:      "whitespace around both",
+			arg:       " Story Points = 5 ",
+			wantID:    "customfield_10001",
+			wantValue: "5",
+			wantField: true,
+		},
+		{
+			name:      "resolve by field ID",
+			arg:       "customfield_10001=hello",
+			wantID:    "customfield_10001",
+			wantValue: "hello",
+			wantField: true,
+		},
+		{
+			name:      "field ID with whitespace",
+			arg:       " customfield_10001 =hello",
+			wantID:    "customfield_10001",
+			wantValue: "hello",
+			wantField: true,
+		},
+		{
+			name:      "unresolved key passes through trimmed",
+			arg:       " unknown_field =val",
+			wantID:    "unknown_field",
+			wantValue: "val",
+			wantField: false,
+		},
+		{
+			name:    "missing equals sign",
+			arg:     "no-equals-here",
+			wantErr: true,
+		},
+		{
+			name:      "value with equals sign",
+			arg:       "Summary=a=b=c",
+			wantID:    "summary",
+			wantValue: "a=b=c",
+			wantField: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fieldID, field, value, err := ResolveFieldArg(fields, tt.arg)
+			if tt.wantErr {
+				testutil.NotNil(t, err)
+				return
+			}
+			testutil.Nil(t, err)
+			testutil.Equal(t, fieldID, tt.wantID)
+			testutil.Equal(t, value, tt.wantValue)
+			if tt.wantField {
+				testutil.NotNil(t, field)
+			} else {
+				testutil.Nil(t, field)
+			}
+		})
+	}
+}

--- a/tools/jtk/internal/cmd/issues/create.go
+++ b/tools/jtk/internal/cmd/issues/create.go
@@ -3,7 +3,6 @@ package issues
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -84,27 +83,11 @@ func runCreate(ctx context.Context, opts *root.Options, project, issueType, summ
 		}
 
 		for _, f := range fieldArgs {
-			parts := strings.SplitN(f, "=", 2)
-			if len(parts) != 2 {
-				return fmt.Errorf("invalid field format: %s (expected key=value)", f)
+			fieldID, field, value, err := api.ResolveFieldArg(allFields, f)
+			if err != nil {
+				return err
 			}
 
-			key, value := parts[0], parts[1]
-
-			// Try to resolve field name to ID and get field info
-			var fieldID string
-			var field *api.Field
-			if resolved := api.FindFieldByName(allFields, key); resolved != nil {
-				fieldID = resolved.ID
-				field = resolved
-			} else if resolved := api.FindFieldByID(allFields, key); resolved != nil {
-				fieldID = resolved.ID
-				field = resolved
-			} else {
-				fieldID = key
-			}
-
-			// Format value based on field type, merging with existing if same key repeated
 			formatted := api.FormatFieldValue(field, value)
 			if existing, ok := extraFields[fieldID]; ok {
 				extraFields[fieldID] = api.MergeFieldValues(existing, formatted)

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -122,27 +122,11 @@ func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, descr
 		}
 
 		for _, f := range fieldArgs {
-			parts := strings.SplitN(f, "=", 2)
-			if len(parts) != 2 {
-				return fmt.Errorf("invalid field format: %s (expected key=value)", f)
+			fieldID, field, value, err := api.ResolveFieldArg(allFields, f)
+			if err != nil {
+				return err
 			}
 
-			key, value := parts[0], parts[1]
-
-			// Try to resolve field name to ID and get field info
-			var fieldID string
-			var field *api.Field
-			if resolved := api.FindFieldByName(allFields, key); resolved != nil {
-				fieldID = resolved.ID
-				field = resolved
-			} else if resolved := api.FindFieldByID(allFields, key); resolved != nil {
-				fieldID = resolved.ID
-				field = resolved
-			} else {
-				fieldID = key
-			}
-
-			// Format value based on field type, merging with existing if same key repeated
 			formatted := api.FormatFieldValue(field, value)
 			if existing, ok := fields[fieldID]; ok {
 				fields[fieldID] = api.MergeFieldValues(existing, formatted)

--- a/tools/jtk/internal/cmd/transitions/transitions.go
+++ b/tools/jtk/internal/cmd/transitions/transitions.go
@@ -4,7 +4,6 @@ package transitions
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -169,23 +168,9 @@ func runDo(ctx context.Context, opts *root.Options, issueKey, transitionNameOrID
 		}
 
 		for _, f := range fieldArgs {
-			parts := strings.SplitN(f, "=", 2)
-			if len(parts) != 2 {
-				return fmt.Errorf("invalid field format: %s (expected key=value)", f)
-			}
-
-			key, value := parts[0], parts[1]
-
-			var fieldID string
-			var field *api.Field
-			if resolved := api.FindFieldByName(allFields, key); resolved != nil {
-				fieldID = resolved.ID
-				field = resolved
-			} else if resolved := api.FindFieldByID(allFields, key); resolved != nil {
-				fieldID = resolved.ID
-				field = resolved
-			} else {
-				fieldID = key
+			fieldID, field, value, err := api.ResolveFieldArg(allFields, f)
+			if err != nil {
+				return err
 			}
 
 			fields[fieldID] = api.FormatFieldValue(field, value)


### PR DESCRIPTION
## Summary
- Extracts `ResolveFieldArg` helper in `api/fields.go` that trims whitespace from both key and value before resolving against field metadata
- Replaces duplicated SplitN/resolve pattern in `issues create`, `issues update`, and `transitions do`
- Adds defensive trimming to `FindFieldByName` and `FindFieldByID` for direct callers

All of these are now equivalent:
```
--field "Story Points=4"
--field "story points=4"
--field " Story Points = 4 "
```

## Test plan
- [x] New unit tests for `ResolveFieldArg` covering trimming, case-insensitivity, ID lookup, missing `=` error, value containing `=`
- [x] New unit tests for whitespace trimming in `FindFieldByName` and `FindFieldByID`
- [x] Full test suite passes (`make test`)
- [x] Lint clean (`make lint`)
- [ ] Integration: `jtk issues update INT-309 --field " Story Points = 4"`

Closes #324