### PR TITLE
fix(jtk): converge --max default to 50 across paginated commands

### DIFF
--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking:** Short alias for `--file` renamed from `-f` to `-F` on `attachments add`, `automation create`, and `automation update`. `-f` continues to mean `--field` on field-setting commands (`issues create`/`update`, `transitions do`). No back-compat alias. ([#339](https://github.com/open-cli-collective/atlassian-cli/issues/339))
+- Default page size for paginated commands converged to 50: `issues list` and `issues search` were 25, `users search` was 10. `users search` and `dashboards list` also gain the `-m` short alias for `--max`. ([#340](https://github.com/open-cli-collective/atlassian-cli/issues/340))
 - Global output flags replaced with `--extended`, `--fulltext`, `--id` per the new output model. The `--full` flag is removed; use `--extended` for admin/schema/audit detail. `--id` takes precedence over `--extended` and `--fulltext`. `--output` / `-o` is hidden but still functional during migration. Per-command `--no-truncate` flags remain as deprecated aliases for `--fulltext`. Initial `--id` support is wired for `me`, `users get`, and `issues get` — remaining commands parse the flag but do not yet collapse output; broader per-command migration continues under #230 follow-ups. ([#231](https://github.com/open-cli-collective/atlassian-cli/issues/231))
 
 ### Added

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -291,7 +291,7 @@ jtk issues list --project MYPROJECT --fields summary,status,customfield_10005
 |------|-------|---------|-------------|
 | `--project` | `-p` | | Project key or name |
 | `--sprint` | `-s` | | Filter by sprint: sprint name, numeric ID, or `current` |
-| `--max` | `-m` | `25` | Maximum number of results to return |
+| `--max` | `-m` | `50` | Maximum number of results to return |
 | `--fields` | | | Comma-separated display columns (headers, Jira field IDs, or human names) |
 | `--next-page-token` | | | Token for next page of results |
 
@@ -397,7 +397,7 @@ jtk issues search --jql "project = MYPROJECT" --fields summary,status
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--jql` | | | JQL query string (**required**) |
-| `--max` | `-m` | `25` | Maximum number of results to return |
+| `--max` | `-m` | `50` | Maximum number of results to return |
 | `--fields` | | | Comma-separated display columns (headers, Jira field IDs, or human names) |
 | `--next-page-token` | | | Token for next page of results |
 
@@ -1098,11 +1098,11 @@ jtk users search "john"
 jtk users search "john" --max 20
 ```
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--max` | `10` | Maximum number of results |
-| `--fields` | | Comma-separated display columns |
-| `--next-page-token` | | Token for next page of results |
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--max` | `-m` | `50` | Maximum number of results |
+| `--fields` | | | Comma-separated display columns |
+| `--next-page-token` | | | Token for next page of results |
 
 **Arguments:**
 - `<query>` - Search query (matches display name, email, etc.) (**required**)
@@ -1292,10 +1292,10 @@ jtk dashboards list --search "Sprint"
 jtk dashboards list --max 10
 ```
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--search` | | Search dashboards by name |
-| `--max` | `50` | Maximum number of results |
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--search` | | | Search dashboards by name |
+| `--max` | `-m` | `50` | Maximum number of results |
 
 > Note: Dashboard commands are not available with bearer auth (scoped tokens lack the Dashboard scope).
 

--- a/tools/jtk/internal/cmd/dashboards/dashboards.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards.go
@@ -63,7 +63,7 @@ Use --extended for additional fields (rank, permissions).`,
 	}
 
 	cmd.Flags().StringVar(&search, "search", "", "Search dashboards by name")
-	cmd.Flags().IntVar(&maxResults, "max", 50, "Maximum number of results")
+	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of results")
 
 	return cmd
 }

--- a/tools/jtk/internal/cmd/dashboards/dashboards_test.go
+++ b/tools/jtk/internal/cmd/dashboards/dashboards_test.go
@@ -710,3 +710,12 @@ func TestRunGadgetsAdd_ZeroPosition(t *testing.T) {
 	testutil.Equal(t, req.Position.Row, 0)
 	testutil.Equal(t, req.Position.Column, 0)
 }
+
+func TestNewListCmd_MaxFlagShape(t *testing.T) {
+	t.Parallel()
+	cmd := newListCmd(&root.Options{})
+	maxFlag := cmd.Flags().Lookup("max")
+	testutil.NotNil(t, maxFlag)
+	testutil.Equal(t, maxFlag.Shorthand, "m")
+	testutil.Equal(t, maxFlag.DefValue, "50")
+}

--- a/tools/jtk/internal/cmd/issues/list.go
+++ b/tools/jtk/internal/cmd/issues/list.go
@@ -54,7 +54,7 @@ func newListCmd(opts *root.Options) *cobra.Command {
 
 	cmd.Flags().StringVarP(&project, "project", "p", "", "Filter by project key or name")
 	cmd.Flags().StringVarP(&sprint, "sprint", "s", "", "Filter by sprint name, numeric ID, or 'current'")
-	cmd.Flags().IntVarP(&maxResults, "max", "m", 25, "Maximum number of results to return")
+	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of results to return")
 	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Token for next page of results")
 	cmd.Flags().BoolVar(&allFields, "all-fields", false, "Include all fields (e.g. description)")
 	_ = cmd.Flags().MarkDeprecated("all-fields", "use --fields description instead")

--- a/tools/jtk/internal/cmd/issues/list_test.go
+++ b/tools/jtk/internal/cmd/issues/list_test.go
@@ -666,3 +666,12 @@ func TestRunList_Fields_HumanName_CacheHit_SkipsFieldsFetch(t *testing.T) {
 		t.Errorf("fresh cache must suppress live GetFields; got %d call(s)", cs.fieldsCalls)
 	}
 }
+
+func TestNewListCmd_MaxFlagShape(t *testing.T) {
+	t.Parallel()
+	cmd := newListCmd(&root.Options{})
+	maxFlag := cmd.Flags().Lookup("max")
+	testutil.NotNil(t, maxFlag)
+	testutil.Equal(t, maxFlag.Shorthand, "m")
+	testutil.Equal(t, maxFlag.DefValue, "50")
+}

--- a/tools/jtk/internal/cmd/issues/search.go
+++ b/tools/jtk/internal/cmd/issues/search.go
@@ -46,7 +46,7 @@ func newSearchCmd(opts *root.Options) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&jql, "jql", "", "JQL query string (required)")
-	cmd.Flags().IntVarP(&maxResults, "max", "m", 25, "Maximum number of results to return")
+	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of results to return")
 	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Token for next page of results")
 	cmd.Flags().BoolVar(&allFields, "all-fields", false, "Include all fields (e.g. description)")
 	_ = cmd.Flags().MarkDeprecated("all-fields", "use --fields description instead")

--- a/tools/jtk/internal/cmd/issues/search_test.go
+++ b/tools/jtk/internal/cmd/issues/search_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cache"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/present/projection"
 )
 
