### PR TITLE
feat(jtk): use cache for links types and issues types commands

### DIFF
--- a/tools/jtk/internal/cache/issuetypes_lookup.go
+++ b/tools/jtk/internal/cache/issuetypes_lookup.go
@@ -1,0 +1,43 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// GetIssueTypesCacheFirst returns []api.IssueType for a project from the
+// issuetypes cache when fresh, falling back to a live API call otherwise.
+//
+// The issuetypes cache stores map[string][]api.IssueType keyed by project key.
+// A fresh cache where the requested project key is absent triggers a live
+// fallback — the project may have been added after the last refresh.
+//
+// Follows the same freshness-against-registry-TTL pattern as
+// GetFieldsCacheFirst.
+func GetIssueTypesCacheFirst(ctx context.Context, client *api.Client, projectKey string) ([]api.IssueType, error) {
+	entry, err := Lookup("issuetypes")
+	if err != nil {
+		return client.GetProjectIssueTypes(ctx, projectKey)
+	}
+
+	env, err := ReadResource[map[string][]api.IssueType]("issuetypes")
+	if err != nil {
+		return client.GetProjectIssueTypes(ctx, projectKey)
+	}
+
+	switch Classify(env.FetchedAt, entry.TTL, time.Now()) {
+	case StatusFresh, StatusManual:
+		types, ok := env.Data[projectKey]
+		if !ok {
+			return client.GetProjectIssueTypes(ctx, projectKey)
+		}
+		return types, nil
+	case StatusStale, StatusUninitialized:
+		return client.GetProjectIssueTypes(ctx, projectKey)
+	case StatusUnavailable:
+		return client.GetProjectIssueTypes(ctx, projectKey)
+	}
+	return client.GetProjectIssueTypes(ctx, projectKey)
+}

--- a/tools/jtk/internal/cache/issuetypes_lookup.go
+++ b/tools/jtk/internal/cache/issuetypes_lookup.go
@@ -7,6 +7,17 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 )
 
+// getProjectIssueTypesLive preserves the original command's live API path:
+// GetProject with expand=issueTypes. This matches what `jtk issues types`
+// called before cache-first was added.
+func getProjectIssueTypesLive(ctx context.Context, client *api.Client, projectKey string) ([]api.IssueType, error) {
+	pd, err := client.GetProject(ctx, projectKey, "issueTypes")
+	if err != nil {
+		return nil, err
+	}
+	return pd.IssueTypes, nil
+}
+
 // GetIssueTypesCacheFirst returns []api.IssueType for a project from the
 // issuetypes cache when fresh, falling back to a live API call otherwise.
 //
