### PR TITLE
fix(jtk): wire --no-wait and --no-notify on issues move

### DIFF
--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `jtk issues move --no-wait` and `--no-notify` now parse correctly. Previously the help text mentioned them but pflag did not register the negations, so they failed with "unknown flag". ([#342](https://github.com/open-cli-collective/atlassian-cli/issues/342))
 - `\n`, `\t`, `\\` escape sequences now work in `comments add --body` ([#188](https://github.com/open-cli-collective/atlassian-cli/pull/188))
 - `issues search` and `issues list` with `-o json` now return all fields including custom fields by default ([#180](https://github.com/open-cli-collective/atlassian-cli/pull/180))
 - Wiki markup conversion no longer mangles hyphens and tildes ([#178](https://github.com/open-cli-collective/atlassian-cli/pull/178))

--- a/tools/jtk/internal/cmd/issues/move.go
+++ b/tools/jtk/internal/cmd/issues/move.go
@@ -21,8 +21,8 @@ import (
 func newMoveCmd(opts *root.Options) *cobra.Command {
 	var targetProject string
 	var targetType string
-	var notify bool
-	var wait bool
+	var notify, wait bool
+	var noNotify, noWait bool
 
 	cmd := &cobra.Command{
 		Use:   "move <issue-key>...",
@@ -53,14 +53,24 @@ Limitations:
   jtk issues move PROJ-123 --to-project NEWPROJ --no-notify`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runMove(cmd.Context(), opts, args, targetProject, targetType, notify, wait)
+			effectiveNotify := notify
+			effectiveWait := wait
+			if noNotify {
+				effectiveNotify = false
+			}
+			if noWait {
+				effectiveWait = false
+			}
+			return runMove(cmd.Context(), opts, args, targetProject, targetType, effectiveNotify, effectiveWait)
 		},
 	}
 
 	cmd.Flags().StringVar(&targetProject, "to-project", "", "Target project key or name (required)")
 	cmd.Flags().StringVar(&targetType, "to-type", "", "Target issue type name (default: same as source, resolved via cache)")
-	cmd.Flags().BoolVar(&notify, "notify", true, "Send notifications for the move")
-	cmd.Flags().BoolVar(&wait, "wait", true, "Wait for the move to complete")
+	cmd.Flags().BoolVar(&notify, "notify", true, "Send notifications for the move (use --no-notify to suppress)")
+	cmd.Flags().BoolVar(&wait, "wait", true, "Wait for the move to complete (use --no-wait to return immediately and poll with move-status)")
+	cmd.Flags().BoolVar(&noNotify, "no-notify", false, "Suppress notifications (equivalent to --notify=false)")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Return immediately with task ID (equivalent to --wait=false)")
 
 	_ = cmd.MarkFlagRequired("to-project")
 

--- a/tools/jtk/internal/cmd/issues/move_test.go
+++ b/tools/jtk/internal/cmd/issues/move_test.go
@@ -468,3 +468,86 @@ func TestRunMove_NoCachedIssueTypesPromptsToSpecifyType(t *testing.T) {
 		t.Fatalf("expected error to suggest --to-type, got: %v", err)
 	}
 }
+
+func TestNewMoveCmd_NegationFlagsApplyOverrides(t *testing.T) {
+	// Drives the cobra command with --no-wait --no-notify and asserts both
+	// overrides reach runMove: the captured request has sendBulkNotification
+	// false (from --no-notify), and the polling endpoint is never hit (from
+	// --no-wait). A buggy implementation that registers the negation flags
+	// but forgets to pass effective values into runMove would fail this.
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("issuetypes", "24h", map[string][]api.IssueType{
+		"TARGET": {{ID: "10050", Name: "Task"}},
+	}))
+	testutil.RequireNoError(t, cache.WriteResource("projects", "24h", []api.Project{
+		{Key: "TARGET", Name: "Target"}, {Key: "PROJ", Name: "Source"},
+	}))
+
+	var moveBody []byte
+	var queueCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/rest/api/3/issue/PROJ-1") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(api.Issue{
+				Key: "PROJ-1",
+				Fields: api.IssueFields{
+					Project:   &api.Project{Key: "PROJ"},
+					IssueType: &api.IssueType{ID: "10000", Name: "Task"},
+				},
+			})
+		case r.URL.Path == "/rest/api/3/bulk/issues/move" && r.Method == http.MethodPost:
+			moveBody, _ = io.ReadAll(r.Body)
+			_ = json.NewEncoder(w).Encode(api.MoveIssuesResponse{TaskID: "task-1"})
+		case strings.HasPrefix(r.URL.Path, "/rest/api/3/bulk/queue/"):
+			queueCalls++
+			t.Errorf("unexpected polling request with --no-wait: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(api.MoveTaskStatus{TaskID: "task-1", Status: "COMPLETE"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &stderr}
+	opts.SetAPIClient(client)
+
+	cmd := newMoveCmd(opts)
+	cmd.SetArgs([]string{"PROJ-1", "--to-project", "TARGET", "--no-wait", "--no-notify"})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	testutil.RequireNoError(t, cmd.ExecuteContext(context.Background()))
+
+	testutil.Equal(t, queueCalls, 0)
+
+	var req api.MoveIssuesRequest
+	testutil.RequireNoError(t, json.Unmarshal(moveBody, &req))
+	testutil.False(t, req.SendBulkNotification)
+}
+
+func TestNewMoveCmd_NegationFlagsRegistered(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"no-wait", "no-notify"} {
+		f := newMoveCmd(&root.Options{}).Flags().Lookup(name)
+		testutil.NotNil(t, f)
+		testutil.Equal(t, f.DefValue, "false")
+	}
+
+	parseCases := [][]string{
+		{"--no-wait", "--to-project", "DEST"},
+		{"--no-notify", "--to-project", "DEST"},
+		{"--no-wait", "--no-notify", "--to-project", "DEST"},
+	}
+	for _, args := range parseCases {
+		cmd := newMoveCmd(&root.Options{})
+		if err := cmd.ParseFlags(args); err != nil {
+			t.Fatalf("expected %v to parse, got: %v", args, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`jtk issues move` documented `--no-wait` and `--no-notify` in its help text, but pflag does not auto-generate `--no-X` negations and they were never explicitly registered — running either form failed with "unknown flag".

- Registers `--no-wait` and `--no-notify` as explicit `BoolVar` flags (default false).
- In `RunE`, derives `effectiveWait` / `effectiveNotify` locals (no mutation of the flag-bound vars) and passes them into `runMove`.
- Negation wins if both forms are supplied.
- Tests cover both flag registration (parser-level) and the override path (Cobra Execute with `--no-wait --no-notify` asserts captured request body has `sendBulkNotification: false` and the polling endpoint is never hit).

Closes #342. Refs #338.

## Test plan

- [x] `go test ./...` — 1741 passed (2 new tests)
- [x] `make lint` — 0 issues
- [x] Behavior test catches a buggy impl that registers the flags but forgets to pass effective values to `runMove` (asserts both axes)
- [ ] Manual: `jtk issues move --help | grep -E 'no-wait|no-notify'` lists both
- [ ] Manual: `jtk issues move PROJ-1 --to-project DEST --no-wait` parses (no "unknown flag")