### PR TITLE
fix(jtk): handle array of component/version in --field formatter

### DIFF
--- a/tools/jtk/CHANGELOG.md
+++ b/tools/jtk/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `jtk issues create --field components=<id-or-name>` and `--field fixVersions=<id-or-name>` now work. Previously the array formatter only handled multi-checkbox (`option` items) and fell through to a plain string array for component and version items, which Jira rejects with `The list contains an invalid value`. Multi-value via repeated `--field` accumulates as expected. ([#227](https://github.com/open-cli-collective/atlassian-cli/issues/227))
 - `--verbose` now logs the outbound request JSON body and any 4xx/5xx response body (each truncated at 4 KB), surfacing field-level Jira errors that previously appeared only as opaque codes like `INVALID_INPUT`. ([#325](https://github.com/open-cli-collective/atlassian-cli/issues/325))
 - Empty fenced/indented code blocks and empty table cells no longer produce invalid ADF text nodes with empty content.
 - `jtk issues move --no-wait` and `--no-notify` now parse correctly. Previously the help text mentioned them but pflag did not register the negations, so they failed with "unknown flag". ([#342](https://github.com/open-cli-collective/atlassian-cli/issues/342))

--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -109,6 +109,7 @@ func IsNullValue(v string) bool {
 // It handles special cases like:
 //   - option fields: wraps value as {"value": "..."}
 //   - array fields: wraps value as [{"value": "..."}] or []string{...}
+//   - array of component/version: wraps as [{"id": "..."}] for numeric or [{"name": "..."}] for names
 //   - user fields: wraps value as {"accountId": "..."}
 //   - number fields: converts string to float64
 //   - issuelink fields (e.g., parent): wraps value as {"key": "..."} or {"id": "..."}
@@ -142,6 +143,12 @@ func FormatFieldValue(field *Field, value string) any {
 	case "array":
 		if field.Schema.Items == "option" {
 			return []map[string]string{{"value": trimmed}}
+		}
+		if field.Schema.Items == "component" || field.Schema.Items == "version" {
+			if _, err := strconv.Atoi(trimmed); err == nil {
+				return []map[string]string{{"id": trimmed}}
+			}
+			return []map[string]string{{"name": trimmed}}
 		}
 		return []string{trimmed}
 	case "user":

--- a/tools/jtk/api/fields_test.go
+++ b/tools/jtk/api/fields_test.go
@@ -491,6 +491,26 @@ func TestFormatFieldValue(t *testing.T) {
 			value: "jira-administrators",
 			want:  []string{"jira-administrators"},
 		},
+		{
+			name: "array of component with surrounding whitespace trims and treats as id",
+			field: &Field{
+				ID:     "components",
+				Name:   "Components",
+				Schema: FieldSchema{Type: "array", Items: "component"},
+			},
+			value: "  10201  ",
+			want:  []map[string]string{{"id": "10201"}},
+		},
+		{
+			name: "array of component with leading-digit name takes name path",
+			field: &Field{
+				ID:     "components",
+				Name:   "Components",
+				Schema: FieldSchema{Type: "array", Items: "component"},
+			},
+			value: "12abc",
+			want:  []map[string]string{{"name": "12abc"}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -607,6 +627,18 @@ func TestMergeFieldValues(t *testing.T) {
 			existing: []map[string]string{{"id": "10200"}},
 			newVal:   []map[string]string{{"id": "10201"}},
 			want:     []map[string]string{{"id": "10200"}, {"id": "10201"}},
+		},
+		{
+			name:     "merge component arrays (name form)",
+			existing: []map[string]string{{"name": "Frontend"}},
+			newVal:   []map[string]string{{"name": "Backend"}},
+			want:     []map[string]string{{"name": "Frontend"}, {"name": "Backend"}},
+		},
+		{
+			name:     "merge component arrays (mixed id and name)",
+			existing: []map[string]string{{"id": "10200"}},
+			newVal:   []map[string]string{{"name": "Frontend"}},
+			want:     []map[string]string{{"id": "10200"}, {"name": "Frontend"}},
 		},
 		{
 			name:     "non-array field overwrites",

--- a/tools/jtk/api/fields_test.go
+++ b/tools/jtk/api/fields_test.go
@@ -441,6 +441,56 @@ func TestFormatFieldValue(t *testing.T) {
 			value: "20001",
 			want:  map[string]string{"id": "20001"},
 		},
+		{
+			name: "array of component by numeric id wraps as id map",
+			field: &Field{
+				ID:     "components",
+				Name:   "Components",
+				Schema: FieldSchema{Type: "array", Items: "component"},
+			},
+			value: "10201",
+			want:  []map[string]string{{"id": "10201"}},
+		},
+		{
+			name: "array of component by name wraps as name map",
+			field: &Field{
+				ID:     "components",
+				Name:   "Components",
+				Schema: FieldSchema{Type: "array", Items: "component"},
+			},
+			value: "Service 2",
+			want:  []map[string]string{{"name": "Service 2"}},
+		},
+		{
+			name: "array of version by numeric id wraps as id map",
+			field: &Field{
+				ID:     "fixVersions",
+				Name:   "Fix Versions",
+				Schema: FieldSchema{Type: "array", Items: "version"},
+			},
+			value: "10100",
+			want:  []map[string]string{{"id": "10100"}},
+		},
+		{
+			name: "array of version by name wraps as name map",
+			field: &Field{
+				ID:     "fixVersions",
+				Name:   "Fix Versions",
+				Schema: FieldSchema{Type: "array", Items: "version"},
+			},
+			value: "v1.0.0",
+			want:  []map[string]string{{"name": "v1.0.0"}},
+		},
+		{
+			name: "array of group falls through to plain string array (regression guard)",
+			field: &Field{
+				ID:     "customfield_10099",
+				Name:   "Reviewers",
+				Schema: FieldSchema{Type: "array", Items: "group"},
+			},
+			value: "jira-administrators",
+			want:  []string{"jira-administrators"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -551,6 +601,12 @@ func TestMergeFieldValues(t *testing.T) {
 			existing: []string{"urgent"},
 			newVal:   []string{"backend"},
 			want:     []string{"urgent", "backend"},
+		},
+		{
+			name:     "merge component arrays (id form)",
+			existing: []map[string]string{{"id": "10200"}},
+			newVal:   []map[string]string{{"id": "10201"}},
+			want:     []map[string]string{{"id": "10200"}, {"id": "10201"}},
 		},
 		{
 			name:     "non-array field overwrites",

--- a/tools/jtk/internal/cmd/issues/create_test.go
+++ b/tools/jtk/internal/cmd/issues/create_test.go
@@ -658,6 +658,7 @@ func TestRunCreate_FieldComponentArrayAndOptionMerge(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(api.Issue{Key: "TEST-1", ID: "10001"})
 		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
@@ -679,17 +680,25 @@ func TestRunCreate_FieldComponentArrayAndOptionMerge(t *testing.T) {
 	testutil.NotEmpty(t, capturedBody)
 	var reqBody map[string]any
 	testutil.RequireNoError(t, json.Unmarshal(capturedBody, &reqBody))
-	fields := reqBody["fields"].(map[string]any)
+	fields, ok := reqBody["fields"].(map[string]any)
+	testutil.True(t, ok, "fields key missing or wrong type in POST body")
 
-	components := fields["components"].([]any)
+	components, ok := fields["components"].([]any)
+	testutil.True(t, ok, "components key missing or wrong type")
 	testutil.Len(t, components, 1)
-	componentEntry := components[0].(map[string]any)
+	componentEntry, ok := components[0].(map[string]any)
+	testutil.True(t, ok, "components[0] not a map")
 	// Lock the shape: exactly {"name": "Frontend"} — no leaked "id" key, no extras.
 	testutil.Equal(t, len(componentEntry), 1)
 	testutil.Equal(t, componentEntry["name"], "Frontend")
 
-	tags := fields["customfield_10100"].([]any)
+	tags, ok := fields["customfield_10100"].([]any)
+	testutil.True(t, ok, "customfield_10100 key missing or wrong type")
 	testutil.Len(t, tags, 2)
-	testutil.Equal(t, tags[0].(map[string]any)["value"], "Opt1")
-	testutil.Equal(t, tags[1].(map[string]any)["value"], "Opt2")
+	tag0, ok := tags[0].(map[string]any)
+	testutil.True(t, ok, "tags[0] not a map")
+	testutil.Equal(t, tag0["value"], "Opt1")
+	tag1, ok := tags[1].(map[string]any)
+	testutil.True(t, ok, "tags[1] not a map")
+	testutil.Equal(t, tag1["value"], "Opt2")
 }

--- a/tools/jtk/internal/cmd/issues/create_test.go
+++ b/tools/jtk/internal/cmd/issues/create_test.go
@@ -631,3 +631,62 @@ func TestRunCreate_IDOnly(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "TEST-1\n")
 }
+
+// TestRunCreate_FieldComponentArrayAndOptionMerge exercises the full --field
+// pipeline (parse → metadata lookup → FormatFieldValue → MergeFieldValues →
+// POST body construction). It guards two paths:
+//
+//   - components (array of component): a single value must be wrapped as
+//     [{name: "Frontend"}], not the legacy [{value: ...}] or string array.
+//   - a multi-checkbox custom field (array of option): repeated --field args
+//     must accumulate as [{value: "Opt1"}, {value: "Opt2"}], unchanged from
+//     before the components fix.
+func TestRunCreate_FieldComponentArrayAndOptionMerge(t *testing.T) {
+	seedCacheForIssues(t)
+
+	var capturedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/field" && r.Method == "GET":
+			fields := []api.Field{
+				{ID: "components", Name: "Components", Schema: api.FieldSchema{Type: "array", Items: "component"}},
+				{ID: "customfield_10100", Name: "Tags", Custom: true, Schema: api.FieldSchema{Type: "array", Items: "option"}},
+			}
+			_ = json.NewEncoder(w).Encode(fields)
+		case r.URL.Path == "/rest/api/3/issue" && r.Method == "POST":
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(api.Issue{Key: "TEST-1", ID: "10001"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "e@x", APIToken: "t"})
+	testutil.RequireNoError(t, err)
+
+	opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runCreate(context.Background(), opts, "PROJ", "Task", "Test", "", "", "", []string{
+		"components=Frontend",
+		"customfield_10100=Opt1",
+		"customfield_10100=Opt2",
+	})
+	testutil.RequireNoError(t, err)
+
+	testutil.NotEmpty(t, capturedBody)
+	var reqBody map[string]any
+	testutil.RequireNoError(t, json.Unmarshal(capturedBody, &reqBody))
+	fields := reqBody["fields"].(map[string]any)
+
+	components := fields["components"].([]any)
+	testutil.Len(t, components, 1)
+	testutil.Equal(t, components[0].(map[string]any)["name"], "Frontend")
+
+	tags := fields["customfield_10100"].([]any)
+	testutil.Len(t, tags, 2)
+	testutil.Equal(t, tags[0].(map[string]any)["value"], "Opt1")
+	testutil.Equal(t, tags[1].(map[string]any)["value"], "Opt2")
+}

--- a/tools/jtk/internal/cmd/issues/create_test.go
+++ b/tools/jtk/internal/cmd/issues/create_test.go
@@ -683,7 +683,10 @@ func TestRunCreate_FieldComponentArrayAndOptionMerge(t *testing.T) {
 
 	components := fields["components"].([]any)
 	testutil.Len(t, components, 1)
-	testutil.Equal(t, components[0].(map[string]any)["name"], "Frontend")
+	componentEntry := components[0].(map[string]any)
+	// Lock the shape: exactly {"name": "Frontend"} — no leaked "id" key, no extras.
+	testutil.Equal(t, len(componentEntry), 1)
+	testutil.Equal(t, componentEntry["name"], "Frontend")
 
 	tags := fields["customfield_10100"].([]any)
 	testutil.Len(t, tags, 2)


### PR DESCRIPTION
## Summary

Fixes #227, originally reported by @romiguelangel who also opened a fix in their fork: https://github.com/romiguelangel/atlassian-cli/pull/1. Pulled the conceptual change into upstream main with attribution preserved on the commit author.

`jtk issues create --field components=<id-or-name>` (and `fixVersions=...`) now works. Before this PR, every input shape — id, name, JSON object, JSON array — produced `creating issue: bad request: components: The list contains an invalid value`.

## Root cause

`FormatFieldValue` in `tools/jtk/api/fields.go`:

```go
case "array":
    if field.Schema.Items == "option" {
        return []map[string]string{{"value": trimmed}}
    }
    return []string{trimmed}   // ← components fell here, Jira rejects
```

The components field has `schema.items: component`, which fell through to the plain string-array path. Jira's create-issue endpoint expects `[{"id":"..."}]` or `[{"name":"..."}]` — not `["Frontend"]`.

## Fix

Added an `Items in {"component", "version"}` branch following the same pattern as `priority/resolution/status` at line 162: numeric input → `{id}`, otherwise → `{name}`.

## Why not group, and why not the JSON pass-through

The contributor's original PR also added `Items == "group"` and a generic `if value starts with [ or {, json.Unmarshal` escape hatch. Dropped both:

- **`group`**: Atlassian's example shows multi-group custom fields as plain string arrays (`["jira-administrators", ...]`), which the existing `[]string` fallback handles correctly. Adding `group` to the new branch would convert working calls into `[{"name":"..."}]` and risk regression. Added a regression-guard test to lock the existing behavior.
- **JSON pass-through**: bypasses schema-aware formatting for any field whose value happens to start with `[` or `{`. Surprising for textarea (ADF), options, etc. The right way to add this back later is an explicit `--field-json key=<json>` flag, opt-in by design — not prefix-sniffing inside `FormatFieldValue`.

## Test plan

- [x] Unit tests in `tools/jtk/api/fields_test.go` cover `array of component/version` by id and name + a `group` regression guard
- [x] Merge test for accumulating components across repeated `--field`
- [x] Full create-path wiring test in `tools/jtk/internal/cmd/issues/create_test.go` using httptest with both `GET /rest/api/3/field` and captured `POST /rest/api/3/issue` body — exercises parse → metadata → format → merge → POST end-to-end, and asserts the existing multi-checkbox `[{value: ...}]` shape still merges correctly
- [x] `cd tools/jtk && go test ./...` → 1748 pass
- [x] Live verification deferred to merge: `jtk issues create --project MON --type SDLC --summary "test" --field 'components=Admin Portal'`

Closes #227