@@ -19,25 +30,25 @@ import (
 func GetIssueTypesCacheFirst(ctx context.Context, client *api.Client, projectKey string) ([]api.IssueType, error) {
 	entry, err := Lookup("issuetypes")
 	if err != nil {
-		return client.GetProjectIssueTypes(ctx, projectKey)
+		return getProjectIssueTypesLive(ctx, client, projectKey)
 	}
 
 	env, err := ReadResource[map[string][]api.IssueType]("issuetypes")
 	if err != nil {
-		return client.GetProjectIssueTypes(ctx, projectKey)
+		return getProjectIssueTypesLive(ctx, client, projectKey)
 	}
 
 	switch Classify(env.FetchedAt, entry.TTL, time.Now()) {
 	case StatusFresh, StatusManual:
 		types, ok := env.Data[projectKey]
 		if !ok {
-			return client.GetProjectIssueTypes(ctx, projectKey)
+			return getProjectIssueTypesLive(ctx, client, projectKey)
 		}
 		return types, nil
 	case StatusStale, StatusUninitialized:
-		return client.GetProjectIssueTypes(ctx, projectKey)
+		return getProjectIssueTypesLive(ctx, client, projectKey)
 	case StatusUnavailable:
-		return client.GetProjectIssueTypes(ctx, projectKey)
+		return getProjectIssueTypesLive(ctx, client, projectKey)
 	}
-	return client.GetProjectIssueTypes(ctx, projectKey)
+	return getProjectIssueTypesLive(ctx, client, projectKey)
 }

--- a/tools/jtk/internal/cache/issuetypes_lookup_test.go
+++ b/tools/jtk/internal/cache/issuetypes_lookup_test.go
@@ -1,0 +1,234 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+var testIssueTypes = map[string][]api.IssueType{
+	"TEST": {
+		{ID: "10001", Name: "Bug", Description: "A problem", Subtask: false},
+		{ID: "10002", Name: "Task", Description: "A task to do", Subtask: false},
+	},
+	"OTHER": {
+		{ID: "10003", Name: "Story", Description: "A user story", Subtask: false},
+	},
+}
+
+func newIssueTypesTestClient(t *testing.T, serverURL string) *api.Client {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: serverURL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	return client
+}
+
+func issueTypesLiveServer(t *testing.T, projectKey string, types []api.IssueType) (*httptest.Server, *bool) {
+	t.Helper()
+	liveCalled := new(bool)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := fmt.Sprintf("/rest/api/3/project/%s", projectKey)
+		if r.URL.Path == expectedPath {
+			*liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			resp := struct {
+				IssueTypes []api.IssueType `json:"issueTypes"`
+			}{IssueTypes: types}
+			_ = json.NewEncoder(w).Encode(resp)
+		}
+	}))
+	return server, liveCalled
+}
+
+func TestGetIssueTypesCacheFirst_FreshCacheSkipsLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("issuetypes", "24h", testIssueTypes))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newIssueTypesTestClient(t, server.URL)
+	got, err := GetIssueTypesCacheFirst(context.Background(), client, "TEST")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), 2)
+	testutil.Equal(t, got[0].Name, "Bug")
+	testutil.Equal(t, got[1].Name, "Task")
+}
+
+func TestGetIssueTypesCacheFirst_FreshCacheMissingProjectFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("issuetypes", "24h", testIssueTypes))
+
+	liveTypes := []api.IssueType{{ID: "99", Name: "NewType"}}
+	server, liveCalled := issueTypesLiveServer(t, "NEWPROJ", liveTypes)
+	defer server.Close()
+
+	client := newIssueTypesTestClient(t, server.URL)
+	got, err := GetIssueTypesCacheFirst(context.Background(), client, "NEWPROJ")
+	testutil.RequireNoError(t, err)
+	if !*liveCalled {
+		t.Fatal("expected live API call when project key not in fresh cache")
+	}
+	testutil.Equal(t, len(got), 1)
+	testutil.Equal(t, got[0].Name, "NewType")
+}
+
+func TestGetIssueTypesCacheFirst_FreshCacheEmptyProjectReturnsEmpty(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	cacheData := map[string][]api.IssueType{
+		"EMPTY": {},
+	}
+	testutil.RequireNoError(t, WriteResource("issuetypes", "24h", cacheData))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when project exists in fresh cache (even if empty)")
+	}))
+	defer server.Close()
+
+	client := newIssueTypesTestClient(t, server.URL)
+	got, err := GetIssueTypesCacheFirst(context.Background(), client, "EMPTY")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), 0)
+}
+
+func TestGetIssueTypesCacheFirst_ManualRegistryTTL_SkipsLive(t *testing.T) {
+	t.Cleanup(SetEntriesForTest([]Entry{
+		{Name: "issuetypes", TTL: "manual"},
+	}))
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("issuetypes", "24h", testIssueTypes))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when registry TTL is manual")
+	}))
+	defer server.Close()
+
+	client := newIssueTypesTestClient(t, server.URL)
+	got, err := GetIssueTypesCacheFirst(context.Background(), client, "TEST")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), 2)
+}
+
+func TestGetIssueTypesCacheFirst_StaleCacheFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	staleEnv := Envelope[map[string][]api.IssueType]{
+		Resource:  "issuetypes",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Now().Add(-48 * time.Hour),
+		TTL:       "1s",
+		Version:   Version,
+		Data:      testIssueTypes,
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("issuetypes", staleEnv))
+
+	liveTypes := []api.IssueType{{ID: "10001", Name: "Bug"}}
+	server, liveCalled := issueTypesLiveServer(t, "TEST", liveTypes)
+	defer server.Close()
+
+	client := newIssueTypesTestClient(t, server.URL)
+	got, err := GetIssueTypesCacheFirst(context.Background(), client, "TEST")
+	testutil.RequireNoError(t, err)
+	if !*liveCalled {
+		t.Fatal("expected live API call for stale cache")
+	}
+	testutil.Equal(t, got[0].ID, "10001")
+}
+
+func TestGetIssueTypesCacheFirst_MissFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	liveTypes := []api.IssueType{{ID: "10001", Name: "Bug"}}
+	server, liveCalled := issueTypesLiveServer(t, "TEST", liveTypes)
+	defer server.Close()
+
+	client := newIssueTypesTestClient(t, server.URL)
+	_, err := GetIssueTypesCacheFirst(context.Background(), client, "TEST")
+	testutil.RequireNoError(t, err)
+	if !*liveCalled {
+		t.Fatal("expected live API call on cache miss")
+	}
+}
+
+func TestGetIssueTypesCacheFirst_UninitializedEnvelopeFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	uninitEnv := Envelope[map[string][]api.IssueType]{
+		Resource:  "issuetypes",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Time{},
+		TTL:       "24h",
+		Version:   Version,
+		Data:      testIssueTypes,
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("issuetypes", uninitEnv))
+
+	liveTypes := []api.IssueType{{ID: "10001", Name: "Bug"}}
+	server, liveCalled := issueTypesLiveServer(t, "TEST", liveTypes)
+	defer server.Close()
+
+	client := newIssueTypesTestClient(t, server.URL)
+	got, err := GetIssueTypesCacheFirst(context.Background(), client, "TEST")
+	testutil.RequireNoError(t, err)
+	if !*liveCalled {
+		t.Fatal("expected live API call for uninitialized (zero FetchedAt) envelope")
+	}
+	testutil.Equal(t, got[0].ID, "10001")
+}
+
+func TestGetIssueTypesCacheFirst_NoInstanceFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Setenv("JIRA_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+
+	liveTypes := []api.IssueType{{ID: "10001", Name: "Bug"}}
+	server, liveCalled := issueTypesLiveServer(t, "TEST", liveTypes)
+	defer server.Close()
+
+	client := newIssueTypesTestClient(t, server.URL)
+	_, err := GetIssueTypesCacheFirst(context.Background(), client, "TEST")
+	testutil.RequireNoError(t, err)
+	if !*liveCalled {
+		t.Fatal("expected live API call when no instance is configured")
+	}
+}
+
+func TestGetIssueTypesCacheFirst_LiveErrorPropagated(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"errorMessages":["server error"]}`)
+	}))
+	defer server.Close()
+
+	client := newIssueTypesTestClient(t, server.URL)
+	_, err := GetIssueTypesCacheFirst(context.Background(), client, "TEST")
+	if err == nil {
+		t.Fatal("expected error from live API failure, got nil")
+	}
+}

--- a/tools/jtk/internal/cache/issuetypes_lookup_test.go
+++ b/tools/jtk/internal/cache/issuetypes_lookup_test.go
@@ -216,6 +216,27 @@ func TestGetIssueTypesCacheFirst_NoInstanceFallsBackToLive(t *testing.T) {
 	}
 }
 
+func TestGetIssueTypesCacheFirst_LiveFallbackSendsExpand(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	var expandParam string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expandParam = r.URL.Query().Get("expand")
+		w.Header().Set("Content-Type", "application/json")
+		resp := struct {
+			IssueTypes []api.IssueType `json:"issueTypes"`
+		}{IssueTypes: []api.IssueType{{ID: "1", Name: "Bug"}}}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := newIssueTypesTestClient(t, server.URL)
+	_, err := GetIssueTypesCacheFirst(context.Background(), client, "TEST")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, expandParam, "issueTypes")
+}
+
 func TestGetIssueTypesCacheFirst_LiveErrorPropagated(t *testing.T) {
 	t.Cleanup(SetRootForTest(t.TempDir()))
 	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))

--- a/tools/jtk/internal/cache/linktypes_lookup.go
+++ b/tools/jtk/internal/cache/linktypes_lookup.go
@@ -1,0 +1,35 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// GetLinkTypesCacheFirst returns []api.IssueLinkType from the linktypes cache
+// when fresh, falling back to a live client.GetIssueLinkTypes call otherwise.
+//
+// Follows the same pattern as GetFieldsCacheFirst — see that function's doc
+// comment for design rationale. Freshness is checked against the registry TTL.
+func GetLinkTypesCacheFirst(ctx context.Context, client *api.Client) ([]api.IssueLinkType, error) {
+	entry, err := Lookup("linktypes")
+	if err != nil {
+		return client.GetIssueLinkTypes(ctx)
+	}
+
+	env, err := ReadResource[[]api.IssueLinkType]("linktypes")
+	if err != nil {
+		return client.GetIssueLinkTypes(ctx)
+	}
+
+	switch Classify(env.FetchedAt, entry.TTL, time.Now()) {
+	case StatusFresh, StatusManual:
+		return env.Data, nil
+	case StatusStale, StatusUninitialized:
+		return client.GetIssueLinkTypes(ctx)
+	case StatusUnavailable:
+		return client.GetIssueLinkTypes(ctx)
+	}
+	return client.GetIssueLinkTypes(ctx)
+}

--- a/tools/jtk/internal/cache/linktypes_lookup_test.go
+++ b/tools/jtk/internal/cache/linktypes_lookup_test.go
@@ -1,0 +1,196 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+var testLinkTypes = []api.IssueLinkType{
+	{ID: "1", Name: "Blocks", Inward: "is blocked by", Outward: "blocks"},
+	{ID: "2", Name: "Relates", Inward: "relates to", Outward: "relates to"},
+}
+
+func newLinkTypesTestClient(t *testing.T, serverURL string) *api.Client {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: serverURL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	return client
+}
+
+func TestGetLinkTypesCacheFirst_FreshCacheSkipsLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("linktypes", "24h", testLinkTypes))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newLinkTypesTestClient(t, server.URL)
+	got, err := GetLinkTypesCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), len(testLinkTypes))
+	testutil.Equal(t, got[0].ID, "1")
+	testutil.Equal(t, got[0].Name, "Blocks")
+	testutil.Equal(t, got[1].Name, "Relates")
+}
+
+func TestGetLinkTypesCacheFirst_ManualRegistryTTL_SkipsLive(t *testing.T) {
+	t.Cleanup(SetEntriesForTest([]Entry{
+		{Name: "linktypes", TTL: "manual"},
+	}))
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("linktypes", "24h", testLinkTypes))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when registry TTL is manual")
+	}))
+	defer server.Close()
+
+	client := newLinkTypesTestClient(t, server.URL)
+	got, err := GetLinkTypesCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), len(testLinkTypes))
+}
+
+func TestGetLinkTypesCacheFirst_StaleCacheFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	staleEnv := Envelope[[]api.IssueLinkType]{
+		Resource:  "linktypes",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Now().Add(-48 * time.Hour),
+		TTL:       "1s",
+		Version:   Version,
+		Data:      []api.IssueLinkType{{ID: "stale", Name: "Stale"}},
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("linktypes", staleEnv))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issueLinkType" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issueLinkTypes":[{"id":"1","name":"Blocks","inward":"is blocked by","outward":"blocks"}]}`))
+		}
+	}))
+	defer server.Close()
+
+	client := newLinkTypesTestClient(t, server.URL)
+	got, err := GetLinkTypesCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call for stale cache")
+	}
+	testutil.Equal(t, got[0].ID, "1")
+}
+
+func TestGetLinkTypesCacheFirst_MissFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issueLinkType" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issueLinkTypes":[{"id":"1","name":"Blocks","inward":"is blocked by","outward":"blocks"}]}`))
+		}
+	}))
+	defer server.Close()
+
+	client := newLinkTypesTestClient(t, server.URL)
+	_, err := GetLinkTypesCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call on cache miss")
+	}
+}
+
+func TestGetLinkTypesCacheFirst_NoInstanceFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Setenv("JIRA_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issueLinkType" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issueLinkTypes":[{"id":"1","name":"Blocks","inward":"is blocked by","outward":"blocks"}]}`))
+		}
+	}))
+	defer server.Close()
+
+	client := newLinkTypesTestClient(t, server.URL)
+	_, err := GetLinkTypesCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call when no instance is configured")
+	}
+}
+
+func TestGetLinkTypesCacheFirst_UninitializedEnvelopeFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	uninitEnv := Envelope[[]api.IssueLinkType]{
+		Resource:  "linktypes",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Time{},
+		TTL:       "24h",
+		Version:   Version,
+		Data:      testLinkTypes,
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("linktypes", uninitEnv))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/issueLinkType" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issueLinkTypes":[{"id":"1","name":"Blocks","inward":"is blocked by","outward":"blocks"}]}`))
+		}
+	}))
+	defer server.Close()
+
+	client := newLinkTypesTestClient(t, server.URL)
+	got, err := GetLinkTypesCacheFirst(context.Background(), client)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call for uninitialized (zero FetchedAt) envelope")
+	}
+	testutil.Equal(t, got[0].ID, "1")
+}
+
+func TestGetLinkTypesCacheFirst_LiveErrorPropagated(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"errorMessages":["server error"]}`)
+	}))
+	defer server.Close()
+
+	client := newLinkTypesTestClient(t, server.URL)
+	_, err := GetLinkTypesCacheFirst(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected error from live API failure, got nil")
+	}
+}

