### PR TITLE
feat(jtk): use cache for users get in default mode

### DIFF
--- a/tools/jtk/internal/cache/users_lookup.go
+++ b/tools/jtk/internal/cache/users_lookup.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// GetUserCacheFirst returns a user from the users cache when fresh and
+// expand is empty (default mode), falling back to a live GetUser call
+// otherwise.
+//
+// Non-empty expand (e.g., "groups,applicationRoles" for --extended) always
+// goes live because the cache stores bulk-enumerated users without expanded
+// fields like group/applicationRole counts.
+//
+// A fresh cache where the account ID is absent falls back to live — the
+// users cache is a partial enumeration and may not contain all users.
+func GetUserCacheFirst(ctx context.Context, client *api.Client, accountID, expand string) (*api.User, error) {
+	if expand != "" {
+		return client.GetUser(ctx, accountID, expand)
+	}
+
+	entry, err := Lookup("users")
+	if err != nil {
+		return client.GetUser(ctx, accountID, "")
+	}
+
+	env, err := ReadResource[[]api.User]("users")
+	if err != nil {
+		return client.GetUser(ctx, accountID, "")
+	}
+
+	switch Classify(env.FetchedAt, entry.TTL, time.Now()) {
+	case StatusFresh, StatusManual:
+		for i := range env.Data {
+			if env.Data[i].AccountID == accountID {
+				return &env.Data[i], nil
+			}
+		}
+		return client.GetUser(ctx, accountID, "")
+	case StatusStale, StatusUninitialized:
+		return client.GetUser(ctx, accountID, "")
+	case StatusUnavailable:
+		return client.GetUser(ctx, accountID, "")
+	}
+	return client.GetUser(ctx, accountID, "")
+}

--- a/tools/jtk/internal/cache/users_lookup_test.go
+++ b/tools/jtk/internal/cache/users_lookup_test.go
@@ -1,0 +1,248 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+var testUsers = []api.User{
+	{AccountID: "abc123", DisplayName: "Alice", EmailAddress: "alice@example.com", Active: true},
+	{AccountID: "def456", DisplayName: "Bob", EmailAddress: "bob@example.com", Active: true},
+}
+
+func newUsersTestClient(t *testing.T, serverURL string) *api.Client {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: serverURL, Email: "t@x.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	return client
+}
+
+func TestGetUserCacheFirst_FreshCacheSkipsLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("users", "24h", testUsers))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when cache is fresh")
+	}))
+	defer server.Close()
+
+	client := newUsersTestClient(t, server.URL)
+	got, err := GetUserCacheFirst(context.Background(), client, "abc123", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, got.AccountID, "abc123")
+	testutil.Equal(t, got.DisplayName, "Alice")
+}
+
+func TestGetUserCacheFirst_ExpandAlwaysGoesLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("users", "24h", testUsers))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/user" {
+			liveCalled = true
+			testutil.Equal(t, r.URL.Query().Get("expand"), "groups,applicationRoles")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.User{
+				AccountID:   "abc123",
+				DisplayName: "Alice",
+				Groups:      &api.UserCountBlock{Size: 3},
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := newUsersTestClient(t, server.URL)
+	got, err := GetUserCacheFirst(context.Background(), client, "abc123", "groups,applicationRoles")
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call when expand is non-empty")
+	}
+	testutil.Equal(t, got.Groups.Size, 3)
+}
+
+func TestGetUserCacheFirst_FreshCacheMissingUserFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("users", "24h", testUsers))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/user" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.User{AccountID: "unknown999", DisplayName: "Unknown"})
+		}
+	}))
+	defer server.Close()
+
+	client := newUsersTestClient(t, server.URL)
+	got, err := GetUserCacheFirst(context.Background(), client, "unknown999", "")
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call when user not in cache")
+	}
+	testutil.Equal(t, got.DisplayName, "Unknown")
+}
+
+func TestGetUserCacheFirst_ManualRegistryTTL_SkipsLive(t *testing.T) {
+	t.Cleanup(SetEntriesForTest([]Entry{
+		{Name: "users", TTL: "manual"},
+	}))
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, WriteResource("users", "24h", testUsers))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when registry TTL is manual")
+	}))
+	defer server.Close()
+
+	client := newUsersTestClient(t, server.URL)
+	got, err := GetUserCacheFirst(context.Background(), client, "abc123", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, got.AccountID, "abc123")
+}
+
+func TestGetUserCacheFirst_StaleCacheFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	staleEnv := Envelope[[]api.User]{
+		Resource:  "users",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Now().Add(-48 * time.Hour),
+		TTL:       "1s",
+		Version:   Version,
+		Data:      testUsers,
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("users", staleEnv))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/user" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.User{AccountID: "abc123", DisplayName: "Alice"})
+		}
+	}))
+	defer server.Close()
+
+	client := newUsersTestClient(t, server.URL)
+	_, err := GetUserCacheFirst(context.Background(), client, "abc123", "")
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call for stale cache")
+	}
+}
+
+func TestGetUserCacheFirst_UninitializedEnvelopeFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	uninitEnv := Envelope[[]api.User]{
+		Resource:  "users",
+		Instance:  "test.atlassian.net",
+		FetchedAt: time.Time{},
+		TTL:       "24h",
+		Version:   Version,
+		Data:      testUsers,
+	}
+	testutil.RequireNoError(t, atomicWriteEnvelope("users", uninitEnv))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/user" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.User{AccountID: "abc123", DisplayName: "Alice"})
+		}
+	}))
+	defer server.Close()
+
+	client := newUsersTestClient(t, server.URL)
+	_, err := GetUserCacheFirst(context.Background(), client, "abc123", "")
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call for uninitialized envelope")
+	}
+}
+
+func TestGetUserCacheFirst_MissFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/user" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.User{AccountID: "abc123", DisplayName: "Alice"})
+		}
+	}))
+	defer server.Close()
+
+	client := newUsersTestClient(t, server.URL)
+	_, err := GetUserCacheFirst(context.Background(), client, "abc123", "")
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call on cache miss")
+	}
+}
+
+func TestGetUserCacheFirst_NoInstanceFallsBackToLive(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Setenv("JIRA_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("JIRA_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/user" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.User{AccountID: "abc123", DisplayName: "Alice"})
+		}
+	}))
+	defer server.Close()
+
+	client := newUsersTestClient(t, server.URL)
+	_, err := GetUserCacheFirst(context.Background(), client, "abc123", "")
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("expected live API call when no instance is configured")
+	}
+}
+
+func TestGetUserCacheFirst_LiveErrorPropagated(t *testing.T) {
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest("test.atlassian.net"))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = fmt.Fprint(w, `{"errorMessages":["server error"]}`)
+	}))
+	defer server.Close()
+
+	client := newUsersTestClient(t, server.URL)
+	_, err := GetUserCacheFirst(context.Background(), client, "abc123", "")
+	if err == nil {
+		t.Fatal("expected error from live API failure, got nil")
+	}
+}

