### PR TITLE
docs(jtk): describe what --verbose actually logs

### DIFF
--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -156,7 +156,7 @@ These flags are available on all commands:
 | `--fulltext` | | `false` | Disable truncation of descriptions and comments |
 | `--id` | | `false` | Emit only the primary identifier (takes precedence over `--extended` and `--fulltext`) |
 | `--no-color` | | `false` | Disable colored output |
-| `--verbose` | `-v` | `false` | Enable verbose output |
+| `--verbose` | `-v` | `false` | Log each request's method/URL, JSON body, status, and any 4xx/5xx response body (each capped at 4 KB). Useful for diagnosing opaque Jira errors like `INVALID_INPUT`. |
 | `--help` | `-h` | | Show help for command |
 | `--version` | | | Show version (root command only) |
 

--- a/tools/jtk/internal/cmd/root/root.go
+++ b/tools/jtk/internal/cmd/root/root.go
@@ -134,7 +134,7 @@ func NewCmd() (*cobra.Command, *Options) {
 	cmd.PersistentFlags().BoolVar(&opts.Extended, "extended", false, "Include admin/schema/audit fields in output")
 	cmd.PersistentFlags().BoolVar(&opts.FullText, "fulltext", false, "Disable truncation of descriptions and comments")
 	cmd.PersistentFlags().BoolVar(&opts.IDOnly, "id", false, "Emit only the primary identifier (takes precedence over --extended and --fulltext)")
-	cmd.PersistentFlags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Enable verbose output")
+	cmd.PersistentFlags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Log each request's method/URL, JSON body, and any 4xx/5xx response body (each capped at 4 KB)")
 
 	return cmd, opts
 }


### PR DESCRIPTION
## Summary

- The `--verbose` flag in #348 was expanded to log request bodies and 4xx/5xx response bodies, but the README still described it as just "Enable verbose output". Updated the description so users can find the diagnostic.

Follow-up to #348 / #325.

## Test plan

- [x] Read-only docs change