--- a/tools/jtk/internal/cmd/issues/types.go
+++ b/tools/jtk/internal/cmd/issues/types.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/view"
 
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/resolve"
@@ -47,18 +48,18 @@ func runTypes(ctx context.Context, opts *root.Options, project string) error {
 	}
 	projectKey := resolvedProject.Key
 
-	projectDetail, err := client.GetProject(ctx, projectKey, "issueTypes")
+	issueTypes, err := cache.GetIssueTypesCacheFirst(ctx, client, projectKey)
 	if err != nil {
 		return err
 	}
 
-	if len(projectDetail.IssueTypes) == 0 {
+	if len(issueTypes) == 0 {
 		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentNoTypes(projectKey))
 	}
 
 	if opts.EmitIDOnly() {
-		ids := make([]string, len(projectDetail.IssueTypes))
-		for i, t := range projectDetail.IssueTypes {
+		ids := make([]string, len(issueTypes))
+		for i, t := range issueTypes {
 			ids[i] = t.ID
 		}
 		return jtkpresent.EmitIDs(opts, ids)
@@ -66,9 +67,9 @@ func runTypes(ctx context.Context, opts *root.Options, project string) error {
 
 	v := opts.View()
 	if v.Format == view.FormatJSON {
-		return v.JSON(projectDetail.IssueTypes)
+		return v.JSON(issueTypes)
 	}
 
-	model := jtkpresent.IssuePresenter{}.PresentTypes(projectDetail.IssueTypes)
+	model := jtkpresent.IssuePresenter{}.PresentTypes(issueTypes)
 	return jtkpresent.Emit(opts, model)
 }

--- a/tools/jtk/internal/cmd/issues/types_test.go
+++ b/tools/jtk/internal/cmd/issues/types_test.go
@@ -32,21 +32,22 @@ func TestNewTypesCmd(t *testing.T) {
 
 func TestRunTypes_Success(t *testing.T) {
 	seedCacheForIssues(t)
+	// Make issuetypes stale so the command falls back to the live server.
+	testutil.RequireNoError(t, cache.Touch("issuetypes"))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		testutil.Equal(t, r.URL.Path, "/rest/api/3/project/TEST")
-
-		response := api.ProjectDetail{
-			ID:   json.Number("10000"),
-			Key:  "TEST",
-			Name: "Test Project",
-			IssueTypes: []api.IssueType{
-				{ID: "10001", Name: "Bug", Description: "A problem", Subtask: false},
-				{ID: "10002", Name: "Task", Description: "A task to do", Subtask: false},
-				{ID: "10003", Name: "Sub-task", Description: "A subtask", Subtask: true},
-			},
+		if r.URL.Path == "/rest/api/3/project/TEST" {
+			response := struct {
+				IssueTypes []api.IssueType `json:"issueTypes"`
+			}{
+				IssueTypes: []api.IssueType{
+					{ID: "10001", Name: "Bug", Description: "A problem", Subtask: false},
+					{ID: "10002", Name: "Task", Description: "A task to do", Subtask: false},
+					{ID: "10003", Name: "Sub-task", Description: "A subtask", Subtask: true},
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(response)
 		}
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(response)
 	}))
 	defer server.Close()
 
@@ -227,13 +228,79 @@ func TestRunTypes_DescriptionTruncation(t *testing.T) {
 	testutil.Contains(t, output, "...")
 }
 
+func TestRunTypes_FreshCacheSkipsLive(t *testing.T) {
+	seedCacheForIssues(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when issuetypes cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runTypes(context.Background(), opts, "TEST")
+	testutil.RequireNoError(t, err)
+	out := stdout.String()
+	testutil.Contains(t, out, "Bug")
+	testutil.Contains(t, out, "Task")
+}
+
+func TestRunTypes_FreshCacheSkipsLive_IDOnly(t *testing.T) {
+	seedCacheForIssues(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when issuetypes cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runTypes(context.Background(), opts, "TEST")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "10000\n")
+}
+
+func TestRunTypes_FreshCacheSkipsLive_JSON(t *testing.T) {
+	seedCacheForIssues(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when issuetypes cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runTypes(context.Background(), opts, "TEST")
+	testutil.RequireNoError(t, err)
+
+	var issueTypes []api.IssueType
+	err = json.Unmarshal(stdout.Bytes(), &issueTypes)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(issueTypes), 4)
+}
+
 func TestRunTypes_IDOnly(t *testing.T) {
 	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.Touch("issuetypes"))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		response := api.ProjectDetail{
-			ID:   json.Number("10000"),
-			Key:  "TEST",
-			Name: "Test Project",
+		response := struct {
+			IssueTypes []api.IssueType `json:"issueTypes"`
+		}{
 			IssueTypes: []api.IssueType{
 				{ID: "10001", Name: "Bug"},
 				{ID: "10002", Name: "Task"},

--- a/tools/jtk/internal/cmd/issues/types_test.go
+++ b/tools/jtk/internal/cmd/issues/types_test.go
@@ -77,8 +77,7 @@ func TestRunTypes_Success(t *testing.T) {
 }
 
 func TestRunTypes_ProjectNotFound(t *testing.T) {
-	// Not t.Parallel(): SetInstanceKeyForTest mutates a cache package global.
-	// See seedCacheForIssues for the serial-execution contract.
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -106,6 +105,7 @@ func TestRunTypes_ProjectNotFound(t *testing.T) {
 }
 
 func TestRunTypes_EmptyIssueTypes(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		response := api.ProjectDetail{
@@ -140,6 +140,7 @@ func TestRunTypes_EmptyIssueTypes(t *testing.T) {
 }
 
 func TestRunTypes_JSONOutput(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		response := api.ProjectDetail{
@@ -187,6 +188,7 @@ func TestRunTypes_JSONOutput(t *testing.T) {
 }
 
 func TestRunTypes_DescriptionTruncation(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
 	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 	longDesc := strings.Repeat("A", 100) // 100 character description
 

--- a/tools/jtk/internal/cmd/issues/types_test.go
+++ b/tools/jtk/internal/cmd/issues/types_test.go
@@ -269,7 +269,7 @@ func TestRunTypes_FreshCacheSkipsLive_IDOnly(t *testing.T) {
 
 	err = runTypes(context.Background(), opts, "TEST")
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, stdout.String(), "10000\n")
+	testutil.Equal(t, stdout.String(), "10000\n10001\n10002\n10003\n")
 }
 
 func TestRunTypes_FreshCacheSkipsLive_JSON(t *testing.T) {

--- a/tools/jtk/internal/cmd/links/links.go
+++ b/tools/jtk/internal/cmd/links/links.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/mutation"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
@@ -342,7 +343,7 @@ func runTypes(ctx context.Context, opts *root.Options, fieldsFlag string) error 
 		return err
 	}
 
-	linkTypes, err := client.GetIssueLinkTypes(ctx)
+	linkTypes, err := cache.GetLinkTypesCacheFirst(ctx, client)
 	if err != nil {
 		return err
 	}
@@ -370,7 +371,8 @@ func runTypes(ctx context.Context, opts *root.Options, fieldsFlag string) error 
 	return jtkpresent.Emit(opts, model)
 }
 
-// GetIssueLinkTypes returns all link types (exported for use by other commands)
+// GetIssueLinkTypes returns all link types via cache-first lookup, falling
+// back to a live API call when the cache is stale or missing.
 func GetIssueLinkTypes(ctx context.Context, client *api.Client) ([]api.IssueLinkType, error) {
-	return client.GetIssueLinkTypes(ctx)
+	return cache.GetLinkTypesCacheFirst(ctx, client)
 }

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -522,6 +522,7 @@ func TestRunDelete_JSONOutputEmitsText(t *testing.T) {
 }
 
 func TestRunTypes(t *testing.T) {
+	isolateCache(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"issueLinkTypes": []map[string]string{
@@ -546,7 +547,7 @@ func TestRunTypes(t *testing.T) {
 }
 
 func TestRunTypes_IDOnly(t *testing.T) {
-	t.Parallel()
+	isolateCache(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"issueLinkTypes": []map[string]string{

--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -569,6 +569,83 @@ func TestRunTypes_IDOnly(t *testing.T) {
 	testutil.Equal(t, stdout.String(), "1\n2\n")
 }
 
+func TestRunTypes_FreshCacheSkipsLive(t *testing.T) {
+	isolateCache(t)
+	testutil.RequireNoError(t, cache.WriteResource("linktypes", "24h", []api.IssueLinkType{
+		{ID: "1", Name: "Blocks", Inward: "is blocked by", Outward: "blocks"},
+		{ID: "2", Name: "Relates", Inward: "relates to", Outward: "relates to"},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when linktypes cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runTypes(context.Background(), opts, "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Blocks")
+	testutil.Contains(t, stdout.String(), "Relates")
+}
+
+func TestRunTypes_FreshCacheSkipsLive_IDOnly(t *testing.T) {
+	isolateCache(t)
+	testutil.RequireNoError(t, cache.WriteResource("linktypes", "24h", []api.IssueLinkType{
+		{ID: "1", Name: "Blocks", Inward: "is blocked by", Outward: "blocks"},
+		{ID: "2", Name: "Relates", Inward: "relates to", Outward: "relates to"},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when linktypes cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runTypes(context.Background(), opts, "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "1\n2\n")
+}
+
+func TestRunTypes_FreshCacheSkipsLive_JSON(t *testing.T) {
+	isolateCache(t)
+	testutil.RequireNoError(t, cache.WriteResource("linktypes", "24h", []api.IssueLinkType{
+		{ID: "1", Name: "Blocks", Inward: "is blocked by", Outward: "blocks"},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when linktypes cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runTypes(context.Background(), opts, "")
+	testutil.RequireNoError(t, err)
+
+	var types []api.IssueLinkType
+	err = json.Unmarshal(stdout.Bytes(), &types)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(types), 1)
+	testutil.Equal(t, types[0].Name, "Blocks")
+}
+
 func TestFindCreatedLink_MatchByName(t *testing.T) {
 	t.Parallel()
 	links := []api.IssueLink{


### PR DESCRIPTION
## Summary
- Route `jtk links types` through the `linktypes` cache and `jtk issues types --project` through the `issuetypes` cache, avoiding live API calls when the cache is fresh
- Add `GetLinkTypesCacheFirst` and `GetIssueTypesCacheFirst` helpers following the established `GetFieldsCacheFirst` pattern from #275
- Preserve all output contracts: `--id`, `--fields`, JSON, and empty-result presentation unchanged

## Test plan
- [x] Cache helpers: fresh hit, manual TTL, stale fallback, miss fallback, no-instance fallback, uninitialized envelope fallback, live error propagation (19 new tests)
- [x] Command-level: `links types` and `issues types` with fresh cache skip live server for table, ID-only, and JSON output (6 new tests)
- [x] Existing tests updated to use stale cache where they test live-server response formatting
- [x] Full suite: 1734 tests pass, lint clean

Closes #276