### PR TITLE
feat(cfl): add cfl me + polish init UX

### DIFF
--- a/tools/cfl/CLAUDE.md
+++ b/tools/cfl/CLAUDE.md
@@ -35,7 +35,8 @@ internal/cmd/            → Cobra command implementations
   page/                  → page list|view|create|edit|delete
   space/                 → space list|view|create|update|delete
   attachment/            → attachment list|upload|download
-  init/                  → Configuration wizard
+  init/                  → Configuration wizard (uses charmbracelet/huh + shared view.View)
+  me/                    → Show currently authenticated user as `accountId | displayName | email`
 internal/config/         → YAML config loading with env var overrides
 internal/view/           → Output formatting (table/json/plain)
 pkg/md/                  → Bidirectional Markdown ↔ XHTML conversion
@@ -156,6 +157,8 @@ Two auth methods are supported:
 - **Bearer Auth**: Uses `Authorization: Bearer <token>` against the `api.atlassian.com` gateway. Required for Atlassian service accounts with scoped API tokens.
 
 Bearer auth routes requests through `https://api.atlassian.com/ex/confluence/{cloudId}/wiki/...` and requires a Cloud ID. The `api/client.go` file has a separate `NewBearerClient()` constructor, selected in `root.go` based on config auth method.
+
+**`cfl init` and `cfl me` both depend on `/wiki/rest/api/user/current` working under bearer auth.** That endpoint is what verifies init's connection and powers the me one-liner. If a future scoped-token policy restricts user-info access for bearer tokens, both commands will surface a `Connection failed` / `getting current user` error rather than silently misbehave.
 
 ## Output Artifact Contract
 

