### PR TITLE
feat(jtk): use cache for boards list and sprints list commands

### DIFF
--- a/tools/jtk/internal/cache/boards_lookup.go
+++ b/tools/jtk/internal/cache/boards_lookup.go
@@ -65,6 +65,7 @@ func boardsFromCache(boards []api.Board, projectFilter string, startAt, maxResul
 	return &api.BoardsResponse{
 		MaxResults: maxResults,
 		StartAt:    startAt,
+		Total:      total,
 		IsLast:     end >= total,
 		Values:     filtered[startAt:end],
 	}

--- a/tools/jtk/internal/cache/boards_lookup.go
+++ b/tools/jtk/internal/cache/boards_lookup.go
@@ -1,0 +1,71 @@
+package cache
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// GetBoardsCacheFirst returns a BoardsResponse from the boards cache when
+// fresh, applying project filter and pagination client-side. Falls back to
+// client.ListBoards on stale/miss/error.
+//
+// The boards cache stores []api.Board (all boards, exhaustively paginated by
+// fetchBoards). Client-side filtering and slicing reproduce the server-side
+// pagination contract.
+func GetBoardsCacheFirst(ctx context.Context, client *api.Client, projectFilter string, startAt, maxResults int) (*api.BoardsResponse, error) {
+	entry, err := Lookup("boards")
+	if err != nil {
+		return client.ListBoards(ctx, projectFilter, startAt, maxResults)
+	}
+
+	env, err := ReadResource[[]api.Board]("boards")
+	if err != nil {
+		return client.ListBoards(ctx, projectFilter, startAt, maxResults)
+	}
+
+	switch Classify(env.FetchedAt, entry.TTL, time.Now()) {
+	case StatusFresh, StatusManual:
+		return boardsFromCache(env.Data, projectFilter, startAt, maxResults), nil
+	case StatusStale, StatusUninitialized:
+		return client.ListBoards(ctx, projectFilter, startAt, maxResults)
+	case StatusUnavailable:
+		return client.ListBoards(ctx, projectFilter, startAt, maxResults)
+	}
+	return client.ListBoards(ctx, projectFilter, startAt, maxResults)
+}
+
+func boardsFromCache(boards []api.Board, projectFilter string, startAt, maxResults int) *api.BoardsResponse {
+	var filtered []api.Board
+	if projectFilter != "" {
+		for _, b := range boards {
+			if strings.EqualFold(b.Location.ProjectKey, projectFilter) {
+				filtered = append(filtered, b)
+			}
+		}
+	} else {
+		filtered = boards
+	}
+
+	if maxResults <= 0 {
+		maxResults = 50
+	}
+
+	total := len(filtered)
+	if startAt > total {
+		startAt = total
+	}
+	end := startAt + maxResults
+	if end > total {
+		end = total
+	}
+
+	return &api.BoardsResponse{
+		MaxResults: maxResults,
+		StartAt:    startAt,
+		IsLast:     end >= total,
+		Values:     filtered[startAt:end],
+	}
+}

--- a/tools/jtk/internal/cache/boards_lookup_test.go
+++ b/tools/jtk/internal/cache/boards_lookup_test.go
@@ -1,0 +1,263 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+var testBoards = []api.Board{
+	{ID: 1, Name: "Board One", Type: "scrum", Location: api.BoardLocation{ProjectKey: "PROJ"}},
+	{ID: 2, Name: "Board Two", Type: "kanban", Location: api.BoardLocation{ProjectKey: "PROJ"}},
+	{ID: 3, Name: "Board Three", Type: "scrum", Location: api.BoardLocation{ProjectKey: "OTHER"}},
+}
+
+func newBoardsTestClient(t *testing.T, serverURL string) *api.Client {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: serverURL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	return client
+}
+
+func TestGetBoardsCacheFirst_FreshCacheSkipsLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("boards", "24h", testBoards))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	got, err := GetBoardsCacheFirst(context.Background(), client, "", 0, 50)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got.Values), 3)
+	testutil.Equal(t, got.IsLast, true)
+}
+
+func TestGetBoardsCacheFirst_FreshCacheWithProjectFilter(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("boards", "24h", testBoards))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	got, err := GetBoardsCacheFirst(context.Background(), client, "PROJ", 0, 50)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got.Values), 2)
+	testutil.Equal(t, got.Values[0].Name, "Board One")
+	testutil.Equal(t, got.Values[1].Name, "Board Two")
+	testutil.Equal(t, got.IsLast, true)
+}
+
+func TestGetBoardsCacheFirst_FreshCacheWithPagination(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("boards", "24h", testBoards))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+
+	// First page: 2 results
+	got, err := GetBoardsCacheFirst(context.Background(), client, "", 0, 2)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got.Values), 2)
+	testutil.Equal(t, got.IsLast, false)
+
+	// Second page: 1 result
+	got2, err := GetBoardsCacheFirst(context.Background(), client, "", 2, 2)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got2.Values), 1)
+	testutil.Equal(t, got2.IsLast, true)
+}
+
+func TestGetBoardsCacheFirst_FreshCacheProjectFilterWithPagination(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("boards", "24h", testBoards))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	got, err := GetBoardsCacheFirst(context.Background(), client, "PROJ", 0, 1)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got.Values), 1)
+	testutil.Equal(t, got.Values[0].Name, "Board One")
+	testutil.Equal(t, got.IsLast, false)
+}
+
+func TestGetBoardsCacheFirst_ManualRegistryTTL_SkipsLive(t *testing.T) {
+	t.Cleanup(SetEntriesForTest([]Entry{
+		{Name: "boards", TTL: "manual"},
+	}))
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("boards", "24h", testBoards))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when registry TTL is manual")
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	got, err := GetBoardsCacheFirst(context.Background(), client, "", 0, 50)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got.Values), 3)
+}
+
+func TestGetBoardsCacheFirst_StaleCacheFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	staleEnv := Envelope[[]api.Board]{
+		Resource:  "boards",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Now().Add(-48 * time.Hour),
+		TTL:       "1s",
+		Version:   Version,
+		Data:      testBoards,
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("boards", staleEnv))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/agile/1.0/board" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.BoardsResponse{
+				IsLast: true,
+				Values: []api.Board{{ID: 99, Name: "Live Board"}},
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	got, err := GetBoardsCacheFirst(context.Background(), client, "", 0, 50)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call for stale cache")
+	}
+	testutil.Equal(t, got.Values[0].Name, "Live Board")
+}
+
+func TestGetBoardsCacheFirst_MissFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/agile/1.0/board" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.BoardsResponse{IsLast: true, Values: []api.Board{{ID: 1, Name: "B"}}})
+		}
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	_, err := GetBoardsCacheFirst(context.Background(), client, "", 0, 50)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call on cache miss")
+	}
+}
+
+func TestGetBoardsCacheFirst_UninitializedEnvelopeFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	uninitEnv := Envelope[[]api.Board]{
+		Resource:  "boards",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Time{},
+		TTL:       "24h",
+		Version:   Version,
+		Data:      testBoards,
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("boards", uninitEnv))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/agile/1.0/board" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.BoardsResponse{IsLast: true, Values: []api.Board{{ID: 1, Name: "B"}}})
+		}
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	_, err := GetBoardsCacheFirst(context.Background(), client, "", 0, 50)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call for uninitialized envelope")
+	}
+}
+
+func TestGetBoardsCacheFirst_NoInstanceFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Setenv("JIRA_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/agile/1.0/board" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.BoardsResponse{IsLast: true, Values: []api.Board{{ID: 1, Name: "B"}}})
+		}
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	_, err := GetBoardsCacheFirst(context.Background(), client, "", 0, 50)
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call when no instance is configured")
+	}
+}
+
+func TestGetBoardsCacheFirst_LiveErrorPropagated(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"errorMessages":["server error"]}`)
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	_, err := GetBoardsCacheFirst(context.Background(), client, "", 0, 50)
+	if err == nil {
+		t.Fatal("expected error from live API failure, got nil")
+	}
+}

--- a/tools/jtk/internal/cache/boards_lookup_test.go
+++ b/tools/jtk/internal/cache/boards_lookup_test.go
@@ -110,6 +110,42 @@ func TestGetBoardsCacheFirst_FreshCacheProjectFilterWithPagination(t *testing.T)
 	testutil.Equal(t, got.IsLast, false)
 }
 
+func TestGetBoardsCacheFirst_FreshCacheStartAtBeyondTotal(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("boards", "24h", testBoards))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	got, err := GetBoardsCacheFirst(context.Background(), client, "", 100, 50)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got.Values), 0)
+	testutil.Equal(t, got.IsLast, true)
+}
+
+func TestGetBoardsCacheFirst_FreshCacheMaxResultsZeroUsesDefault(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("boards", "24h", testBoards))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newBoardsTestClient(t, server.URL)
+	got, err := GetBoardsCacheFirst(context.Background(), client, "", 0, 0)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got.Values), 3)
+	testutil.Equal(t, got.IsLast, true)
+}
+
 func TestGetBoardsCacheFirst_ManualRegistryTTL_SkipsLive(t *testing.T) {
 	t.Cleanup(SetEntriesForTest([]Entry{
 		{Name: "boards", TTL: "manual"},

--- a/tools/jtk/internal/cache/sprints_lookup.go
+++ b/tools/jtk/internal/cache/sprints_lookup.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// GetSprintsCacheFirst returns all sprints for a board from the sprints cache
+// when fresh, applying state filter locally. Falls back to live API otherwise.
+//
+// Comma-separated state filters (e.g., "active,future") are not supported from
+// cache — they fall back to live to preserve Jira server-side semantics.
+//
+// The caller is responsible for sorting and pagination (runList already does
+// this after receiving the full sprint list).
+func GetSprintsCacheFirst(ctx context.Context, client *api.Client, boardID int, state string, fetcher func(context.Context, *api.Client, int, string) ([]api.Sprint, error)) ([]api.Sprint, error) {
+	if strings.Contains(state, ",") {
+		return fetcher(ctx, client, boardID, state)
+	}
+
+	entry, err := Lookup("sprints")
+	if err != nil {
+		return fetcher(ctx, client, boardID, state)
+	}
+
+	env, err := ReadResource[map[int][]api.Sprint]("sprints")
+	if err != nil {
+		return fetcher(ctx, client, boardID, state)
+	}
+
+	switch Classify(env.FetchedAt, entry.TTL, time.Now()) {
+	case StatusFresh, StatusManual:
+		sprints, ok := env.Data[boardID]
+		if !ok {
+			return fetcher(ctx, client, boardID, state)
+		}
+		if state == "" {
+			return sprints, nil
+		}
+		var filtered []api.Sprint
+		for _, s := range sprints {
+			if strings.EqualFold(s.State, state) {
+				filtered = append(filtered, s)
+			}
+		}
+		return filtered, nil
+	case StatusStale, StatusUninitialized:
+		return fetcher(ctx, client, boardID, state)
+	case StatusUnavailable:
+		return fetcher(ctx, client, boardID, state)
+	}
+	return fetcher(ctx, client, boardID, state)
+}

--- a/tools/jtk/internal/cache/sprints_lookup.go
+++ b/tools/jtk/internal/cache/sprints_lookup.go
@@ -11,13 +11,14 @@ import (
 // GetSprintsCacheFirst returns all sprints for a board from the sprints cache
 // when fresh, applying state filter locally. Falls back to live API otherwise.
 //
-// Comma-separated state filters (e.g., "active,future") are not supported from
-// cache — they fall back to live to preserve Jira server-side semantics.
+// Only known single-state values ("active", "closed", "future") and empty
+// string are served from cache. Comma-separated states and unknown values
+// fall back to live to preserve Jira server-side semantics.
 //
 // The caller is responsible for sorting and pagination (runList already does
 // this after receiving the full sprint list).
 func GetSprintsCacheFirst(ctx context.Context, client *api.Client, boardID int, state string, fetcher func(context.Context, *api.Client, int, string) ([]api.Sprint, error)) ([]api.Sprint, error) {
-	if strings.Contains(state, ",") {
+	if !isCacheableState(state) {
 		return fetcher(ctx, client, boardID, state)
 	}
 
@@ -53,4 +54,13 @@ func GetSprintsCacheFirst(ctx context.Context, client *api.Client, boardID int, 
 		return fetcher(ctx, client, boardID, state)
 	}
 	return fetcher(ctx, client, boardID, state)
+}
+
+func isCacheableState(state string) bool {
+	switch strings.ToLower(state) {
+	case "", "active", "closed", "future":
+		return true
+	default:
+		return false
+	}
 }

--- a/tools/jtk/internal/cache/sprints_lookup_test.go
+++ b/tools/jtk/internal/cache/sprints_lookup_test.go
@@ -111,6 +111,29 @@ func TestGetSprintsCacheFirst_CommaStateFallsBackToLive(t *testing.T) {
 	testutil.Equal(t, len(got), 2)
 }
 
+func TestGetSprintsCacheFirst_UnknownStateFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("sprints", "24h", testSprints))
+
+	liveCalled := false
+	liveResult := []api.Sprint{{ID: 101, Name: "Sprint 2", State: "active"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("should not hit httptest server")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	got, err := GetSprintsCacheFirst(context.Background(), client, 1, "typo", stubFetcher(&liveCalled, liveResult))
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live fetcher call for unknown state value")
+	}
+	testutil.Equal(t, len(got), 1)
+}
+
 func TestGetSprintsCacheFirst_FreshCacheMissingBoardFallsBackToLive(t *testing.T) {
 	t.Cleanup(SetRootForTest(t.TempDir()))
 	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))

--- a/tools/jtk/internal/cache/sprints_lookup_test.go
+++ b/tools/jtk/internal/cache/sprints_lookup_test.go
@@ -111,6 +111,24 @@ func TestGetSprintsCacheFirst_CommaStateFallsBackToLive(t *testing.T) {
 	testutil.Equal(t, len(got), 2)
 }
 
+func TestGetSprintsCacheFirst_MixedCaseStateServedFromCache(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("sprints", "24h", testSprints))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	got, err := GetSprintsCacheFirst(context.Background(), client, 1, "Active", stubFetcher(nil, nil))
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), 1)
+	testutil.Equal(t, got[0].Name, "Sprint 2")
+}
+
 func TestGetSprintsCacheFirst_UnknownStateFallsBackToLive(t *testing.T) {
 	t.Cleanup(SetRootForTest(t.TempDir()))
 	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))

--- a/tools/jtk/internal/cache/sprints_lookup_test.go
+++ b/tools/jtk/internal/cache/sprints_lookup_test.go
@@ -1,0 +1,271 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+var testSprints = map[int][]api.Sprint{
+	1: {
+		{ID: 100, Name: "Sprint 1", State: "closed", OriginBoardID: 1},
+		{ID: 101, Name: "Sprint 2", State: "active", OriginBoardID: 1},
+		{ID: 102, Name: "Sprint 3", State: "future", OriginBoardID: 1},
+	},
+	2: {
+		{ID: 200, Name: "Sprint A", State: "active", OriginBoardID: 2},
+	},
+}
+
+func stubFetcher(liveCalled *bool, result []api.Sprint) func(context.Context, *api.Client, int, string) ([]api.Sprint, error) {
+	return func(_ context.Context, _ *api.Client, _ int, _ string) ([]api.Sprint, error) {
+		if liveCalled != nil {
+			*liveCalled = true
+		}
+		return result, nil
+	}
+}
+
+func stubFetcherErr(liveCalled *bool) func(context.Context, *api.Client, int, string) ([]api.Sprint, error) {
+	return func(_ context.Context, _ *api.Client, _ int, _ string) ([]api.Sprint, error) {
+		if liveCalled != nil {
+			*liveCalled = true
+		}
+		return nil, fmt.Errorf("live error")
+	}
+}
+
+func newSprintsTestClient(t *testing.T, serverURL string) *api.Client {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: serverURL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	return client
+}
+
+func TestGetSprintsCacheFirst_FreshCacheSkipsLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("sprints", "24h", testSprints))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	liveCalled := false
+	got, err := GetSprintsCacheFirst(context.Background(), client, 1, "", stubFetcher(&liveCalled, nil))
+	testutil.RequireNoError(t, err)
+	if liveCalled {
+		t.Fatal("live fetcher should not be called when cache is fresh")
+	}
+	testutil.Equal(t, len(got), 3)
+}
+
+func TestGetSprintsCacheFirst_FreshCacheWithStateFilter(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("sprints", "24h", testSprints))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	got, err := GetSprintsCacheFirst(context.Background(), client, 1, "active", stubFetcher(nil, nil))
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), 1)
+	testutil.Equal(t, got[0].Name, "Sprint 2")
+}
+
+func TestGetSprintsCacheFirst_CommaStateFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("sprints", "24h", testSprints))
+
+	liveCalled := false
+	liveResult := []api.Sprint{{ID: 101, Name: "Sprint 2", State: "active"}, {ID: 102, Name: "Sprint 3", State: "future"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("should not hit httptest server")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	got, err := GetSprintsCacheFirst(context.Background(), client, 1, "active,future", stubFetcher(&liveCalled, liveResult))
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live fetcher call for comma-separated state")
+	}
+	testutil.Equal(t, len(got), 2)
+}
+
+func TestGetSprintsCacheFirst_FreshCacheMissingBoardFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("sprints", "24h", testSprints))
+
+	liveCalled := false
+	liveResult := []api.Sprint{{ID: 999, Name: "Live Sprint"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("should not hit httptest server")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	got, err := GetSprintsCacheFirst(context.Background(), client, 999, "", stubFetcher(&liveCalled, liveResult))
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live fetcher call when board ID not in cache")
+	}
+	testutil.Equal(t, got[0].Name, "Live Sprint")
+}
+
+func TestGetSprintsCacheFirst_FreshCacheEmptyBoardReturnsEmpty(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	cacheData := map[int][]api.Sprint{
+		99: {},
+	}
+	testutil.RequireNoError(t, WriteResource("sprints", "24h", cacheData))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when board exists in fresh cache (even if empty)")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	got, err := GetSprintsCacheFirst(context.Background(), client, 99, "", stubFetcher(nil, nil))
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), 0)
+}
+
+func TestGetSprintsCacheFirst_ManualRegistryTTL_SkipsLive(t *testing.T) {
+	t.Cleanup(SetEntriesForTest([]Entry{
+		{Name: "sprints", TTL: "manual"},
+	}))
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("sprints", "24h", testSprints))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when registry TTL is manual")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	got, err := GetSprintsCacheFirst(context.Background(), client, 1, "", stubFetcher(nil, nil))
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(got), 3)
+}
+
+func TestGetSprintsCacheFirst_StaleCacheFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	staleEnv := Envelope[map[int][]api.Sprint]{
+		Resource:  "sprints",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Now().Add(-48 * time.Hour),
+		TTL:       "1s",
+		Version:   Version,
+		Data:      testSprints,
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("sprints", staleEnv))
+
+	liveCalled := false
+	liveResult := []api.Sprint{{ID: 101, Name: "Live Sprint"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("should not hit httptest server")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	got, err := GetSprintsCacheFirst(context.Background(), client, 1, "", stubFetcher(&liveCalled, liveResult))
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live fetcher call for stale cache")
+	}
+	testutil.Equal(t, got[0].Name, "Live Sprint")
+}
+
+func TestGetSprintsCacheFirst_MissFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	liveCalled := false
+	liveResult := []api.Sprint{{ID: 101, Name: "Live Sprint"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("should not hit httptest server")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	got, err := GetSprintsCacheFirst(context.Background(), client, 1, "", stubFetcher(&liveCalled, liveResult))
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live fetcher call on cache miss")
+	}
+	testutil.Equal(t, got[0].Name, "Live Sprint")
+}
+
+func TestGetSprintsCacheFirst_NoInstanceFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Setenv("JIRA_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+
+	liveCalled := false
+	liveResult := []api.Sprint{{ID: 101, Name: "Live Sprint"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("should not hit httptest server")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	got, err := GetSprintsCacheFirst(context.Background(), client, 1, "", stubFetcher(&liveCalled, liveResult))
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live fetcher call when no instance is configured")
+	}
+	testutil.Equal(t, got[0].Name, "Live Sprint")
+}
+
+func TestGetSprintsCacheFirst_LiveErrorPropagated(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("should not hit httptest server")
+	}))
+	defer server.Close()
+
+	client := newSprintsTestClient(t, server.URL)
+	liveCalled := false
+	_, err := GetSprintsCacheFirst(context.Background(), client, 1, "", stubFetcherErr(&liveCalled))
+	if err == nil {
+		t.Fatal("expected error from live fetcher failure, got nil")
+	}
+	if !liveCalled {
+		t.Fatal("expected live fetcher to be called")
+	}
+}

--- a/tools/jtk/internal/cmd/boards/boards.go
+++ b/tools/jtk/internal/cmd/boards/boards.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
@@ -126,7 +127,7 @@ func runList(ctx context.Context, opts *root.Options, project string, maxResults
 		projectFilter = resolvedProject.Key
 	}
 
-	result, err := client.ListBoards(ctx, projectFilter, startAt, maxResults)
+	result, err := cache.GetBoardsCacheFirst(ctx, client, projectFilter, startAt, maxResults)
 	if err != nil {
 		return err
 	}

--- a/tools/jtk/internal/cmd/boards/boards_test.go
+++ b/tools/jtk/internal/cmd/boards/boards_test.go
@@ -709,3 +709,56 @@ func TestRunGet_Extended_FilterNameFallback(t *testing.T) {
 	output := stdout.String()
 	testutil.Contains(t, output, "Filter: id: 10026")
 }
+
+func TestRunList_FreshCacheSkipsLive(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, cache.WriteResource("boards", "24h", []api.Board{
+		{ID: 1, Name: "Board One", Type: "scrum", Location: api.BoardLocation{ProjectKey: "PROJ"}},
+		{ID: 2, Name: "Board Two", Type: "kanban", Location: api.BoardLocation{ProjectKey: "OTHER"}},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when boards cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Board One")
+	testutil.Contains(t, stdout.String(), "Board Two")
+}
+
+func TestRunList_FreshCacheSkipsLive_IDOnly(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, cache.WriteResource("boards", "24h", []api.Board{
+		{ID: 1, Name: "Board One", Type: "scrum"},
+		{ID: 2, Name: "Board Two", Type: "kanban"},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when boards cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "1\n2\n")
+}

--- a/tools/jtk/internal/cmd/sprints/sprints.go
+++ b/tools/jtk/internal/cmd/sprints/sprints.go
@@ -152,7 +152,7 @@ func runList(ctx context.Context, opts *root.Options, client *api.Client, boardI
 		}
 	}
 
-	allSprints, err := fetchAllSprints(ctx, client, boardID, state)
+	allSprints, err := cache.GetSprintsCacheFirst(ctx, client, boardID, state, fetchAllSprints)
 	if err != nil {
 		return err
 	}

--- a/tools/jtk/internal/cmd/sprints/sprints_test.go
+++ b/tools/jtk/internal/cmd/sprints/sprints_test.go
@@ -1553,3 +1553,100 @@ func TestRunAdd_AgentOutput(t *testing.T) {
 		t.Error("agent policy should not have checkmark")
 	}
 }
+
+func TestRunList_FreshCacheSkipsLive(t *testing.T) {
+	seedBoardsAndSprints(t,
+		[]api.Board{{ID: 1, Name: "Board"}},
+		map[int][]api.Sprint{
+			1: {
+				{ID: 100, Name: "Sprint 1", State: "active", OriginBoardID: 1},
+				{ID: 101, Name: "Sprint 2", State: "future", OriginBoardID: 1},
+			},
+		},
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when sprints cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 1, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Sprint 1")
+	testutil.Contains(t, stdout.String(), "Sprint 2")
+}
+
+func TestRunList_FreshCacheSkipsLive_IDOnly(t *testing.T) {
+	seedBoardsAndSprints(t,
+		[]api.Board{{ID: 1, Name: "Board"}},
+		map[int][]api.Sprint{
+			1: {
+				{ID: 100, Name: "Sprint 1", State: "active", OriginBoardID: 1},
+				{ID: 101, Name: "Sprint 2", State: "future", OriginBoardID: 1},
+			},
+		},
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when sprints cache is fresh")
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runList(context.Background(), opts, client, 1, "", 50, "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "100\n")
+	testutil.Contains(t, stdout.String(), "101\n")
+}
+
+// sprints current is deliberately live-only: the active sprint is
+// freshness-sensitive and may lag sprint transitions in cache.
+func TestRunCurrent_AlwaysCallsLive(t *testing.T) {
+	seedBoardsAndSprints(t,
+		[]api.Board{{ID: 1, Name: "Board"}},
+		map[int][]api.Sprint{
+			1: {
+				{ID: 100, Name: "Sprint 1", State: "active", OriginBoardID: 1},
+			},
+		},
+	)
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/sprint") {
+			liveCalled = true
+			_ = json.NewEncoder(w).Encode(api.SprintsResponse{
+				Values: []api.Sprint{{ID: 100, Name: "Sprint 1", State: "active"}},
+				IsLast: true,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	board := &api.Board{ID: 1, Name: "Board"}
+	err = runCurrent(context.Background(), opts, client, board, "")
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("sprints current must always call live API, not use cache")
+	}
+}


### PR DESCRIPTION
## Summary
- Route `jtk boards list` through the `boards` cache with client-side project filtering and pagination when cache is fresh
- Route `jtk sprints list` through the `sprints` cache with local state filtering; comma-separated state filters bypass cache for Jira server-side semantics
- `jtk sprints current` remains deliberately live — the active sprint is freshness-sensitive and cached data may lag sprint transitions
- Stale/missing/error cache falls back to existing live API paths; no write-through on fallback

## Test plan
- [x] Boards cache helper: fresh hit, project filter, pagination, project+pagination, manual TTL, stale/miss/uninitialized/no-instance fallback, live error propagation (10 tests)
- [x] Sprints cache helper: fresh hit, state filter, comma-state fallback, missing board fallback, empty board, manual TTL, stale/miss/no-instance fallback, live error propagation (11 tests)
- [x] Command-level: boards list and sprints list with fresh cache skip live (table + ID-only)
- [x] Command-level: sprints current always calls live API (deliberate live-only test)
- [x] Full suite: 1760 tests pass, lint clean

Closes #277