### PR TITLE
docs(jtk): fix issues field-options example in OUTPUT_SPEC

### DIFF
--- a/tools/jtk/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/jtk/internal/cmd/OUTPUT_SPEC.md
@@ -316,7 +316,7 @@ ID | NAME | SUBTASK | DESCRIPTION
 10026 | Kanban | no | Task following Kanban Flow
 ```
 
-**`issues field-options MON customfield_10050`** — default:
+**`issues field-options MON-4970 customfield_10050`** — default:
 ```
 ID | VALUE | DISABLED
 20001 | Platform | no


### PR DESCRIPTION
## Summary

The OUTPUT_SPEC example for `issues field-options` showed a project key (`MON`), but the command takes an issue key (`MON-4970`). Surfaced while verifying the #230 audit gaps against a live Jira instance.

The implementation choice (issue key) is more correct — field options can vary by project context, and the issue key carries that. So updating the spec to match.

## Test plan

- [x] No code changes; doc-only one-line fix