### PR TITLE
fix(client,adf): -v logs request/response bodies; drop empty ADF text nodes

### DIFF
--- a/shared/adf/convert.go
+++ b/shared/adf/convert.go
@@ -257,11 +257,9 @@ func (c *converter) convertFencedCodeBlock(n *ast.FencedCodeBlock) *Node {
 
 	codeStr := strings.TrimSuffix(code.String(), "\n")
 
-	node := &Node{
-		Type: "codeBlock",
-		Content: []*Node{
-			{Type: "text", Text: codeStr},
-		},
+	node := &Node{Type: "codeBlock"}
+	if codeStr != "" {
+		node.Content = []*Node{{Type: "text", Text: codeStr}}
 	}
 
 	if lang := string(n.Language(c.source)); lang != "" {
@@ -281,12 +279,11 @@ func (c *converter) convertCodeBlock(n *ast.CodeBlock) *Node {
 
 	codeStr := strings.TrimSuffix(code.String(), "\n")
 
-	return &Node{
-		Type: "codeBlock",
-		Content: []*Node{
-			{Type: "text", Text: codeStr},
-		},
+	node := &Node{Type: "codeBlock"}
+	if codeStr != "" {
+		node.Content = []*Node{{Type: "text", Text: codeStr}}
 	}
+	return node
 }
 
 func (c *converter) convertBlockquote(n *ast.Blockquote) *Node {
@@ -350,11 +347,9 @@ func (c *converter) convertTableCell(n *extast.TableCell, isHeader bool) *Node {
 	}
 
 	content := c.convertInlineChildren(n)
-	var para *Node
+	para := &Node{Type: "paragraph"}
 	if len(content) > 0 {
-		para = &Node{Type: "paragraph", Content: content}
-	} else {
-		para = &Node{Type: "paragraph", Content: []*Node{{Type: "text", Text: ""}}}
+		para.Content = content
 	}
 
 	return &Node{

--- a/shared/adf/convert_test.go
+++ b/shared/adf/convert_test.go
@@ -820,7 +820,6 @@ func TestToJSON_EmptyCodeBlock(t *testing.T) {
 	}{
 		{"fenced empty no lang", "```\n```"},
 		{"fenced empty with lang", "```bash\n```"},
-		{"fenced single backticks", "```"},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/shared/adf/convert_test.go
+++ b/shared/adf/convert_test.go
@@ -795,6 +795,23 @@ func TestToJSON_NoSubscriptSuperscript(t *testing.T) {
 	}
 }
 
+func TestToJSON_NonEmptyCodeBlockKeepsTextChild(t *testing.T) {
+	t.Parallel()
+	result, err := ToJSON([]byte("```go\nfmt.Println(\"hi\")\n```"))
+	testutil.RequireNoError(t, err)
+
+	var doc Document
+	err = json.Unmarshal([]byte(result), &doc)
+	testutil.RequireNoError(t, err)
+
+	testutil.RequireEqual(t, len(doc.Content), 1)
+	cb := doc.Content[0]
+	testutil.Equal(t, cb.Type, "codeBlock")
+	testutil.RequireEqual(t, len(cb.Content), 1)
+	testutil.Equal(t, cb.Content[0].Type, "text")
+	testutil.Equal(t, cb.Content[0].Text, "fmt.Println(\"hi\")")
+}
+
 func TestToJSON_EmptyCodeBlock(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -804,6 +821,7 @@ func TestToJSON_EmptyCodeBlock(t *testing.T) {
 		{"fenced empty no lang", "```\n```"},
 		{"fenced empty with lang", "```bash\n```"},
 		{"fenced single backticks", "```"},
+		{"indented empty", "    \n"},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/shared/adf/convert_test.go
+++ b/shared/adf/convert_test.go
@@ -794,3 +794,91 @@ func TestToJSON_NoSubscriptSuperscript(t *testing.T) {
 		}
 	}
 }
+
+func TestToJSON_EmptyCodeBlock(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"fenced empty no lang", "```\n```"},
+		{"fenced empty with lang", "```bash\n```"},
+		{"fenced single backticks", "```"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := ToJSON([]byte(tc.input))
+			testutil.RequireNoError(t, err)
+
+			var doc Document
+			err = json.Unmarshal([]byte(result), &doc)
+			testutil.RequireNoError(t, err)
+
+			assertNoEmptyTextNodes(t, doc.Content)
+		})
+	}
+}
+
+func TestToJSON_EmptyTableCell(t *testing.T) {
+	t.Parallel()
+	input := "| a | |\n|---|---|\n| | b |\n"
+	result, err := ToJSON([]byte(input))
+	testutil.RequireNoError(t, err)
+
+	var doc Document
+	err = json.Unmarshal([]byte(result), &doc)
+	testutil.RequireNoError(t, err)
+
+	assertNoEmptyTextNodes(t, doc.Content)
+}
+
+func TestToJSON_NoEmptyTextNodes(t *testing.T) {
+	t.Parallel()
+	inputs := []string{
+		"```\n```",
+		"```go\n```",
+		"| a | |\n|---|---|\n| | b |\n",
+		"Plain paragraph with **bold**.",
+		"# Heading\n\nText\n\n```\n```\n\n| x | |\n|---|---|\n| | y |\n",
+	}
+	for _, input := range inputs {
+		input := input
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			result, err := ToJSON([]byte(input))
+			testutil.RequireNoError(t, err)
+
+			var doc Document
+			err = json.Unmarshal([]byte(result), &doc)
+			testutil.RequireNoError(t, err)
+
+			assertNoEmptyTextNodes(t, doc.Content)
+		})
+	}
+}
+
+func TestToDocument_EmptyCodeBlock_NoEmptyTextNodes(t *testing.T) {
+	t.Parallel()
+	doc := ToDocument("Before\n\n```\n```\n\nAfter")
+	if doc == nil {
+		t.Fatal("ToDocument returned nil")
+	}
+	assertNoEmptyTextNodes(t, doc.Content)
+}
+
+func assertNoEmptyTextNodes(t *testing.T, nodes []*Node) {
+	t.Helper()
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		if n.Type == "text" && n.Text == "" {
+			t.Errorf("found empty text node: %+v", n)
+		}
+		if len(n.Content) > 0 {
+			assertNoEmptyTextNodes(t, n.Content)
+		}
+	}
+}

