### PR TITLE
feat(jtk): issues get with multiple keys renders summary table

### DIFF
--- a/tools/jtk/internal/cmd/issues/get.go
+++ b/tools/jtk/internal/cmd/issues/get.go
@@ -2,9 +2,11 @@ package issues
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/artifact"
 	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/view"
 
@@ -22,17 +24,27 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 	var customFields bool
 
 	cmd := &cobra.Command{
-		Use:   "get <issue-key>",
+		Use:   "get <issue-key> [issue-key...]",
 		Short: "Get issue details",
-		Long:  "Retrieve and display details for a specific issue.",
+		Long:  "Retrieve and display details for a specific issue, or a summary table when multiple keys are given.",
 		Example: `  jtk issues get PROJ-123
+  jtk issues get PROJ-123 PROJ-456 PROJ-789
   jtk issues get PROJ-123 --fulltext
   jtk issues get PROJ-123 --id
   jtk issues get PROJ-123 --fields Status,Assignee
   jtk issues get PROJ-123 --fields "Issue Type"
   jtk issues get PROJ-123 --custom-fields`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				if fieldsFlag != "" {
+					return fmt.Errorf("--fields is only supported with a single issue key")
+				}
+				if customFields {
+					return fmt.Errorf("--custom-fields is only supported with a single issue key")
+				}
+				return runGetMulti(cmd.Context(), opts, args)
+			}
 			return runGet(cmd.Context(), opts, args[0], noTruncate || opts.IsFullText(), fieldsFlag, customFields)
 		},
 	}
@@ -109,6 +121,44 @@ func runGet(ctx context.Context, opts *root.Options, issueKey string, noTruncate
 	if customFields {
 		appendCustomFields(ctx, client, issue, model)
 	}
+	return jtkpresent.Emit(opts, model)
+}
+
+func runGetMulti(ctx context.Context, opts *root.Options, issueKeys []string) error {
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	if opts.EmitIDOnly() {
+		ids := make([]string, 0, len(issueKeys))
+		for _, key := range issueKeys {
+			issue, err := client.GetIssue(ctx, key)
+			if err != nil {
+				return err
+			}
+			ids = append(ids, issue.Key)
+		}
+		return jtkpresent.EmitIDs(opts, ids)
+	}
+
+	issues := make([]api.Issue, 0, len(issueKeys))
+	for _, key := range issueKeys {
+		issue, err := client.GetIssue(ctx, key)
+		if err != nil {
+			return err
+		}
+		issues = append(issues, *issue)
+	}
+
+	v := opts.View()
+
+	if v.Format == view.FormatJSON {
+		arts := jtkartifact.ProjectIssues(issues, opts.ArtifactMode())
+		return v.RenderArtifactList(artifact.NewListResult(arts, false))
+	}
+
+	model := jtkpresent.IssuePresenter{}.PresentList(issues, opts.IsExtended())
 	return jtkpresent.Emit(opts, model)
 }
 

