### PR TITLE
fix(jtk): swap -f to -F on --file, keep -f for --field

### DIFF
--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** Short alias for `--file` renamed from `-f` to `-F` on `attachments add`, `automation create`, and `automation update`. `-f` continues to mean `--field` on field-setting commands (`issues create`/`update`, `transitions do`). No back-compat alias. ([#339](https://github.com/open-cli-collective/atlassian-cli/issues/339))
 - Global output flags replaced with `--extended`, `--fulltext`, `--id` per the new output model. The `--full` flag is removed; use `--extended` for admin/schema/audit detail. `--id` takes precedence over `--extended` and `--fulltext`. `--output` / `-o` is hidden but still functional during migration. Per-command `--no-truncate` flags remain as deprecated aliases for `--fulltext`. Initial `--id` support is wired for `me`, `users get`, and `issues get` — remaining commands parse the flag but do not yet collapse output; broader per-command migration continues under #230 follow-ups. ([#231](https://github.com/open-cli-collective/atlassian-cli/issues/231))
 
 ### Added

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -798,7 +798,7 @@ jtk attachments add PROJ-123 --file doc.pdf --file image.png
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--file` | `-f` | | File to attach (**required**, can be repeated) |
+| `--file` | `-F` | | File to attach (**required**, can be repeated) |
 
 **Arguments:**
 - `<issue-key>` - The issue key (**required**)
@@ -1203,7 +1203,7 @@ jtk automation create --file rule-definition.json
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--file` | `-f` | | Path to JSON file containing the rule definition (**required**) |
+| `--file` | `-F` | | Path to JSON file containing the rule definition (**required**) |
 
 > Note: New rules are created in DISABLED state by default.
 
@@ -1221,7 +1221,7 @@ jtk automation update 123 --file updated-rule.json
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--file` | `-f` | | Path to JSON file containing the rule definition (**required**) |
+| `--file` | `-F` | | Path to JSON file containing the rule definition (**required**) |
 
 **Arguments:**
 - `<rule-id>` - The rule ID (**required**)

--- a/tools/jtk/internal/cmd/attachments/attachments.go
+++ b/tools/jtk/internal/cmd/attachments/attachments.go
@@ -124,7 +124,7 @@ func newAddCmd(opts *root.Options) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringArrayVarP(&files, "file", "f", nil, "File(s) to attach (can be specified multiple times)")
+	cmd.Flags().StringArrayVarP(&files, "file", "F", nil, "File(s) to attach (can be specified multiple times)")
 	_ = cmd.MarkFlagRequired("file")
 
 	return cmd

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -208,7 +208,13 @@ func TestNewAddCmd(t *testing.T) {
 
 	fileFlag := cmd.Flags().Lookup("file")
 	testutil.NotNil(t, fileFlag)
-	testutil.Equal(t, fileFlag.Shorthand, "f")
+	testutil.Equal(t, fileFlag.Shorthand, "F")
+
+	// -f must not resolve to a registered shorthand on this command.
+	testutil.Nil(t, cmd.Flags().ShorthandLookup("f"))
+	if err := cmd.ParseFlags([]string{"-f", "x.txt"}); err == nil {
+		t.Fatalf("expected error parsing legacy -f shorthand, got nil")
+	}
 }
 
 func TestRunAdd_Success(t *testing.T) {

--- a/tools/jtk/internal/cmd/automation/create.go
+++ b/tools/jtk/internal/cmd/automation/create.go
@@ -35,13 +35,13 @@ the exported JSON are ignored — the new rule gets its own identifiers.
 
 New rules are created in DISABLED state by default.`,
 		Example: `  jtk automation create --file rule.json
-  jtk auto create -f new-rule.json`,
+  jtk auto create -F new-rule.json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runCreate(cmd.Context(), opts, filePath)
 		},
 	}
 
-	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to JSON file containing the rule definition (required)")
+	cmd.Flags().StringVarP(&filePath, "file", "F", "", "Path to JSON file containing the rule definition (required)")
 	_ = cmd.MarkFlagRequired("file")
 
 	return cmd

--- a/tools/jtk/internal/cmd/automation/create_test.go
+++ b/tools/jtk/internal/cmd/automation/create_test.go
@@ -16,6 +16,20 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
+func TestNewCreateCmd_FileFlagShorthand(t *testing.T) {
+	t.Parallel()
+	cmd := newCreateCmd(&root.Options{})
+
+	fileFlag := cmd.Flags().Lookup("file")
+	testutil.NotNil(t, fileFlag)
+	testutil.Equal(t, fileFlag.Shorthand, "F")
+
+	testutil.Nil(t, cmd.Flags().ShorthandLookup("f"))
+	if err := cmd.ParseFlags([]string{"-f", "rule.json"}); err == nil {
+		t.Fatalf("expected error parsing legacy -f shorthand, got nil")
+	}
+}
+
 func TestRunCreate(t *testing.T) {
 	t.Parallel()
 	t.Run("strips server-assigned fields", func(t *testing.T) {

--- a/tools/jtk/internal/cmd/automation/update.go
+++ b/tools/jtk/internal/cmd/automation/update.go
@@ -45,7 +45,7 @@ field mappings and workflow configuration.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to JSON file containing the rule definition (required)")
+	cmd.Flags().StringVarP(&filePath, "file", "F", "", "Path to JSON file containing the rule definition (required)")
 	_ = cmd.MarkFlagRequired("file")
 
 	return cmd

--- a/tools/jtk/internal/cmd/automation/update_test.go
+++ b/tools/jtk/internal/cmd/automation/update_test.go
@@ -12,6 +12,20 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
+func TestNewUpdateCmd_FileFlagShorthand(t *testing.T) {
+	t.Parallel()
+	cmd := newUpdateCmd(&root.Options{})
+
+	fileFlag := cmd.Flags().Lookup("file")
+	testutil.NotNil(t, fileFlag)
+	testutil.Equal(t, fileFlag.Shorthand, "F")
+
+	testutil.Nil(t, cmd.Flags().ShorthandLookup("f"))
+	if err := cmd.ParseFlags([]string{"-f", "rule.json"}); err == nil {
+		t.Fatalf("expected error parsing legacy -f shorthand, got nil")
+	}
+}
+
 func TestRunUpdate(t *testing.T) {
 	t.Parallel()
 	t.Run("invalid JSON file", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Renames the short alias for `--file` from `-f` to `-F` on `attachments add`, `automation create`, and `automation update`.
- Frees `-f` to mean `--field` consistently on field-setting commands (`issues create`/`update`, `transitions do`).
- Clean break — no back-compat alias, per the design guardrails.

Closes #339. Refs #338.

## Test plan

- [x] `cd tools/jtk && go test ./...` — 1736 tests pass
- [x] `make lint` — 0 issues
- [x] Three commands cover both positive and negative shorthand assertions (`Shorthand=="F"`, `ShorthandLookup("f")==nil`, `ParseFlags(["-f", ...])` errors)
- [ ] Manual: `jtk attachments add PROJ-1 -f x.txt` returns `unknown shorthand` error
- [ ] Manual: `jtk attachments add PROJ-1 -F x.txt` works