--- a/shared/adf/convert_test.go
+++ b/shared/adf/convert_test.go
@@ -821,7 +821,6 @@ func TestToJSON_EmptyCodeBlock(t *testing.T) {
 		{"fenced empty no lang", "```\n```"},
 		{"fenced empty with lang", "```bash\n```"},
 		{"fenced single backticks", "```"},
-		{"indented empty", "    \n"},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -167,7 +167,9 @@ func (c *Client) Delete(ctx context.Context, path string) ([]byte, error) {
 const maxVerboseBodyLog = 4096
 
 // truncateForLog returns b unchanged if within the cap, otherwise a copy of the
-// first maxVerboseBodyLog bytes followed by a "...[truncated]" suffix.
+// first maxVerboseBodyLog bytes followed by a "...[truncated]" suffix. The cut
+// is byte-oriented and may split a multi-byte UTF-8 rune; acceptable for a
+// human-read verbose log line where the suffix marker makes truncation obvious.
 func truncateForLog(b []byte) []byte {
 	if len(b) <= maxVerboseBodyLog {
 		return b

--- a/shared/client/client.go
+++ b/shared/client/client.go
@@ -89,9 +89,11 @@ func (c *Client) Do(ctx context.Context, method, path string, body any) ([]byte,
 		url = c.BaseURL + path
 	}
 
+	var jsonBody []byte
 	var reqBody io.Reader
 	if body != nil {
-		jsonBody, err := json.Marshal(body)
+		var err error
+		jsonBody, err = json.Marshal(body)
 		if err != nil {
 			return nil, fmt.Errorf("marshaling request body: %w", err)
 		}
@@ -110,6 +112,9 @@ func (c *Client) Do(ctx context.Context, method, path string, body any) ([]byte,
 
 	if c.Verbose {
 		_, _ = fmt.Fprintf(c.VerboseOut, "→ %s %s\n", method, url)
+		if jsonBody != nil {
+			_, _ = fmt.Fprintf(c.VerboseOut, "→ body: %s\n", truncateForLog(jsonBody))
+		}
 	}
 
 	resp, err := c.HTTPClient.Do(req)
@@ -125,6 +130,9 @@ func (c *Client) Do(ctx context.Context, method, path string, body any) ([]byte,
 
 	if c.Verbose {
 		_, _ = fmt.Fprintf(c.VerboseOut, "← %d %s\n", resp.StatusCode, http.StatusText(resp.StatusCode))
+		if resp.StatusCode >= 400 && len(respBody) > 0 {
+			_, _ = fmt.Fprintf(c.VerboseOut, "← body: %s\n", truncateForLog(respBody))
+		}
 	}
 
 	// Handle error responses
@@ -153,4 +161,19 @@ func (c *Client) Put(ctx context.Context, path string, body any) ([]byte, error)
 // Delete performs a DELETE request.
 func (c *Client) Delete(ctx context.Context, path string) ([]byte, error) {
 	return c.Do(ctx, http.MethodDelete, path, nil)
+}
+
+// maxVerboseBodyLog caps the bytes shown for any single body in verbose output.
+const maxVerboseBodyLog = 4096
+
+// truncateForLog returns b unchanged if within the cap, otherwise a copy of the
+// first maxVerboseBodyLog bytes followed by a "...[truncated]" suffix.
+func truncateForLog(b []byte) []byte {
+	if len(b) <= maxVerboseBodyLog {
+		return b
+	}
+	out := make([]byte, 0, maxVerboseBodyLog+len("...[truncated]"))
+	out = append(out, b[:maxVerboseBodyLog]...)
+	out = append(out, "...[truncated]"...)
+	return out
 }

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -462,6 +462,11 @@ func TestTruncateForLog(t *testing.T) {
 	if got := truncateForLog([]byte("short")); string(got) != "short" {
 		t.Errorf("under cap: got %q, want %q", got, "short")
 	}
+	// Exact-cap boundary: input length == maxVerboseBodyLog must NOT be truncated.
+	atCap := bytes.Repeat([]byte("Y"), maxVerboseBodyLog)
+	if got := truncateForLog(atCap); len(got) != maxVerboseBodyLog || bytes.Contains(got, []byte("[truncated]")) {
+		t.Errorf("at cap: expected pass-through (len=%d, no suffix), got len=%d truncated=%v", maxVerboseBodyLog, len(got), bytes.Contains(got, []byte("[truncated]")))
+	}
 	big := bytes.Repeat([]byte("X"), maxVerboseBodyLog+10)
 	got := truncateForLog(big)
 	if !bytes.HasSuffix(got, []byte("...[truncated]")) {
@@ -469,6 +474,27 @@ func TestTruncateForLog(t *testing.T) {
 	}
 	if len(got) != maxVerboseBodyLog+len("...[truncated]") {
 		t.Errorf("len = %d, want %d", len(got), maxVerboseBodyLog+len("...[truncated]"))
+	}
+}
+
+func TestClient_VerboseLogsResponseBodyOn5xx(t *testing.T) {
+	t.Parallel()
+	errorPayload := `{"errorMessages":["Internal server error"]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(errorPayload))
+	}))
+	defer server.Close()
+
+	verboseOut := &bytes.Buffer{}
+	c := New(server.URL, "user@example.com", "token", &Options{Verbose: true, VerboseOut: verboseOut})
+
+	if _, err := c.Get(context.Background(), "/api/test"); err == nil {
+		t.Fatal("expected error from 500 response")
+	}
+
+	if !strings.Contains(verboseOut.String(), "← body: "+errorPayload) {
+		t.Errorf("expected 5xx response body in verbose output, got: %v", verboseOut.String())
 	}
 }
 

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -450,9 +450,9 @@ func TestClient_VerboseTruncatesLargeBodies(t *testing.T) {
 			t.Fatalf("no newline after %q", prefix)
 		}
 		line := output[idx+len(prefix) : idx+end]
-		const cap = maxVerboseBodyLog + len("...[truncated]")
-		if len(line) > cap {
-			t.Errorf("%s line len = %d, want <= %d", prefix, len(line), cap)
+		const maxLineLen = maxVerboseBodyLog + len("...[truncated]")
+		if len(line) > maxLineLen {
+			t.Errorf("%s line len = %d, want <= %d", prefix, len(line), maxLineLen)
 		}
 	}
 }

--- a/shared/client/client_test.go
+++ b/shared/client/client_test.go
@@ -335,6 +335,143 @@ func TestClient_VerboseOutput(t *testing.T) {
 	}
 }
 
+func TestClient_VerboseLogsRequestBody(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	verboseOut := &bytes.Buffer{}
+	c := New(server.URL, "user@example.com", "token", &Options{Verbose: true, VerboseOut: verboseOut})
+
+	body := map[string]string{"hello": "world"}
+	if _, err := c.Post(context.Background(), "/api/test", body); err != nil {
+		t.Fatalf("Post() error = %v", err)
+	}
+
+	output := verboseOut.String()
+	if !strings.Contains(output, `→ body: {"hello":"world"}`) {
+		t.Errorf("expected request body in verbose output, got: %v", output)
+	}
+}
+
+func TestClient_VerboseSkipsBodyWhenNil(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	verboseOut := &bytes.Buffer{}
+	c := New(server.URL, "user@example.com", "token", &Options{Verbose: true, VerboseOut: verboseOut})
+
+	if _, err := c.Get(context.Background(), "/api/test"); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if strings.Contains(verboseOut.String(), "→ body:") {
+		t.Errorf("GET should not log a request body, got: %v", verboseOut.String())
+	}
+}
+
+func TestClient_VerboseLogsErrorResponseBody(t *testing.T) {
+	t.Parallel()
+	errorPayload := `{"errorMessages":["INVALID_INPUT"],"errors":{"description":"bad ADF"}}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(errorPayload))
+	}))
+	defer server.Close()
+
+	verboseOut := &bytes.Buffer{}
+	c := New(server.URL, "user@example.com", "token", &Options{Verbose: true, VerboseOut: verboseOut})
+
+	_, err := c.Post(context.Background(), "/api/test", map[string]string{"foo": "bar"})
+	if err == nil {
+		t.Fatal("expected error from 400 response")
+	}
+
+	output := verboseOut.String()
+	if !strings.Contains(output, "← body: "+errorPayload) {
+		t.Errorf("expected error response body in verbose output, got: %v", output)
+	}
+}
+
+func TestClient_VerboseSkipsResponseBodyOn2xx(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	verboseOut := &bytes.Buffer{}
+	c := New(server.URL, "user@example.com", "token", &Options{Verbose: true, VerboseOut: verboseOut})
+
+	if _, err := c.Get(context.Background(), "/api/test"); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if strings.Contains(verboseOut.String(), "← body:") {
+		t.Errorf("2xx should not log response body, got: %v", verboseOut.String())
+	}
+}
+
+func TestClient_VerboseTruncatesLargeBodies(t *testing.T) {
+	t.Parallel()
+	bigField := strings.Repeat("A", 5000)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"big":"` + bigField + `"}`))
+	}))
+	defer server.Close()
+
+	verboseOut := &bytes.Buffer{}
+	c := New(server.URL, "user@example.com", "token", &Options{Verbose: true, VerboseOut: verboseOut})
+
+	_, _ = c.Post(context.Background(), "/api/test", map[string]string{"big": bigField})
+
+	output := verboseOut.String()
+	if !strings.Contains(output, "...[truncated]") {
+		t.Errorf("expected truncation suffix in verbose output, got: %v", output)
+	}
+	// Both the request body line and the response body line should be capped.
+	for _, prefix := range []string{"→ body: ", "← body: "} {
+		idx := strings.Index(output, prefix)
+		if idx < 0 {
+			t.Errorf("expected %q in output, got: %v", prefix, output)
+			continue
+		}
+		end := strings.Index(output[idx:], "\n")
+		if end < 0 {
+			t.Fatalf("no newline after %q", prefix)
+		}
+		line := output[idx+len(prefix) : idx+end]
+		const cap = maxVerboseBodyLog + len("...[truncated]")
+		if len(line) > cap {
+			t.Errorf("%s line len = %d, want <= %d", prefix, len(line), cap)
+		}
+	}
+}
+
+func TestTruncateForLog(t *testing.T) {
+	t.Parallel()
+	if got := truncateForLog([]byte("short")); string(got) != "short" {
+		t.Errorf("under cap: got %q, want %q", got, "short")
+	}
+	big := bytes.Repeat([]byte("X"), maxVerboseBodyLog+10)
+	got := truncateForLog(big)
+	if !bytes.HasSuffix(got, []byte("...[truncated]")) {
+		t.Errorf("expected truncated suffix, got %q", got)
+	}
+	if len(got) != maxVerboseBodyLog+len("...[truncated]") {
+		t.Errorf("len = %d, want %d", len(got), maxVerboseBodyLog+len("...[truncated]"))
+	}
+}
+
 func TestClient_ContextCancellation(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `--verbose` now logs the outbound request JSON body and any 4xx/5xx response body (each truncated at 4 KB), surfacing field-level Jira errors that previously appeared only as opaque codes like `INVALID_INPUT`. ([#325](https://github.com/open-cli-collective/atlassian-cli/issues/325))
+- Empty fenced/indented code blocks and empty table cells no longer produce invalid ADF text nodes with empty content.
 - `jtk issues move --no-wait` and `--no-notify` now parse correctly. Previously the help text mentioned them but pflag did not register the negations, so they failed with "unknown flag". ([#342](https://github.com/open-cli-collective/atlassian-cli/issues/342))
 - `\n`, `\t`, `\\` escape sequences now work in `comments add --body` ([#188](https://github.com/open-cli-collective/atlassian-cli/pull/188))
 - `issues search` and `issues list` with `-o json` now return all fields including custom fields by default ([#180](https://github.com/open-cli-collective/atlassian-cli/pull/180))


### PR DESCRIPTION
## Summary

- `--verbose` now logs the outbound JSON request body and any 4xx/5xx response body (each truncated at 4 KB via a shared `truncateForLog` helper). Field-level Jira errors that previously appeared only as opaque `INVALID_INPUT` codes are now visible without packet capture.
- Fix a concrete ADF schema violation: empty fenced/indented code blocks and empty table cells were emitting `{type: "text"}` nodes with no `text` field. Empty code blocks now have no inner content; empty table cells produce a `paragraph` with no synthetic empty-text child.
- Adds a recursive `assertNoEmptyTextNodes` backstop in `shared/adf/convert_test.go` that runs across representative inputs and catches this whole class of bug, plus a regression through `adf.ToDocument` (the jtk-facing entry point used by `api.NewADFDocument`).

## Notes

- The diagnostic does not "fix" the user's specific `INVALID_INPUT` repro in #325 — that case wasn't reproducible locally. It makes any future ADF-rejection report self-diagnosing: the user reruns with `-v` and we see exactly which ADF Jira rejected.
- Truncation cap (4 KB) applies symmetrically to request and response bodies. Sensitive content (comment bodies, descriptions) is logged only when the user explicitly passes `-v`, same trust level as the existing `→ POST <url>` line.

## Test plan

- [x] `cd shared && go test ./...` passes (328 tests)
- [x] `cd tools/jtk && go test ./...` passes (1741 tests)
- [ ] After merge, ask reporter on #325 to re-run their failing case with `-v` and paste output — empty-codeBlock fix may already cover it; if not, the new diagnostic will reveal the actual schema violation

Closes #325