--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -215,6 +215,32 @@ cfl init --auth-method bearer --url https://mycompany.atlassian.net \
 
 > **Bearer Auth:** For [Atlassian service accounts](https://support.atlassian.com/user-management/docs/manage-api-tokens-for-service-accounts/) with scoped API tokens. Email is not required. Requests route through the `api.atlassian.com` gateway.
 
+After a successful save, `cfl init` prints the equivalent of `cfl me` so you can confirm which user the saved credentials authenticate as.
+
+---
+
+### `cfl me`
+
+Show the currently authenticated user as a token-dense one-liner: `accountId | displayName | email`. Missing fields render as `-` so the row is always exactly three pipe-delimited fields and stable to parse.
+
+```bash
+# Show current user
+cfl me
+# → 60e09bae7fcd820073089249 | Rian Stockbower | rian@example.com
+
+# Show only the account ID (for scripting)
+cfl me --id
+# → 60e09bae7fcd820073089249
+
+# -o json falls through to the one-liner — there is no JSON representation of `cfl me`.
+cfl me -o json
+# → 60e09bae7fcd820073089249 | Rian Stockbower | rian@example.com
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--id` | | `false` | Print only the account ID |
+
 ---
 
 ### `cfl space list`

--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -215,7 +215,7 @@ cfl init --auth-method bearer --url https://mycompany.atlassian.net \
 
 > **Bearer Auth:** For [Atlassian service accounts](https://support.atlassian.com/user-management/docs/manage-api-tokens-for-service-accounts/) with scoped API tokens. Email is not required. Requests route through the `api.atlassian.com` gateway.
 
-After a successful save, `cfl init` prints the equivalent of `cfl me` so you can confirm which user the saved credentials authenticate as.
+After a successful save, `cfl init` prints the equivalent of `cfl me` so you can confirm which user the saved credentials authenticate as. (Skipped when `--no-verify` is set, since no live API call is made and there is no user to render.)
 
 ---
 

--- a/tools/cfl/cmd/cfl/main.go
+++ b/tools/cfl/cmd/cfl/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/completion"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/configcmd"
 	initcmd "github.com/open-cli-collective/confluence-cli/internal/cmd/init"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/me"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/page"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/search"
@@ -29,6 +30,7 @@ func main() {
 	root.RegisterCommands(cmd, opts,
 		initcmd.Register,
 		configcmd.Register,
+		me.Register,
 		page.Register,
 		space.Register,
 		attachment.Register,

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -4,27 +4,38 @@ package init
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
-	"time"
 
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/auth"
-	"github.com/open-cli-collective/atlassian-go/client"
 
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/me"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	"github.com/open-cli-collective/confluence-cli/internal/config"
 )
 
+// clientBuilder constructs an *api.Client from a config.
+// Pulled out as a parameter so tests can inject an httptest-pointed client
+// without depending on api.NewBearerClient's hardcoded gateway URL.
+type clientBuilder func(cfg *config.Config) (*api.Client, error)
+
+func defaultClientBuilder(cfg *config.Config) (*api.Client, error) {
+	if cfg.AuthMethod == auth.AuthMethodBearer {
+		return api.NewBearerClient(cfg.APIToken, cfg.CloudID)
+	}
+	return api.NewClient(cfg.URL, cfg.Email, cfg.APIToken), nil
+}
+
 // Register adds the init command to the root command.
-func Register(rootCmd *cobra.Command, _ *root.Options) {
-	rootCmd.AddCommand(newInitCmd())
+func Register(rootCmd *cobra.Command, opts *root.Options) {
+	rootCmd.AddCommand(newInitCmd(opts))
 }
 
 // newInitCmd creates the init command.
-func newInitCmd() *cobra.Command {
+func newInitCmd(opts *root.Options) *cobra.Command {
 	var (
 		url        string
 		email      string
@@ -58,7 +69,7 @@ For service account scoped tokens (bearer auth):
   # Service account (bearer auth) setup
   cfl init --auth-method bearer --url https://mycompany.atlassian.net --cloud-id YOUR_CLOUD_ID`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runInit(cmd.Context(), url, email, authMethod, cloudID, noVerify)
+			return runInit(cmd.Context(), opts, url, email, authMethod, cloudID, noVerify)
 		},
 	}
 
@@ -71,7 +82,9 @@ For service account scoped tokens (bearer auth):
 	return cmd
 }
 
-func runInit(ctx context.Context, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string, noVerify bool) error {
+func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string, noVerify bool) error {
+	v := opts.View()
+
 	// Validate --auth-method flag early, before any interactive prompts
 	if prefillAuthMethod != "" {
 		if err := auth.ValidateAuthMethod(prefillAuthMethod); err != nil {
@@ -99,7 +112,7 @@ func runInit(ctx context.Context, prefillURL, prefillEmail, prefillAuthMethod, p
 			return err
 		}
 		if !overwrite {
-			_, _ = fmt.Fprintln(os.Stderr, "Initialization cancelled.")
+			v.Info("Initialization cancelled.")
 			return nil
 		}
 	}
@@ -243,87 +256,69 @@ func runInit(ctx context.Context, prefillURL, prefillEmail, prefillAuthMethod, p
 		return err
 	}
 
-	// Normalize URL
 	cfg.NormalizeURL()
 
-	// Validate
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	// Verify connection unless skipped
+	return finalizeInit(ctx, opts, cfg, configPath, noVerify, defaultClientBuilder)
+}
+
+// finalizeInit runs the verify/save/render pipeline after the form has produced
+// a normalized + validated config. Extracted as a non-interactive seam so tests
+// can supply an httptest-backed clientBuilder and a temp configPath.
+func finalizeInit(
+	ctx context.Context,
+	opts *root.Options,
+	cfg *config.Config,
+	configPath string,
+	noVerify bool,
+	build clientBuilder,
+) error {
+	v := opts.View()
+
+	var verifiedUser *api.User
+
 	if !noVerify {
-		_, _ = fmt.Fprint(os.Stderr, "Verifying connection... ")
-		if err := verifyConnection(ctx, cfg); err != nil {
-			_, _ = fmt.Fprintln(os.Stderr, "failed!")
-			return fmt.Errorf("verifying connection: %w", err)
+		client, err := build(cfg)
+		if err != nil {
+			return fmt.Errorf("creating client: %w", err)
 		}
-		_, _ = fmt.Fprintln(os.Stderr, "success!")
+
+		user, err := client.GetCurrentUser(ctx)
+		if err != nil {
+			v.Error("Connection failed: %v", err)
+			v.Println("")
+			v.Info("Check your credentials and try again")
+			return fmt.Errorf("authentication failed")
+		}
+
+		v.Success("Connected to %s", cfg.URL)
+		verifiedUser = user
 	}
 
-	// Save configuration
 	if err := cfg.Save(configPath); err != nil {
 		return err
 	}
 
-	_, _ = fmt.Fprintf(os.Stderr, "\nConfiguration saved to %s\n", configPath)
-	_, _ = fmt.Fprintln(os.Stderr, "\nYou're all set! Try running:")
-	_, _ = fmt.Fprintln(os.Stderr, "  cfl space list")
-	_, _ = fmt.Fprintln(os.Stderr, "  cfl page list --space <SPACE_KEY>")
+	v.Success("Configuration saved to %s", configPath)
 
-	if isBearer {
-		_, _ = fmt.Fprintln(os.Stderr, "")
-		_, _ = fmt.Fprintln(os.Stderr, "To switch back to basic auth later, run: cfl init --auth-method basic")
+	// Render the equivalent of `cfl me` using the user we already fetched
+	// during verify. No second API call, no opts state mutation.
+	if verifiedUser != nil {
+		v.Println("")
+		me.RenderUserOneLiner(v, verifiedUser)
 	}
 
-	return nil
-}
-
-func verifyConnection(ctx context.Context, cfg *config.Config) error {
-	httpClient := &http.Client{Timeout: 10 * time.Second}
-
-	var verifyURL string
+	v.Println("")
+	v.Println("You're all set! Try running:")
+	v.Println("  cfl space list")
+	v.Println("  cfl page list --space <SPACE_KEY>")
 
 	if cfg.AuthMethod == auth.AuthMethodBearer {
-		if cfg.CloudID == "" {
-			return fmt.Errorf("cloud ID is required for bearer auth connection verification")
-		}
-		// Bearer auth: use API gateway
-		verifyURL = fmt.Sprintf("%s/ex/confluence/%s/wiki/api/v2/spaces?limit=1", client.GatewayBaseURL, cfg.CloudID)
-	} else {
-		// Basic auth: use instance URL
-		verifyURL = cfg.URL + "/api/v2/spaces?limit=1"
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", verifyURL, nil)
-	if err != nil {
-		return err
-	}
-
-	if cfg.AuthMethod == auth.AuthMethodBearer {
-		req.Header.Set("Authorization", auth.BearerAuthHeader(cfg.APIToken))
-	} else {
-		req.SetBasicAuth(cfg.Email, cfg.APIToken)
-	}
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode == 401 {
-		if cfg.AuthMethod == auth.AuthMethodBearer {
-			return fmt.Errorf("authentication failed - check your API token and cloud ID")
-		}
-		return fmt.Errorf("authentication failed - check your email and API token")
-	}
-	if resp.StatusCode == 403 {
-		return fmt.Errorf("access denied - check your permissions")
-	}
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		v.Println("")
+		v.Info("To switch back to basic auth later, run: cfl init --auth-method basic")
 	}
 
 	return nil

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -288,10 +288,11 @@ func finalizeInit(
 
 		user, err := client.GetCurrentUser(ctx)
 		if err != nil {
+			// Both lines go to stderr (via v.Error) so a script capturing
+			// only stderr sees the failure AND the remediation hint.
 			v.Error("Connection failed: %v", err)
-			v.Println("")
-			v.Info("Check your credentials and try again")
-			return fmt.Errorf("authentication failed")
+			v.Error("Check your credentials and try again")
+			return fmt.Errorf("authentication failed: %w", err)
 		}
 
 		v.Success("Connected to %s", cfg.URL)

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -283,6 +283,7 @@ func finalizeInit(
 	if !noVerify {
 		client, err := build(cfg)
 		if err != nil {
+			v.Error("Could not construct API client: %v", err)
 			return fmt.Errorf("creating client: %w", err)
 		}
 

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -3,6 +3,7 @@ package init
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -295,6 +296,33 @@ func TestFinalizeInit_AuthFailure(t *testing.T) {
 
 	_, statErr := os.Stat(configPath)
 	testutil.True(t, os.IsNotExist(statErr), "config file should not exist after auth failure")
+}
+
+func TestFinalizeInit_BuildFailureSurfacesError(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	opts := newFinalizeOpts()
+	cfg := &config.Config{
+		URL:      "https://example.atlassian.net",
+		Email:    "rian@example.com",
+		APIToken: "test-token",
+	}
+
+	build := func(_ *config.Config) (*api.Client, error) {
+		return nil, errors.New("simulated builder failure")
+	}
+
+	err := finalizeInit(context.Background(), opts, cfg, configPath, false, build)
+	testutil.RequireError(t, err)
+	testutil.Contains(t, err.Error(), "simulated builder failure")
+
+	// User must see WHY init failed, not just a non-zero exit.
+	stderr := opts.Stderr.(*bytes.Buffer).String()
+	testutil.Contains(t, stderr, "Could not construct API client")
+
+	_, statErr := os.Stat(configPath)
+	testutil.True(t, os.IsNotExist(statErr), "config should not be saved when builder fails")
 }
 
 func TestFinalizeInit_NoVerify(t *testing.T) {

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -7,188 +7,20 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/auth"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	"github.com/open-cli-collective/confluence-cli/internal/config"
 )
 
-func TestVerifyConnection_Success(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify the request
-		testutil.Equal(t, "/api/v2/spaces", r.URL.Path)
-		testutil.Equal(t, "1", r.URL.Query().Get("limit"))
-		testutil.Equal(t, "application/json", r.Header.Get("Accept"))
-
-		// Verify basic auth is present
-		user, pass, ok := r.BasicAuth()
-		testutil.True(t, ok, "basic auth should be present")
-		testutil.Equal(t, "test@example.com", user)
-		testutil.Equal(t, "test-token", pass)
-
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"results": []}`))
-	}))
-	defer server.Close()
-
-	cfg := &config.Config{
-		URL:      server.URL,
-		Email:    "test@example.com",
-		APIToken: "test-token",
-	}
-
-	err := verifyConnection(context.Background(), cfg)
-	testutil.NoError(t, err)
-}
-
-func TestVerifyConnection_Unauthorized(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"message": "Unauthorized"}`))
-	}))
-	defer server.Close()
-
-	cfg := &config.Config{
-		URL:      server.URL,
-		Email:    "bad@example.com",
-		APIToken: "wrong-token",
-	}
-
-	err := verifyConnection(context.Background(), cfg)
-	testutil.RequireError(t, err)
-	testutil.Contains(t, err.Error(), "authentication failed")
-	testutil.Contains(t, err.Error(), "email and API token")
-}
-
-func TestVerifyConnection_Forbidden(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"message": "Forbidden"}`))
-	}))
-	defer server.Close()
-
-	cfg := &config.Config{ //nolint:gosec // test credentials
-		URL:      server.URL,
-		Email:    "test@example.com",
-		APIToken: "token-no-perms",
-	}
-
-	err := verifyConnection(context.Background(), cfg)
-	testutil.RequireError(t, err)
-	testutil.Contains(t, err.Error(), "access denied")
-	testutil.Contains(t, err.Error(), "permissions")
-}
-
-func TestVerifyConnection_ServerError(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	cfg := &config.Config{
-		URL:      server.URL,
-		Email:    "test@example.com",
-		APIToken: "test-token",
-	}
-
-	err := verifyConnection(context.Background(), cfg)
-	testutil.RequireError(t, err)
-	testutil.Contains(t, err.Error(), "unexpected status code: 500")
-}
-
-func TestVerifyConnection_NetworkError(t *testing.T) {
-	t.Parallel()
-	cfg := &config.Config{
-		URL:      "http://localhost:99999", // Non-existent server
-		Email:    "test@example.com",
-		APIToken: "test-token",
-	}
-
-	err := verifyConnection(context.Background(), cfg)
-	testutil.RequireError(t, err)
-	// Should fail to connect
-}
-
-func TestVerifyConnection_StatusCodes(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name       string
-		statusCode int
-		wantErr    bool
-		errContain string
-	}{
-		{
-			name:       "200 OK",
-			statusCode: http.StatusOK,
-			wantErr:    false,
-		},
-		{
-			name:       "401 Unauthorized",
-			statusCode: http.StatusUnauthorized,
-			wantErr:    true,
-			errContain: "authentication failed",
-		},
-		{
-			name:       "403 Forbidden",
-			statusCode: http.StatusForbidden,
-			wantErr:    true,
-			errContain: "access denied",
-		},
-		{
-			name:       "404 Not Found",
-			statusCode: http.StatusNotFound,
-			wantErr:    true,
-			errContain: "unexpected status code: 404",
-		},
-		{
-			name:       "502 Bad Gateway",
-			statusCode: http.StatusBadGateway,
-			wantErr:    true,
-			errContain: "unexpected status code: 502",
-		},
-		{
-			name:       "503 Service Unavailable",
-			statusCode: http.StatusServiceUnavailable,
-			wantErr:    true,
-			errContain: "unexpected status code: 503",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(tt.statusCode)
-			}))
-			defer server.Close()
-
-			cfg := &config.Config{
-				URL:      server.URL,
-				Email:    "test@example.com",
-				APIToken: "test-token",
-			}
-
-			err := verifyConnection(context.Background(), cfg)
-			if tt.wantErr {
-				testutil.RequireError(t, err)
-				testutil.Contains(t, err.Error(), tt.errContain)
-			} else {
-				testutil.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestConfigFilePermissions(t *testing.T) {
 	t.Parallel()
-	// Create a temp directory
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yml")
 
@@ -198,23 +30,18 @@ func TestConfigFilePermissions(t *testing.T) {
 		APIToken: "secret-token",
 	}
 
-	// Save the config
 	err := cfg.Save(configPath)
 	testutil.RequireNoError(t, err)
 
-	// Check the file permissions
 	info, err := os.Stat(configPath)
 	testutil.RequireNoError(t, err)
 
-	// On Unix, permissions should be 0600 (user read/write only)
-	// The exact mode includes the file type bits, so we mask with 0777
 	perm := info.Mode().Perm()
 	testutil.Equal(t, perm, os.FileMode(0600))
 }
 
 func TestConfigFilePermissions_DirectoryCreation(t *testing.T) {
 	t.Parallel()
-	// Create a temp directory with nested path
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "nested", "deeply", "config.yml")
 
@@ -224,15 +51,12 @@ func TestConfigFilePermissions_DirectoryCreation(t *testing.T) {
 		APIToken: "secret-token",
 	}
 
-	// Save should create the directory structure
 	err := cfg.Save(configPath)
 	testutil.RequireNoError(t, err)
 
-	// Verify file exists
 	_, err = os.Stat(configPath)
 	testutil.RequireNoError(t, err)
 
-	// Verify directory was created
 	dirInfo, err := os.Stat(filepath.Dir(configPath))
 	testutil.RequireNoError(t, err)
 	testutil.True(t, dirInfo.IsDir())
@@ -240,7 +64,6 @@ func TestConfigFilePermissions_DirectoryCreation(t *testing.T) {
 
 func TestInitCommand_Flags(t *testing.T) {
 	t.Parallel()
-	// Create root command with init registered
 	rootCmd := &cobra.Command{
 		Use:   "cfl",
 		Short: "Test CLI",
@@ -255,16 +78,13 @@ func TestInitCommand_Flags(t *testing.T) {
 
 	Register(rootCmd, opts)
 
-	// Find the init command
 	initCmd, _, err := rootCmd.Find([]string{"init"})
 	testutil.RequireNoError(t, err)
 
-	// Verify command structure
 	testutil.Equal(t, "init", initCmd.Use)
 	testutil.NotEmpty(t, initCmd.Short)
 	testutil.NotEmpty(t, initCmd.Long)
 
-	// Verify original flags exist
 	urlFlag := initCmd.Flags().Lookup("url")
 	testutil.NotNil(t, urlFlag)
 	testutil.Equal(t, "", urlFlag.DefValue)
@@ -277,7 +97,6 @@ func TestInitCommand_Flags(t *testing.T) {
 	testutil.NotNil(t, noVerifyFlag)
 	testutil.Equal(t, "false", noVerifyFlag.DefValue)
 
-	// Verify new auth flags exist
 	authMethodFlag := initCmd.Flags().Lookup("auth-method")
 	testutil.NotNil(t, authMethodFlag)
 	testutil.Equal(t, "", authMethodFlag.DefValue)
@@ -289,42 +108,164 @@ func TestInitCommand_Flags(t *testing.T) {
 
 func TestRunInit_InvalidAuthMethod(t *testing.T) {
 	t.Parallel()
-	// An invalid auth method should be rejected before the interactive form runs
-	err := runInit(context.Background(), "", "", "Bearer", "", true)
+	opts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts, "", "", "Bearer", "", true)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "invalid auth method")
 }
 
-func TestVerifyConnection_Bearer_EmptyCloudID(t *testing.T) {
-	t.Parallel()
-	cfg := &config.Config{
-		URL:        "https://example.atlassian.net/wiki",
-		APIToken:   "scoped-token",
-		AuthMethod: "bearer",
-		CloudID:    "",
-	}
+// finalizeInit tests use t.TempDir() for configPath and an httptest-backed
+// clientBuilder so the user's real config is never touched and no real
+// network call is made.
 
-	err := verifyConnection(context.Background(), cfg)
-	testutil.RequireError(t, err)
-	testutil.Contains(t, err.Error(), "cloud ID is required")
+func newFinalizeOpts() *root.Options {
+	return &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
 }
 
-func TestVerifyConnection_BasicAuth_Unauthorized(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"message": "Unauthorized"}`))
+func userResponseServer(t *testing.T, body string, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, "/wiki/rest/api/user/current", r.URL.Path)
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
 	}))