--- a/tools/jtk/internal/cmd/users/users.go
+++ b/tools/jtk/internal/cmd/users/users.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	jtkartifact "github.com/open-cli-collective/jira-ticket-cli/internal/artifact"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
@@ -106,7 +107,7 @@ func runGet(ctx context.Context, opts *root.Options, accountID, fieldsFlag strin
 	if opts.IsExtended() {
 		expand = api.UserExtendedExpand
 	}
-	user, err := client.GetUser(ctx, accountID, expand)
+	user, err := cache.GetUserCacheFirst(ctx, client, accountID, expand)
 	if err != nil {
 		return err
 	}

--- a/tools/jtk/internal/cmd/users/users_test.go
+++ b/tools/jtk/internal/cmd/users/users_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -490,4 +491,87 @@ func TestRunSearch_ExpandParamNotSentOnSearchEndpoint(t *testing.T) {
 	if captured != "" {
 		t.Errorf("expand param should not be sent to /user/search, got %q", captured)
 	}
+}
+
+// ----- cache-backed users get -----
+
+func TestRunGet_FreshCacheSkipsLive(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, cache.WriteResource("users", "24h", []api.User{
+		{AccountID: "abc123", DisplayName: "Alice", EmailAddress: "alice@example.com", Active: true},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when users cache is fresh")
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	err := runGet(context.Background(), opts, "abc123", "")
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Alice")
+}
+
+func TestRunGet_FreshCacheSkipsLive_JSON(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, cache.WriteResource("users", "24h", []api.User{
+		{AccountID: "abc123", DisplayName: "Alice", EmailAddress: "alice@example.com", Active: true},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("live API must not be called when users cache is fresh")
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "json", Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	err := runGet(context.Background(), opts, "abc123", "")
+	testutil.RequireNoError(t, err)
+
+	var user api.User
+	testutil.RequireNoError(t, json.Unmarshal(stdout.Bytes(), &user))
+	testutil.Equal(t, user.AccountID, "abc123")
+}
+
+func TestRunGet_ExtendedAlwaysCallsLive(t *testing.T) {
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
+
+	testutil.RequireNoError(t, cache.WriteResource("users", "24h", []api.User{
+		{AccountID: "abc123", DisplayName: "Cached Alice"},
+	}))
+
+	liveCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/user" {
+			liveCalled = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.User{
+				AccountID:   "abc123",
+				DisplayName: "Live Alice",
+				Groups:      &api.UserCountBlock{Size: 2},
+			})
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Output: "table", Stdout: &stdout, Stderr: &bytes.Buffer{}, Extended: true}
+	opts.SetAPIClient(newClient(t, server.URL))
+
+	err := runGet(context.Background(), opts, "abc123", "")
+	testutil.RequireNoError(t, err)
+	if !liveCalled {
+		t.Fatal("users get --extended must always call live API, not use cache")
+	}
+	testutil.Contains(t, stdout.String(), "Live Alice")
 }


### PR DESCRIPTION
## Summary
- Route `jtk users get <account-id>` through the `users` cache in default (non-extended) mode when cache is fresh
- `--extended` stays live because it needs expanded groups/applicationRoles counts not present in cached bulk-enumerated data
- `users search` remains live — server search semantics and pagination are not safely reproducible from cached data
- Missing cache entries fall back to live since the users cache is a partial enumeration

## Test plan
- [x] Cache helper: fresh hit, expand-always-live, missing user fallback, manual TTL, stale/miss/uninitialized/no-instance fallback, live error propagation (10 tests)
- [x] Command-level: `users get` with fresh cache skips live (table + JSON), `users get --extended` always calls live
- [x] Full suite: 1776 tests pass, lint clean

Closes #278