@@ -196,4 +197,13 @@ func TestRunSearch_Fields_HumanName_CacheHit_SkipsFieldsFetch(t *testing.T) {
 	if cs.fieldsCalls != 0 {
 		t.Errorf("fresh cache must suppress live GetFields; got %d call(s)", cs.fieldsCalls)
 	}
+}
+
+func TestNewSearchCmd_MaxFlagShape(t *testing.T) {
+	t.Parallel()
+	cmd := newSearchCmd(&root.Options{})
+	maxFlag := cmd.Flags().Lookup("max")
+	testutil.NotNil(t, maxFlag)
+	testutil.Equal(t, maxFlag.Shorthand, "m")
+	testutil.Equal(t, maxFlag.DefValue, "50")
 }

--- a/tools/jtk/internal/cmd/users/users.go
+++ b/tools/jtk/internal/cmd/users/users.go
@@ -151,7 +151,7 @@ from the page being full (len(results) == --max).`,
 		},
 	}
 
-	cmd.Flags().IntVar(&maxResults, "max", 10, "Maximum number of results")
+	cmd.Flags().IntVarP(&maxResults, "max", "m", 50, "Maximum number of results")
 	cmd.Flags().StringVar(&nextPageToken, "next-page-token", "", "Decimal startAt for the next page")
 	cmd.Flags().StringVar(&fieldsFlag, "fields", "", "Comma-separated display columns (UserListSpec headers)")
 

--- a/tools/jtk/internal/cmd/users/users_test.go
+++ b/tools/jtk/internal/cmd/users/users_test.go
@@ -166,11 +166,12 @@ func TestNewSearchCmd(t *testing.T) {
 	cmd := newSearchCmd(opts)
 
 	testutil.Equal(t, cmd.Use, "search <query>")
-	testutil.NotNil(t, cmd.Flags().Lookup("max"))
+	maxFlag := cmd.Flags().Lookup("max")
+	testutil.NotNil(t, maxFlag)
 	testutil.NotNil(t, cmd.Flags().Lookup("next-page-token"))
 	testutil.NotNil(t, cmd.Flags().Lookup("fields"))
-	testutil.Equal(t, cmd.Flags().Lookup("max").DefValue, "50")
-	testutil.Equal(t, cmd.Flags().Lookup("max").Shorthand, "m")
+	testutil.Equal(t, maxFlag.DefValue, "50")
+	testutil.Equal(t, maxFlag.Shorthand, "m")
 }
 
 func TestRunSearch_DefaultTableMatchesSpecColumnOrder(t *testing.T) {

--- a/tools/jtk/internal/cmd/users/users_test.go
+++ b/tools/jtk/internal/cmd/users/users_test.go
@@ -169,7 +169,8 @@ func TestNewSearchCmd(t *testing.T) {
 	testutil.NotNil(t, cmd.Flags().Lookup("max"))
 	testutil.NotNil(t, cmd.Flags().Lookup("next-page-token"))
 	testutil.NotNil(t, cmd.Flags().Lookup("fields"))
-	testutil.Equal(t, cmd.Flags().Lookup("max").DefValue, "10")
+	testutil.Equal(t, cmd.Flags().Lookup("max").DefValue, "50")
+	testutil.Equal(t, cmd.Flags().Lookup("max").Shorthand, "m")
 }
 
 func TestRunSearch_DefaultTableMatchesSpecColumnOrder(t *testing.T) {


### PR DESCRIPTION
## Summary

Per the surface-area guardrails, paginated commands take `-m, --max` with a default of 50. Aligns four commands:

- `issues list`: default 25 → 50 (`-m` unchanged)
- `issues search`: default 25 → 50 (`-m` unchanged)
- `users search`: default 10 → 50, **adds `-m`**
- `dashboards list`: default already 50, **adds `-m`**

Behavior change: `users search` now returns up to 50 by default (was 10). Tracked in CHANGELOG.

Closes #340. Refs #338.

## Test plan

- [x] `go test ./...` — 1739 passed (3 new flag-shape tests added)
- [x] `make lint` — 0 issues
- [x] Each touched command has `Lookup("max").DefValue == "50"` and `Shorthand == "m"` asserted
- [ ] Manual: `jtk users search foo -m 5` parses
- [ ] Manual: `jtk dashboards list -m 5` parses