+}
+
+func TestFinalizeInit_BasicHappyPath(t *testing.T) {
+	t.Parallel()
+	server := userResponseServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`, http.StatusOK)
 	defer server.Close()
 
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	opts := newFinalizeOpts()
 	cfg := &config.Config{
 		URL:      server.URL,
-		Email:    "bad@example.com",
+		Email:    "rian@example.com",
+		APIToken: "test-token",
+	}
+
+	build := func(_ *config.Config) (*api.Client, error) {
+		return api.NewClient(server.URL, "rian@example.com", "test-token"), nil
+	}
+
+	err := finalizeInit(context.Background(), opts, cfg, configPath, false, build)
+	testutil.RequireNoError(t, err)
+
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Contains(t, stdout, "Connected to")
+	testutil.Contains(t, stdout, "Configuration saved to")
+	testutil.Contains(t, stdout, "abc123 | Rian Stockbower | rian@example.com")
+
+	_, err = os.Stat(configPath)
+	testutil.RequireNoError(t, err)
+}
+
+func TestFinalizeInit_BearerHappyPath(t *testing.T) {
+	t.Parallel()
+	server := userResponseServer(t, `{"accountId":"svc456","displayName":"Service Account","email":"svc@example.com"}`, http.StatusOK)
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	opts := newFinalizeOpts()
+	cfg := &config.Config{
+		URL:        server.URL,
+		APIToken:   "scoped-token",
+		AuthMethod: auth.AuthMethodBearer,
+		CloudID:    "test-cloud-id",
+	}
+
+	// Builder returns the same httptest-backed client regardless of auth method.
+	// This exercises finalizeInit's bearer control flow without depending on
+	// api.NewBearerClient's hardcoded gateway URL.
+	build := func(_ *config.Config) (*api.Client, error) {
+		return api.NewClient(server.URL, "", "scoped-token"), nil
+	}
+
+	err := finalizeInit(context.Background(), opts, cfg, configPath, false, build)
+	testutil.RequireNoError(t, err)
+
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Contains(t, stdout, "Connected to")
+	testutil.Contains(t, stdout, "Configuration saved to")
+	testutil.Contains(t, stdout, "svc456 | Service Account | svc@example.com")
+	testutil.Contains(t, stdout, "switch back to basic auth")
+
+	_, err = os.Stat(configPath)
+	testutil.RequireNoError(t, err)
+}
+
+func TestFinalizeInit_AuthFailure(t *testing.T) {
+	t.Parallel()
+	server := userResponseServer(t, `{"message":"Unauthorized"}`, http.StatusUnauthorized)
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	opts := newFinalizeOpts()
+	cfg := &config.Config{
+		URL:      server.URL,
+		Email:    "rian@example.com",
 		APIToken: "wrong-token",
 	}
 
-	err := verifyConnection(context.Background(), cfg)
+	build := func(_ *config.Config) (*api.Client, error) {
+		return api.NewClient(server.URL, "rian@example.com", "wrong-token"), nil
+	}
+
+	err := finalizeInit(context.Background(), opts, cfg, configPath, false, build)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "authentication failed")
-	testutil.Contains(t, err.Error(), "email and API token")
+
+	stderr := opts.Stderr.(*bytes.Buffer).String()
+	testutil.Contains(t, stderr, "Connection failed")
+
+	_, statErr := os.Stat(configPath)
+	testutil.True(t, os.IsNotExist(statErr), "config file should not exist after auth failure")
+}
+
+func TestFinalizeInit_NoVerify(t *testing.T) {
+	t.Parallel()
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	opts := newFinalizeOpts()
+	cfg := &config.Config{
+		URL:      server.URL,
+		Email:    "rian@example.com",
+		APIToken: "test-token",
+	}
+
+	build := func(_ *config.Config) (*api.Client, error) {
+		return api.NewClient(server.URL, "rian@example.com", "test-token"), nil
+	}
+
+	err := finalizeInit(context.Background(), opts, cfg, configPath, true, build)
+	testutil.RequireNoError(t, err)
+
+	testutil.False(t, called, "no API call should be made when --no-verify is set")
+
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Contains(t, stdout, "Configuration saved to")
+	// No verify → no fetched user → no one-liner rendered.
+	testutil.False(t, strings.Contains(stdout, " | "), "user one-liner should not appear without verify")
+
+	_, err = os.Stat(configPath)
+	testutil.RequireNoError(t, err)
 }

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/auth"
+	sharedclient "github.com/open-cli-collective/atlassian-go/client"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/spf13/cobra"
 
@@ -173,7 +174,15 @@ func TestFinalizeInit_BasicHappyPath(t *testing.T) {
 
 func TestFinalizeInit_BearerHappyPath(t *testing.T) {
 	t.Parallel()
-	server := userResponseServer(t, `{"accountId":"svc456","displayName":"Service Account","email":"svc@example.com"}`, http.StatusOK)
+	// Server asserts that the verify request actually carries a Bearer
+	// Authorization header — i.e. the bearer code path emits bearer auth on
+	// the wire, not just bearer-themed UI copy.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, "/wiki/rest/api/user/current", r.URL.Path)
+		testutil.Equal(t, "Bearer scoped-token", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"accountId":"svc456","displayName":"Service Account","email":"svc@example.com"}`))
+	}))
 	defer server.Close()
 
 	tmpDir := t.TempDir()
