### PR TITLE
fix(jtk): replace string-based 404 detection in move/type-change

### DIFF
--- a/tools/jtk/internal/cmd/issues/move.go
+++ b/tools/jtk/internal/cmd/issues/move.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
+	sharederrors "github.com/open-cli-collective/atlassian-go/errors"
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -149,8 +149,7 @@ func runMove(ctx context.Context, opts *root.Options, issueKeys []string, target
 
 	resp, err := client.MoveIssues(ctx, req)
 	if err != nil {
-		// Check if this is a Server/DC instance
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+		if sharederrors.IsNotFound(err) {
 			return fmt.Errorf("move operation failed - this feature is only available on Jira Cloud")
 		}
 		return fmt.Errorf("initiating move: %w", err)
@@ -164,44 +163,44 @@ func runMove(ctx context.Context, opts *root.Options, issueKeys []string, target
 		return nil
 	}
 
-	// Wait for completion - progress to stderr
 	waitModel := ip.PresentMoveWaiting()
 	waitOut := present.Render(waitModel, opts.RenderStyle())
 	_, _ = fmt.Fprint(opts.Stderr, waitOut.Stderr)
 
-	for {
-		status, err := client.GetMoveTaskStatus(ctx, resp.TaskID)
-		if err != nil {
-			return fmt.Errorf("getting task status: %w", err)
-		}
+	status, err := pollMoveTask(ctx, client, resp.TaskID)
+	if errors.Is(err, errStatusUnavailable) {
+		model := ip.PresentMoveInitiated(resp.TaskID)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		_, _ = fmt.Fprintf(opts.Stderr, "Task status unavailable — verify with `jtk issues get`\n")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("getting task status: %w", err)
+	}
 
-		switch status.Status {
-		case "COMPLETE":
-			if status.Result != nil && len(status.Result.Failed) > 0 {
-				model := ip.PresentMovePartialFailure(status.Result.Successful, status.Result.Failed)
-				out := present.Render(model, opts.RenderStyle())
-				_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-				_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
-				return fmt.Errorf("some issues failed to move")
-			}
-			model := ip.PresentMoved(len(issueKeys), projectKey)
+	switch status.Status {
+	case "COMPLETE":
+		if status.Result != nil && len(status.Result.Failed) > 0 {
+			model := ip.PresentMovePartialFailure(status.Result.Successful, status.Result.Failed)
 			out := present.Render(model, opts.RenderStyle())
 			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-			return nil
-
-		case "FAILED":
-			return fmt.Errorf("move failed")
-
-		case "CANCELLED":
-			return fmt.Errorf("move was cancelled")
-
-		case "ENQUEUED", "RUNNING":
-			// Still in progress
-			time.Sleep(1 * time.Second)
-
-		default:
-			return fmt.Errorf("unknown task status: %s", status.Status)
+			_, _ = fmt.Fprint(opts.Stderr, out.Stderr)
+			return fmt.Errorf("some issues failed to move")
 		}
+		model := ip.PresentMoved(len(issueKeys), projectKey)
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		return nil
+
+	case "FAILED":
+		return fmt.Errorf("move failed")
+
+	case "CANCELLED":
+		return fmt.Errorf("move was cancelled")
+
+	default:
+		return fmt.Errorf("unknown task status: %s", status.Status)
 	}
 }
 

--- a/tools/jtk/internal/cmd/issues/move_test.go
+++ b/tools/jtk/internal/cmd/issues/move_test.go
@@ -329,6 +329,91 @@ func TestRunMove_ColdCacheErrorsInsteadOfEmptyID(t *testing.T) {
 	}
 }
 
+func TestRunMove_PollNotFound_GracefulDegradation(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("issuetypes", "24h", map[string][]api.IssueType{
+		"TARGET": {{ID: "10050", Name: "Task"}},
+	}))
+	testutil.RequireNoError(t, cache.WriteResource("projects", "24h", []api.Project{
+		{Key: "TARGET", Name: "Target"}, {Key: "PROJ", Name: "Source"},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/rest/api/3/issue/PROJ-1") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(api.Issue{
+				Key: "PROJ-1",
+				Fields: api.IssueFields{
+					Project:   &api.Project{Key: "PROJ"},
+					IssueType: &api.IssueType{ID: "10000", Name: "Task"},
+				},
+			})
+		case r.URL.Path == "/rest/api/3/bulk/issues/move" && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(api.MoveIssuesResponse{TaskID: "task-1"})
+		case strings.HasPrefix(r.URL.Path, "/rest/api/3/bulk/queue/"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errorMessages":["not found"]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runMove(context.Background(), opts, []string{"PROJ-1"}, "TARGET", "Task", false, true)
+	testutil.RequireNoError(t, err)
+
+	testutil.Contains(t, stdout.String(), "task-1")
+	testutil.Contains(t, stderr.String(), "status unavailable")
+}
+
+func TestRunMove_MoveIssuesNotFound_ServerDCError(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("issuetypes", "24h", map[string][]api.IssueType{
+		"TARGET": {{ID: "10050", Name: "Task"}},
+	}))
+	testutil.RequireNoError(t, cache.WriteResource("projects", "24h", []api.Project{
+		{Key: "TARGET", Name: "Target"}, {Key: "PROJ", Name: "Source"},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/rest/api/3/issue/PROJ-1") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(api.Issue{
+				Key: "PROJ-1",
+				Fields: api.IssueFields{
+					Project:   &api.Project{Key: "PROJ"},
+					IssueType: &api.IssueType{ID: "10000", Name: "Task"},
+				},
+			})
+		case r.URL.Path == "/rest/api/3/bulk/issues/move" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errorMessages":["not found"]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runMove(context.Background(), opts, []string{"PROJ-1"}, "TARGET", "Task", false, true)
+	if err == nil {
+		t.Fatal("expected error for Server/DC detection")
+	}
+	testutil.Contains(t, err.Error(), "only available on Jira Cloud")
+}
+
 func TestRunMove_NoCachedIssueTypesPromptsToSpecifyType(t *testing.T) {
 	// --to-type omitted. Source is Epic, target project has NO cached
 	// issuetypes at all. Resolver should surface an actionable error

--- a/tools/jtk/internal/cmd/issues/poll.go
+++ b/tools/jtk/internal/cmd/issues/poll.go
@@ -1,0 +1,59 @@
+package issues
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	sharederrors "github.com/open-cli-collective/atlassian-go/errors"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+var errStatusUnavailable = errors.New("task status unavailable after retries")
+
+var errTypeChangeUnverified = errors.New("type change accepted but status could not be verified")
+
+var pollRetryDelay = 2 * time.Second
+
+const maxPollNotFoundRetries = 3
+
+// pollMoveTask polls GetMoveTaskStatus until a terminal state is reached.
+// Transient 404s are retried up to maxPollNotFoundRetries times.
+// Persistent 404s return errStatusUnavailable.
+func pollMoveTask(ctx context.Context, client *api.Client, taskID string) (*api.MoveTaskStatus, error) {
+	notFoundRetries := 0
+
+	for {
+		status, err := client.GetMoveTaskStatus(ctx, taskID)
+		if err != nil {
+			if sharederrors.IsNotFound(err) && notFoundRetries < maxPollNotFoundRetries {
+				notFoundRetries++
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(pollRetryDelay):
+				}
+				continue
+			}
+			if sharederrors.IsNotFound(err) {
+				return nil, errStatusUnavailable
+			}
+			return nil, err
+		}
+		notFoundRetries = 0
+
+		switch status.Status {
+		case "COMPLETE", "FAILED", "CANCELLED":
+			return status, nil
+		case "ENQUEUED", "RUNNING":
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(1 * time.Second):
+			}
+		default:
+			return status, nil
+		}
+	}
+}

--- a/tools/jtk/internal/cmd/issues/poll_test.go
+++ b/tools/jtk/internal/cmd/issues/poll_test.go
@@ -1,0 +1,115 @@
+package issues
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func init() {
+	pollRetryDelay = 0
+}
+
+func TestPollMoveTask_TerminalComplete(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.MoveTaskStatus{Status: "COMPLETE"})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	status, err := pollMoveTask(context.Background(), client, "task-1")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "COMPLETE", status.Status)
+}
+
+func TestPollMoveTask_TerminalFailed(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(api.MoveTaskStatus{Status: "FAILED"})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	status, err := pollMoveTask(context.Background(), client, "task-1")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "FAILED", status.Status)
+}
+
+func TestPollMoveTask_TransientNotFound_ThenComplete(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := calls.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errorMessages":["not found"]}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(api.MoveTaskStatus{Status: "COMPLETE"})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	status, err := pollMoveTask(context.Background(), client, "task-1")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "COMPLETE", status.Status)
+	testutil.Equal(t, int32(3), calls.Load())
+}
+
+func TestPollMoveTask_PersistentNotFound_ReturnsStatusUnavailable(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errorMessages":["not found"]}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	_, err := pollMoveTask(context.Background(), client, "task-1")
+	testutil.True(t, errors.Is(err, errStatusUnavailable))
+	testutil.Equal(t, int32(maxPollNotFoundRetries+1), calls.Load())
+}
+
+func TestPollMoveTask_ContextCancellation(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errorMessages":["not found"]}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// Use a real delay so context cancellation can kick in
+	origDelay := pollRetryDelay
+	pollRetryDelay = 5 * time.Second
+	defer func() { pollRetryDelay = origDelay }()
+
+	client := newTestClient(t, server.URL)
+	_, err := pollMoveTask(ctx, client, "task-1")
+	testutil.True(t, errors.Is(err, context.DeadlineExceeded))
+}
+
+func newTestClient(t *testing.T, url string) *api.Client {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{
+		URL:      url,
+		Email:    "test@example.com",
+		APIToken: "token",
+	})
+	testutil.RequireNoError(t, err)
+	return client
+}