--- a/tools/jtk/internal/cmd/issues/get_test.go
+++ b/tools/jtk/internal/cmd/issues/get_test.go
@@ -21,7 +21,7 @@ func TestNewGetCmd(t *testing.T) {
 	opts := &root.Options{}
 	cmd := newGetCmd(opts)
 
-	testutil.Equal(t, cmd.Use, "get <issue-key>")
+	testutil.Equal(t, cmd.Use, "get <issue-key> [issue-key...]")
 	testutil.Equal(t, cmd.Short, "Get issue details")
 
 	// Check that no-truncate flag exists
@@ -467,4 +467,180 @@ func TestRunGet_CustomFields_WithJSON_Errors(t *testing.T) {
 	err = runGet(context.Background(), opts, "TEST-1", false, "", true)
 	testutil.NotNil(t, err)
 	testutil.Contains(t, err.Error(), "not supported")
+}
+
+func newMultiIssueServer(t *testing.T, issues map[string]api.Issue) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for key, issue := range issues {
+			if strings.Contains(r.URL.Path, "/issue/"+key) {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(issue)
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+func testIssues() map[string]api.Issue {
+	return map[string]api.Issue{
+		"PROJ-1": {
+			Key: "PROJ-1",
+			Fields: api.IssueFields{
+				Summary:   "First issue",
+				Status:    &api.Status{Name: "In Progress"},
+				IssueType: &api.IssueType{Name: "Story"},
+				Assignee:  &api.User{DisplayName: "Alice"},
+			},
+		},
+		"PROJ-2": {
+			Key: "PROJ-2",
+			Fields: api.IssueFields{
+				Summary:   "Second issue",
+				Status:    &api.Status{Name: "Done"},
+				IssueType: &api.IssueType{Name: "Bug"},
+				Assignee:  &api.User{DisplayName: "Bob"},
+			},
+		},
+		"PROJ-3": {
+			Key: "PROJ-3",
+			Fields: api.IssueFields{
+				Summary:   "Third issue",
+				Status:    &api.Status{Name: "Backlog"},
+				IssueType: &api.IssueType{Name: "Task"},
+			},
+		},
+	}
+}
+
+func TestRunGetMulti_Table(t *testing.T) {
+	t.Parallel()
+	issues := testIssues()
+	server := newMultiIssueServer(t, issues)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGetMulti(context.Background(), opts, []string{"PROJ-1", "PROJ-2", "PROJ-3"})
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "PROJ-1")
+	testutil.Contains(t, output, "PROJ-2")
+	testutil.Contains(t, output, "PROJ-3")
+	testutil.Contains(t, output, "First issue")
+	testutil.Contains(t, output, "Second issue")
+	testutil.Contains(t, output, "Third issue")
+}
+
+func TestRunGetMulti_PreservesOrder(t *testing.T) {
+	t.Parallel()
+	issues := testIssues()
+	server := newMultiIssueServer(t, issues)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGetMulti(context.Background(), opts, []string{"PROJ-3", "PROJ-1", "PROJ-2"})
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	pos1 := strings.Index(output, "PROJ-3")
+	pos2 := strings.Index(output, "PROJ-1")
+	pos3 := strings.Index(output, "PROJ-2")
+	if pos1 >= pos2 || pos2 >= pos3 {
+		t.Errorf("order not preserved: PROJ-3 at %d, PROJ-1 at %d, PROJ-2 at %d", pos1, pos2, pos3)
+	}
+}
+
+func TestRunGetMulti_IDOnly(t *testing.T) {
+	t.Parallel()
+	issues := testIssues()
+	server := newMultiIssueServer(t, issues)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runGetMulti(context.Background(), opts, []string{"PROJ-1", "PROJ-2"})
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "PROJ-1")
+	testutil.Contains(t, output, "PROJ-2")
+}
+
+func TestRunGetMulti_JSON(t *testing.T) {
+	t.Parallel()
+	issues := testIssues()
+	server := newMultiIssueServer(t, issues)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGetMulti(context.Background(), opts, []string{"PROJ-1", "PROJ-2"})
+	testutil.RequireNoError(t, err)
+
+	output := stdout.String()
+	testutil.Contains(t, output, "PROJ-1")
+	testutil.Contains(t, output, "PROJ-2")
+}
+
+func TestRunGetMulti_FieldsFlagError(t *testing.T) {
+	t.Parallel()
+	opts := &root.Options{}
+	cmd := newGetCmd(opts)
+
+	cmd.SetArgs([]string{"PROJ-1", "PROJ-2", "--fields", "Status"})
+	err := cmd.Execute()
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--fields is only supported with a single issue key")
+}
+
+func TestRunGetMulti_CustomFieldsFlagError(t *testing.T) {
+	t.Parallel()
+	opts := &root.Options{}
+	cmd := newGetCmd(opts)
+
+	cmd.SetArgs([]string{"PROJ-1", "PROJ-2", "--custom-fields"})
+	err := cmd.Execute()
+	testutil.NotNil(t, err)
+	testutil.Contains(t, err.Error(), "--custom-fields is only supported with a single issue key")
+}
+
+func TestRunGetMulti_FailsOnBadKey(t *testing.T) {
+	t.Parallel()
+	issues := testIssues()
+	server := newMultiIssueServer(t, issues)
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runGetMulti(context.Background(), opts, []string{"PROJ-1", "NONEXIST-999"})
+	testutil.NotNil(t, err)
 }


### PR DESCRIPTION
## Summary
- `jtk issues get PROJ-1 PROJ-2 PROJ-3` now fetches all keys and renders a summary table (same format as `issues search`)
- Single-key behavior unchanged — still renders the full detail view
- `--id` with multiple keys emits one key per line
- `-o json` with multiple keys emits an artifact array
- `--fields` and `--custom-fields` error when multiple keys are given (detail-view-only flags)

## Test plan
- [x] `TestRunGetMulti_Table` — multiple keys render table with all issues
- [x] `TestRunGetMulti_PreservesOrder` — output order matches command-line arg order
- [x] `TestRunGetMulti_IDOnly` — emits keys one-per-line
- [x] `TestRunGetMulti_JSON` — emits JSON array
- [x] `TestRunGetMulti_FieldsFlagError` — errors on `--fields` with multiple keys
- [x] `TestRunGetMulti_CustomFieldsFlagError` — errors on `--custom-fields` with multiple keys
- [x] `TestRunGetMulti_FailsOnBadKey` — fail-fast on invalid key
- [x] Full test suite passes (1712 tests)
- [x] Lint clean
- [ ] Integration: `jtk issues get MON-100 MON-101 MON-102`

Closes #281