@@ -186,11 +195,15 @@ func TestFinalizeInit_BearerHappyPath(t *testing.T) {
 		CloudID:    "test-cloud-id",
 	}
 
-	// Builder returns the same httptest-backed client regardless of auth method.
-	// This exercises finalizeInit's bearer control flow without depending on
-	// api.NewBearerClient's hardcoded gateway URL.
-	build := func(_ *config.Config) (*api.Client, error) {
-		return api.NewClient(server.URL, "", "scoped-token"), nil
+	// Construct a real bearer-style client (auth header injected via Options)
+	// pointed at the httptest URL. This mirrors what api.NewBearerClient
+	// produces, just with a routable base URL.
+	build := func(c *config.Config) (*api.Client, error) {
+		return &api.Client{
+			Client: sharedclient.New(server.URL, "", "", &sharedclient.Options{
+				AuthHeader: auth.BearerAuthHeader(c.APIToken),
+			}),
+		}, nil
 	}
 
 	err := finalizeInit(context.Background(), opts, cfg, configPath, false, build)
@@ -204,6 +217,51 @@ func TestFinalizeInit_BearerHappyPath(t *testing.T) {
 
 	_, err = os.Stat(configPath)
 	testutil.RequireNoError(t, err)
+}
+
+// TestDefaultClientBuilder verifies the production wiring between
+// cfg.AuthMethod and which client constructor runs. In the finalizeInit
+// tests the builder is always replaced; this test pins the default.
+func TestDefaultClientBuilder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic constructs basic-auth client", func(t *testing.T) {
+		t.Parallel()
+		cfg := &config.Config{
+			URL:      "https://example.atlassian.net",
+			Email:    "user@example.com",
+			APIToken: "secret",
+		}
+		c, err := defaultClientBuilder(cfg)
+		testutil.RequireNoError(t, err)
+		testutil.Equal(t, "https://example.atlassian.net", c.BaseURL)
+		// Basic auth header is "Basic <base64(email:token)>"; presence of the
+		// "Basic " prefix is enough to confirm dispatch.
+		testutil.True(t, strings.HasPrefix(c.AuthHeader, "Basic "), "expected Basic prefix, got: "+c.AuthHeader)
+	})
+
+	t.Run("bearer constructs bearer-auth client at gateway", func(t *testing.T) {
+		t.Parallel()
+		cfg := &config.Config{
+			APIToken:   "scoped-token",
+			AuthMethod: auth.AuthMethodBearer,
+			CloudID:    "cloud-abc",
+		}
+		c, err := defaultClientBuilder(cfg)
+		testutil.RequireNoError(t, err)
+		testutil.Contains(t, c.BaseURL, "/ex/confluence/cloud-abc/wiki")
+		testutil.Equal(t, "Bearer scoped-token", c.AuthHeader)
+	})
+
+	t.Run("bearer rejects empty cloud ID", func(t *testing.T) {
+		t.Parallel()
+		cfg := &config.Config{
+			APIToken:   "scoped-token",
+			AuthMethod: auth.AuthMethodBearer,
+		}
+		_, err := defaultClientBuilder(cfg)
+		testutil.RequireError(t, err)
+	})
 }
 
 func TestFinalizeInit_AuthFailure(t *testing.T) {
@@ -230,6 +288,10 @@ func TestFinalizeInit_AuthFailure(t *testing.T) {
 
 	stderr := opts.Stderr.(*bytes.Buffer).String()
 	testutil.Contains(t, stderr, "Connection failed")
+	// Friendly remediation copy is part of the contract — surface a clear
+	// next step rather than just dumping the error.
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Contains(t, stdout, "Check your credentials and try again")
 
 	_, statErr := os.Stat(configPath)
 	testutil.True(t, os.IsNotExist(statErr), "config file should not exist after auth failure")
@@ -263,8 +325,10 @@ func TestFinalizeInit_NoVerify(t *testing.T) {
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
 	testutil.Contains(t, stdout, "Configuration saved to")
-	// No verify → no fetched user → no one-liner rendered.
-	testutil.False(t, strings.Contains(stdout, " | "), "user one-liner should not appear without verify")
+	// No verify → no fetched user → no one-liner rendered. Pin on the
+	// would-be account ID rather than the " | " separator so that future
+	// log lines containing pipes don't false-positive.
+	testutil.False(t, strings.Contains(stdout, "Connected to"), "verify confirmation should not appear without verify")
 
 	_, err = os.Stat(configPath)
 	testutil.RequireNoError(t, err)

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -286,12 +286,12 @@ func TestFinalizeInit_AuthFailure(t *testing.T) {
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "authentication failed")
 
+	// Both the error and the remediation hint must land on stderr — splitting
+	// them across stdout/stderr would mean a script capturing only stderr
+	// sees the failure with no actionable next step.
 	stderr := opts.Stderr.(*bytes.Buffer).String()
 	testutil.Contains(t, stderr, "Connection failed")
-	// Friendly remediation copy is part of the contract — surface a clear
-	// next step rather than just dumping the error.
-	stdout := opts.Stdout.(*bytes.Buffer).String()
-	testutil.Contains(t, stdout, "Check your credentials and try again")
+	testutil.Contains(t, stderr, "Check your credentials and try again")
 
 	_, statErr := os.Stat(configPath)
 	testutil.True(t, os.IsNotExist(statErr), "config file should not exist after auth failure")
@@ -299,9 +299,9 @@ func TestFinalizeInit_AuthFailure(t *testing.T) {
 
 func TestFinalizeInit_NoVerify(t *testing.T) {
 	t.Parallel()
-	called := false
+	httpCalled := false
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		called = true
+		httpCalled = true
 	}))
 	defer server.Close()
 
@@ -314,20 +314,25 @@ func TestFinalizeInit_NoVerify(t *testing.T) {
 		APIToken: "test-token",
 	}
 
+	// Track builder invocation directly. If the noVerify guard regresses
+	// (e.g. moves below the build call), the server-not-called assertion
+	// alone wouldn't catch it — the builder running but never being used
+	// would still leave httpCalled=false.
+	builderCalled := false
 	build := func(_ *config.Config) (*api.Client, error) {
+		builderCalled = true
 		return api.NewClient(server.URL, "rian@example.com", "test-token"), nil
 	}
 
 	err := finalizeInit(context.Background(), opts, cfg, configPath, true, build)
 	testutil.RequireNoError(t, err)
 
-	testutil.False(t, called, "no API call should be made when --no-verify is set")
+	testutil.False(t, builderCalled, "clientBuilder should not be invoked when --no-verify is set")
+	testutil.False(t, httpCalled, "no API call should be made when --no-verify is set")
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
 	testutil.Contains(t, stdout, "Configuration saved to")
-	// No verify → no fetched user → no one-liner rendered. Pin on the
-	// would-be account ID rather than the " | " separator so that future
-	// log lines containing pipes don't false-positive.
+	// No verify → no "Connected to" confirmation, no user one-liner.
 	testutil.False(t, strings.Contains(stdout, "Connected to"), "verify confirmation should not appear without verify")
 
 	_, err = os.Stat(configPath)

--- a/tools/cfl/internal/cmd/me/me.go
+++ b/tools/cfl/internal/cmd/me/me.go
@@ -1,0 +1,76 @@
+// Package me provides the me command for cfl.
+package me
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+// Register adds the me command to the root command.
+func Register(rootCmd *cobra.Command, opts *root.Options) {
+	rootCmd.AddCommand(newMeCmd(opts))
+}
+
+func newMeCmd(opts *root.Options) *cobra.Command {
+	var idOnly bool
+	cmd := &cobra.Command{
+		Use:   "me",
+		Short: "Show the currently authenticated user",
+		Long: `Show the user authenticated by the current cfl configuration as a token-dense one-liner: accountId | displayName | email.
+
+Missing fields render as "-" so the row is always exactly three pipe-delimited fields.`,
+		Example: `  # Show current user
+  cfl me
+
+  # Show only the account ID (for scripting)
+  cfl me --id`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return Run(cmd.Context(), opts, idOnly)
+		},
+	}
+	cmd.Flags().BoolVar(&idOnly, "id", false, "Print only the account ID")
+	return cmd
+}
+
+// Run fetches and renders the currently authenticated user.
+func Run(ctx context.Context, opts *root.Options, idOnly bool) error {
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+	user, err := client.GetCurrentUser(ctx)
+	if err != nil {
+		return fmt.Errorf("getting current user: %w", err)
+	}
+
+	v := opts.View()
+	if idOnly {
+		v.Println("%s", user.AccountID)
+		return nil
+	}
+	RenderUserOneLiner(v, user)
+	return nil
+}
+
+// RenderUserOneLiner writes the canonical 3-field user one-liner to v.
+// Exported so cfl init can render the same output after a successful save
+// without re-fetching the user or going through opts.APIClient().
+func RenderUserOneLiner(v *view.View, user *api.User) {
+	name := dashIfEmpty(user.DisplayName)
+	email := dashIfEmpty(user.Email)
+	v.Println("%s | %s | %s", user.AccountID, name, email)
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/tools/cfl/internal/cmd/me/me.go
+++ b/tools/cfl/internal/cmd/me/me.go
@@ -44,7 +44,7 @@ Missing fields render as "-" so the row is always exactly three pipe-delimited f
 func Run(ctx context.Context, opts *root.Options, idOnly bool) error {
 	client, err := opts.APIClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("getting API client: %w", err)
 	}
 	user, err := client.GetCurrentUser(ctx)
 	if err != nil {

--- a/tools/cfl/internal/cmd/me/me.go
+++ b/tools/cfl/internal/cmd/me/me.go
@@ -4,6 +4,7 @@ package me
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -62,15 +63,24 @@ func Run(ctx context.Context, opts *root.Options, idOnly bool) error {
 // RenderUserOneLiner writes the canonical 3-field user one-liner to v.
 // Exported so cfl init can render the same output after a successful save
 // without re-fetching the user or going through opts.APIClient().
+//
+// Field values are normalized so the output is always exactly three
+// pipe-delimited fields on a single line — newlines collapse to spaces and
+// embedded pipes are escaped to "\|" so downstream parsers can rely on
+// `split('|')` returning three columns.
 func RenderUserOneLiner(v *view.View, user *api.User) {
-	name := dashIfEmpty(user.DisplayName)
-	email := dashIfEmpty(user.Email)
-	v.Println("%s | %s | %s", user.AccountID, name, email)
+	id := normalizeField(user.AccountID)
+	name := normalizeField(user.DisplayName)
+	email := normalizeField(user.Email)
+	v.Println("%s | %s | %s", id, name, email)
 }
 
-func dashIfEmpty(s string) string {
+func normalizeField(s string) string {
 	if s == "" {
 		return "-"
 	}
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", `\|`)
 	return s
 }

--- a/tools/cfl/internal/cmd/me/me.go
+++ b/tools/cfl/internal/cmd/me/me.go
@@ -53,7 +53,7 @@ func Run(ctx context.Context, opts *root.Options, idOnly bool) error {
 
 	v := opts.View()
 	if idOnly {
-		v.Println("%s", user.AccountID)
+		v.Println("%s", normalizeField(user.AccountID))
 		return nil
 	}
 	RenderUserOneLiner(v, user)
@@ -81,6 +81,7 @@ func normalizeField(s string) string {
 	}
 	s = strings.ReplaceAll(s, "\r\n", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
 	s = strings.ReplaceAll(s, "|", `\|`)
 	return s
 }

--- a/tools/cfl/internal/cmd/me/me_test.go
+++ b/tools/cfl/internal/cmd/me/me_test.go
@@ -110,10 +110,11 @@ func TestRun_JSONOutputFallsThroughToOneLiner(t *testing.T) {
 
 func TestRun_NormalizesPipesAndNewlines(t *testing.T) {
 	t.Parallel()
-	// Display name contains an embedded pipe and newline; without normalization
-	// the row would have more than three pipe-delimited fields and would split
-	// across multiple lines, breaking the documented contract.
-	server := userServer(t, `{"accountId":"abc123","displayName":"Joe | Pwn\nNext","email":"joe@example.com"}`)
+	// Display name contains embedded pipe + LF + bare CR; without normalization
+	// the row would have more than three pipe-delimited fields, span multiple
+	// lines, or render with terminal-CR overwrite artifacts. All three would
+	// break the documented contract.
+	server := userServer(t, `{"accountId":"abc123","displayName":"Joe | Pwn\nNext\rEnd","email":"joe@example.com"}`)
 	defer server.Close()
 
 	opts := newTestRootOptions()
@@ -123,7 +124,38 @@ func TestRun_NormalizesPipesAndNewlines(t *testing.T) {
 	testutil.RequireNoError(t, err)
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
-	testutil.Equal(t, "abc123 | Joe \\| Pwn Next | joe@example.com\n", stdout)
+	testutil.Equal(t, "abc123 | Joe \\| Pwn Next End | joe@example.com\n", stdout)
+}
+
+func TestRun_IDOnly_NormalizesAccountID(t *testing.T) {
+	t.Parallel()
+	// --id should also honor the field-normalization contract: empty
+	// AccountID renders as "-", embedded specials are escaped/collapsed.
+	t.Run("empty AccountID renders as -", func(t *testing.T) {
+		t.Parallel()
+		server := userServer(t, `{"accountId":"","displayName":"Joe","email":"joe@example.com"}`)
+		defer server.Close()
+
+		opts := newTestRootOptions()
+		opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+		err := Run(context.Background(), opts, true)
+		testutil.RequireNoError(t, err)
+		testutil.Equal(t, "-\n", opts.Stdout.(*bytes.Buffer).String())
+	})
+
+	t.Run("pathological AccountID is normalized", func(t *testing.T) {
+		t.Parallel()
+		server := userServer(t, `{"accountId":"abc|def\nghi","displayName":"Joe","email":"joe@example.com"}`)
+		defer server.Close()
+
+		opts := newTestRootOptions()
+		opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+		err := Run(context.Background(), opts, true)
+		testutil.RequireNoError(t, err)
+		testutil.Equal(t, "abc\\|def ghi\n", opts.Stdout.(*bytes.Buffer).String())
+	})
 }
 
 func TestRegister_RegistersMeWithIDFlag(t *testing.T) {

--- a/tools/cfl/internal/cmd/me/me_test.go
+++ b/tools/cfl/internal/cmd/me/me_test.go
@@ -108,6 +108,19 @@ func TestRun_JSONOutputFallsThroughToOneLiner(t *testing.T) {
 	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com\n", stdout)
 }
 
+func TestRun_MissingAccountID(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"displayName":"Joe","email":"joe@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	err := Run(context.Background(), opts, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "- | Joe | joe@example.com\n", opts.Stdout.(*bytes.Buffer).String())
+}
+
 func TestRun_NormalizesPipesAndNewlines(t *testing.T) {
 	t.Parallel()
 	// Display name contains embedded pipe + LF + bare CR; without normalization

--- a/tools/cfl/internal/cmd/me/me_test.go
+++ b/tools/cfl/internal/cmd/me/me_test.go
@@ -1,0 +1,124 @@
+package me
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+func newTestRootOptions() *root.Options {
+	return &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+}
+
+func userServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, "/wiki/rest/api/user/current", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestRun_Default(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	err := Run(context.Background(), opts, false)
+	testutil.RequireNoError(t, err)
+
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com\n", stdout)
+}
+
+func TestRun_IDOnly(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	err := Run(context.Background(), opts, true)
+	testutil.RequireNoError(t, err)
+
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Equal(t, "abc123\n", stdout)
+}
+
+func TestRun_MissingDisplayName(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","email":"rian@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	err := Run(context.Background(), opts, false)
+	testutil.RequireNoError(t, err)
+
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Equal(t, "abc123 | - | rian@example.com\n", stdout)
+}
+
+func TestRun_MissingEmail(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	err := Run(context.Background(), opts, false)
+	testutil.RequireNoError(t, err)
+
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Equal(t, "abc123 | Rian Stockbower | -\n", stdout)
+}
+
+func TestRun_JSONOutputFallsThroughToOneLiner(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.Output = "json"
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	err := Run(context.Background(), opts, false)
+	testutil.RequireNoError(t, err)
+
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com\n", stdout)
+}
+
+func TestRun_APIError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
+	}))
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	err := Run(context.Background(), opts, false)
+	testutil.RequireError(t, err)
+	testutil.Contains(t, err.Error(), "getting current user")
+}

--- a/tools/cfl/internal/cmd/me/me_test.go
+++ b/tools/cfl/internal/cmd/me/me_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
+	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
@@ -105,6 +106,69 @@ func TestRun_JSONOutputFallsThroughToOneLiner(t *testing.T) {
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
 	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com\n", stdout)
+}
+
+func TestRun_NormalizesPipesAndNewlines(t *testing.T) {
+	t.Parallel()
+	// Display name contains an embedded pipe and newline; without normalization
+	// the row would have more than three pipe-delimited fields and would split
+	// across multiple lines, breaking the documented contract.
+	server := userServer(t, `{"accountId":"abc123","displayName":"Joe | Pwn\nNext","email":"joe@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	err := Run(context.Background(), opts, false)
+	testutil.RequireNoError(t, err)
+
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Equal(t, "abc123 | Joe \\| Pwn Next | joe@example.com\n", stdout)
+}
+
+func TestRegister_RegistersMeWithIDFlag(t *testing.T) {
+	t.Parallel()
+	rootCmd := &cobra.Command{Use: "cfl"}
+	opts := &root.Options{
+		Output:  "table",
+		NoColor: true,
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+
+	Register(rootCmd, opts)
+
+	meCmd, _, err := rootCmd.Find([]string{"me"})
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "me", meCmd.Use)
+	testutil.NotEmpty(t, meCmd.Short)
+
+	idFlag := meCmd.Flags().Lookup("id")
+	testutil.NotNil(t, idFlag)
+	testutil.Equal(t, "false", idFlag.DefValue)
+}
+
+// TestExecute_IDFlagWiredThroughCobra drives the command via cobra.Execute()
+// to confirm the --id flag actually toggles output, not just that the flag
+// exists. Catches regressions where the flag is dropped or the RunE glue
+// stops threading the boolean through to Run().
+func TestExecute_IDFlagWiredThroughCobra(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	rootCmd := &cobra.Command{Use: "cfl"}
+	Register(rootCmd, opts)
+	rootCmd.SetArgs([]string{"me", "--id"})
+
+	err := rootCmd.Execute()
+	testutil.RequireNoError(t, err)
+
+	stdout := opts.Stdout.(*bytes.Buffer).String()
+	testutil.Equal(t, "abc123\n", stdout)
 }
 
 func TestRun_APIError(t *testing.T) {


### PR DESCRIPTION
## Summary

- New `cfl me` command: prints the currently-authenticated user as a fixed 3-field one-liner — `accountId | displayName | email` — matching jtk's token-dense agentic output style. `--id` flag prints just the account ID. Missing fields render as `-` so the row is always exactly three pipe-delimited fields and stable to parse. No JSON output (`-o json` falls through to the one-liner).
- `cfl init` UX brought to parity with `jtk init`: replaced the raw `fmt.Fprintln(os.Stderr, ...)` calls with the shared `view.View` helper, so the verify/save lines now have colored ✓ decorators and route through the configurable Out/Err writers. Form (`charmbracelet/huh`) is unchanged.
- After a successful `cfl init` save, the equivalent of `cfl me` is rendered via a shared `me.RenderUserOneLiner` helper — reusing the `*api.User` already returned by the verify call. No second API hit, no test-only opts hooks promoted into production code.
- Removed the hand-rolled `verifyConnection` HTTP probe (and its tests). Verify now calls `api.Client.GetCurrentUser`, the same path `cfl me` uses. Both work for basic and bearer auth.

The verify/save/render pipeline is extracted to a `finalizeInit` helper with an injectable `clientBuilder` seam, so the new behavior is unit-testable end-to-end without driving the interactive form. Tests use `t.TempDir()` for the config path and an httptest-backed builder so the real user config is never touched.

Closes #355

## Test plan

- [x] `make -C tools/cfl build` — green
- [x] `make -C tools/cfl test` — 944 tests pass across 14 packages, 0 failures (race detection on)
- [x] `make -C tools/cfl lint` — 0 issues
- [x] New `TestRun_*` cases in `internal/cmd/me/me_test.go` (default, --id, missing displayName, missing email, -o json fallthrough, API error)
- [x] New `TestFinalizeInit_*` cases in `internal/cmd/init/init_test.go` (basic happy, bearer happy, auth failure, --no-verify)
- [x] Manual smoke (basic auth): `./tools/cfl/bin/cfl me` prints `60e09bae7fcd820073089249 | Rian Stockbower | rian@monitapp.io` and `cfl me --id` prints just the ID
- [ ] Manual smoke (bearer auth): not run pre-merge — no scoped service-account token available. The plan acknowledges this risk: if bearer scoped tokens lack access to `/wiki/rest/api/user/current`, both `cfl init --auth-method bearer` and `cfl me` will surface a clear `Connection failed` / `getting current user` error and we'll fast-follow with a v2 endpoint wrapper.

## Notes for reviewers

- `finalizeInit` takes `configPath` as a parameter (not `config.DefaultConfigPath()`) specifically so tests can isolate writes via `t.TempDir()`.
- The post-init render reuses the user from the verify call rather than re-routing through `opts.APIClient()` after a `SetAPIClient` mutation — that earlier draft conflated the test seam with production wiring.
- `huh.NewForm.Run()` remains uncovered by tests (interactive, requires a real TTY); the `finalizeInit` seam covers everything after the form completes.