--- a/tools/jtk/internal/cmd/issues/poll_test.go
+++ b/tools/jtk/internal/cmd/issues/poll_test.go
@@ -83,7 +83,7 @@ func TestPollMoveTask_PersistentNotFound_ReturnsStatusUnavailable(t *testing.T) 
 }
 
 func TestPollMoveTask_ContextCancellation(t *testing.T) {
-	t.Parallel()
+	// Not parallel: mutates package-level pollRetryDelay.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(`{"errorMessages":["not found"]}`))
@@ -93,7 +93,6 @@ func TestPollMoveTask_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	// Use a real delay so context cancellation can kick in
 	origDelay := pollRetryDelay
 	pollRetryDelay = 5 * time.Second
 	defer func() { pollRetryDelay = origDelay }()

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -2,12 +2,13 @@ package issues
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
+	sharederrors "github.com/open-cli-collective/atlassian-go/errors"
 	"github.com/open-cli-collective/atlassian-go/present"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -83,7 +84,11 @@ func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, descr
 	// Handle type change via the move API
 	if issueType != "" {
 		if err := changeIssueType(ctx, client, opts, issueKey, issueType); err != nil {
-			return err
+			if errors.Is(err, errTypeChangeUnverified) {
+				_, _ = fmt.Fprintf(opts.Stderr, "Type change accepted but status could not be verified\n")
+			} else {
+				return err
+			}
 		}
 	}
 
@@ -209,38 +214,36 @@ func changeIssueType(ctx context.Context, client *api.Client, opts *root.Options
 
 	resp, err := client.MoveIssues(ctx, req)
 	if err != nil {
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+		if sharederrors.IsNotFound(err) {
 			return fmt.Errorf("type change failed - this feature requires Jira Cloud")
 		}
 		return fmt.Errorf("failed to change issue type: %w", err)
 	}
 
-	for {
-		status, err := client.GetMoveTaskStatus(ctx, resp.TaskID)
-		if err != nil {
-			return fmt.Errorf("failed to get task status: %w", err)
-		}
+	status, err := pollMoveTask(ctx, client, resp.TaskID)
+	if errors.Is(err, errStatusUnavailable) {
+		return errTypeChangeUnverified
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get task status: %w", err)
+	}
 
-		switch status.Status {
-		case "COMPLETE":
-			if status.Result != nil && len(status.Result.Failed) > 0 {
-				for _, failed := range status.Result.Failed {
-					return fmt.Errorf("type change failed for %s: %s", failed.IssueKey, strings.Join(failed.Errors, ", "))
-				}
+	switch status.Status {
+	case "COMPLETE":
+		if status.Result != nil && len(status.Result.Failed) > 0 {
+			for _, failed := range status.Result.Failed {
+				return fmt.Errorf("type change failed for %s: %s", failed.IssueKey, strings.Join(failed.Errors, ", "))
 			}
-			return nil
-
-		case "FAILED":
-			return fmt.Errorf("type change failed")
-
-		case "CANCELLED":
-			return fmt.Errorf("type change was cancelled")
-
-		case "ENQUEUED", "RUNNING":
-			time.Sleep(1 * time.Second)
-
-		default:
-			return fmt.Errorf("unknown task status: %s", status.Status)
 		}
+		return nil
+
+	case "FAILED":
+		return fmt.Errorf("type change failed")
+
+	case "CANCELLED":
+		return fmt.Errorf("type change was cancelled")
+
+	default:
+		return fmt.Errorf("unknown task status: %s", status.Status)
 	}
 }

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -564,4 +565,55 @@ func TestUpdateCmd_CobraExecution_WithAssignee(t *testing.T) {
 	fields := reqBody["fields"].(map[string]any)
 	assigneeField := fields["assignee"].(map[string]any)
 	testutil.Equal(t, assigneeField["accountId"], "61292e4c4f29230069621c5f")
+}
+
+func TestRunUpdate_TypeChange_PollNotFound_ContinuesFieldUpdates(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("issuetypes", "24h", map[string][]api.IssueType{
+		"PROJ": {
+			{ID: "10000", Name: "Epic"},
+			{ID: "10001", Name: "Task"},
+		},
+	}))
+
+	var putCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(api.Issue{
+				Key: "PROJ-123",
+				ID:  "10001",
+				Fields: api.IssueFields{
+					Summary:   "Original",
+					Project:   &api.Project{Key: "PROJ"},
+					IssueType: &api.IssueType{ID: "10000", Name: "Epic"},
+					Status:    &api.Status{Name: "Open"},
+				},
+			})
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "PUT":
+			putCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		case r.URL.Path == "/rest/api/3/bulk/issues/move" && r.Method == "POST":
+			_ = json.NewEncoder(w).Encode(api.MoveIssuesResponse{TaskID: "task-1"})
+		case strings.HasPrefix(r.URL.Path, "/rest/api/3/bulk/queue/"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errorMessages":["not found"]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	err = runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "Task", nil)
+	testutil.RequireNoError(t, err)
+
+	testutil.Contains(t, stderr.String(), "could not be verified")
+	testutil.True(t, putCalled, "field update PUT should still have been called")
 }

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -567,6 +567,48 @@ func TestUpdateCmd_CobraExecution_WithAssignee(t *testing.T) {
 	testutil.Equal(t, assigneeField["accountId"], "61292e4c4f29230069621c5f")
 }
 
+func TestRunUpdate_TypeChange_MoveNotFound_ServerDCError(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("issuetypes", "24h", map[string][]api.IssueType{
+		"PROJ": {
+			{ID: "10000", Name: "Epic"},
+			{ID: "10001", Name: "Task"},
+		},
+	}))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(api.Issue{
+				Key: "PROJ-123",
+				ID:  "10001",
+				Fields: api.IssueFields{
+					Project:   &api.Project{Key: "PROJ"},
+					IssueType: &api.IssueType{ID: "10000", Name: "Epic"},
+				},
+			})
+		case r.URL.Path == "/rest/api/3/bulk/issues/move" && r.Method == "POST":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errorMessages":["not found"]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "Task", nil)
+	if err == nil {
+		t.Fatal("expected error for Server/DC detection")
+	}
+	testutil.Contains(t, err.Error(), "requires Jira Cloud")
+}
+
 func TestRunUpdate_TypeChange_PollNotFound_ContinuesFieldUpdates(t *testing.T) {
 	seedCacheForIssues(t)
 	testutil.RequireNoError(t, cache.WriteResource("issuetypes", "24h", map[string][]api.IssueType{


### PR DESCRIPTION
## Summary

- Replace `strings.Contains(err.Error(), "404")` with `sharederrors.IsNotFound(err)` in `issues move` and `issues update --type`
- Extract shared `pollMoveTask` helper with retry logic for transient 404s during task status polling
- Degrade gracefully on persistent poll 404s (exit 0 with advisory instead of false failure)
- `update --type` returns `errTypeChangeUnverified` so remaining field updates proceed normally

## Test plan

- [x] `make build` — compiles
- [x] `make test` — all tests pass (1729 jtk + 948 cfl)
- [x] `make lint` — 0 issues
- [x] New `poll_test.go` covers: terminal states, transient 404 retry, persistent 404 sentinel, context cancellation
- [ ] Integration: `jtk issues move MON-XXXX --to-project INT` exits 0 on success

Closes #280