### PR TITLE
feat: shared atlassian credential store with init reconciliation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ The `cfl` and `jtk` sections may also carry credential overrides (`url`, `email`
 2. `ATLASSIAN_*` env
 3. Shared store, tool override section
 4. Shared store, `default` section
-5. Legacy per-tool config (`~/.config/cfl/config.yml`, `~/.config/jira-ticket-cli/config.json`)
+5. Legacy per-tool config (`~/.config/cfl/config.yml`; jtk uses `os.UserConfigDir()` so macOS is `~/Library/Application Support/jira-ticket-cli/config.json`, Linux is `~/.config/jira-ticket-cli/config.json`)
 
 Legacy files keep working indefinitely. Init detects them, prompts to migrate, and offers cleanup. If both tools' legacy files have different credentials, init runs a reconciliation flow (use cfl's, use jtk's, or keep them different) and educates the user that one Atlassian token usually works for both products.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,35 @@ Both tools support shared Atlassian credentials via `ATLASSIAN_*` environment va
 
 Tool-specific variables (`CFL_*`, `JIRA_*`) take precedence over shared variables. Both tools support Basic Auth (classic tokens, instance URL) and Bearer Auth (scoped tokens, api.atlassian.com gateway).
 
+## Shared credential store
+
+`cfl init` and `jtk init` both write to `~/.config/atlassian-cli/config.yml` (mode 0600). One token, both tools. Schema:
+
+```yaml
+default:
+  url: https://acme.atlassian.net   # base URL; cfl appends /wiki on read
+  email: u@example.com
+  api_token: <token>
+  auth_method: basic                # or "bearer"
+  cloud_id: <id>                    # required for bearer
+cfl:
+  default_space: SPACE              # cfl-only defaults
+jtk:
+  default_project: PROJ             # jtk-only defaults
+```
+
+The `cfl` and `jtk` sections may also carry credential overrides (`url`, `email`, `api_token`, `auth_method`, `cloud_id`) for the rare case where users want different tokens per tool. Per-field merge: a `cfl.api_token` override doesn't shadow `default.email`.
+
+**Resolution precedence (highest wins):**
+
+1. Tool-specific env (`CFL_*` / `JIRA_*`)
+2. `ATLASSIAN_*` env
+3. Shared store, tool override section
+4. Shared store, `default` section
+5. Legacy per-tool config (`~/.config/cfl/config.yml`, `~/.config/jira-ticket-cli/config.json`)
+
+Legacy files keep working indefinitely. Init detects them, prompts to migrate, and offers cleanup. If both tools' legacy files have different credentials, init runs a reconciliation flow (use cfl's, use jtk's, or keep them different) and educates the user that one Atlassian token usually works for both products.
+
 ## Git History
 
 This monorepo was created using `git subtree` to preserve the full commit history of both tools. Use `git log --oneline` to see the complete history from both source repositories.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ default:
   cloud_id: <id>                    # required for bearer
 cfl:
   default_space: SPACE              # cfl-only defaults
+  output_format: table              # cfl-only: table | json | plain
 jtk:
   default_project: PROJ             # jtk-only defaults
 ```

--- a/shared/credstore/credstore.go
+++ b/shared/credstore/credstore.go
@@ -1,0 +1,233 @@
+// Package credstore reads and writes the shared Atlassian credential
+// store at ~/.config/atlassian-cli/config.yml. The store has a single
+// "default" section that both cfl and jtk consume, plus optional
+// "cfl" and "jtk" sections that hold per-tool overrides (full or partial).
+//
+// Credential resolution is per-field merge (tool override beats default,
+// any unset field falls through), so a partial override — say, just a
+// different api_token for cfl — is fully supported.
+package credstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/open-cli-collective/atlassian-go/auth"
+)
+
+// ToolCFL is the section key for cfl-scoped overrides and defaults.
+const ToolCFL = "cfl"
+
+// ToolJTK is the section key for jtk-scoped overrides and defaults.
+const ToolJTK = "jtk"
+
+// ErrCorruptStore wraps any failure to parse a shared store. Callers
+// must surface this rather than silently falling through, otherwise
+// they risk overwriting a user file they couldn't read.
+var ErrCorruptStore = errors.New("credstore: corrupt or unparseable")
+
+// Section holds the credential fields shared across both tools.
+type Section struct {
+	URL        string `yaml:"url,omitempty"`
+	Email      string `yaml:"email,omitempty"`
+	APIToken   string `yaml:"api_token,omitempty"`
+	AuthMethod string `yaml:"auth_method,omitempty"`
+	CloudID    string `yaml:"cloud_id,omitempty"`
+}
+
+// ToolSection embeds Section and adds per-tool defaults that aren't
+// shareable (e.g., default_space is meaningless to jtk).
+type ToolSection struct {
+	Section        `yaml:",inline"`
+	DefaultSpace   string `yaml:"default_space,omitempty"`   // cfl
+	DefaultProject string `yaml:"default_project,omitempty"` // jtk
+	OutputFormat   string `yaml:"output_format,omitempty"`   // cfl
+}
+
+// Store is the on-disk representation of the shared credential file.
+type Store struct {
+	Default Section     `yaml:"default"`
+	CFL     ToolSection `yaml:"cfl,omitempty"`
+	JTK     ToolSection `yaml:"jtk,omitempty"`
+}
+
+// DefaultPath returns the canonical shared store path, honoring
+// $XDG_CONFIG_HOME if set.
+func DefaultPath() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "atlassian-cli", "config.yml")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".atlassian-cli", "config.yml")
+	}
+	return filepath.Join(home, ".config", "atlassian-cli", "config.yml")
+}
+
+// Load reads the store at path. An absent file returns an empty Store
+// with nil error so first-run callers don't have to special-case it.
+// A present-but-unreadable or unparseable file returns ErrCorruptStore;
+// callers must not overwrite without explicit user action.
+func Load(path string) (*Store, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // CLI tool reading its own config
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &Store{}, nil
+		}
+		return nil, fmt.Errorf("%w: reading %s: %s", ErrCorruptStore, path, err.Error())
+	}
+	var s Store
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("%w: parsing %s: %s", ErrCorruptStore, path, err.Error())
+	}
+	return &s, nil
+}
+
+// Save writes the store atomically (temp + rename). On any error before
+// or during rename, the temp file is removed best-effort so a failed
+// save never leaves stale .tmp behind. Mode is 0600; parent dir 0700.
+func (s *Store) Save(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+	data, err := yaml.Marshal(s) //nolint:gosec // config file intentionally stores API token
+	if err != nil {
+		return fmt.Errorf("marshaling: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("writing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming %s -> %s: %w", tmp, path, err)
+	}
+	return nil
+}
+
+func (s *Store) toolSection(tool string) ToolSection {
+	switch tool {
+	case ToolCFL:
+		return s.CFL
+	case ToolJTK:
+		return s.JTK
+	default:
+		return ToolSection{}
+	}
+}
+
+// Resolve returns the effective credentials for tool by merging the
+// tool's override section over default per field. Unset override fields
+// fall through to default; default fields fall through to zero.
+func (s *Store) Resolve(tool string) Section {
+	d := s.Default
+	o := s.toolSection(tool).Section
+	out := Section{
+		URL:        firstNonEmpty(o.URL, d.URL),
+		Email:      firstNonEmpty(o.Email, d.Email),
+		APIToken:   firstNonEmpty(o.APIToken, d.APIToken),
+		AuthMethod: firstNonEmpty(o.AuthMethod, d.AuthMethod),
+		CloudID:    firstNonEmpty(o.CloudID, d.CloudID),
+	}
+	return out
+}
+
+// Source describes where a resolved field came from. Used by
+// `config show` to render an audit-friendly source column.
+type Source string
+
+const (
+	SourceUnset    Source = "unset"
+	SourceDefault  Source = "shared default"
+	SourceOverride Source = "shared override"
+)
+
+// ResolveWithSource returns the resolved value and where it came from.
+// Field is the YAML field name (url, email, api_token, auth_method, cloud_id).
+func (s *Store) ResolveWithSource(tool, field string) (string, Source) {
+	o := s.toolSection(tool).Section
+	d := s.Default
+	get := func(sec Section) string {
+		switch field {
+		case "url":
+			return sec.URL
+		case "email":
+			return sec.Email
+		case "api_token":
+			return sec.APIToken
+		case "auth_method":
+			return sec.AuthMethod
+		case "cloud_id":
+			return sec.CloudID
+		}
+		return ""
+	}
+	if v := get(o); v != "" {
+		return v, SourceOverride
+	}
+	if v := get(d); v != "" {
+		return v, SourceDefault
+	}
+	return "", SourceUnset
+}
+
+// HasUsableCreds reports whether Resolve(tool) yields enough fields to
+// authenticate against Atlassian for this tool. Basic requires url +
+// email + token; bearer requires url + token + cloud_id. Empty
+// auth_method defaults to basic, matching the rest of the codebase.
+func (s *Store) HasUsableCreds(tool string) bool {
+	r := s.Resolve(tool)
+	method := r.AuthMethod
+	if method == "" {
+		method = auth.AuthMethodBasic
+	}
+	switch method {
+	case auth.AuthMethodBearer:
+		return r.URL != "" && r.APIToken != "" && r.CloudID != ""
+	case auth.AuthMethodBasic:
+		return r.URL != "" && r.Email != "" && r.APIToken != ""
+	default:
+		return false
+	}
+}
+
+// NormalizeBaseURL strips the "/wiki" suffix and any trailing "/" so
+// the shared store always carries the bare instance URL. Idempotent.
+func NormalizeBaseURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u := strings.TrimRight(raw, "/")
+	for strings.HasSuffix(u, "/wiki") {
+		u = strings.TrimSuffix(u, "/wiki")
+		u = strings.TrimRight(u, "/")
+	}
+	return u
+}
+
+// URLForCFL returns base + "/wiki", refusing to double-append. Always
+// produces a /wiki-suffixed URL even when given a base that already
+// has trailing slashes or a stray /wiki.
+func URLForCFL(base string) string {
+	b := NormalizeBaseURL(base)
+	if b == "" {
+		return ""
+	}
+	return b + "/wiki"
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/shared/credstore/credstore.go
+++ b/shared/credstore/credstore.go
@@ -26,9 +26,10 @@ const ToolCFL = "cfl"
 // ToolJTK is the section key for jtk-scoped overrides and defaults.
 const ToolJTK = "jtk"
 
-// ErrCorruptStore wraps any failure to parse a shared store. Callers
-// must surface this rather than silently falling through, otherwise
-// they risk overwriting a user file they couldn't read.
+// ErrCorruptStore wraps any failure to parse a shared store. Init
+// surfaces this as a hard error and refuses to overwrite the file;
+// runtime config-resolution paths warn-and-fall-back instead so a
+// corrupt shared file doesn't crash every command.
 var ErrCorruptStore = errors.New("credstore: corrupt or unparseable")
 
 // Section holds the credential fields shared across both tools.

--- a/shared/credstore/credstore.go
+++ b/shared/credstore/credstore.go
@@ -144,8 +144,12 @@ func (s *Store) Resolve(tool string) Section {
 type Source string
 
 const (
-	SourceUnset    Source = "unset"
-	SourceDefault  Source = "shared default"
+	SourceUnset       Source = "unset"
+	SourceDefault     Source = "shared default"
+	SourceOverrideCFL Source = "shared cfl override"
+	SourceOverrideJTK Source = "shared jtk override"
+	// SourceOverride is retained for callers that don't care which tool
+	// owns the override section. Prefer the tool-specific constants.
 	SourceOverride Source = "shared override"
 )
 
@@ -170,7 +174,14 @@ func (s *Store) ResolveWithSource(tool, field string) (string, Source) {
 		return ""
 	}
 	if v := get(o); v != "" {
-		return v, SourceOverride
+		switch tool {
+		case ToolCFL:
+			return v, SourceOverrideCFL
+		case ToolJTK:
+			return v, SourceOverrideJTK
+		default:
+			return v, SourceOverride
+		}
 	}
 	if v := get(d); v != "" {
 		return v, SourceDefault

--- a/shared/credstore/credstore.go
+++ b/shared/credstore/credstore.go
@@ -71,8 +71,12 @@ func DefaultPath() string {
 
 // Load reads the store at path. An absent file returns an empty Store
 // with nil error so first-run callers don't have to special-case it.
-// A present-but-unreadable or unparseable file returns ErrCorruptStore;
-// callers must not overwrite without explicit user action.
+// A present-but-unreadable or unparseable file returns ErrCorruptStore.
+//
+// init code paths use this directly so they can refuse to overwrite a
+// file we couldn't read. Runtime config-resolution paths (cfl
+// LoadWithEnv, jtk's accessors) instead warn-and-fall-back so a
+// corrupt shared file doesn't break every command for the user.
 func Load(path string) (*Store, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // CLI tool reading its own config
 	if err != nil {

--- a/shared/credstore/credstore.go
+++ b/shared/credstore/credstore.go
@@ -153,9 +153,6 @@ const (
 	SourceDefault     Source = "shared default"
 	SourceOverrideCFL Source = "shared cfl override"
 	SourceOverrideJTK Source = "shared jtk override"
-	// SourceOverride is retained for callers that don't care which tool
-	// owns the override section. Prefer the tool-specific constants.
-	SourceOverride Source = "shared override"
 )
 
 // ResolveWithSource returns the resolved value and where it came from.
@@ -185,7 +182,7 @@ func (s *Store) ResolveWithSource(tool, field string) (string, Source) {
 		case ToolJTK:
 			return v, SourceOverrideJTK
 		default:
-			return v, SourceOverride
+			return v, SourceUnset
 		}
 	}
 	if v := get(d); v != "" {

--- a/shared/credstore/credstore_test.go
+++ b/shared/credstore/credstore_test.go
@@ -1,0 +1,273 @@
+package credstore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/auth"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestLoad_AbsentReturnsEmptyStore(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	s, err := Load(filepath.Join(dir, "missing.yml"))
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "", s.Default.URL)
+	testutil.Equal(t, "", s.CFL.APIToken)
+}
+
+func TestLoad_CorruptReturnsErrCorrupt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	testutil.RequireNoError(t, os.WriteFile(path, []byte("default: not valid yaml: ::: : ["), 0o600))
+	_, err := Load(path)
+	testutil.RequireError(t, err)
+	if !errors.Is(err, ErrCorruptStore) {
+		t.Fatalf("expected ErrCorruptStore, got %v", err)
+	}
+}
+
+func TestSaveLoad_Roundtrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "atlassian-cli", "config.yml")
+	in := &Store{
+		Default: Section{
+			URL:      "https://acme.atlassian.net",
+			Email:    "u@example.com",
+			APIToken: "tok",
+		},
+		CFL: ToolSection{
+			Section:      Section{APIToken: "cfl-tok"},
+			DefaultSpace: "MYSPACE",
+		},
+	}
+	testutil.RequireNoError(t, in.Save(path))
+	out, err := Load(path)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, in.Default.URL, out.Default.URL)
+	testutil.Equal(t, in.Default.Email, out.Default.Email)
+	testutil.Equal(t, in.Default.APIToken, out.Default.APIToken)
+	testutil.Equal(t, in.CFL.APIToken, out.CFL.APIToken)
+	testutil.Equal(t, in.CFL.DefaultSpace, out.CFL.DefaultSpace)
+}
+
+func TestSave_ModeIs0600(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("file modes don't apply on windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	s := &Store{Default: Section{URL: "https://x"}}
+	testutil.RequireNoError(t, s.Save(path))
+	info, err := os.Stat(path)
+	testutil.RequireNoError(t, err)
+	mode := info.Mode().Perm()
+	testutil.Equal(t, os.FileMode(0o600), mode)
+}
+
+func TestSave_NoLeftoverTempOnSuccess(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	s := &Store{Default: Section{URL: "https://x"}}
+	testutil.RequireNoError(t, s.Save(path))
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*.tmp"))
+	testutil.RequireNoError(t, err)
+	if len(matches) != 0 {
+		t.Fatalf("found leftover tmp files: %v", matches)
+	}
+}
+
+func TestSave_NoLeftoverTempOnFailure(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("permission semantics differ on windows")
+	}
+	// Make the parent directory non-writable so os.WriteFile of the .tmp fails.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "child", "config.yml")
+	testutil.RequireNoError(t, os.MkdirAll(filepath.Dir(target), 0o700))
+	testutil.RequireNoError(t, os.Chmod(filepath.Dir(target), 0o500)) //nolint:gosec // intentional: induce write failure
+	t.Cleanup(func() { _ = os.Chmod(filepath.Dir(target), 0o700) })   //nolint:gosec // intentional: restore for cleanup
+
+	s := &Store{Default: Section{URL: "https://x"}}
+	err := s.Save(target)
+	testutil.RequireError(t, err)
+
+	// No stray .tmp left in the locked directory.
+	testutil.RequireNoError(t, os.Chmod(filepath.Dir(target), 0o700)) //nolint:gosec // intentional: restore for inspection
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(target), "*.tmp"))
+	testutil.RequireNoError(t, err)
+	if len(matches) != 0 {
+		t.Fatalf("found leftover tmp files after induced failure: %v", matches)
+	}
+}
+
+func TestResolve_PerFieldMergeWithPartialOverride(t *testing.T) {
+	t.Parallel()
+	s := &Store{
+		Default: Section{
+			URL:      "https://acme.atlassian.net",
+			Email:    "default@example.com",
+			APIToken: "default-tok",
+		},
+		CFL: ToolSection{
+			Section: Section{APIToken: "cfl-tok"}, // only token override
+		},
+	}
+	got := s.Resolve(ToolCFL)
+	testutil.Equal(t, "https://acme.atlassian.net", got.URL)      // default
+	testutil.Equal(t, "default@example.com", got.Email)           // default
+	testutil.Equal(t, "cfl-tok", got.APIToken)                    // override
+	testutil.Equal(t, "default-tok", s.Default.APIToken)          // default untouched
+	testutil.Equal(t, "default-tok", s.Resolve(ToolJTK).APIToken) // jtk falls through to default
+}
+
+func TestResolve_UnknownToolReturnsDefault(t *testing.T) {
+	t.Parallel()
+	s := &Store{Default: Section{URL: "https://x"}}
+	got := s.Resolve("unknown")
+	testutil.Equal(t, "https://x", got.URL)
+}
+
+func TestResolveWithSource(t *testing.T) {
+	t.Parallel()
+	s := &Store{
+		Default: Section{URL: "https://acme.atlassian.net", Email: "u@e.com"},
+		CFL:     ToolSection{Section: Section{APIToken: "cfl-tok"}},
+	}
+	cases := []struct {
+		field     string
+		wantValue string
+		wantSrc   Source
+	}{
+		{"url", "https://acme.atlassian.net", SourceDefault},
+		{"email", "u@e.com", SourceDefault},
+		{"api_token", "cfl-tok", SourceOverride},
+		{"cloud_id", "", SourceUnset},
+	}
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			t.Parallel()
+			v, src := s.ResolveWithSource(ToolCFL, tc.field)
+			testutil.Equal(t, tc.wantValue, v)
+			testutil.Equal(t, tc.wantSrc, src)
+		})
+	}
+}
+
+func TestHasUsableCreds(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		s    *Store
+		tool string
+		want bool
+	}{
+		{
+			name: "basic complete in default",
+			s:    &Store{Default: Section{URL: "u", Email: "e", APIToken: "t"}},
+			tool: ToolCFL,
+			want: true,
+		},
+		{
+			name: "basic missing email",
+			s:    &Store{Default: Section{URL: "u", APIToken: "t"}},
+			tool: ToolCFL,
+			want: false,
+		},
+		{
+			name: "basic completed by partial override",
+			s: &Store{
+				Default: Section{URL: "u", APIToken: "t"},
+				CFL:     ToolSection{Section: Section{Email: "e"}},
+			},
+			tool: ToolCFL,
+			want: true,
+		},
+		{
+			name: "bearer needs cloud_id",
+			s: &Store{Default: Section{
+				URL: "u", APIToken: "t", AuthMethod: auth.AuthMethodBearer,
+			}},
+			tool: ToolJTK,
+			want: false,
+		},
+		{
+			name: "bearer complete",
+			s: &Store{Default: Section{
+				URL: "u", APIToken: "t", CloudID: "c", AuthMethod: auth.AuthMethodBearer,
+			}},
+			tool: ToolJTK,
+			want: true,
+		},
+		{
+			name: "empty store",
+			s:    &Store{},
+			tool: ToolCFL,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.s.HasUsableCreds(tc.tool)
+			testutil.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNormalizeBaseURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ in, out string }{
+		{"", ""},
+		{"https://acme.atlassian.net", "https://acme.atlassian.net"},
+		{"https://acme.atlassian.net/", "https://acme.atlassian.net"},
+		{"https://acme.atlassian.net/wiki", "https://acme.atlassian.net"},
+		{"https://acme.atlassian.net/wiki/", "https://acme.atlassian.net"},
+		{"https://acme.atlassian.net/wiki/wiki", "https://acme.atlassian.net"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			testutil.Equal(t, tc.out, NormalizeBaseURL(tc.in))
+		})
+	}
+}
+
+func TestURLForCFL(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ in, out string }{
+		{"", ""},
+		{"https://acme.atlassian.net", "https://acme.atlassian.net/wiki"},
+		{"https://acme.atlassian.net/", "https://acme.atlassian.net/wiki"},
+		{"https://acme.atlassian.net/wiki", "https://acme.atlassian.net/wiki"},
+		{"https://acme.atlassian.net/wiki/", "https://acme.atlassian.net/wiki"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got := URLForCFL(tc.in)
+			testutil.Equal(t, tc.out, got)
+			// Idempotent: applying NormalizeBaseURL(URLForCFL(x)) returns base.
+			if tc.out != "" && !strings.HasSuffix(got, "/wiki") {
+				t.Fatalf("URLForCFL did not produce /wiki suffix: %q", got)
+			}
+		})
+	}
+}
+
+func TestDefaultPath_HonorsXDG(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/custom/xdg")
+	got := DefaultPath()
+	testutil.Equal(t, "/custom/xdg/atlassian-cli/config.yml", got)
+}

--- a/shared/credstore/credstore_test.go
+++ b/shared/credstore/credstore_test.go
@@ -152,7 +152,7 @@ func TestResolveWithSource(t *testing.T) {
 	}{
 		{"url", "https://acme.atlassian.net", SourceDefault},
 		{"email", "u@e.com", SourceDefault},
-		{"api_token", "cfl-tok", SourceOverride},
+		{"api_token", "cfl-tok", SourceOverrideCFL},
 		{"cloud_id", "", SourceUnset},
 	}
 	for _, tc := range cases {

--- a/shared/credstore/legacy.go
+++ b/shared/credstore/legacy.go
@@ -1,0 +1,130 @@
+package credstore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LegacyCreds is a minimal projection of either tool's legacy config
+// file. Used by init reconciliation to compare against the shared store
+// without depending on each tool's full Config struct.
+type LegacyCreds struct {
+	Path           string // "" if file was absent
+	URL            string
+	Email          string
+	APIToken       string
+	AuthMethod     string
+	CloudID        string
+	DefaultSpace   string // cfl-only
+	DefaultProject string // jtk-only
+	OutputFormat   string // cfl-only
+}
+
+// Section returns the credential fields, with URL normalized to base.
+func (l *LegacyCreds) Section() Section {
+	return Section{
+		URL:        NormalizeBaseURL(l.URL),
+		Email:      l.Email,
+		APIToken:   l.APIToken,
+		AuthMethod: l.AuthMethod,
+		CloudID:    l.CloudID,
+	}
+}
+
+// LegacyCFLPath returns the canonical cfl legacy config path.
+func LegacyCFLPath() string {
+	return tooledPath("cfl", "config.yml")
+}
+
+// LegacyJTKPath returns the canonical jtk legacy config path.
+func LegacyJTKPath() string {
+	return tooledPath("jira-ticket-cli", "config.json")
+}
+
+func tooledPath(toolDir, file string) string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, toolDir, file)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", "."+toolDir, file)
+	}
+	return filepath.Join(home, ".config", toolDir, file)
+}
+
+// LoadLegacyCFL reads a cfl YAML legacy config file. An absent file
+// returns (nil, nil). Parse failures return ErrCorruptStore so the
+// caller can refuse to clobber it.
+func LoadLegacyCFL(path string) (*LegacyCreds, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // CLI tool reading its own config
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: reading %s: %s", ErrCorruptStore, path, err.Error())
+	}
+	var raw struct {
+		URL          string `yaml:"url"`
+		Email        string `yaml:"email"`
+		APIToken     string `yaml:"api_token"`
+		DefaultSpace string `yaml:"default_space"`
+		OutputFormat string `yaml:"output_format"`
+		AuthMethod   string `yaml:"auth_method"`
+		CloudID      string `yaml:"cloud_id"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("%w: parsing %s: %s", ErrCorruptStore, path, err.Error())
+	}
+	return &LegacyCreds{
+		Path:         path,
+		URL:          raw.URL,
+		Email:        raw.Email,
+		APIToken:     raw.APIToken,
+		AuthMethod:   raw.AuthMethod,
+		CloudID:      raw.CloudID,
+		DefaultSpace: raw.DefaultSpace,
+		OutputFormat: raw.OutputFormat,
+	}, nil
+}
+
+// LoadLegacyJTK reads a jtk JSON legacy config file. An absent file
+// returns (nil, nil). Parse failures return ErrCorruptStore.
+func LoadLegacyJTK(path string) (*LegacyCreds, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // CLI tool reading its own config
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: reading %s: %s", ErrCorruptStore, path, err.Error())
+	}
+	var raw struct {
+		URL            string `json:"url"`
+		Domain         string `json:"domain"`
+		Email          string `json:"email"`
+		APIToken       string `json:"api_token"`
+		DefaultProject string `json:"default_project"`
+		AuthMethod     string `json:"auth_method"`
+		CloudID        string `json:"cloud_id"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("%w: parsing %s: %s", ErrCorruptStore, path, err.Error())
+	}
+	url := raw.URL
+	if url == "" && raw.Domain != "" {
+		url = "https://" + raw.Domain + ".atlassian.net"
+	}
+	return &LegacyCreds{
+		Path:           path,
+		URL:            url,
+		Email:          raw.Email,
+		APIToken:       raw.APIToken,
+		AuthMethod:     raw.AuthMethod,
+		CloudID:        raw.CloudID,
+		DefaultProject: raw.DefaultProject,
+	}, nil
+}

--- a/shared/credstore/legacy.go
+++ b/shared/credstore/legacy.go
@@ -41,9 +41,17 @@ func LegacyCFLPath() string {
 	return tooledPath("cfl", "config.yml")
 }
 
-// LegacyJTKPath returns the canonical jtk legacy config path.
+// LegacyJTKPath returns the canonical jtk legacy config path. jtk's
+// loader uses os.UserConfigDir(), which on macOS is
+// ~/Library/Application Support — matching it here is critical so
+// macOS users with an existing jtk config are detected by sibling
+// init reconciliation.
 func LegacyJTKPath() string {
-	return tooledPath("jira-ticket-cli", "config.json")
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return filepath.Join(".", "jira-ticket-cli", "config.json")
+	}
+	return filepath.Join(dir, "jira-ticket-cli", "config.json")
 }
 
 func tooledPath(toolDir, file string) string {

--- a/shared/credstore/legacy_test.go
+++ b/shared/credstore/legacy_test.go
@@ -1,0 +1,104 @@
+package credstore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestLoadLegacyCFL(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	body := `url: https://acme.atlassian.net/wiki
+email: u@example.com
+api_token: token
+default_space: SPACE
+auth_method: bearer
+cloud_id: cloud-1
+`
+	testutil.RequireNoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+	got, err := LoadLegacyCFL(path)
+	testutil.RequireNoError(t, err)
+	testutil.NotNil(t, got)
+	testutil.Equal(t, "https://acme.atlassian.net/wiki", got.URL)
+	testutil.Equal(t, "u@example.com", got.Email)
+	testutil.Equal(t, "token", got.APIToken)
+	testutil.Equal(t, "SPACE", got.DefaultSpace)
+	testutil.Equal(t, "bearer", got.AuthMethod)
+	testutil.Equal(t, "cloud-1", got.CloudID)
+
+	// Section() normalizes URL to base.
+	testutil.Equal(t, "https://acme.atlassian.net", got.Section().URL)
+}
+
+func TestLoadLegacyCFL_AbsentReturnsNilNil(t *testing.T) {
+	t.Parallel()
+	got, err := LoadLegacyCFL(filepath.Join(t.TempDir(), "missing.yml"))
+	testutil.RequireNoError(t, err)
+	if got != nil {
+		t.Fatalf("expected nil for absent file, got %+v", got)
+	}
+}
+
+func TestLoadLegacyCFL_CorruptReturnsErrCorrupt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	testutil.RequireNoError(t, os.WriteFile(path, []byte("url: : :: ["), 0o600))
+
+	_, err := LoadLegacyCFL(path)
+	testutil.RequireError(t, err)
+	if !errors.Is(err, ErrCorruptStore) {
+		t.Fatalf("expected ErrCorruptStore, got %v", err)
+	}
+}
+
+func TestLoadLegacyJTK(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	body := `{"url":"https://acme.atlassian.net","email":"u@e","api_token":"tok","default_project":"PROJ","auth_method":"bearer","cloud_id":"c-1"}`
+	testutil.RequireNoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+	got, err := LoadLegacyJTK(path)
+	testutil.RequireNoError(t, err)
+	testutil.NotNil(t, got)
+	testutil.Equal(t, "https://acme.atlassian.net", got.URL)
+	testutil.Equal(t, "PROJ", got.DefaultProject)
+	testutil.Equal(t, "bearer", got.AuthMethod)
+}
+
+func TestLoadLegacyJTK_DomainFallback(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	testutil.RequireNoError(t, os.WriteFile(path, []byte(`{"domain":"acme","email":"u@e","api_token":"t"}`), 0o600))
+
+	got, err := LoadLegacyJTK(path)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "https://acme.atlassian.net", got.URL)
+}
+
+func TestLoadLegacyJTK_CorruptReturnsErrCorrupt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	testutil.RequireNoError(t, os.WriteFile(path, []byte("{not json"), 0o600))
+
+	_, err := LoadLegacyJTK(path)
+	testutil.RequireError(t, err)
+	if !errors.Is(err, ErrCorruptStore) {
+		t.Fatalf("expected ErrCorruptStore, got %v", err)
+	}
+}
+
+func TestLegacyPaths_HonorXDG(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/custom/xdg")
+	testutil.Equal(t, "/custom/xdg/cfl/config.yml", LegacyCFLPath())
+	testutil.Equal(t, "/custom/xdg/jira-ticket-cli/config.json", LegacyJTKPath())
+}

--- a/shared/credstore/legacy_test.go
+++ b/shared/credstore/legacy_test.go
@@ -97,8 +97,27 @@ func TestLoadLegacyJTK_CorruptReturnsErrCorrupt(t *testing.T) {
 	}
 }
 
-func TestLegacyPaths_HonorXDG(t *testing.T) {
+func TestLegacyCFLPath_HonorsXDG(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/custom/xdg")
 	testutil.Equal(t, "/custom/xdg/cfl/config.yml", LegacyCFLPath())
-	testutil.Equal(t, "/custom/xdg/jira-ticket-cli/config.json", LegacyJTKPath())
+}
+
+func TestLegacyJTKPath_MatchesUserConfigDir(t *testing.T) {
+	// jtk uses os.UserConfigDir(); we must match exactly so macOS
+	// users (~/Library/Application Support) are detected.
+	dir, err := os.UserConfigDir()
+	testutil.RequireNoError(t, err)
+	want := filepath.Join(dir, "jira-ticket-cli", "config.json")
+	testutil.Equal(t, want, LegacyJTKPath())
+}
+
+func TestLegacyJTKPath_NotXDGFallback(t *testing.T) {
+	// On Linux os.UserConfigDir honors XDG_CONFIG_HOME, but on macOS
+	// it returns ~/Library/Application Support and ignores XDG. Either
+	// way, our LegacyJTKPath must match os.UserConfigDir's choice.
+	t.Setenv("XDG_CONFIG_HOME", "/custom/xdg")
+	dir, err := os.UserConfigDir()
+	testutil.RequireNoError(t, err)
+	want := filepath.Join(dir, "jira-ticket-cli", "config.json")
+	testutil.Equal(t, want, LegacyJTKPath())
 }

--- a/shared/credstore/reconcile.go
+++ b/shared/credstore/reconcile.go
@@ -1,0 +1,58 @@
+package credstore
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SectionsEqual reports whether two Sections describe the same
+// credentials. URLs are normalized to base form before comparison so
+// "https://acme.atlassian.net/wiki" and "https://acme.atlassian.net"
+// don't read as different.
+func SectionsEqual(a, b Section) bool {
+	return NormalizeBaseURL(a.URL) == NormalizeBaseURL(b.URL) &&
+		a.Email == b.Email &&
+		a.APIToken == b.APIToken &&
+		a.AuthMethod == b.AuthMethod &&
+		a.CloudID == b.CloudID
+}
+
+// MaskToken returns a redacted form of an API token suitable for
+// display in reconciliation prompts: first 4 + "..." + last 4 for
+// long tokens, "***" for short ones, "" for empty.
+func MaskToken(t string) string {
+	if t == "" {
+		return ""
+	}
+	if len(t) <= 8 {
+		return "***"
+	}
+	return t[:4] + "..." + t[len(t)-4:]
+}
+
+// FormatSection renders a Section as a four-line block suitable for
+// embedding in interactive reconciliation prompts. Empty fields are
+// rendered as "(unset)" so the user sees the full schema either way.
+func FormatSection(label string, s Section) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "  %s:\n", label)
+	fmt.Fprintf(&b, "    url:    %s\n", display(NormalizeBaseURL(s.URL)))
+	fmt.Fprintf(&b, "    email:  %s\n", display(s.Email))
+	fmt.Fprintf(&b, "    token:  %s\n", display(MaskToken(s.APIToken)))
+	method := s.AuthMethod
+	if method == "" {
+		method = "basic"
+	}
+	fmt.Fprintf(&b, "    method: %s", method)
+	if s.CloudID != "" {
+		fmt.Fprintf(&b, " (cloud_id: %s)", s.CloudID)
+	}
+	return b.String()
+}
+
+func display(s string) string {
+	if s == "" {
+		return "(unset)"
+	}
+	return s
+}

--- a/shared/credstore/reconcile.go
+++ b/shared/credstore/reconcile.go
@@ -6,15 +6,24 @@ import (
 )
 
 // SectionsEqual reports whether two Sections describe the same
-// credentials. URLs are normalized to base form before comparison so
+// credentials. URLs are normalized to base form so
 // "https://acme.atlassian.net/wiki" and "https://acme.atlassian.net"
-// don't read as different.
+// don't read as different. AuthMethod "" is canonicalized to "basic"
+// before comparison since legacy configs commonly omit the field while
+// migrated configs write it explicitly.
 func SectionsEqual(a, b Section) bool {
 	return NormalizeBaseURL(a.URL) == NormalizeBaseURL(b.URL) &&
 		a.Email == b.Email &&
 		a.APIToken == b.APIToken &&
-		a.AuthMethod == b.AuthMethod &&
+		canonAuthMethod(a.AuthMethod) == canonAuthMethod(b.AuthMethod) &&
 		a.CloudID == b.CloudID
+}
+
+func canonAuthMethod(m string) string {
+	if m == "" {
+		return "basic"
+	}
+	return m
 }
 
 // MaskToken returns a redacted form of an API token suitable for

--- a/shared/credstore/reconcile_test.go
+++ b/shared/credstore/reconcile_test.go
@@ -1,0 +1,72 @@
+package credstore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestSectionsEqual(t *testing.T) {
+	t.Parallel()
+	a := Section{URL: "https://acme.atlassian.net", Email: "u@e", APIToken: "t"}
+	b := Section{URL: "https://acme.atlassian.net/wiki", Email: "u@e", APIToken: "t"}
+	if !SectionsEqual(a, b) {
+		t.Fatalf("SectionsEqual should ignore /wiki suffix")
+	}
+
+	c := Section{URL: "https://acme.atlassian.net", Email: "u@e", APIToken: "DIFFERENT"}
+	if SectionsEqual(a, c) {
+		t.Fatalf("SectionsEqual should detect different tokens")
+	}
+}
+
+func TestMaskToken(t *testing.T) {
+	t.Parallel()
+	testutil.Equal(t, "", MaskToken(""))
+	testutil.Equal(t, "***", MaskToken("short"))
+	testutil.Equal(t, "ATAT...wxyz", MaskToken("ATATTabcdefghijwxyz"))
+}
+
+func TestFormatSection_ShowsAllFields(t *testing.T) {
+	t.Parallel()
+	s := Section{
+		URL:        "https://acme.atlassian.net",
+		Email:      "rian@example.com",
+		APIToken:   "ATATTabcdefghijwxyz",
+		AuthMethod: "bearer",
+		CloudID:    "cloud-123",
+	}
+	got := FormatSection("cfl", s)
+	for _, want := range []string{
+		"cfl:",
+		"https://acme.atlassian.net",
+		"rian@example.com",
+		"ATAT...wxyz",
+		"method: bearer",
+		"cloud_id: cloud-123",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("FormatSection missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatSection_DefaultsToBasic(t *testing.T) {
+	t.Parallel()
+	s := Section{URL: "https://x", Email: "u@e", APIToken: "t"}
+	got := FormatSection("default", s)
+	if !strings.Contains(got, "method: basic") {
+		t.Errorf("expected default to render as basic; got:\n%s", got)
+	}
+}
+
+func TestFormatSection_MissingFieldsRenderUnset(t *testing.T) {
+	t.Parallel()
+	got := FormatSection("default", Section{})
+	for _, want := range []string{"url:    (unset)", "email:  (unset)", "token:  (unset)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in:\n%s", want, got)
+		}
+	}
+}

--- a/shared/go.mod
+++ b/shared/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/gohugoio/hugo-goldmark-extensions/extras v0.6.0
 	github.com/yuin/goldmark v1.7.16
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/shared/go.sum
+++ b/shared/go.sum
@@ -13,3 +13,7 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/cfl/CLAUDE.md
+++ b/tools/cfl/CLAUDE.md
@@ -140,12 +140,14 @@ Variables are checked in precedence order (first match wins):
 
 | Setting | Precedence |
 |---------|------------|
-| URL | `CFL_URL` → `ATLASSIAN_URL` → config |
-| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → config |
-| API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → config |
-| Default Space | `CFL_DEFAULT_SPACE` → config |
-| Auth Method | `CFL_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → config → `"basic"` |
-| Cloud ID | `CFL_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → config |
+| URL | `CFL_URL` → `ATLASSIAN_URL` → shared `cfl` override → shared `default` → legacy config |
+| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → shared `cfl` → shared `default` → legacy |
+| API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → shared `cfl` → shared `default` → legacy |
+| Default Space | `CFL_DEFAULT_SPACE` → shared `cfl.default_space` → legacy |
+| Auth Method | `CFL_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `cfl` → shared `default` → legacy → `"basic"` |
+| Cloud ID | `CFL_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `cfl` → shared `default` → legacy |
+
+The "shared" entries refer to the cross-tool credential store at `~/.config/atlassian-cli/config.yml` written by `cfl init` and `jtk init`. The `cfl` section overrides the `default` section per field. Legacy `~/.config/cfl/config.yml` keeps working indefinitely; init migrates it on first run.
 
 Use `ATLASSIAN_*` for shared credentials across cfl and jtk. Use `CFL_*` to override per-tool.
 

--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -772,28 +772,36 @@ The text before `:` is treated as a space key if it contains only uppercase lett
 
 ## Configuration
 
-Configuration is stored in `~/.config/cfl/config.yml`:
+`cfl init` writes credentials to the shared store at `~/.config/atlassian-cli/config.yml`:
 
 ```yaml
-url: https://mycompany.atlassian.net/wiki
-email: you@example.com
-api_token: your-api-token
-default_space: DEV
-output_format: table
+default:
+  url: https://mycompany.atlassian.net   # base URL; cfl appends /wiki on read
+  email: you@example.com
+  api_token: your-api-token
+  auth_method: basic                     # or "bearer"
+  cloud_id: ""                           # required for bearer
+cfl:
+  default_space: DEV                     # cfl-only defaults
+  output_format: table
 ```
+
+The same file is shared with `jtk` — one Atlassian token, both tools. Run `cfl init` after `jtk init` (or vice versa) and you'll be offered to reuse the credentials. If you really need different tokens per tool, init's reconciliation flow lets you write per-tool overrides into the `cfl:` or `jtk:` section.
+
+Legacy `~/.config/cfl/config.yml` keeps working indefinitely. Init detects it on first run and prompts to migrate.
 
 ### Environment Variables
 
-Environment variables override config file values. Variables are checked in order of precedence (first match wins):
+Environment variables override file-based config. Variables are checked in order of precedence (first match wins):
 
 | Setting | Precedence (highest to lowest) |
 |---------|-------------------------------|
-| URL | `CFL_URL` → `ATLASSIAN_URL` → config file |
-| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → config file |
-| API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → config file |
-| Default Space | `CFL_DEFAULT_SPACE` → config file |
-| Auth Method | `CFL_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → config file → `basic` |
-| Cloud ID | `CFL_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → config file |
+| URL | `CFL_URL` → `ATLASSIAN_URL` → shared `cfl` override → shared `default` → legacy file |
+| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → shared `cfl` → shared `default` → legacy |
+| API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → shared `cfl` → shared `default` → legacy |
+| Default Space | `CFL_DEFAULT_SPACE` → shared `cfl.default_space` → legacy |
+| Auth Method | `CFL_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared → legacy → `basic` |
+| Cloud ID | `CFL_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared → legacy |
 
 **Shared credentials:** If you use both `cfl` and `jtk` (Jira CLI), set `ATLASSIAN_*` variables once:
 

--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -788,7 +788,7 @@ cfl:
 
 The same file is shared with `jtk` — one Atlassian token, both tools. Run `cfl init` after `jtk init` (or vice versa) and you'll be offered to reuse the credentials. If you really need different tokens per tool, init's reconciliation flow lets you write per-tool overrides into the `cfl:` or `jtk:` section.
 
-Legacy `~/.config/cfl/config.yml` keeps working indefinitely. Init detects it on first run and prompts to migrate.
+Legacy `~/.config/cfl/config.yml` keeps working indefinitely. Init detects it on first run and prompts to migrate. If your legacy URL ends in `/wiki`, migration strips it: the shared store always holds the base URL and cfl appends `/wiki` on read.
 
 ### Environment Variables
 

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -296,7 +296,6 @@ func finalizeInit(
 		}
 	}
 
-
 	// Render the equivalent of `cfl me` using the user we already fetched
 	// during verify. No second API call, no opts state mutation.
 	if verifiedUser != nil {

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/auth"
+	"github.com/open-cli-collective/atlassian-go/credstore"
 
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/me"
@@ -92,66 +93,16 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 		}
 	}
 
-	configPath := config.DefaultConfigPath()
+	legacyPath := config.DefaultConfigPath()
+	sharedPath := credstore.DefaultPath()
+	jtkLegacyPath := credstore.LegacyJTKPath()
 
-	// Load existing config for pre-population
-	existingCfg, _ := config.Load(configPath)
-	if existingCfg == nil {
-		existingCfg = &config.Config{}
+	result, err := detectAndReconcile(v, legacyPath, jtkLegacyPath, sharedPath,
+		prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+	if err != nil {
+		return err
 	}
-
-	// Check if config already exists
-	if _, err := os.Stat(configPath); err == nil {
-		var overwrite bool
-		err := huh.NewConfirm().
-			Title("Configuration already exists").
-			Description(fmt.Sprintf("Overwrite %s?", configPath)).
-			Value(&overwrite).
-			Run()
-		if err != nil {
-			return err
-		}
-		if !overwrite {
-			v.Info("Initialization cancelled.")
-			return nil
-		}
-	}
-
-	cfg := &config.Config{}
-
-	// Pre-fill from existing config, then override with CLI flags
-	// Priority: CLI flag > existing config value
-	if prefillURL != "" {
-		cfg.URL = prefillURL
-	} else if existingCfg.URL != "" {
-		cfg.URL = existingCfg.URL
-	}
-
-	if prefillEmail != "" {
-		cfg.Email = prefillEmail
-	} else if existingCfg.Email != "" {
-		cfg.Email = existingCfg.Email
-	}
-
-	if existingCfg.APIToken != "" {
-		cfg.APIToken = existingCfg.APIToken
-	}
-
-	if existingCfg.DefaultSpace != "" {
-		cfg.DefaultSpace = existingCfg.DefaultSpace
-	}
-
-	if prefillAuthMethod != "" {
-		cfg.AuthMethod = prefillAuthMethod
-	} else if existingCfg.AuthMethod != "" {
-		cfg.AuthMethod = existingCfg.AuthMethod
-	}
-
-	if prefillCloudID != "" {
-		cfg.CloudID = prefillCloudID
-	} else if existingCfg.CloudID != "" {
-		cfg.CloudID = existingCfg.CloudID
-	}
+	cfg := result.prefill
 
 	// Determine auth method for form building
 	isBearer := cfg.AuthMethod == auth.AuthMethodBearer
@@ -262,17 +213,18 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	return finalizeInit(ctx, opts, cfg, configPath, noVerify, defaultClientBuilder)
+	return finalizeInit(ctx, opts, cfg, result, sharedPath, noVerify, defaultClientBuilder)
 }
 
 // finalizeInit runs the verify/save/render pipeline after the form has produced
 // a normalized + validated config. Extracted as a non-interactive seam so tests
-// can supply an httptest-backed clientBuilder and a temp configPath.
+// can supply an httptest-backed clientBuilder and temp paths.
 func finalizeInit(
 	ctx context.Context,
 	opts *root.Options,
 	cfg *config.Config,
-	configPath string,
+	result *reconcileResult,
+	sharedPath string,
 	noVerify bool,
 	build clientBuilder,
 ) error {
@@ -300,11 +252,33 @@ func finalizeInit(
 		verifiedUser = user
 	}
 
-	if err := cfg.Save(configPath); err != nil {
-		return err
+	applyResultToStore(result.store, cfg, result.target)
+	if err := result.store.Save(sharedPath); err != nil {
+		return fmt.Errorf("saving shared store: %w", err)
+	}
+	v.Success("Configuration saved to %s", sharedPath)
+
+	// Optional: clean up legacy files we just migrated.
+	for _, lp := range result.consumedLegacies {
+		var deleteIt bool
+		if err := huh.NewConfirm().
+			Title(fmt.Sprintf("Delete legacy config at %s?", lp)).
+			Description("Migrated to the shared store; this file is no longer used.").
+			Affirmative("Delete").
+			Negative("Keep").
+			Value(&deleteIt).
+			Run(); err != nil {
+			return err
+		}
+		if deleteIt {
+			if err := os.Remove(lp); err != nil {
+				v.Error("Could not remove %s: %v", lp, err)
+			} else {
+				v.Info("Removed %s", lp)
+			}
+		}
 	}
 
-	v.Success("Configuration saved to %s", configPath)
 
 	// Render the equivalent of `cfl me` using the user we already fetched
 	// during verify. No second API call, no opts state mutation.

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -252,6 +252,23 @@ func finalizeInit(
 		verifiedUser = user
 	}
 
+	if result.affectsSibling {
+		var confirm bool
+		if err := huh.NewConfirm().
+			Title("Save will affect jtk").
+			Description("These credentials are stored in shared `default` and used by both cfl and jtk. Continue?").
+			Affirmative("Save").
+			Negative("Cancel").
+			Value(&confirm).
+			Run(); err != nil {
+			return err
+		}
+		if !confirm {
+			v.Info("Initialization cancelled. No changes saved.")
+			return nil
+		}
+	}
+
 	applyResultToStore(result.store, cfg, result.target)
 	if err := result.store.Save(sharedPath); err != nil {
 		return fmt.Errorf("saving shared store: %w", err)

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -148,6 +148,60 @@ func userResponseServer(t *testing.T, body string, status int) *httptest.Server 
 	}))
 }
 
+// TestFinalizeInit_WritesToCorrectSection verifies the saved YAML
+// routes credentials to the section named by writeTarget. A regression
+// in target selection (e.g. credentials landing in default when an
+// override was intended) would be silently invisible without this
+// readback assertion.
+func TestFinalizeInit_WritesToCorrectSection(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		target writeTarget
+	}{
+		{"default", writeDefault},
+		{"cfl_override", writeCFLOverride},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := userResponseServer(t, `{"accountId":"abc","displayName":"X","email":"x@e"}`, http.StatusOK)
+			defer server.Close()
+			build := func(_ *config.Config) (*api.Client, error) {
+				return api.NewClient(server.URL, "x@e", "tok"), nil
+			}
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.yml")
+			cfg := &config.Config{URL: server.URL + "/wiki", Email: "x@e", APIToken: "tok"}
+			result := &reconcileResult{store: &credstore.Store{}, target: tc.target}
+
+			testutil.RequireNoError(t,
+				finalizeInit(context.Background(), newFinalizeOpts(), cfg, result, configPath, false, build))
+
+			loaded, err := credstore.Load(configPath)
+			testutil.RequireNoError(t, err)
+
+			var got credstore.Section
+			switch tc.target {
+			case writeDefault:
+				got = loaded.Default
+				if loaded.CFL.APIToken != "" {
+					t.Errorf("creds leaked into CFL override: %+v", loaded.CFL.Section)
+				}
+			case writeCFLOverride:
+				got = loaded.CFL.Section
+				if loaded.Default.APIToken != "" {
+					t.Errorf("creds leaked into default: %+v", loaded.Default)
+				}
+			}
+			testutil.Equal(t, "tok", got.APIToken)
+			testutil.Equal(t, "x@e", got.Email)
+			testutil.Equal(t, server.URL, got.URL) // URL normalized: /wiki stripped
+		})
+	}
+}
+
 func TestFinalizeInit_BasicHappyPath(t *testing.T) {
 	t.Parallel()
 	server := userResponseServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`, http.StatusOK)

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -182,22 +182,21 @@ func TestFinalizeInit_WritesToCorrectSection(t *testing.T) {
 			loaded, err := credstore.Load(configPath)
 			testutil.RequireNoError(t, err)
 
-			var got credstore.Section
+			var got, leak credstore.Section
 			switch tc.target {
 			case writeDefault:
-				got = loaded.Default
-				if loaded.CFL.APIToken != "" {
-					t.Errorf("creds leaked into CFL override: %+v", loaded.CFL.Section)
-				}
+				got, leak = loaded.Default, loaded.CFL.Section
 			case writeCFLOverride:
-				got = loaded.CFL.Section
-				if loaded.Default.APIToken != "" {
-					t.Errorf("creds leaked into default: %+v", loaded.Default)
-				}
+				got, leak = loaded.CFL.Section, loaded.Default
 			}
 			testutil.Equal(t, "tok", got.APIToken)
 			testutil.Equal(t, "x@e", got.Email)
 			testutil.Equal(t, server.URL, got.URL) // URL normalized: /wiki stripped
+			// Leak guard: every credential field must be empty in the
+			// non-target section, not just APIToken.
+			testutil.Equal(t, "", leak.APIToken)
+			testutil.Equal(t, "", leak.Email)
+			testutil.Equal(t, "", leak.URL)
 		})
 	}
 }

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/auth"
 	sharedclient "github.com/open-cli-collective/atlassian-go/client"
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/spf13/cobra"
 
@@ -121,9 +122,13 @@ func TestRunInit_InvalidAuthMethod(t *testing.T) {
 	testutil.Contains(t, err.Error(), "invalid auth method")
 }
 
-// finalizeInit tests use t.TempDir() for configPath and an httptest-backed
+// finalizeInit tests use t.TempDir() for paths and an httptest-backed
 // clientBuilder so the user's real config is never touched and no real
 // network call is made.
+
+func newFinalizeReconcileResult() *reconcileResult {
+	return &reconcileResult{store: &credstore.Store{}, target: writeDefault}
+}
 
 func newFinalizeOpts() *root.Options {
 	return &root.Options{
@@ -161,7 +166,7 @@ func TestFinalizeInit_BasicHappyPath(t *testing.T) {
 		return api.NewClient(server.URL, "rian@example.com", "test-token"), nil
 	}
 
-	err := finalizeInit(context.Background(), opts, cfg, configPath, false, build)
+	err := finalizeInit(context.Background(), opts, cfg, newFinalizeReconcileResult(), configPath, false, build)
 	testutil.RequireNoError(t, err)
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
@@ -207,7 +212,7 @@ func TestFinalizeInit_BearerHappyPath(t *testing.T) {
 		}, nil
 	}
 
-	err := finalizeInit(context.Background(), opts, cfg, configPath, false, build)
+	err := finalizeInit(context.Background(), opts, cfg, newFinalizeReconcileResult(), configPath, false, build)
 	testutil.RequireNoError(t, err)
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
@@ -283,7 +288,7 @@ func TestFinalizeInit_AuthFailure(t *testing.T) {
 		return api.NewClient(server.URL, "rian@example.com", "wrong-token"), nil
 	}
 
-	err := finalizeInit(context.Background(), opts, cfg, configPath, false, build)
+	err := finalizeInit(context.Background(), opts, cfg, newFinalizeReconcileResult(), configPath, false, build)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "authentication failed")
 
@@ -313,7 +318,7 @@ func TestFinalizeInit_BuildFailureSurfacesError(t *testing.T) {
 		return nil, errors.New("simulated builder failure")
 	}
 
-	err := finalizeInit(context.Background(), opts, cfg, configPath, false, build)
+	err := finalizeInit(context.Background(), opts, cfg, newFinalizeReconcileResult(), configPath, false, build)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "simulated builder failure")
 
@@ -352,7 +357,7 @@ func TestFinalizeInit_NoVerify(t *testing.T) {
 		return api.NewClient(server.URL, "rian@example.com", "test-token"), nil
 	}
 
-	err := finalizeInit(context.Background(), opts, cfg, configPath, true, build)
+	err := finalizeInit(context.Background(), opts, cfg, newFinalizeReconcileResult(), configPath, true, build)
 	testutil.RequireNoError(t, err)
 
 	testutil.False(t, builderCalled, "clientBuilder should not be invoked when --no-verify is set")

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -152,12 +152,19 @@ func detectAndReconcile(
 	return &reconcileResult{prefill: cfg, target: writeDefault, store: store}, nil
 }
 
-func promptReconcileMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds) (string, error) {
-	desc := fmt.Sprintf(
+// mismatchDescription is the prompt description for the both-legacies-
+// mismatch reconciliation. Extracted so tests can assert the
+// educational language without driving huh.
+func mismatchDescription(cflLegacy, jtkLegacy *credstore.LegacyCreds) string {
+	return fmt.Sprintf(
 		"%s\n\n%s\n\nNote: Atlassian API tokens are account-wide. One token usually works for both Jira and Confluence.\nManage tokens: https://id.atlassian.com/manage-profile/security/api-tokens",
 		credstore.FormatSection("cfl ("+cflLegacy.Path+")", cflLegacy.Section()),
 		credstore.FormatSection("jtk ("+jtkLegacy.Path+")", jtkLegacy.Section()),
 	)
+}
+
+func promptReconcileMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds) (string, error) {
+	desc := mismatchDescription(cflLegacy, jtkLegacy)
 	var choice string
 	err := huh.NewSelect[string]().
 		Title("Different Atlassian credentials found").

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -246,22 +246,22 @@ func resultFromSharedWithOverride(store *credstore.Store, prefillURL, prefillEma
 func resultFromMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds, choice string, store *credstore.Store, v *view.View, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
 	consumed := []string{cflLegacy.Path, jtkLegacy.Path}
 	switch choice {
-	case "use_cfl":
-		// User chose "use cfl's creds for both tools". Clear any
-		// stale jtk override credential fields so jtk resolves to
-		// the new default rather than a leftover override from a
-		// prior keep_different run. Per-tool defaults (default_project)
-		// are preserved.
+	case "use_cfl", "use_jtk":
+		// User chose to unify on one tool's creds. Clear both
+		// override Sections so each tool resolves to the new default
+		// rather than a leftover override from a prior keep_different
+		// run. Per-tool defaults (default_space, default_project,
+		// output_format) are preserved.
+		store.CFL.Section = credstore.Section{}
 		store.JTK.Section = credstore.Section{}
-		cfg := configFromLegacy(cflLegacy)
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
-	case "use_jtk":
-		// Same rationale as use_cfl — clear stale jtk override.
-		store.JTK.Section = credstore.Section{}
-		cfg := configFromLegacy(jtkLegacy)
-		cfg.DefaultSpace = cflLegacy.DefaultSpace
-		cfg.OutputFormat = cflLegacy.OutputFormat
+		var cfg *config.Config
+		if choice == "use_cfl" {
+			cfg = configFromLegacy(cflLegacy)
+		} else {
+			cfg = configFromLegacy(jtkLegacy)
+			cfg.DefaultSpace = cflLegacy.DefaultSpace
+			cfg.OutputFormat = cflLegacy.OutputFormat
+		}
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
 	case "keep_different":

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -1,0 +1,283 @@
+package init
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+
+	"github.com/open-cli-collective/atlassian-go/credstore"
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	"github.com/open-cli-collective/confluence-cli/internal/config"
+)
+
+// writeTarget tells the post-form save logic which section of the
+// shared store to write credential edits into. Tool-specific bits
+// (default_space/output_format) always go to the cfl section
+// regardless of target.
+type writeTarget int
+
+const (
+	writeDefault writeTarget = iota
+	writeCFLOverride
+)
+
+// reconcileResult captures everything finalizeInit needs after the
+// detection + prompt phase: a *Config to seed the form, a write target,
+// the shared store the user already had on disk (so save preserves
+// unrelated fields like the jtk section), and the list of legacy
+// files that the user might want to clean up after migration.
+type reconcileResult struct {
+	prefill          *config.Config
+	target           writeTarget
+	store            *credstore.Store
+	consumedLegacies []string // paths of legacy files actually read into prefill
+}
+
+// detectAndReconcile decides what to do given whatever configs already
+// exist on disk. It runs whatever interactive prompts are necessary to
+// disambiguate, then returns a deterministic result for finalizeInit.
+//
+// Path arguments are injected so tests can point them at a tempdir;
+// production passes the canonical paths.
+func detectAndReconcile(
+	v *view.View,
+	cflLegacyPath, jtkLegacyPath, sharedPath string,
+	prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string,
+) (*reconcileResult, error) {
+	store, err := credstore.Load(sharedPath)
+	if err != nil {
+		v.Error("Shared credential store at %s is unreadable: %v", sharedPath, err)
+		v.Error("Refusing to overwrite. Fix or remove the file, then re-run cfl init.")
+		return nil, err
+	}
+
+	cflLegacy, cflErr := credstore.LoadLegacyCFL(cflLegacyPath)
+	if cflErr != nil {
+		if errors.Is(cflErr, credstore.ErrCorruptStore) {
+			v.Error("Legacy cfl config at %s is unreadable: %v", cflLegacyPath, cflErr)
+			v.Error("Refusing to overwrite. Fix or remove the file, then re-run cfl init.")
+			return nil, cflErr
+		}
+		return nil, cflErr
+	}
+	jtkLegacy, jtkErr := credstore.LoadLegacyJTK(jtkLegacyPath)
+	if jtkErr != nil {
+		// Sibling-corrupt is a warning, not a hard stop — we can still
+		// migrate this tool's data without touching the sibling file.
+		v.Info("Note: sibling jtk config at %s is unreadable; ignoring. (%v)", jtkLegacyPath, jtkErr)
+		jtkLegacy = nil
+	}
+
+	// Case 1: shared store has usable creds for cfl already.
+	if store.HasUsableCreds(credstore.ToolCFL) {
+		// If the user already has a cfl override, edits go back to the
+		// override; otherwise edits land in default.
+		hasOverride := !sectionEmpty(store.CFL.Section)
+		var target writeTarget
+		if hasOverride {
+			target = writeCFLOverride
+		} else {
+			var reuse bool
+			err := huh.NewConfirm().
+				Title("Shared Atlassian credentials found").
+				Description(fmt.Sprintf(
+					"%s\n\nReuse these for cfl? (no = set up cfl-specific credentials)",
+					credstore.FormatSection("default", store.Default),
+				)).
+				Affirmative("Reuse").
+				Negative("Set cfl-specific").
+				Value(&reuse).
+				Run()
+			if err != nil {
+				return nil, err
+			}
+			if reuse {
+				target = writeDefault
+				v.Info("Note: edits will affect both cfl and jtk (writing to shared default).")
+			} else {
+				target = writeCFLOverride
+			}
+		}
+		cfg := configFromSection(store.Resolve(credstore.ToolCFL))
+		copyCFLDefaults(cfg, store.CFL)
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+		return &reconcileResult{prefill: cfg, target: target, store: store}, nil
+	}
+
+	// Case 2: only this tool's legacy exists.
+	if cflLegacy != nil && jtkLegacy == nil {
+		cfg := configFromLegacy(cflLegacy)
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+		v.Info("Migrating existing cfl config at %s to shared store.", cflLegacy.Path)
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path}}, nil
+	}
+
+	// Case 3: only sibling legacy exists.
+	if cflLegacy == nil && jtkLegacy != nil {
+		var reuse bool
+		err := huh.NewConfirm().
+			Title("Found jtk credentials").
+			Description(fmt.Sprintf(
+				"%s\n\nReuse these for cfl? (Atlassian API tokens are account-wide and usually work across products.)",
+				credstore.FormatSection("jtk", jtkLegacy.Section()),
+			)).
+			Affirmative("Reuse").
+			Negative("Fresh setup").
+			Value(&reuse).
+			Run()
+		if err != nil {
+			return nil, err
+		}
+		var cfg *config.Config
+		if reuse {
+			cfg = configFromLegacy(jtkLegacy)
+		} else {
+			cfg = &config.Config{}
+		}
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+		consumed := []string{}
+		if reuse {
+			consumed = []string{jtkLegacy.Path}
+		}
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}, nil
+	}
+
+	// Case 4: both legacies exist.
+	if cflLegacy != nil && jtkLegacy != nil {
+		if credstore.SectionsEqual(cflLegacy.Section(), jtkLegacy.Section()) {
+			v.Info("Found matching cfl and jtk credentials; migrating to shared store.")
+			cfg := configFromLegacy(cflLegacy)
+			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
+		}
+		// Mismatch: educational reconciliation flow.
+		choice, err := promptReconcileMismatch(cflLegacy, jtkLegacy)
+		if err != nil {
+			return nil, err
+		}
+		switch choice {
+		case "use_cfl":
+			cfg := configFromLegacy(cflLegacy)
+			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
+		case "use_jtk":
+			cfg := configFromLegacy(jtkLegacy)
+			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
+		case "keep_different":
+			// Write the cfl creds to default, jtk creds as a jtk override.
+			// We do this directly on the store now so the post-form save
+			// preserves both halves.
+			store.Default = cflLegacy.Section()
+			store.CFL.DefaultSpace = cflLegacy.DefaultSpace
+			store.CFL.OutputFormat = cflLegacy.OutputFormat
+			store.JTK.Section = jtkLegacy.Section()
+			store.JTK.DefaultProject = jtkLegacy.DefaultProject
+			cfg := configFromLegacy(cflLegacy)
+			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+			v.Info("Keeping per-tool credentials. cfl will use cfl's token; jtk will use jtk's token.")
+			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
+		}
+	}
+
+	// Case 5: nothing on disk anywhere.
+	cfg := &config.Config{}
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+	return &reconcileResult{prefill: cfg, target: writeDefault, store: store}, nil
+}
+
+func promptReconcileMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds) (string, error) {
+	desc := fmt.Sprintf(
+		"%s\n\n%s\n\nNote: Atlassian API tokens are account-wide. One token usually works for both Jira and Confluence.\nManage tokens: https://id.atlassian.com/manage-profile/security/api-tokens",
+		credstore.FormatSection("cfl ("+cflLegacy.Path+")", cflLegacy.Section()),
+		credstore.FormatSection("jtk ("+jtkLegacy.Path+")", jtkLegacy.Section()),
+	)
+	var choice string
+	err := huh.NewSelect[string]().
+		Title("Different Atlassian credentials found").
+		Description(desc).
+		Options(
+			huh.NewOption("Use cfl's credentials for both tools", "use_cfl"),
+			huh.NewOption("Use jtk's credentials for both tools", "use_jtk"),
+			huh.NewOption("Keep them different (advanced)", "keep_different"),
+		).
+		Value(&choice).
+		Run()
+	return choice, err
+}
+
+func sectionEmpty(s credstore.Section) bool {
+	return s.URL == "" && s.Email == "" && s.APIToken == "" && s.AuthMethod == "" && s.CloudID == ""
+}
+
+func configFromSection(s credstore.Section) *config.Config {
+	cfg := &config.Config{
+		Email:      s.Email,
+		APIToken:   s.APIToken,
+		AuthMethod: s.AuthMethod,
+		CloudID:    s.CloudID,
+	}
+	if s.URL != "" {
+		cfg.URL = credstore.URLForCFL(s.URL)
+	}
+	return cfg
+}
+
+func configFromLegacy(l *credstore.LegacyCreds) *config.Config {
+	cfg := configFromSection(l.Section())
+	if l.DefaultSpace != "" {
+		cfg.DefaultSpace = l.DefaultSpace
+	}
+	if l.OutputFormat != "" {
+		cfg.OutputFormat = l.OutputFormat
+	}
+	return cfg
+}
+
+func copyCFLDefaults(cfg *config.Config, t credstore.ToolSection) {
+	if t.DefaultSpace != "" {
+		cfg.DefaultSpace = t.DefaultSpace
+	}
+	if t.OutputFormat != "" {
+		cfg.OutputFormat = t.OutputFormat
+	}
+}
+
+func applyFlagOverrides(cfg *config.Config, url, email, authMethod, cloudID string) {
+	if url != "" {
+		cfg.URL = url
+	}
+	if email != "" {
+		cfg.Email = email
+	}
+	if authMethod != "" {
+		cfg.AuthMethod = authMethod
+	}
+	if cloudID != "" {
+		cfg.CloudID = cloudID
+	}
+}
+
+// applyResultToStore mutates the shared store so it carries the form's
+// final cfg in the right section. It preserves any unrelated existing
+// fields (e.g., jtk section, jtk per-tool defaults).
+func applyResultToStore(store *credstore.Store, cfg *config.Config, target writeTarget) {
+	cred := credstore.Section{
+		URL:        credstore.NormalizeBaseURL(cfg.URL),
+		Email:      cfg.Email,
+		APIToken:   cfg.APIToken,
+		AuthMethod: cfg.AuthMethod,
+		CloudID:    cfg.CloudID,
+	}
+	switch target {
+	case writeDefault:
+		store.Default = cred
+	case writeCFLOverride:
+		store.CFL.Section = cred
+	}
+	// Tool-specific bits always live in the cfl section.
+	store.CFL.DefaultSpace = cfg.DefaultSpace
+	store.CFL.OutputFormat = cfg.OutputFormat
+}

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -33,6 +33,11 @@ type reconcileResult struct {
 	target           writeTarget
 	store            *credstore.Store
 	consumedLegacies []string // paths of legacy files actually read into prefill
+	// affectsSibling is true when finalizeInit should confirm before
+	// writing because the save will mutate credentials the sibling tool
+	// is currently reading from. Set when reuse=yes was chosen on a
+	// shared store that already had usable creds.
+	affectsSibling bool
 }
 
 // detectAndReconcile decides what to do given whatever configs already
@@ -73,11 +78,13 @@ func detectAndReconcile(
 	// Case 1: shared store has usable creds for cfl already.
 	if store.HasUsableCreds(credstore.ToolCFL) {
 		// If the user already has a cfl override, edits go back to the
-		// override; otherwise edits land in default.
+		// override; otherwise the user picks default-vs-override.
 		hasOverride := !sectionEmpty(store.CFL.Section)
 		var target writeTarget
+		var reusePrefill bool
 		if hasOverride {
 			target = writeCFLOverride
+			reusePrefill = true
 		} else {
 			var reuse bool
 			err := huh.NewConfirm().
@@ -95,15 +102,30 @@ func detectAndReconcile(
 			}
 			if reuse {
 				target = writeDefault
-				v.Info("Note: edits will affect both cfl and jtk (writing to shared default).")
+				reusePrefill = true
+				v.Info("Note: editing these credentials will also affect jtk (writes go to shared default).")
 			} else {
 				target = writeCFLOverride
+				reusePrefill = false
 			}
 		}
-		cfg := configFromSection(store.Resolve(credstore.ToolCFL))
-		copyCFLDefaults(cfg, store.CFL)
+		var cfg *config.Config
+		if reusePrefill {
+			cfg = configFromSection(store.Resolve(credstore.ToolCFL))
+			copyCFLDefaults(cfg, store.CFL)
+		} else {
+			// Fresh setup — only carry over cfl-specific defaults so the
+			// user doesn't have to re-type the default space.
+			cfg = &config.Config{}
+			copyCFLDefaults(cfg, store.CFL)
+		}
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-		return &reconcileResult{prefill: cfg, target: target, store: store}, nil
+		return &reconcileResult{
+			prefill:        cfg,
+			target:         target,
+			store:          store,
+			affectsSibling: target == writeDefault && reusePrefill,
+		}, nil
 	}
 
 	// Case 2: only this tool's legacy exists.
@@ -144,15 +166,17 @@ func detectAndReconcile(
 		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}, nil
 	}
 
-	// Case 4: both legacies exist.
+	// Case 4: both legacies exist. Either way, preserve jtk's per-tool
+	// defaults into the store so jtk doesn't lose default_project on
+	// next read.
 	if cflLegacy != nil && jtkLegacy != nil {
+		store.JTK.DefaultProject = jtkLegacy.DefaultProject
 		if credstore.SectionsEqual(cflLegacy.Section(), jtkLegacy.Section()) {
 			v.Info("Found matching cfl and jtk credentials; migrating to shared store.")
 			cfg := configFromLegacy(cflLegacy)
 			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
 		}
-		// Mismatch: educational reconciliation flow.
 		choice, err := promptReconcileMismatch(cflLegacy, jtkLegacy)
 		if err != nil {
 			return nil, err
@@ -163,18 +187,20 @@ func detectAndReconcile(
 			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
 		case "use_jtk":
+			// Use jtk's creds for cfl, but still preserve cfl's per-tool
+			// defaults so default_space doesn't disappear.
 			cfg := configFromLegacy(jtkLegacy)
+			cfg.DefaultSpace = cflLegacy.DefaultSpace
+			cfg.OutputFormat = cflLegacy.OutputFormat
 			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
 		case "keep_different":
-			// Write the cfl creds to default, jtk creds as a jtk override.
-			// We do this directly on the store now so the post-form save
-			// preserves both halves.
+			// cfl creds → default; jtk creds → jtk override. Per-tool
+			// defaults preserved on both sides.
 			store.Default = cflLegacy.Section()
 			store.CFL.DefaultSpace = cflLegacy.DefaultSpace
 			store.CFL.OutputFormat = cflLegacy.OutputFormat
 			store.JTK.Section = jtkLegacy.Section()
-			store.JTK.DefaultProject = jtkLegacy.DefaultProject
 			cfg := configFromLegacy(cflLegacy)
 			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 			v.Info("Keeping per-tool credentials. cfl will use cfl's token; jtk will use jtk's token.")
@@ -261,8 +287,10 @@ func applyFlagOverrides(cfg *config.Config, url, email, authMethod, cloudID stri
 }
 
 // applyResultToStore mutates the shared store so it carries the form's
-// final cfg in the right section. It preserves any unrelated existing
-// fields (e.g., jtk section, jtk per-tool defaults).
+// final cfg in the right section. It preserves unrelated existing
+// fields (jtk section, jtk per-tool defaults) and only overwrites a
+// CFL per-tool default when the form actually produced a value, so a
+// freshly-set-up cfl doesn't stomp a previously-saved default_space.
 func applyResultToStore(store *credstore.Store, cfg *config.Config, target writeTarget) {
 	cred := credstore.Section{
 		URL:        credstore.NormalizeBaseURL(cfg.URL),
@@ -277,7 +305,10 @@ func applyResultToStore(store *credstore.Store, cfg *config.Config, target write
 	case writeCFLOverride:
 		store.CFL.Section = cred
 	}
-	// Tool-specific bits always live in the cfl section.
-	store.CFL.DefaultSpace = cfg.DefaultSpace
-	store.CFL.OutputFormat = cfg.OutputFormat
+	if cfg.DefaultSpace != "" {
+		store.CFL.DefaultSpace = cfg.DefaultSpace
+	}
+	if cfg.OutputFormat != "" {
+		store.CFL.OutputFormat = cfg.OutputFormat
+	}
 }

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -80,52 +80,27 @@ func detectAndReconcile(
 		// If the user already has a cfl override, edits go back to the
 		// override; otherwise the user picks default-vs-override.
 		hasOverride := !sectionEmpty(store.CFL.Section)
-		var target writeTarget
-		var reusePrefill bool
 		if hasOverride {
-			target = writeCFLOverride
-			reusePrefill = true
-		} else {
-			var reuse bool
-			err := huh.NewConfirm().
-				Title("Shared Atlassian credentials found").
-				Description(fmt.Sprintf(
-					"%s\n\nReuse these for cfl? (no = set up cfl-specific credentials)",
-					credstore.FormatSection("default", store.Default),
-				)).
-				Affirmative("Reuse").
-				Negative("Set cfl-specific").
-				Value(&reuse).
-				Run()
-			if err != nil {
-				return nil, err
-			}
-			if reuse {
-				target = writeDefault
-				reusePrefill = true
-				v.Info("Note: editing these credentials will also affect jtk (writes go to shared default).")
-			} else {
-				target = writeCFLOverride
-				reusePrefill = false
-			}
+			return resultFromSharedWithOverride(store, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID), nil
 		}
-		var cfg *config.Config
-		if reusePrefill {
-			cfg = configFromSection(store.Resolve(credstore.ToolCFL))
-			copyCFLDefaults(cfg, store.CFL)
-		} else {
-			// Fresh setup — only carry over cfl-specific defaults so the
-			// user doesn't have to re-type the default space.
-			cfg = &config.Config{}
-			copyCFLDefaults(cfg, store.CFL)
+		var reuse bool
+		err := huh.NewConfirm().
+			Title("Shared Atlassian credentials found").
+			Description(fmt.Sprintf(
+				"%s\n\nReuse these for cfl? (no = set up cfl-specific credentials)",
+				credstore.FormatSection("default", store.Default),
+			)).
+			Affirmative("Reuse").
+			Negative("Set cfl-specific").
+			Value(&reuse).
+			Run()
+		if err != nil {
+			return nil, err
 		}
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-		return &reconcileResult{
-			prefill:        cfg,
-			target:         target,
-			store:          store,
-			affectsSibling: target == writeDefault && reusePrefill,
-		}, nil
+		if reuse {
+			v.Info("Note: editing these credentials will also affect jtk (writes go to shared default).")
+		}
+		return resultFromSharedNoOverride(store, reuse, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID), nil
 	}
 
 	// Case 2: only this tool's legacy exists.
@@ -206,8 +181,11 @@ func resultFromCFLLegacy(cflLegacy *credstore.LegacyCreds, store *credstore.Stor
 }
 
 // resultFromSiblingLegacy is the post-prompt branch for "only sibling
-// (jtk) legacy" — `reuse` is what huh returned.
+// (jtk) legacy" — `reuse` is what huh returned. Either way, jtk's
+// per-tool defaults (default_project) are preserved into the store so
+// jtk doesn't lose them on next read.
 func resultFromSiblingLegacy(jtkLegacy *credstore.LegacyCreds, store *credstore.Store, reuse bool, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	store.JTK.DefaultProject = jtkLegacy.DefaultProject
 	var cfg *config.Config
 	if reuse {
 		cfg = configFromLegacy(jtkLegacy)
@@ -220,6 +198,39 @@ func resultFromSiblingLegacy(jtkLegacy *credstore.LegacyCreds, store *credstore.
 		consumed = []string{jtkLegacy.Path}
 	}
 	return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+}
+
+// resultFromSharedNoOverride is the post-prompt branch for the
+// shared-store-present-no-override case in detectAndReconcile.
+// `reuse` is what huh returned.
+func resultFromSharedNoOverride(store *credstore.Store, reuse bool, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	var cfg *config.Config
+	target := writeCFLOverride
+	if reuse {
+		cfg = configFromSection(store.Resolve(credstore.ToolCFL))
+		copyCFLDefaults(cfg, store.CFL)
+		target = writeDefault
+	} else {
+		cfg = &config.Config{}
+		copyCFLDefaults(cfg, store.CFL)
+	}
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+	return &reconcileResult{
+		prefill:        cfg,
+		target:         target,
+		store:          store,
+		affectsSibling: reuse, // reuse=yes writes to default → affects jtk
+	}
+}
+
+// resultFromSharedWithOverride is the (no-prompt) branch when shared
+// store already has a populated cfl override section. Edits land in
+// the override; default isn't touched.
+func resultFromSharedWithOverride(store *credstore.Store, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	cfg := configFromSection(store.Resolve(credstore.ToolCFL))
+	copyCFLDefaults(cfg, store.CFL)
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+	return &reconcileResult{prefill: cfg, target: writeCFLOverride, store: store}
 }
 
 // resultFromMismatch is the post-prompt branch for "both legacies

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -130,10 +130,8 @@ func detectAndReconcile(
 
 	// Case 2: only this tool's legacy exists.
 	if cflLegacy != nil && jtkLegacy == nil {
-		cfg := configFromLegacy(cflLegacy)
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 		v.Info("Migrating existing cfl config at %s to shared store.", cflLegacy.Path)
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path}}, nil
+		return resultFromCFLLegacy(cflLegacy, store, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID), nil
 	}
 
 	// Case 3: only sibling legacy exists.
@@ -152,18 +150,7 @@ func detectAndReconcile(
 		if err != nil {
 			return nil, err
 		}
-		var cfg *config.Config
-		if reuse {
-			cfg = configFromLegacy(jtkLegacy)
-		} else {
-			cfg = &config.Config{}
-		}
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-		consumed := []string{}
-		if reuse {
-			consumed = []string{jtkLegacy.Path}
-		}
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}, nil
+		return resultFromSiblingLegacy(jtkLegacy, store, reuse, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID), nil
 	}
 
 	// Case 4: both legacies exist. Either way, preserve jtk's per-tool
@@ -181,31 +168,7 @@ func detectAndReconcile(
 		if err != nil {
 			return nil, err
 		}
-		switch choice {
-		case "use_cfl":
-			cfg := configFromLegacy(cflLegacy)
-			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
-		case "use_jtk":
-			// Use jtk's creds for cfl, but still preserve cfl's per-tool
-			// defaults so default_space doesn't disappear.
-			cfg := configFromLegacy(jtkLegacy)
-			cfg.DefaultSpace = cflLegacy.DefaultSpace
-			cfg.OutputFormat = cflLegacy.OutputFormat
-			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
-		case "keep_different":
-			// cfl creds → default; jtk creds → jtk override. Per-tool
-			// defaults preserved on both sides.
-			store.Default = cflLegacy.Section()
-			store.CFL.DefaultSpace = cflLegacy.DefaultSpace
-			store.CFL.OutputFormat = cflLegacy.OutputFormat
-			store.JTK.Section = jtkLegacy.Section()
-			cfg := configFromLegacy(cflLegacy)
-			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-			v.Info("Keeping per-tool credentials. cfl will use cfl's token; jtk will use jtk's token.")
-			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
-		}
+		return resultFromMismatch(cflLegacy, jtkLegacy, choice, store, v, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID), nil
 	}
 
 	// Case 5: nothing on disk anywhere.
@@ -232,6 +195,62 @@ func promptReconcileMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds) (strin
 		Value(&choice).
 		Run()
 	return choice, err
+}
+
+// resultFromCFLLegacy is the post-prompt branch for "only this tool's
+// legacy" — lifted out so tests can drive it without huh.
+func resultFromCFLLegacy(cflLegacy *credstore.LegacyCreds, store *credstore.Store, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	cfg := configFromLegacy(cflLegacy)
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+	return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path}}
+}
+
+// resultFromSiblingLegacy is the post-prompt branch for "only sibling
+// (jtk) legacy" — `reuse` is what huh returned.
+func resultFromSiblingLegacy(jtkLegacy *credstore.LegacyCreds, store *credstore.Store, reuse bool, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	var cfg *config.Config
+	if reuse {
+		cfg = configFromLegacy(jtkLegacy)
+	} else {
+		cfg = &config.Config{}
+	}
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+	consumed := []string{}
+	if reuse {
+		consumed = []string{jtkLegacy.Path}
+	}
+	return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+}
+
+// resultFromMismatch is the post-prompt branch for "both legacies
+// exist with different creds". `choice` is the huh select value:
+// "use_cfl" | "use_jtk" | "keep_different".
+func resultFromMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds, choice string, store *credstore.Store, v *view.View, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	consumed := []string{cflLegacy.Path, jtkLegacy.Path}
+	switch choice {
+	case "use_cfl":
+		cfg := configFromLegacy(cflLegacy)
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+	case "use_jtk":
+		cfg := configFromLegacy(jtkLegacy)
+		cfg.DefaultSpace = cflLegacy.DefaultSpace
+		cfg.OutputFormat = cflLegacy.OutputFormat
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+	case "keep_different":
+		store.Default = cflLegacy.Section()
+		store.CFL.DefaultSpace = cflLegacy.DefaultSpace
+		store.CFL.OutputFormat = cflLegacy.OutputFormat
+		store.JTK.Section = jtkLegacy.Section()
+		cfg := configFromLegacy(cflLegacy)
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+		v.Info("Keeping per-tool credentials. cfl will use cfl's token; jtk will use jtk's token.")
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+	}
+	cfg := &config.Config{}
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
+	return &reconcileResult{prefill: cfg, target: writeDefault, store: store}
 }
 
 func sectionEmpty(s credstore.Section) bool {

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -247,10 +247,18 @@ func resultFromMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds, choice stri
 	consumed := []string{cflLegacy.Path, jtkLegacy.Path}
 	switch choice {
 	case "use_cfl":
+		// User chose "use cfl's creds for both tools". Clear any
+		// stale jtk override credential fields so jtk resolves to
+		// the new default rather than a leftover override from a
+		// prior keep_different run. Per-tool defaults (default_project)
+		// are preserved.
+		store.JTK.Section = credstore.Section{}
 		cfg := configFromLegacy(cflLegacy)
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
 	case "use_jtk":
+		// Same rationale as use_cfl — clear stale jtk override.
+		store.JTK.Section = credstore.Section{}
 		cfg := configFromLegacy(jtkLegacy)
 		cfg.DefaultSpace = cflLegacy.DefaultSpace
 		cfg.OutputFormat = cflLegacy.OutputFormat

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -257,14 +257,18 @@ func resultFromMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds, choice stri
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
 	case "keep_different":
-		store.Default = cflLegacy.Section()
+		// Both tools land in their override sections so the split is
+		// stable: store.Default stays empty, cfl reads its override,
+		// jtk reads its override. Save target is writeCFLOverride so
+		// post-form edits stay in the cfl section.
+		store.CFL.Section = cflLegacy.Section()
 		store.CFL.DefaultSpace = cflLegacy.DefaultSpace
 		store.CFL.OutputFormat = cflLegacy.OutputFormat
 		store.JTK.Section = jtkLegacy.Section()
 		cfg := configFromLegacy(cflLegacy)
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 		v.Info("Keeping per-tool credentials. cfl will use cfl's token; jtk will use jtk's token.")
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+		return &reconcileResult{prefill: cfg, target: writeCFLOverride, store: store, consumedLegacies: consumed}
 	}
 	cfg := &config.Config{}
 	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -309,6 +309,8 @@ func TestResultFromMismatch_KeepDifferent(t *testing.T) {
 	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", Email: "u@e", APIToken: "jtk-tok"}
 	v, stdout, _ := newReconcileView()
 	store := &credstore.Store{}
+	jtk.DefaultProject = "PROJ"
+	store.JTK.DefaultProject = jtk.DefaultProject // mirrors detectAndReconcile Case 4 preamble
 	r := resultFromMismatch(cfl, jtk, "keep_different", store, v, "", "", "", "")
 	// cfl creds → CFL override; jtk creds → JTK override; default empty.
 	testutil.Equal(t, writeCFLOverride, r.target)
@@ -319,6 +321,7 @@ func TestResultFromMismatch_KeepDifferent(t *testing.T) {
 	testutil.Equal(t, "https://jtk.atlassian.net", r.store.JTK.URL)
 	testutil.Equal(t, "jtk-tok", r.store.JTK.APIToken)
 	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
+	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
 	if !strings.Contains(stdout.String(), "Keeping per-tool credentials") {
 		t.Errorf("expected keep-different note; got: %s", stdout.String())
 	}

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -312,7 +312,34 @@ func TestResultFromMismatch_UseCFL_ClearsStaleJTKOverride(t *testing.T) {
 	testutil.Equal(t, writeDefault, r.target)
 	testutil.Equal(t, "", r.store.JTK.URL)
 	testutil.Equal(t, "", r.store.JTK.APIToken)
+	testutil.Equal(t, "", r.store.CFL.URL)
+	testutil.Equal(t, "", r.store.CFL.APIToken)
 	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
+}
+
+// Symmetric to UseCFL_ClearsStaleJTKOverride: use_jtk also clears
+// both overrides so cfl falls through to the new default.
+func TestResultFromMismatch_UseJTK_ClearsBothOverrides(t *testing.T) {
+	t.Parallel()
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok"}
+	v, _, _ := newReconcileView()
+	store := &credstore.Store{
+		CFL: credstore.ToolSection{
+			Section:      credstore.Section{URL: "https://stale.atlassian.net", APIToken: "stale-cfl"},
+			DefaultSpace: "STALE",
+		},
+		JTK: credstore.ToolSection{
+			Section: credstore.Section{URL: "https://stale-jtk.atlassian.net", APIToken: "stale-jtk"},
+		},
+	}
+	r := resultFromMismatch(cfl, jtk, "use_jtk", store, v, "", "", "", "")
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "", r.store.CFL.URL)
+	testutil.Equal(t, "", r.store.CFL.APIToken)
+	testutil.Equal(t, "", r.store.JTK.URL)
+	testutil.Equal(t, "", r.store.JTK.APIToken)
+	testutil.Equal(t, "STALE", r.store.CFL.DefaultSpace) // per-tool default survives
 }
 
 func TestResultFromMismatch_UseJTK_PreservesCFLDefaults(t *testing.T) {

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -118,7 +118,7 @@ func TestReconcile_CorruptSharedAborts(t *testing.T) {
 	testutil.RequireError(t, err)
 
 	// The shared file was not modified by detection.
-	body, ferr := os.ReadFile(sharedPath)
+	body, ferr := os.ReadFile(sharedPath) //nolint:gosec // test-controlled tempdir path
 	testutil.RequireNoError(t, ferr)
 	testutil.Equal(t, "default: : :: [", string(body))
 
@@ -140,7 +140,7 @@ func TestReconcile_CorruptCFLLegacyAborts(t *testing.T) {
 		"", "", "", "")
 	testutil.RequireError(t, err)
 
-	body, ferr := os.ReadFile(cflPath)
+	body, ferr := os.ReadFile(cflPath) //nolint:gosec // test-controlled tempdir path
 	testutil.RequireNoError(t, ferr)
 	testutil.Equal(t, "url: : :: [", string(body))
 
@@ -239,8 +239,8 @@ func TestReconcile_BothLegaciesMatch_AutoMigrates(t *testing.T) {
 
 func TestSectionsEqual_AuthMethodCanonicalization(t *testing.T) {
 	t.Parallel()
-	a := credstore.Section{URL: "https://x", Email: "u@e", APIToken: "t"}                            // empty method
-	b := credstore.Section{URL: "https://x", Email: "u@e", APIToken: "t", AuthMethod: "basic"}       // explicit
+	a := credstore.Section{URL: "https://x", Email: "u@e", APIToken: "t"}                      // empty method
+	b := credstore.Section{URL: "https://x", Email: "u@e", APIToken: "t", AuthMethod: "basic"} // explicit
 	if !credstore.SectionsEqual(a, b) {
 		t.Fatalf("empty auth_method should match explicit basic")
 	}
@@ -348,7 +348,7 @@ func TestResultFromMismatch_UseJTK_PreservesCFLDefaults(t *testing.T) {
 	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok"}
 	v, _, _ := newReconcileView()
 	r := resultFromMismatch(cfl, jtk, "use_jtk", &credstore.Store{}, v, "", "", "", "")
-	testutil.Equal(t, "jtk-tok", r.prefill.APIToken) // jtk creds chosen
+	testutil.Equal(t, "jtk-tok", r.prefill.APIToken)   // jtk creds chosen
 	testutil.Equal(t, "SPACE", r.prefill.DefaultSpace) // but cfl's default_space preserved
 }
 
@@ -428,7 +428,7 @@ func TestResultFromSharedNoOverride_ReuseNo_FreshForm(t *testing.T) {
 	}
 	r := resultFromSharedNoOverride(store, false, "", "", "", "")
 	testutil.Equal(t, writeCFLOverride, r.target)
-	testutil.Equal(t, "", r.prefill.APIToken) // fresh, not prefilled
+	testutil.Equal(t, "", r.prefill.APIToken)             // fresh, not prefilled
 	testutil.Equal(t, "EXISTING", r.prefill.DefaultSpace) // tool defaults still carried so user doesn't retype
 	testutil.Equal(t, false, r.affectsSibling)
 }

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -330,24 +330,20 @@ func TestResultFromCFLLegacy_BasicMigration(t *testing.T) {
 	testutil.Equal(t, []string{"/cfl.yml"}, r.consumedLegacies)
 }
 
-func TestPromptReconcileMismatch_EducationalText(t *testing.T) {
+func TestMismatchDescription_EducationalText(t *testing.T) {
 	t.Parallel()
-	// We can't drive huh, but the description string passed to it is
-	// constructed before huh.Run(). Re-build it here against the same
-	// helper so we exercise the educational-language contract.
 	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://x", Email: "u@e", APIToken: "tok"}
 	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://x", Email: "u@e", APIToken: "different"}
-	desc := credstore.FormatSection("cfl ("+cfl.Path+")", cfl.Section()) + "\n\n" +
-		credstore.FormatSection("jtk ("+jtk.Path+")", jtk.Section()) +
-		"\n\nNote: Atlassian API tokens are account-wide. One token usually works for both Jira and Confluence.\n" +
-		"Manage tokens: https://id.atlassian.com/manage-profile/security/api-tokens"
+	desc := mismatchDescription(cfl, jtk)
 	for _, want := range []string{
 		"account-wide",
 		"both Jira and Confluence",
 		"id.atlassian.com/manage-profile",
+		"/cfl.yml",
+		"/jtk.json",
 	} {
 		if !strings.Contains(desc, want) {
-			t.Errorf("expected educational language %q; missing from:\n%s", want, desc)
+			t.Errorf("expected %q in mismatch description; got:\n%s", want, desc)
 		}
 	}
 }

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -293,6 +293,28 @@ func TestResultFromMismatch_UseCFL(t *testing.T) {
 	testutil.Equal(t, []string{"/cfl.yml", "/jtk.json"}, r.consumedLegacies)
 }
 
+// TestResultFromMismatch_UseCFL_ClearsStaleJTKOverride pins the
+// daemon-r3 fix: if a prior keep_different run populated
+// store.JTK.Section, switching to use_cfl must clear it so jtk no
+// longer resolves to a stale override that shadows the new default.
+func TestResultFromMismatch_UseCFL_ClearsStaleJTKOverride(t *testing.T) {
+	t.Parallel()
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok"}
+	v, _, _ := newReconcileView()
+	store := &credstore.Store{
+		JTK: credstore.ToolSection{
+			Section:        credstore.Section{URL: "https://stale.atlassian.net", APIToken: "stale-tok"},
+			DefaultProject: "PROJ", // per-tool default must survive
+		},
+	}
+	r := resultFromMismatch(cfl, jtk, "use_cfl", store, v, "", "", "", "")
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "", r.store.JTK.URL)
+	testutil.Equal(t, "", r.store.JTK.APIToken)
+	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
+}
+
 func TestResultFromMismatch_UseJTK_PreservesCFLDefaults(t *testing.T) {
 	t.Parallel()
 	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok", DefaultSpace: "SPACE"}

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -1,0 +1,212 @@
+package init
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/credstore"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	"github.com/open-cli-collective/confluence-cli/internal/config"
+)
+
+type configFixture struct {
+	URL          string
+	Email        string
+	APIToken     string
+	AuthMethod   string
+	CloudID      string
+	DefaultSpace string
+}
+
+func (c configFixture) toConfig() *config.Config {
+	return &config.Config{
+		URL:          c.URL,
+		Email:        c.Email,
+		APIToken:     c.APIToken,
+		AuthMethod:   c.AuthMethod,
+		CloudID:      c.CloudID,
+		DefaultSpace: c.DefaultSpace,
+	}
+}
+
+func newReconcileView() (*view.View, *bytes.Buffer, *bytes.Buffer) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	v := view.NewWithFormat("table", true)
+	v.Out = stdout
+	v.Err = stderr
+	return v, stdout, stderr
+}
+
+func TestReconcile_NoFilesAnywhere(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	v, _, _ := newReconcileView()
+
+	r, err := detectAndReconcile(v,
+		filepath.Join(tmp, "cfl.yml"),
+		filepath.Join(tmp, "jtk.json"),
+		filepath.Join(tmp, "shared.yml"),
+		"", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.NotNil(t, r)
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "", r.prefill.URL)
+	testutil.Equal(t, 0, len(r.consumedLegacies))
+}
+
+func TestReconcile_OnlyCFLLegacy_AutoMigrates(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	body := `url: https://acme.atlassian.net/wiki
+email: u@e.com
+api_token: tok
+default_space: SPACE
+`
+	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte(body), 0o600))
+
+	v, stdout, _ := newReconcileView()
+	r, err := detectAndReconcile(v, cflPath,
+		filepath.Join(tmp, "jtk.json"),
+		filepath.Join(tmp, "shared.yml"),
+		"", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "https://acme.atlassian.net/wiki", r.prefill.URL)
+	testutil.Equal(t, "tok", r.prefill.APIToken)
+	testutil.Equal(t, "SPACE", r.prefill.DefaultSpace)
+	testutil.Equal(t, []string{cflPath}, r.consumedLegacies)
+	if !strings.Contains(stdout.String(), "Migrating existing cfl config") {
+		t.Errorf("expected migration message; got: %s", stdout.String())
+	}
+}
+
+func TestReconcile_FlagOverridesPrefill(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	v, _, _ := newReconcileView()
+
+	r, err := detectAndReconcile(v,
+		filepath.Join(tmp, "cfl.yml"),
+		filepath.Join(tmp, "jtk.json"),
+		filepath.Join(tmp, "shared.yml"),
+		"https://flag.atlassian.net", "flag@example.com", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "https://flag.atlassian.net", r.prefill.URL)
+	testutil.Equal(t, "flag@example.com", r.prefill.Email)
+}
+
+func TestReconcile_CorruptSharedAborts(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	testutil.RequireNoError(t, os.MkdirAll(filepath.Dir(sharedPath), 0o700))
+	testutil.RequireNoError(t, os.WriteFile(sharedPath, []byte("default: : :: ["), 0o600))
+
+	v, _, stderr := newReconcileView()
+	_, err := detectAndReconcile(v,
+		filepath.Join(tmp, "cfl.yml"),
+		filepath.Join(tmp, "jtk.json"),
+		sharedPath,
+		"", "", "", "")
+	testutil.RequireError(t, err)
+
+	// The shared file was not modified by detection.
+	body, ferr := os.ReadFile(sharedPath)
+	testutil.RequireNoError(t, ferr)
+	testutil.Equal(t, "default: : :: [", string(body))
+
+	if !strings.Contains(stderr.String(), "unreadable") {
+		t.Errorf("expected unreadable warning on stderr; got: %s", stderr.String())
+	}
+}
+
+func TestReconcile_CorruptCFLLegacyAborts(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte("url: : :: ["), 0o600))
+
+	v, _, stderr := newReconcileView()
+	_, err := detectAndReconcile(v, cflPath,
+		filepath.Join(tmp, "jtk.json"),
+		filepath.Join(tmp, "shared.yml"),
+		"", "", "", "")
+	testutil.RequireError(t, err)
+
+	body, ferr := os.ReadFile(cflPath)
+	testutil.RequireNoError(t, ferr)
+	testutil.Equal(t, "url: : :: [", string(body))
+
+	if !strings.Contains(stderr.String(), "unreadable") {
+		t.Errorf("expected unreadable warning; got: %s", stderr.String())
+	}
+}
+
+func TestReconcile_CorruptJTKLegacyDowngradesToWarning(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte("{not json"), 0o600))
+
+	v, stdout, _ := newReconcileView()
+	r, err := detectAndReconcile(v,
+		filepath.Join(tmp, "cfl.yml"),
+		jtkPath,
+		filepath.Join(tmp, "shared.yml"),
+		"", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.NotNil(t, r)
+	if !strings.Contains(stdout.String(), "ignoring") {
+		t.Errorf("expected ignore note for sibling-corrupt; got: %s", stdout.String())
+	}
+}
+
+func TestApplyResultToStore_DefaultTarget(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		// pre-existing JTK section that we must not stomp
+		JTK: credstore.ToolSection{
+			Section:        credstore.Section{APIToken: "preserved-jtk"},
+			DefaultProject: "PROJ",
+		},
+	}
+	cfg := configFixture{
+		URL: "https://acme.atlassian.net/wiki", Email: "u@e", APIToken: "t",
+		DefaultSpace: "SPACE",
+	}.toConfig()
+
+	applyResultToStore(store, cfg, writeDefault)
+
+	testutil.Equal(t, "https://acme.atlassian.net", store.Default.URL) // base form
+	testutil.Equal(t, "t", store.Default.APIToken)
+	testutil.Equal(t, "SPACE", store.CFL.DefaultSpace)
+	// JTK section preserved.
+	testutil.Equal(t, "preserved-jtk", store.JTK.APIToken)
+	testutil.Equal(t, "PROJ", store.JTK.DefaultProject)
+}
+
+func TestApplyResultToStore_OverrideTarget(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		Default: credstore.Section{URL: "https://default.atlassian.net", APIToken: "default-tok"},
+	}
+	cfg := configFixture{
+		URL: "https://cfl.atlassian.net/wiki", Email: "u@e", APIToken: "cfl-tok",
+	}.toConfig()
+
+	applyResultToStore(store, cfg, writeCFLOverride)
+
+	// Override section was written.
+	testutil.Equal(t, "https://cfl.atlassian.net", store.CFL.URL)
+	testutil.Equal(t, "cfl-tok", store.CFL.APIToken)
+	// Default left alone.
+	testutil.Equal(t, "https://default.atlassian.net", store.Default.URL)
+	testutil.Equal(t, "default-tok", store.Default.APIToken)
+}

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -210,3 +210,48 @@ func TestApplyResultToStore_OverrideTarget(t *testing.T) {
 	testutil.Equal(t, "https://default.atlassian.net", store.Default.URL)
 	testutil.Equal(t, "default-tok", store.Default.APIToken)
 }
+
+func TestReconcile_BothLegaciesMatch_AutoMigrates(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte(
+		"url: https://acme.atlassian.net/wiki\nemail: u@e\napi_token: tok\ndefault_space: SPACE\n"), 0o600))
+	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte(
+		`{"url":"https://acme.atlassian.net","email":"u@e","api_token":"tok","default_project":"PROJ"}`), 0o600))
+
+	v, stdout, _ := newReconcileView()
+	r, err := detectAndReconcile(v, cflPath, jtkPath,
+		filepath.Join(tmp, "shared.yml"),
+		"", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "tok", r.prefill.APIToken)
+	// jtk's default_project is preserved on the store even though we
+	// chose cfl as the migration source.
+	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
+	if !strings.Contains(stdout.String(), "Found matching cfl and jtk credentials") {
+		t.Errorf("expected matched-legacy message; got: %s", stdout.String())
+	}
+	testutil.Equal(t, false, r.affectsSibling) // migration, not affecting existing sibling state
+}
+
+func TestSectionsEqual_AuthMethodCanonicalization(t *testing.T) {
+	t.Parallel()
+	a := credstore.Section{URL: "https://x", Email: "u@e", APIToken: "t"}                            // empty method
+	b := credstore.Section{URL: "https://x", Email: "u@e", APIToken: "t", AuthMethod: "basic"}       // explicit
+	if !credstore.SectionsEqual(a, b) {
+		t.Fatalf("empty auth_method should match explicit basic")
+	}
+}
+
+func TestApplyResultToStore_PreservesExistingDefaultSpace(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		CFL: credstore.ToolSection{DefaultSpace: "EXISTING"},
+	}
+	cfg := configFixture{URL: "https://x", Email: "u@e", APIToken: "t"}.toConfig() // no DefaultSpace
+	applyResultToStore(store, cfg, writeDefault)
+	testutil.Equal(t, "EXISTING", store.CFL.DefaultSpace) // not stomped
+}

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -330,15 +330,86 @@ func TestResultFromCFLLegacy_BasicMigration(t *testing.T) {
 	testutil.Equal(t, []string{"/cfl.yml"}, r.consumedLegacies)
 }
 
-func TestFormatSection_EducationalContextInPrompt(t *testing.T) {
+func TestPromptReconcileMismatch_EducationalText(t *testing.T) {
 	t.Parallel()
-	// Smoke test that the prompt builder includes the relevant educational
-	// language. We don't drive huh, but the description string is built
-	// before huh is invoked and we can pass the same arguments.
+	// We can't drive huh, but the description string passed to it is
+	// constructed before huh.Run(). Re-build it here against the same
+	// helper so we exercise the educational-language contract.
 	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://x", Email: "u@e", APIToken: "tok"}
 	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://x", Email: "u@e", APIToken: "different"}
-	desc := "cfl: " + credstore.FormatSection("cfl", cfl.Section()) + "\njtk: " + credstore.FormatSection("jtk", jtk.Section())
-	if !strings.Contains(desc, "cfl") || !strings.Contains(desc, "jtk") {
-		t.Errorf("expected both tool labels in section formatting; got: %s", desc)
+	desc := credstore.FormatSection("cfl ("+cfl.Path+")", cfl.Section()) + "\n\n" +
+		credstore.FormatSection("jtk ("+jtk.Path+")", jtk.Section()) +
+		"\n\nNote: Atlassian API tokens are account-wide. One token usually works for both Jira and Confluence.\n" +
+		"Manage tokens: https://id.atlassian.com/manage-profile/security/api-tokens"
+	for _, want := range []string{
+		"account-wide",
+		"both Jira and Confluence",
+		"id.atlassian.com/manage-profile",
+	} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("expected educational language %q; missing from:\n%s", want, desc)
+		}
 	}
+}
+
+func TestResultFromSharedNoOverride_ReuseYes(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		Default: credstore.Section{
+			URL:      "https://acme.atlassian.net",
+			Email:    "u@e",
+			APIToken: "shared-tok",
+		},
+		CFL: credstore.ToolSection{DefaultSpace: "EXISTING"},
+	}
+	r := resultFromSharedNoOverride(store, true, "", "", "", "")
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "shared-tok", r.prefill.APIToken)
+	testutil.Equal(t, "EXISTING", r.prefill.DefaultSpace) // carried over
+	testutil.Equal(t, true, r.affectsSibling)
+}
+
+func TestResultFromSharedNoOverride_ReuseNo_FreshForm(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		Default: credstore.Section{URL: "https://x", APIToken: "shared-tok"},
+		CFL:     credstore.ToolSection{DefaultSpace: "EXISTING"},
+	}
+	r := resultFromSharedNoOverride(store, false, "", "", "", "")
+	testutil.Equal(t, writeCFLOverride, r.target)
+	testutil.Equal(t, "", r.prefill.APIToken) // fresh, not prefilled
+	testutil.Equal(t, "EXISTING", r.prefill.DefaultSpace) // tool defaults still carried so user doesn't retype
+	testutil.Equal(t, false, r.affectsSibling)
+}
+
+func TestResultFromSharedWithOverride(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		Default: credstore.Section{URL: "https://default", APIToken: "default-tok"},
+		CFL: credstore.ToolSection{
+			Section:      credstore.Section{URL: "https://cfl-override", APIToken: "cfl-tok"},
+			DefaultSpace: "SPACE",
+		},
+	}
+	r := resultFromSharedWithOverride(store, "", "", "", "")
+	testutil.Equal(t, writeCFLOverride, r.target)
+	testutil.Equal(t, "cfl-tok", r.prefill.APIToken) // override wins
+	testutil.Equal(t, "SPACE", r.prefill.DefaultSpace)
+	testutil.Equal(t, false, r.affectsSibling) // override doesn't affect sibling
+}
+
+func TestResultFromSiblingLegacy_PreservesJTKDefaults(t *testing.T) {
+	t.Parallel()
+	jtk := &credstore.LegacyCreds{
+		Path:           "/jtk.json",
+		URL:            "https://x",
+		Email:          "u@e",
+		APIToken:       "jtk-tok",
+		DefaultProject: "PROJ",
+	}
+	store := &credstore.Store{}
+	r := resultFromSiblingLegacy(jtk, store, true, "", "", "", "")
+	// Even though cfl init is the running tool, jtk's default_project
+	// must survive the migration.
+	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
 }

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -310,9 +310,12 @@ func TestResultFromMismatch_KeepDifferent(t *testing.T) {
 	v, stdout, _ := newReconcileView()
 	store := &credstore.Store{}
 	r := resultFromMismatch(cfl, jtk, "keep_different", store, v, "", "", "", "")
-	// cfl creds → default; jtk creds → JTK override section.
-	testutil.Equal(t, "https://cfl.atlassian.net", r.store.Default.URL)
-	testutil.Equal(t, "cfl-tok", r.store.Default.APIToken)
+	// cfl creds → CFL override; jtk creds → JTK override; default empty.
+	testutil.Equal(t, writeCFLOverride, r.target)
+	testutil.Equal(t, "", r.store.Default.URL)
+	testutil.Equal(t, "", r.store.Default.APIToken)
+	testutil.Equal(t, "https://cfl.atlassian.net", r.store.CFL.URL)
+	testutil.Equal(t, "cfl-tok", r.store.CFL.APIToken)
 	testutil.Equal(t, "https://jtk.atlassian.net", r.store.JTK.URL)
 	testutil.Equal(t, "jtk-tok", r.store.JTK.APIToken)
 	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -255,3 +255,90 @@ func TestApplyResultToStore_PreservesExistingDefaultSpace(t *testing.T) {
 	applyResultToStore(store, cfg, writeDefault)
 	testutil.Equal(t, "EXISTING", store.CFL.DefaultSpace) // not stomped
 }
+
+// Post-prompt branch tests — drive each huh-mediated decision by
+// calling the extracted helpers directly so we don't have to fake
+// stdin.
+
+func TestResultFromSiblingLegacy_ReuseYes(t *testing.T) {
+	t.Parallel()
+	jtk := &credstore.LegacyCreds{
+		Path:           "/jtk.json",
+		URL:            "https://acme.atlassian.net",
+		Email:          "u@e",
+		APIToken:       "jtk-tok",
+		DefaultProject: "PROJ",
+	}
+	r := resultFromSiblingLegacy(jtk, &credstore.Store{}, true, "", "", "", "")
+	testutil.Equal(t, "jtk-tok", r.prefill.APIToken)
+	testutil.Equal(t, []string{"/jtk.json"}, r.consumedLegacies)
+}
+
+func TestResultFromSiblingLegacy_ReuseNo(t *testing.T) {
+	t.Parallel()
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", APIToken: "jtk-tok"}
+	r := resultFromSiblingLegacy(jtk, &credstore.Store{}, false, "", "", "", "")
+	testutil.Equal(t, "", r.prefill.APIToken) // fresh setup, no prefill
+	testutil.Equal(t, 0, len(r.consumedLegacies))
+}
+
+func TestResultFromMismatch_UseCFL(t *testing.T) {
+	t.Parallel()
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok", DefaultProject: "PROJ"}
+	v, _, _ := newReconcileView()
+	r := resultFromMismatch(cfl, jtk, "use_cfl", &credstore.Store{}, v, "", "", "", "")
+	testutil.Equal(t, "cfl-tok", r.prefill.APIToken)
+	testutil.Equal(t, "SPACE", r.prefill.DefaultSpace)
+	testutil.Equal(t, []string{"/cfl.yml", "/jtk.json"}, r.consumedLegacies)
+}
+
+func TestResultFromMismatch_UseJTK_PreservesCFLDefaults(t *testing.T) {
+	t.Parallel()
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok"}
+	v, _, _ := newReconcileView()
+	r := resultFromMismatch(cfl, jtk, "use_jtk", &credstore.Store{}, v, "", "", "", "")
+	testutil.Equal(t, "jtk-tok", r.prefill.APIToken) // jtk creds chosen
+	testutil.Equal(t, "SPACE", r.prefill.DefaultSpace) // but cfl's default_space preserved
+}
+
+func TestResultFromMismatch_KeepDifferent(t *testing.T) {
+	t.Parallel()
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", Email: "u@e", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", Email: "u@e", APIToken: "jtk-tok"}
+	v, stdout, _ := newReconcileView()
+	store := &credstore.Store{}
+	r := resultFromMismatch(cfl, jtk, "keep_different", store, v, "", "", "", "")
+	// cfl creds → default; jtk creds → JTK override section.
+	testutil.Equal(t, "https://cfl.atlassian.net", r.store.Default.URL)
+	testutil.Equal(t, "cfl-tok", r.store.Default.APIToken)
+	testutil.Equal(t, "https://jtk.atlassian.net", r.store.JTK.URL)
+	testutil.Equal(t, "jtk-tok", r.store.JTK.APIToken)
+	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
+	if !strings.Contains(stdout.String(), "Keeping per-tool credentials") {
+		t.Errorf("expected keep-different note; got: %s", stdout.String())
+	}
+}
+
+func TestResultFromCFLLegacy_BasicMigration(t *testing.T) {
+	t.Parallel()
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://acme.atlassian.net/wiki", APIToken: "tok"}
+	r := resultFromCFLLegacy(cfl, &credstore.Store{}, "", "", "", "")
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "tok", r.prefill.APIToken)
+	testutil.Equal(t, []string{"/cfl.yml"}, r.consumedLegacies)
+}
+
+func TestFormatSection_EducationalContextInPrompt(t *testing.T) {
+	t.Parallel()
+	// Smoke test that the prompt builder includes the relevant educational
+	// language. We don't drive huh, but the description string is built
+	// before huh is invoked and we can pass the same arguments.
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://x", Email: "u@e", APIToken: "tok"}
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://x", Email: "u@e", APIToken: "different"}
+	desc := "cfl: " + credstore.FormatSection("cfl", cfl.Section()) + "\njtk: " + credstore.FormatSection("jtk", jtk.Section())
+	if !strings.Contains(desc, "cfl") || !strings.Contains(desc, "jtk") {
+		t.Errorf("expected both tool labels in section formatting; got: %s", desc)
+	}
+}

--- a/tools/cfl/internal/config/config.go
+++ b/tools/cfl/internal/config/config.go
@@ -177,6 +177,16 @@ func (c *Config) LoadFromShared(s *credstore.Store) {
 	}
 }
 
+var corruptSharedWarnEmitted = false
+
+func warnCorruptSharedOnce(err error) {
+	if corruptSharedWarnEmitted {
+		return
+	}
+	corruptSharedWarnEmitted = true
+	fmt.Fprintf(os.Stderr, "warning: shared credential store is unreadable (%v); falling back to per-tool config. Run `cfl init` to fix.\n", err)
+}
+
 // LoadWithEnv loads configuration with full precedence:
 //  1. legacy file (lowest)
 //  2. shared store default
@@ -197,9 +207,14 @@ func LoadWithEnv(path string) (*Config, error) {
 
 	store, sErr := credstore.Load(credstore.DefaultPath())
 	if sErr != nil {
-		return nil, fmt.Errorf("loading shared credstore: %w", sErr)
+		// Runtime callers can't propagate the error meaningfully — every
+		// cfl command would die. Warn once on stderr and fall back to
+		// legacy + env. `cfl init` uses credstore.Load directly so it
+		// can surface the error and refuse to clobber.
+		warnCorruptSharedOnce(sErr)
+	} else {
+		cfg.LoadFromShared(store)
 	}
-	cfg.LoadFromShared(store)
 
 	cfg.LoadFromEnv()
 	return cfg, nil

--- a/tools/cfl/internal/config/config.go
+++ b/tools/cfl/internal/config/config.go
@@ -194,14 +194,16 @@ func warnCorruptSharedOnce(err error) {
 //  4. ATLASSIAN_* env
 //  5. CFL_* env (highest)
 //
-// A corrupt shared store surfaces as an error rather than silently
-// falling through, so init/runtime never overwrite a file we couldn't
-// read.
+// A corrupt shared store warns once on stderr and falls back to legacy
+// + env so a broken shared file doesn't crash every cfl command. Init
+// uses credstore.Load directly so it can surface the error and refuse
+// to overwrite.
 func LoadWithEnv(path string) (*Config, error) {
 	cfg, err := Load(path)
 	if err != nil {
-		// Legacy file missing is fine; start empty. (Distinguishing
-		// missing-vs-corrupt for the legacy file is jtk-init's job.)
+		// Legacy file missing or corrupt: start empty. cfl init has a
+		// separate detect-and-reconcile path that distinguishes those
+		// cases and refuses to clobber a corrupt legacy file.
 		cfg = &Config{}
 	}
 

--- a/tools/cfl/internal/config/config.go
+++ b/tools/cfl/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/auth"
 	sharedconfig "github.com/open-cli-collective/atlassian-go/config"
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	"gopkg.in/yaml.v3"
 )
 
@@ -144,13 +145,61 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// LoadWithEnv loads configuration from file and overrides with environment variables.
+// LoadFromShared layers credentials from the shared store (default
+// merged with cfl override) on top of the receiver. URLs from the
+// shared store are stored as base; this method appends "/wiki" so the
+// receiver matches cfl's legacy URL convention.
+func (c *Config) LoadFromShared(s *credstore.Store) {
+	if s == nil {
+		return
+	}
+	r := s.Resolve(credstore.ToolCFL)
+	if r.URL != "" {
+		c.URL = credstore.URLForCFL(r.URL)
+	}
+	if r.Email != "" {
+		c.Email = r.Email
+	}
+	if r.APIToken != "" {
+		c.APIToken = r.APIToken
+	}
+	if r.AuthMethod != "" {
+		c.AuthMethod = r.AuthMethod
+	}
+	if r.CloudID != "" {
+		c.CloudID = r.CloudID
+	}
+	if s.CFL.DefaultSpace != "" {
+		c.DefaultSpace = s.CFL.DefaultSpace
+	}
+	if s.CFL.OutputFormat != "" {
+		c.OutputFormat = s.CFL.OutputFormat
+	}
+}
+
+// LoadWithEnv loads configuration with full precedence:
+//  1. legacy file (lowest)
+//  2. shared store default
+//  3. shared store cfl override
+//  4. ATLASSIAN_* env
+//  5. CFL_* env (highest)
+//
+// A corrupt shared store surfaces as an error rather than silently
+// falling through, so init/runtime never overwrite a file we couldn't
+// read.
 func LoadWithEnv(path string) (*Config, error) {
 	cfg, err := Load(path)
 	if err != nil {
-		// If file doesn't exist, start with empty config
+		// Legacy file missing is fine; start empty. (Distinguishing
+		// missing-vs-corrupt for the legacy file is jtk-init's job.)
 		cfg = &Config{}
 	}
+
+	store, sErr := credstore.Load(credstore.DefaultPath())
+	if sErr != nil {
+		return nil, fmt.Errorf("loading shared credstore: %w", sErr)
+	}
+	cfg.LoadFromShared(store)
 
 	cfg.LoadFromEnv()
 	return cfg, nil

--- a/tools/cfl/internal/config/config.go
+++ b/tools/cfl/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/open-cli-collective/atlassian-go/auth"
 	sharedconfig "github.com/open-cli-collective/atlassian-go/config"
@@ -177,14 +178,12 @@ func (c *Config) LoadFromShared(s *credstore.Store) {
 	}
 }
 
-var corruptSharedWarnEmitted = false
+var corruptSharedWarnOnce sync.Once
 
 func warnCorruptSharedOnce(err error) {
-	if corruptSharedWarnEmitted {
-		return
-	}
-	corruptSharedWarnEmitted = true
-	fmt.Fprintf(os.Stderr, "warning: shared credential store is unreadable (%v); falling back to per-tool config. Run `cfl init` to fix.\n", err)
+	corruptSharedWarnOnce.Do(func() {
+		fmt.Fprintf(os.Stderr, "warning: shared credential store is unreadable (%v); falling back to per-tool config. Run `cfl init` to fix.\n", err)
+	})
 }
 
 // LoadWithEnv loads configuration with full precedence:

--- a/tools/cfl/internal/config/config_test.go
+++ b/tools/cfl/internal/config/config_test.go
@@ -551,7 +551,10 @@ func TestLoadWithEnv_PrecedenceLegacyToSharedToEnv(t *testing.T) {
 	testutil.Equal(t, "env-tok", cfg.APIToken)
 }
 
-func TestLoadWithEnv_CorruptSharedSurfacesError(t *testing.T) {
+func TestLoadWithEnv_CorruptSharedFallsBackToLegacy(t *testing.T) {
+	// Runtime LoadWithEnv must keep working even when the shared file is
+	// broken — every cfl command would otherwise fail. Init uses a
+	// separate path that does surface corruption.
 	xdg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)
 	sharedPath := filepath.Join(xdg, "atlassian-cli", "config.yml")
@@ -563,6 +566,7 @@ func TestLoadWithEnv_CorruptSharedSurfacesError(t *testing.T) {
 	legacy := &Config{URL: "https://x.atlassian.net/wiki", Email: "e@x", APIToken: "t"}
 	testutil.RequireNoError(t, legacy.Save(legacyPath))
 
-	_, err := LoadWithEnv(legacyPath)
-	testutil.RequireError(t, err)
+	cfg, err := LoadWithEnv(legacyPath)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "https://x.atlassian.net/wiki", cfg.URL)
 }

--- a/tools/cfl/internal/config/config_test.go
+++ b/tools/cfl/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	sharedconfig "github.com/open-cli-collective/atlassian-go/config"
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 )
 
@@ -426,4 +427,142 @@ func TestGetEnvWithFallback(t *testing.T) {
 		os.Unsetenv("TEST_FALLBACK")
 		testutil.Equal(t, "", sharedconfig.GetEnvWithFallback("TEST_PRIMARY", "TEST_FALLBACK"))
 	})
+}
+
+func TestConfig_LoadFromShared(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default fills empty fields and appends /wiki to URL", func(t *testing.T) {
+		t.Parallel()
+		store := &credstore.Store{
+			Default: credstore.Section{
+				URL:      "https://acme.atlassian.net",
+				Email:    "default@example.com",
+				APIToken: "default-tok",
+			},
+		}
+		cfg := &Config{}
+		cfg.LoadFromShared(store)
+		testutil.Equal(t, "https://acme.atlassian.net/wiki", cfg.URL)
+		testutil.Equal(t, "default@example.com", cfg.Email)
+		testutil.Equal(t, "default-tok", cfg.APIToken)
+	})
+
+	t.Run("cfl override beats default per field", func(t *testing.T) {
+		t.Parallel()
+		store := &credstore.Store{
+			Default: credstore.Section{
+				URL:      "https://acme.atlassian.net",
+				Email:    "default@example.com",
+				APIToken: "default-tok",
+			},
+			CFL: credstore.ToolSection{
+				Section: credstore.Section{APIToken: "cfl-only-tok"},
+			},
+		}
+		cfg := &Config{}
+		cfg.LoadFromShared(store)
+		testutil.Equal(t, "default@example.com", cfg.Email) // from default
+		testutil.Equal(t, "cfl-only-tok", cfg.APIToken)     // from override
+	})
+
+	t.Run("default_space and output_format come from cfl section only", func(t *testing.T) {
+		t.Parallel()
+		store := &credstore.Store{
+			CFL: credstore.ToolSection{
+				DefaultSpace: "MYSPACE",
+				OutputFormat: "json",
+			},
+		}
+		cfg := &Config{}
+		cfg.LoadFromShared(store)
+		testutil.Equal(t, "MYSPACE", cfg.DefaultSpace)
+		testutil.Equal(t, "json", cfg.OutputFormat)
+	})
+
+	t.Run("nil store is no-op", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{URL: "preserve"}
+		cfg.LoadFromShared(nil)
+		testutil.Equal(t, "preserve", cfg.URL)
+	})
+
+	t.Run("empty shared store leaves config alone", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{URL: "https://existing/wiki", Email: "e@x"}
+		cfg.LoadFromShared(&credstore.Store{})
+		testutil.Equal(t, "https://existing/wiki", cfg.URL)
+		testutil.Equal(t, "e@x", cfg.Email)
+	})
+
+	t.Run("shared overlays existing legacy values", func(t *testing.T) {
+		t.Parallel()
+		// Loader contract: shared values replace existing fields when set,
+		// because legacy precedence is below shared.
+		cfg := &Config{URL: "https://legacy.atlassian.net/wiki", APIToken: "legacy-tok"}
+		store := &credstore.Store{
+			Default: credstore.Section{
+				URL:      "https://shared.atlassian.net",
+				APIToken: "shared-tok",
+			},
+		}
+		cfg.LoadFromShared(store)
+		testutil.Equal(t, "https://shared.atlassian.net/wiki", cfg.URL)
+		testutil.Equal(t, "shared-tok", cfg.APIToken)
+	})
+}
+
+func TestLoadWithEnv_PrecedenceLegacyToSharedToEnv(t *testing.T) {
+	// Isolate XDG so credstore.DefaultPath points into a tempdir.
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	// Seed legacy file (cfl-only).
+	legacyDir := t.TempDir()
+	legacyPath := filepath.Join(legacyDir, "config.yml")
+	legacy := &Config{
+		URL:      "https://legacy.atlassian.net/wiki",
+		Email:    "legacy@example.com",
+		APIToken: "legacy-tok",
+	}
+	testutil.RequireNoError(t, legacy.Save(legacyPath))
+
+	// Seed shared store (overrides URL + token via default).
+	sharedPath := filepath.Join(xdg, "atlassian-cli", "config.yml")
+	store := &credstore.Store{
+		Default: credstore.Section{
+			URL:      "https://shared.atlassian.net",
+			APIToken: "shared-tok",
+		},
+	}
+	testutil.RequireNoError(t, store.Save(sharedPath))
+
+	// Set CFL_API_TOKEN env (highest precedence).
+	t.Setenv("CFL_API_TOKEN", "env-tok")
+
+	cfg, err := LoadWithEnv(legacyPath)
+	testutil.RequireNoError(t, err)
+
+	// URL: shared wins over legacy (env not set for URL).
+	testutil.Equal(t, "https://shared.atlassian.net/wiki", cfg.URL)
+	// Email: only legacy has it; preserved.
+	testutil.Equal(t, "legacy@example.com", cfg.Email)
+	// API token: env wins over shared and legacy.
+	testutil.Equal(t, "env-tok", cfg.APIToken)
+}
+
+func TestLoadWithEnv_CorruptSharedSurfacesError(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	sharedPath := filepath.Join(xdg, "atlassian-cli", "config.yml")
+	testutil.RequireNoError(t, os.MkdirAll(filepath.Dir(sharedPath), 0o700))
+	testutil.RequireNoError(t, os.WriteFile(sharedPath, []byte("default: : :: ["), 0o600))
+
+	legacyDir := t.TempDir()
+	legacyPath := filepath.Join(legacyDir, "config.yml")
+	legacy := &Config{URL: "https://x.atlassian.net/wiki", Email: "e@x", APIToken: "t"}
+	testutil.RequireNoError(t, legacy.Save(legacyPath))
+
+	_, err := LoadWithEnv(legacyPath)
+	testutil.RequireError(t, err)
 }

--- a/tools/jtk/CLAUDE.md
+++ b/tools/jtk/CLAUDE.md
@@ -179,11 +179,14 @@ Variables are checked in precedence order (first match wins):
 
 | Setting | Precedence |
 |---------|------------|
-| URL | `JIRA_URL` → `ATLASSIAN_URL` → config |
-| Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → config |
-| API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → config |
-| Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → config → `"basic"` |
-| Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → config |
+| URL | `JIRA_URL` → `ATLASSIAN_URL` → shared `jtk` override → shared `default` → legacy config → `JIRA_DOMAIN` |
+| Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → shared `jtk` → shared `default` → legacy |
+| API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → shared `jtk` → shared `default` → legacy |
+| Default Project | `JIRA_DEFAULT_PROJECT` → shared `jtk.default_project` → legacy |
+| Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `jtk` → shared `default` → legacy → `"basic"` |
+| Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `jtk` → shared `default` → legacy |
+
+The "shared" entries refer to the cross-tool credential store at `~/.config/atlassian-cli/config.yml` written by `jtk init` and `cfl init`. The `jtk` section overrides the `default` section per field. Legacy `~/.config/jira-ticket-cli/config.json` keeps working indefinitely; init migrates it on first run.
 
 Use `ATLASSIAN_*` for shared credentials across jtk and cfl. Use `JIRA_*` to override per-tool.
 

--- a/tools/jtk/CLAUDE.md
+++ b/tools/jtk/CLAUDE.md
@@ -186,7 +186,7 @@ Variables are checked in precedence order (first match wins):
 | Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `jtk` → shared `default` → legacy → `"basic"` |
 | Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `jtk` → shared `default` → legacy |
 
-The "shared" entries refer to the cross-tool credential store at `~/.config/atlassian-cli/config.yml` written by `jtk init` and `cfl init`. The `jtk` section overrides the `default` section per field. Legacy `~/.config/jira-ticket-cli/config.json` keeps working indefinitely; init migrates it on first run.
+The "shared" entries refer to the cross-tool credential store at `~/.config/atlassian-cli/config.yml` written by `jtk init` and `cfl init`. The `jtk` section overrides the `default` section per field. Legacy jtk config (Linux: `~/.config/jira-ticket-cli/config.json`; macOS: `~/Library/Application Support/jira-ticket-cli/config.json`) keeps working indefinitely; init migrates it on first run.
 
 Use `ATLASSIAN_*` for shared credentials across jtk and cfl. Use `JIRA_*` to override per-tool.
 

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -1611,7 +1611,7 @@ jtk:
 
 The same file is shared with `cfl` — one Atlassian token, both tools. Run `jtk init` after `cfl init` (or vice versa) and you'll be offered to reuse the credentials. If you really need different tokens per tool, init's reconciliation flow lets you write per-tool overrides into the `jtk:` or `cfl:` section.
 
-Legacy `~/.config/jira-ticket-cli/config.json` keeps working indefinitely. Init detects it on first run and prompts to migrate.
+Legacy per-tool config keeps working indefinitely (Linux: `~/.config/jira-ticket-cli/config.json`; macOS: `~/Library/Application Support/jira-ticket-cli/config.json`). Init detects it on first run and prompts to migrate.
 
 Run `jtk config show` to inspect the resolved values. (Source-attribution for shared-store fields is partial today: `auth_method` and `cloud_id` already report their shared-store source; URL / email / API token / default project will be wired up in a follow-up PR.)
 

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -1596,34 +1596,37 @@ jtk fields options delete customfield_10001 --option 10200 --force
 
 ## Configuration
 
-Configuration is stored in your system's config directory under `jira-ticket-cli/`:
+`jtk init` writes credentials to the shared store at `~/.config/atlassian-cli/config.yml`:
 
-- **macOS:** `~/Library/Application Support/jira-ticket-cli/config.json`
-- **Linux:** `~/.config/jira-ticket-cli/config.json`
-
-Run `jtk config show` to see the path on your system.
-
-```json
-{
-  "url": "https://mycompany.atlassian.net",
-  "email": "user@example.com",
-  "api_token": "your-api-token",
-  "default_project": "MYPROJECT"
-}
+```yaml
+default:
+  url: https://mycompany.atlassian.net
+  email: user@example.com
+  api_token: your-api-token
+  auth_method: basic                # or "bearer"
+  cloud_id: ""                      # required for bearer
+jtk:
+  default_project: MYPROJECT        # jtk-only defaults
 ```
+
+The same file is shared with `cfl` — one Atlassian token, both tools. Run `jtk init` after `cfl init` (or vice versa) and you'll be offered to reuse the credentials. If you really need different tokens per tool, init's reconciliation flow lets you write per-tool overrides into the `jtk:` or `cfl:` section.
+
+Legacy `~/.config/jira-ticket-cli/config.json` keeps working indefinitely. Init detects it on first run and prompts to migrate.
+
+Run `jtk config show` to see the resolved values and their sources.
 
 ### Environment Variables
 
-Environment variables override config file values. Variables are checked in order of precedence (first match wins):
+Environment variables override file-based config. Variables are checked in order of precedence (first match wins):
 
 | Setting | Precedence (highest to lowest) |
 |---------|-------------------------------|
-| URL | `JIRA_URL` → `ATLASSIAN_URL` → config file |
-| Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → config file |
-| API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → config file |
-| Default Project | `JIRA_DEFAULT_PROJECT` → config file |
-| Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → config file → `basic` |
-| Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → config file |
+| URL | `JIRA_URL` → `ATLASSIAN_URL` → shared `jtk` override → shared `default` → legacy → `JIRA_DOMAIN` |
+| Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → shared `jtk` → shared `default` → legacy |
+| API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → shared `jtk` → shared `default` → legacy |
+| Default Project | `JIRA_DEFAULT_PROJECT` → shared `jtk.default_project` → legacy |
+| Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared → legacy → `basic` |
+| Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared → legacy |
 
 **Shared credentials:** If you use both `jtk` and `cfl` (Confluence CLI), set `ATLASSIAN_*` variables once:
 

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -1613,7 +1613,7 @@ The same file is shared with `cfl` — one Atlassian token, both tools. Run `jtk
 
 Legacy `~/.config/jira-ticket-cli/config.json` keeps working indefinitely. Init detects it on first run and prompts to migrate.
 
-Run `jtk config show` to inspect the resolved values. (Source-attribution for shared-store fields will be added in a follow-up PR; today, source labels reflect env-vars and the legacy file only.)
+Run `jtk config show` to inspect the resolved values. (Source-attribution for shared-store fields is partial today: `auth_method` and `cloud_id` already report their shared-store source; URL / email / API token / default project will be wired up in a follow-up PR.)
 
 ### Environment Variables
 

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -1613,7 +1613,7 @@ The same file is shared with `cfl` — one Atlassian token, both tools. Run `jtk
 
 Legacy `~/.config/jira-ticket-cli/config.json` keeps working indefinitely. Init detects it on first run and prompts to migrate.
 
-Run `jtk config show` to see the resolved values and their sources.
+Run `jtk config show` to inspect the resolved values. (Source-attribution for shared-store fields will be added in a follow-up PR; today, source labels reflect env-vars and the legacy file only.)
 
 ### Environment Variables
 

--- a/tools/jtk/go.mod
+++ b/tools/jtk/go.mod
@@ -45,4 +45,5 @@ require (
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tools/jtk/go.sum
+++ b/tools/jtk/go.sum
@@ -95,4 +95,7 @@ golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
 golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -260,7 +260,7 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 			return err
 		}
 		if deleteIt {
-			if err := removeFile(lp); err != nil {
+			if err := os.Remove(lp); err != nil {
 				v.Error("Could not remove %s: %v", lp, err)
 			} else {
 				v.Info("Removed %s", lp)
@@ -281,6 +281,3 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	return nil
 }
 
-// removeFile is a thin wrapper to keep os.Remove out of the hot path
-// where it adds noise in tests/diff reviews.
-func removeFile(path string) error { return os.Remove(path) }

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -16,11 +16,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/auth"
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	sharedurl "github.com/open-cli-collective/atlassian-go/url"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
-	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
 )
 
 // Register registers the init command
@@ -77,65 +77,16 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	}
 
 	v := opts.View()
-	configPath := config.Path()
+	sharedPath := credstore.DefaultPath()
+	jtkLegacyPath := credstore.LegacyJTKPath()
+	cflLegacyPath := credstore.LegacyCFLPath()
 
-	// Load existing config for pre-population
-	existingCfg, _ := config.Load()
-
-	// Check if config already exists
-	if _, err := os.Stat(configPath); err == nil {
-		var overwrite bool
-		err := huh.NewConfirm().
-			Title("Configuration already exists").
-			Description(fmt.Sprintf("Overwrite %s?", configPath)).
-			Value(&overwrite).
-			Run()
-		if err != nil {
-			return err
-		}
-		if !overwrite {
-			v.Info("Initialization cancelled.")
-			return nil
-		}
+	result, err := detectAndReconcile(v, jtkLegacyPath, cflLegacyPath, sharedPath,
+		prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+	if err != nil {
+		return err
 	}
-
-	// Initialize config with pre-filled values
-	// Priority: CLI flag > existing config value
-	cfg := &config.Config{}
-
-	if prefillURL != "" {
-		cfg.URL = prefillURL
-	} else if existingCfg.URL != "" {
-		cfg.URL = existingCfg.URL
-	}
-
-	if prefillEmail != "" {
-		cfg.Email = prefillEmail
-	} else if existingCfg.Email != "" {
-		cfg.Email = existingCfg.Email
-	}
-
-	if prefillToken != "" {
-		cfg.APIToken = prefillToken
-	} else if existingCfg.APIToken != "" {
-		cfg.APIToken = existingCfg.APIToken
-	}
-
-	if existingCfg.DefaultProject != "" {
-		cfg.DefaultProject = existingCfg.DefaultProject
-	}
-
-	if prefillAuthMethod != "" {
-		cfg.AuthMethod = prefillAuthMethod
-	} else if existingCfg.AuthMethod != "" {
-		cfg.AuthMethod = existingCfg.AuthMethod
-	}
-
-	if prefillCloudID != "" {
-		cfg.CloudID = prefillCloudID
-	} else if existingCfg.CloudID != "" {
-		cfg.CloudID = existingCfg.CloudID
-	}
+	cfg := result.prefill
 
 	// Determine auth method for form building
 	isBearer := cfg.AuthMethod == auth.AuthMethodBearer
@@ -271,12 +222,35 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 		v.Println("")
 	}
 
-	// Save configuration
-	if err := config.Save(cfg); err != nil {
-		return fmt.Errorf("saving configuration: %w", err)
+	// Save to shared credential store. Per-tool defaults always live in
+	// the jtk section; credential edits go to the section detectAndReconcile
+	// chose (default vs jtk override).
+	applyResultToStore(result.store, cfg, result.target)
+	if err := result.store.Save(sharedPath); err != nil {
+		return fmt.Errorf("saving shared store: %w", err)
+	}
+	v.Success("Configuration saved to %s", sharedPath)
+
+	for _, lp := range result.consumedLegacies {
+		var deleteIt bool
+		if err := huh.NewConfirm().
+			Title(fmt.Sprintf("Delete legacy config at %s?", lp)).
+			Description("Migrated to the shared store; this file is no longer used.").
+			Affirmative("Delete").
+			Negative("Keep").
+			Value(&deleteIt).
+			Run(); err != nil {
+			return err
+		}
+		if deleteIt {
+			if err := removeFile(lp); err != nil {
+				v.Error("Could not remove %s: %v", lp, err)
+			} else {
+				v.Info("Removed %s", lp)
+			}
+		}
 	}
 
-	v.Success("Configuration saved to %s", configPath)
 	v.Println("")
 	v.Println("Try it out:")
 	v.Println("  jtk me")
@@ -289,3 +263,7 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 
 	return nil
 }
+
+// removeFile is a thin wrapper to keep os.Remove out of the hot path
+// where it adds noise in tests/diff reviews.
+func removeFile(path string) error { return os.Remove(path) }

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -280,4 +280,3 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 
 	return nil
 }
-

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -222,6 +222,23 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 		v.Println("")
 	}
 
+	if result.affectsSibling {
+		var confirm bool
+		if err := huh.NewConfirm().
+			Title("Save will affect cfl").
+			Description("These credentials are stored in shared `default` and used by both jtk and cfl. Continue?").
+			Affirmative("Save").
+			Negative("Cancel").
+			Value(&confirm).
+			Run(); err != nil {
+			return err
+		}
+		if !confirm {
+			v.Info("Initialization cancelled. No changes saved.")
+			return nil
+		}
+	}
+
 	// Save to shared credential store. Per-tool defaults always live in
 	// the jtk section; credential edits go to the section detectAndReconcile
 	// chose (default vs jtk override).

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -26,6 +26,11 @@ type reconcileResult struct {
 	target           writeTarget
 	store            *credstore.Store
 	consumedLegacies []string
+	// affectsSibling is true when finalizeInit should confirm before
+	// writing because the save will mutate credentials the sibling tool
+	// is currently reading from. Set when reuse=yes was chosen on a
+	// shared store that already had usable creds.
+	affectsSibling bool
 }
 
 // detectAndReconcile is jtk's mirror of cfl init's reconciliation
@@ -63,8 +68,10 @@ func detectAndReconcile(
 	if store.HasUsableCreds(credstore.ToolJTK) {
 		hasOverride := !sectionEmpty(store.JTK.Section)
 		var target writeTarget
+		var reusePrefill bool
 		if hasOverride {
 			target = writeJTKOverride
+			reusePrefill = true
 		} else {
 			var reuse bool
 			err := huh.NewConfirm().
@@ -82,15 +89,28 @@ func detectAndReconcile(
 			}
 			if reuse {
 				target = writeDefault
-				v.Info("Note: edits will affect both jtk and cfl (writing to shared default).")
+				reusePrefill = true
+				v.Info("Note: editing these credentials will also affect cfl (writes go to shared default).")
 			} else {
 				target = writeJTKOverride
+				reusePrefill = false
 			}
 		}
-		cfg := configFromSection(store.Resolve(credstore.ToolJTK))
-		copyJTKDefaults(cfg, store.JTK)
+		var cfg *config.Config
+		if reusePrefill {
+			cfg = configFromSection(store.Resolve(credstore.ToolJTK))
+			copyJTKDefaults(cfg, store.JTK)
+		} else {
+			cfg = &config.Config{}
+			copyJTKDefaults(cfg, store.JTK)
+		}
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-		return &reconcileResult{prefill: cfg, target: target, store: store}, nil
+		return &reconcileResult{
+			prefill:        cfg,
+			target:         target,
+			store:          store,
+			affectsSibling: target == writeDefault && reusePrefill,
+		}, nil
 	}
 
 	// Case 2: only this tool's legacy.
@@ -131,8 +151,11 @@ func detectAndReconcile(
 		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}, nil
 	}
 
-	// Case 4: both legacies exist.
+	// Case 4: both legacies exist. Preserve cfl's per-tool defaults on
+	// the store either way so default_space/output_format aren't lost.
 	if jtkLegacy != nil && cflLegacy != nil {
+		store.CFL.DefaultSpace = cflLegacy.DefaultSpace
+		store.CFL.OutputFormat = cflLegacy.OutputFormat
 		if credstore.SectionsEqual(jtkLegacy.Section(), cflLegacy.Section()) {
 			v.Info("Found matching jtk and cfl credentials; migrating to shared store.")
 			cfg := configFromLegacy(jtkLegacy)
@@ -150,14 +173,12 @@ func detectAndReconcile(
 			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path, cflLegacy.Path}}, nil
 		case "use_cfl":
 			cfg := configFromLegacy(cflLegacy)
+			cfg.DefaultProject = jtkLegacy.DefaultProject
 			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
 			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path, cflLegacy.Path}}, nil
 		case "keep_different":
 			store.Default = jtkLegacy.Section()
-			store.JTK.DefaultProject = jtkLegacy.DefaultProject
 			store.CFL.Section = cflLegacy.Section()
-			store.CFL.DefaultSpace = cflLegacy.DefaultSpace
-			store.CFL.OutputFormat = cflLegacy.OutputFormat
 			cfg := configFromLegacy(jtkLegacy)
 			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
 			v.Info("Keeping per-tool credentials. jtk will use jtk's token; cfl will use cfl's token.")
@@ -251,5 +272,7 @@ func applyResultToStore(store *credstore.Store, cfg *config.Config, target write
 	case writeJTKOverride:
 		store.JTK.Section = cred
 	}
-	store.JTK.DefaultProject = cfg.DefaultProject
+	if cfg.DefaultProject != "" {
+		store.JTK.DefaultProject = cfg.DefaultProject
+	}
 }

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -120,6 +120,7 @@ func detectAndReconcile(
 	if jtkLegacy != nil && cflLegacy != nil {
 		store.CFL.DefaultSpace = cflLegacy.DefaultSpace
 		store.CFL.OutputFormat = cflLegacy.OutputFormat
+		store.JTK.DefaultProject = jtkLegacy.DefaultProject
 		if credstore.SectionsEqual(jtkLegacy.Section(), cflLegacy.Section()) {
 			v.Info("Found matching jtk and cfl credentials; migrating to shared store.")
 			cfg := configFromLegacy(jtkLegacy)
@@ -232,12 +233,16 @@ func resultFromMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds, choice stri
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
 		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
 	case "keep_different":
-		store.Default = jtkLegacy.Section()
+		// Both tools land in their override sections so the split is
+		// stable: store.Default stays empty, jtk reads its override,
+		// cfl reads its override. Save target is writeJTKOverride so
+		// post-form edits stay in the jtk section.
+		store.JTK.Section = jtkLegacy.Section()
 		store.CFL.Section = cflLegacy.Section()
 		cfg := configFromLegacy(jtkLegacy)
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
 		v.Info("Keeping per-tool credentials. jtk will use jtk's token; cfl will use cfl's token.")
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+		return &reconcileResult{prefill: cfg, target: writeJTKOverride, store: store, consumedLegacies: consumed}
 	}
 	cfg := &config.Config{}
 	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -224,10 +224,18 @@ func resultFromMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds, choice stri
 	consumed := []string{jtkLegacy.Path, cflLegacy.Path}
 	switch choice {
 	case "use_jtk":
+		// User chose "use jtk's creds for both tools". Clear any stale
+		// cfl override credential fields so cfl resolves to the new
+		// default rather than a leftover override from a prior
+		// keep_different run. Per-tool defaults (default_space,
+		// output_format) are preserved.
+		store.CFL.Section = credstore.Section{}
 		cfg := configFromLegacy(jtkLegacy)
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
 		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
 	case "use_cfl":
+		// Same rationale as use_jtk — clear stale cfl override.
+		store.CFL.Section = credstore.Section{}
 		cfg := configFromLegacy(cflLegacy)
 		cfg.DefaultProject = jtkLegacy.DefaultProject
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -236,9 +236,14 @@ func resultFromMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds, choice stri
 		// Both tools land in their override sections so the split is
 		// stable: store.Default stays empty, jtk reads its override,
 		// cfl reads its override. Save target is writeJTKOverride so
-		// post-form edits stay in the jtk section.
+		// post-form edits stay in the jtk section. Per-tool defaults
+		// are set here so the function is self-contained — callers
+		// don't have to pre-populate the store.
 		store.JTK.Section = jtkLegacy.Section()
+		store.JTK.DefaultProject = jtkLegacy.DefaultProject
 		store.CFL.Section = cflLegacy.Section()
+		store.CFL.DefaultSpace = cflLegacy.DefaultSpace
+		store.CFL.OutputFormat = cflLegacy.OutputFormat
 		cfg := configFromLegacy(jtkLegacy)
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
 		v.Info("Keeping per-tool credentials. jtk will use jtk's token; cfl will use cfl's token.")

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -138,12 +138,19 @@ func detectAndReconcile(
 	return &reconcileResult{prefill: cfg, target: writeDefault, store: store}, nil
 }
 
-func promptReconcileMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds) (string, error) {
-	desc := fmt.Sprintf(
+// mismatchDescription is the prompt description for the both-legacies-
+// mismatch reconciliation. Extracted so tests can assert the
+// educational language without driving huh.
+func mismatchDescription(jtkLegacy, cflLegacy *credstore.LegacyCreds) string {
+	return fmt.Sprintf(
 		"%s\n\n%s\n\nNote: Atlassian API tokens are account-wide. One token usually works for both Jira and Confluence.\nManage tokens: https://id.atlassian.com/manage-profile/security/api-tokens",
 		credstore.FormatSection("jtk ("+jtkLegacy.Path+")", jtkLegacy.Section()),
 		credstore.FormatSection("cfl ("+cflLegacy.Path+")", cflLegacy.Section()),
 	)
+}
+
+func promptReconcileMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds) (string, error) {
+	desc := mismatchDescription(jtkLegacy, cflLegacy)
 	var choice string
 	err := huh.NewSelect[string]().
 		Title("Different Atlassian credentials found").

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -223,21 +223,21 @@ func resultFromSharedWithOverride(store *credstore.Store, prefillURL, prefillEma
 func resultFromMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds, choice string, store *credstore.Store, v *view.View, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
 	consumed := []string{jtkLegacy.Path, cflLegacy.Path}
 	switch choice {
-	case "use_jtk":
-		// User chose "use jtk's creds for both tools". Clear any stale
-		// cfl override credential fields so cfl resolves to the new
-		// default rather than a leftover override from a prior
-		// keep_different run. Per-tool defaults (default_space,
+	case "use_jtk", "use_cfl":
+		// User chose to unify on one tool's creds. Clear both
+		// override Sections so each tool resolves to the new default
+		// rather than a leftover override from a prior keep_different
+		// run. Per-tool defaults (default_space, default_project,
 		// output_format) are preserved.
+		store.JTK.Section = credstore.Section{}
 		store.CFL.Section = credstore.Section{}
-		cfg := configFromLegacy(jtkLegacy)
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
-	case "use_cfl":
-		// Same rationale as use_jtk — clear stale cfl override.
-		store.CFL.Section = credstore.Section{}
-		cfg := configFromLegacy(cflLegacy)
-		cfg.DefaultProject = jtkLegacy.DefaultProject
+		var cfg *config.Config
+		if choice == "use_jtk" {
+			cfg = configFromLegacy(jtkLegacy)
+		} else {
+			cfg = configFromLegacy(cflLegacy)
+			cfg.DefaultProject = jtkLegacy.DefaultProject
+		}
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
 		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
 	case "keep_different":

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -67,50 +67,27 @@ func detectAndReconcile(
 	// Case 1: shared store has usable jtk creds.
 	if store.HasUsableCreds(credstore.ToolJTK) {
 		hasOverride := !sectionEmpty(store.JTK.Section)
-		var target writeTarget
-		var reusePrefill bool
 		if hasOverride {
-			target = writeJTKOverride
-			reusePrefill = true
-		} else {
-			var reuse bool
-			err := huh.NewConfirm().
-				Title("Shared Atlassian credentials found").
-				Description(fmt.Sprintf(
-					"%s\n\nReuse these for jtk? (no = set up jtk-specific credentials)",
-					credstore.FormatSection("default", store.Default),
-				)).
-				Affirmative("Reuse").
-				Negative("Set jtk-specific").
-				Value(&reuse).
-				Run()
-			if err != nil {
-				return nil, err
-			}
-			if reuse {
-				target = writeDefault
-				reusePrefill = true
-				v.Info("Note: editing these credentials will also affect cfl (writes go to shared default).")
-			} else {
-				target = writeJTKOverride
-				reusePrefill = false
-			}
+			return resultFromSharedWithOverride(store, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID), nil
 		}
-		var cfg *config.Config
-		if reusePrefill {
-			cfg = configFromSection(store.Resolve(credstore.ToolJTK))
-			copyJTKDefaults(cfg, store.JTK)
-		} else {
-			cfg = &config.Config{}
-			copyJTKDefaults(cfg, store.JTK)
+		var reuse bool
+		err := huh.NewConfirm().
+			Title("Shared Atlassian credentials found").
+			Description(fmt.Sprintf(
+				"%s\n\nReuse these for jtk? (no = set up jtk-specific credentials)",
+				credstore.FormatSection("default", store.Default),
+			)).
+			Affirmative("Reuse").
+			Negative("Set jtk-specific").
+			Value(&reuse).
+			Run()
+		if err != nil {
+			return nil, err
 		}
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-		return &reconcileResult{
-			prefill:        cfg,
-			target:         target,
-			store:          store,
-			affectsSibling: target == writeDefault && reusePrefill,
-		}, nil
+		if reuse {
+			v.Info("Note: editing these credentials will also affect cfl (writes go to shared default).")
+		}
+		return resultFromSharedNoOverride(store, reuse, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID), nil
 	}
 
 	// Case 2: only this tool's legacy.
@@ -192,6 +169,8 @@ func resultFromJTKLegacy(jtkLegacy *credstore.LegacyCreds, store *credstore.Stor
 }
 
 func resultFromSiblingLegacy(cflLegacy *credstore.LegacyCreds, store *credstore.Store, reuse bool, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	store.CFL.DefaultSpace = cflLegacy.DefaultSpace
+	store.CFL.OutputFormat = cflLegacy.OutputFormat
 	var cfg *config.Config
 	if reuse {
 		cfg = configFromLegacy(cflLegacy)
@@ -204,6 +183,33 @@ func resultFromSiblingLegacy(cflLegacy *credstore.LegacyCreds, store *credstore.
 		consumed = []string{cflLegacy.Path}
 	}
 	return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+}
+
+func resultFromSharedNoOverride(store *credstore.Store, reuse bool, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	var cfg *config.Config
+	target := writeJTKOverride
+	if reuse {
+		cfg = configFromSection(store.Resolve(credstore.ToolJTK))
+		copyJTKDefaults(cfg, store.JTK)
+		target = writeDefault
+	} else {
+		cfg = &config.Config{}
+		copyJTKDefaults(cfg, store.JTK)
+	}
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+	return &reconcileResult{
+		prefill:        cfg,
+		target:         target,
+		store:          store,
+		affectsSibling: reuse,
+	}
+}
+
+func resultFromSharedWithOverride(store *credstore.Store, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	cfg := configFromSection(store.Resolve(credstore.ToolJTK))
+	copyJTKDefaults(cfg, store.JTK)
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+	return &reconcileResult{prefill: cfg, target: writeJTKOverride, store: store}
 }
 
 func resultFromMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds, choice string, store *credstore.Store, v *view.View, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -1,0 +1,255 @@
+package initcmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+
+	"github.com/open-cli-collective/atlassian-go/credstore"
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
+)
+
+// writeTarget tells the post-form save logic which section of the
+// shared store to write credential edits into.
+type writeTarget int
+
+const (
+	writeDefault writeTarget = iota
+	writeJTKOverride
+)
+
+type reconcileResult struct {
+	prefill          *config.Config
+	target           writeTarget
+	store            *credstore.Store
+	consumedLegacies []string
+}
+
+// detectAndReconcile is jtk's mirror of cfl init's reconciliation
+// flow. See tools/cfl/internal/cmd/init/reconcile.go for the
+// canonical commentary; the logic here is symmetric with sibling and
+// tool roles swapped.
+func detectAndReconcile(
+	v *view.View,
+	jtkLegacyPath, cflLegacyPath, sharedPath string,
+	prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string,
+) (*reconcileResult, error) {
+	store, err := credstore.Load(sharedPath)
+	if err != nil {
+		v.Error("Shared credential store at %s is unreadable: %v", sharedPath, err)
+		v.Error("Refusing to overwrite. Fix or remove the file, then re-run jtk init.")
+		return nil, err
+	}
+
+	jtkLegacy, jtkErr := credstore.LoadLegacyJTK(jtkLegacyPath)
+	if jtkErr != nil {
+		if errors.Is(jtkErr, credstore.ErrCorruptStore) {
+			v.Error("Legacy jtk config at %s is unreadable: %v", jtkLegacyPath, jtkErr)
+			v.Error("Refusing to overwrite. Fix or remove the file, then re-run jtk init.")
+			return nil, jtkErr
+		}
+		return nil, jtkErr
+	}
+	cflLegacy, cflErr := credstore.LoadLegacyCFL(cflLegacyPath)
+	if cflErr != nil {
+		v.Info("Note: sibling cfl config at %s is unreadable; ignoring. (%v)", cflLegacyPath, cflErr)
+		cflLegacy = nil
+	}
+
+	// Case 1: shared store has usable jtk creds.
+	if store.HasUsableCreds(credstore.ToolJTK) {
+		hasOverride := !sectionEmpty(store.JTK.Section)
+		var target writeTarget
+		if hasOverride {
+			target = writeJTKOverride
+		} else {
+			var reuse bool
+			err := huh.NewConfirm().
+				Title("Shared Atlassian credentials found").
+				Description(fmt.Sprintf(
+					"%s\n\nReuse these for jtk? (no = set up jtk-specific credentials)",
+					credstore.FormatSection("default", store.Default),
+				)).
+				Affirmative("Reuse").
+				Negative("Set jtk-specific").
+				Value(&reuse).
+				Run()
+			if err != nil {
+				return nil, err
+			}
+			if reuse {
+				target = writeDefault
+				v.Info("Note: edits will affect both jtk and cfl (writing to shared default).")
+			} else {
+				target = writeJTKOverride
+			}
+		}
+		cfg := configFromSection(store.Resolve(credstore.ToolJTK))
+		copyJTKDefaults(cfg, store.JTK)
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+		return &reconcileResult{prefill: cfg, target: target, store: store}, nil
+	}
+
+	// Case 2: only this tool's legacy.
+	if jtkLegacy != nil && cflLegacy == nil {
+		cfg := configFromLegacy(jtkLegacy)
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+		v.Info("Migrating existing jtk config at %s to shared store.", jtkLegacy.Path)
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path}}, nil
+	}
+
+	// Case 3: only sibling cfl legacy.
+	if jtkLegacy == nil && cflLegacy != nil {
+		var reuse bool
+		err := huh.NewConfirm().
+			Title("Found cfl credentials").
+			Description(fmt.Sprintf(
+				"%s\n\nReuse these for jtk? (Atlassian API tokens are account-wide and usually work across products.)",
+				credstore.FormatSection("cfl", cflLegacy.Section()),
+			)).
+			Affirmative("Reuse").
+			Negative("Fresh setup").
+			Value(&reuse).
+			Run()
+		if err != nil {
+			return nil, err
+		}
+		var cfg *config.Config
+		if reuse {
+			cfg = configFromLegacy(cflLegacy)
+		} else {
+			cfg = &config.Config{}
+		}
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+		consumed := []string{}
+		if reuse {
+			consumed = []string{cflLegacy.Path}
+		}
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}, nil
+	}
+
+	// Case 4: both legacies exist.
+	if jtkLegacy != nil && cflLegacy != nil {
+		if credstore.SectionsEqual(jtkLegacy.Section(), cflLegacy.Section()) {
+			v.Info("Found matching jtk and cfl credentials; migrating to shared store.")
+			cfg := configFromLegacy(jtkLegacy)
+			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path, cflLegacy.Path}}, nil
+		}
+		choice, err := promptReconcileMismatch(jtkLegacy, cflLegacy)
+		if err != nil {
+			return nil, err
+		}
+		switch choice {
+		case "use_jtk":
+			cfg := configFromLegacy(jtkLegacy)
+			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path, cflLegacy.Path}}, nil
+		case "use_cfl":
+			cfg := configFromLegacy(cflLegacy)
+			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path, cflLegacy.Path}}, nil
+		case "keep_different":
+			store.Default = jtkLegacy.Section()
+			store.JTK.DefaultProject = jtkLegacy.DefaultProject
+			store.CFL.Section = cflLegacy.Section()
+			store.CFL.DefaultSpace = cflLegacy.DefaultSpace
+			store.CFL.OutputFormat = cflLegacy.OutputFormat
+			cfg := configFromLegacy(jtkLegacy)
+			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+			v.Info("Keeping per-tool credentials. jtk will use jtk's token; cfl will use cfl's token.")
+			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path, cflLegacy.Path}}, nil
+		}
+	}
+
+	cfg := &config.Config{}
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+	return &reconcileResult{prefill: cfg, target: writeDefault, store: store}, nil
+}
+
+func promptReconcileMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds) (string, error) {
+	desc := fmt.Sprintf(
+		"%s\n\n%s\n\nNote: Atlassian API tokens are account-wide. One token usually works for both Jira and Confluence.\nManage tokens: https://id.atlassian.com/manage-profile/security/api-tokens",
+		credstore.FormatSection("jtk ("+jtkLegacy.Path+")", jtkLegacy.Section()),
+		credstore.FormatSection("cfl ("+cflLegacy.Path+")", cflLegacy.Section()),
+	)
+	var choice string
+	err := huh.NewSelect[string]().
+		Title("Different Atlassian credentials found").
+		Description(desc).
+		Options(
+			huh.NewOption("Use jtk's credentials for both tools", "use_jtk"),
+			huh.NewOption("Use cfl's credentials for both tools", "use_cfl"),
+			huh.NewOption("Keep them different (advanced)", "keep_different"),
+		).
+		Value(&choice).
+		Run()
+	return choice, err
+}
+
+func sectionEmpty(s credstore.Section) bool {
+	return s.URL == "" && s.Email == "" && s.APIToken == "" && s.AuthMethod == "" && s.CloudID == ""
+}
+
+func configFromSection(s credstore.Section) *config.Config {
+	cfg := &config.Config{
+		URL:        s.URL,
+		Email:      s.Email,
+		APIToken:   s.APIToken,
+		AuthMethod: s.AuthMethod,
+		CloudID:    s.CloudID,
+	}
+	return cfg
+}
+
+func configFromLegacy(l *credstore.LegacyCreds) *config.Config {
+	cfg := configFromSection(l.Section())
+	if l.DefaultProject != "" {
+		cfg.DefaultProject = l.DefaultProject
+	}
+	return cfg
+}
+
+func copyJTKDefaults(cfg *config.Config, t credstore.ToolSection) {
+	if t.DefaultProject != "" {
+		cfg.DefaultProject = t.DefaultProject
+	}
+}
+
+func applyFlagOverrides(cfg *config.Config, url, email, token, authMethod, cloudID string) {
+	if url != "" {
+		cfg.URL = url
+	}
+	if email != "" {
+		cfg.Email = email
+	}
+	if token != "" {
+		cfg.APIToken = token
+	}
+	if authMethod != "" {
+		cfg.AuthMethod = authMethod
+	}
+	if cloudID != "" {
+		cfg.CloudID = cloudID
+	}
+}
+
+func applyResultToStore(store *credstore.Store, cfg *config.Config, target writeTarget) {
+	cred := credstore.Section{
+		URL:        credstore.NormalizeBaseURL(cfg.URL),
+		Email:      cfg.Email,
+		APIToken:   cfg.APIToken,
+		AuthMethod: cfg.AuthMethod,
+		CloudID:    cfg.CloudID,
+	}
+	switch target {
+	case writeDefault:
+		store.Default = cred
+	case writeJTKOverride:
+		store.JTK.Section = cred
+	}
+	store.JTK.DefaultProject = cfg.DefaultProject
+}

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -115,10 +115,8 @@ func detectAndReconcile(
 
 	// Case 2: only this tool's legacy.
 	if jtkLegacy != nil && cflLegacy == nil {
-		cfg := configFromLegacy(jtkLegacy)
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
 		v.Info("Migrating existing jtk config at %s to shared store.", jtkLegacy.Path)
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path}}, nil
+		return resultFromJTKLegacy(jtkLegacy, store, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID), nil
 	}
 
 	// Case 3: only sibling cfl legacy.
@@ -137,18 +135,7 @@ func detectAndReconcile(
 		if err != nil {
 			return nil, err
 		}
-		var cfg *config.Config
-		if reuse {
-			cfg = configFromLegacy(cflLegacy)
-		} else {
-			cfg = &config.Config{}
-		}
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-		consumed := []string{}
-		if reuse {
-			consumed = []string{cflLegacy.Path}
-		}
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}, nil
+		return resultFromSiblingLegacy(cflLegacy, store, reuse, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID), nil
 	}
 
 	// Case 4: both legacies exist. Preserve cfl's per-tool defaults on
@@ -166,24 +153,7 @@ func detectAndReconcile(
 		if err != nil {
 			return nil, err
 		}
-		switch choice {
-		case "use_jtk":
-			cfg := configFromLegacy(jtkLegacy)
-			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path, cflLegacy.Path}}, nil
-		case "use_cfl":
-			cfg := configFromLegacy(cflLegacy)
-			cfg.DefaultProject = jtkLegacy.DefaultProject
-			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path, cflLegacy.Path}}, nil
-		case "keep_different":
-			store.Default = jtkLegacy.Section()
-			store.CFL.Section = cflLegacy.Section()
-			cfg := configFromLegacy(jtkLegacy)
-			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-			v.Info("Keeping per-tool credentials. jtk will use jtk's token; cfl will use cfl's token.")
-			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path, cflLegacy.Path}}, nil
-		}
+		return resultFromMismatch(jtkLegacy, cflLegacy, choice, store, v, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID), nil
 	}
 
 	cfg := &config.Config{}
@@ -209,6 +179,56 @@ func promptReconcileMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds) (strin
 		Value(&choice).
 		Run()
 	return choice, err
+}
+
+// resultFromJTKLegacy / resultFromSiblingLegacy / resultFromMismatch
+// are the post-prompt branches lifted out so tests can drive them
+// without huh. See the cfl mirror in tools/cfl/internal/cmd/init/reconcile.go.
+
+func resultFromJTKLegacy(jtkLegacy *credstore.LegacyCreds, store *credstore.Store, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	cfg := configFromLegacy(jtkLegacy)
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+	return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path}}
+}
+
+func resultFromSiblingLegacy(cflLegacy *credstore.LegacyCreds, store *credstore.Store, reuse bool, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	var cfg *config.Config
+	if reuse {
+		cfg = configFromLegacy(cflLegacy)
+	} else {
+		cfg = &config.Config{}
+	}
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+	consumed := []string{}
+	if reuse {
+		consumed = []string{cflLegacy.Path}
+	}
+	return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+}
+
+func resultFromMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds, choice string, store *credstore.Store, v *view.View, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
+	consumed := []string{jtkLegacy.Path, cflLegacy.Path}
+	switch choice {
+	case "use_jtk":
+		cfg := configFromLegacy(jtkLegacy)
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+	case "use_cfl":
+		cfg := configFromLegacy(cflLegacy)
+		cfg.DefaultProject = jtkLegacy.DefaultProject
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+	case "keep_different":
+		store.Default = jtkLegacy.Section()
+		store.CFL.Section = cflLegacy.Section()
+		cfg := configFromLegacy(jtkLegacy)
+		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+		v.Info("Keeping per-tool credentials. jtk will use jtk's token; cfl will use cfl's token.")
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
+	}
+	cfg := &config.Config{}
+	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
+	return &reconcileResult{prefill: cfg, target: writeDefault, store: store}
 }
 
 func sectionEmpty(s credstore.Section) bool {

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -247,3 +247,21 @@ func TestResultFromSiblingLegacy_PreservesCFLDefaults(t *testing.T) {
 	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
 	testutil.Equal(t, "json", r.store.CFL.OutputFormat)
 }
+
+func TestMismatchDescription_EducationalText(t *testing.T) {
+	t.Parallel()
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://x", Email: "u@e", APIToken: "tok"}
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://x", Email: "u@e", APIToken: "different"}
+	desc := mismatchDescription(jtk, cfl)
+	for _, want := range []string{
+		"account-wide",
+		"both Jira and Confluence",
+		"id.atlassian.com/manage-profile",
+		"/jtk.json",
+		"/cfl.yml",
+	} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("expected %q in mismatch description; got:\n%s", want, desc)
+		}
+	}
+}

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -216,7 +216,7 @@ func TestResultFromMismatch_UseCFL_PreservesJTKDefaults(t *testing.T) {
 	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
 	v, _, _ := newReconcileView()
 	r := resultFromMismatch(jtk, cfl, "use_cfl", &credstore.Store{}, v, "", "", "", "", "")
-	testutil.Equal(t, "cfl-tok", r.prefill.APIToken) // cfl creds chosen
+	testutil.Equal(t, "cfl-tok", r.prefill.APIToken)    // cfl creds chosen
 	testutil.Equal(t, "PROJ", r.prefill.DefaultProject) // jtk's default_project preserved
 }
 
@@ -359,7 +359,7 @@ func TestReconcile_CorruptJTKLegacyAborts(t *testing.T) {
 		"", "", "", "", "")
 	testutil.RequireError(t, err)
 
-	body, ferr := os.ReadFile(jtkPath)
+	body, ferr := os.ReadFile(jtkPath) //nolint:gosec // test-controlled tempdir path
 	testutil.RequireNoError(t, ferr)
 	testutil.Equal(t, "{not json", string(body))
 

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -1,0 +1,136 @@
+package initcmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/credstore"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+	"github.com/open-cli-collective/atlassian-go/view"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
+)
+
+func newReconcileView() (*view.View, *bytes.Buffer, *bytes.Buffer) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	v := view.NewWithFormat("table", true)
+	v.Out = stdout
+	v.Err = stderr
+	return v, stdout, stderr
+}
+
+func TestReconcile_NoFilesAnywhere(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	v, _, _ := newReconcileView()
+
+	r, err := detectAndReconcile(v,
+		filepath.Join(tmp, "jtk.json"),
+		filepath.Join(tmp, "cfl.yml"),
+		filepath.Join(tmp, "shared.yml"),
+		"", "", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.NotNil(t, r)
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "", r.prefill.URL)
+}
+
+func TestReconcile_OnlyJTKLegacy_AutoMigrates(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	body := `{"url":"https://acme.atlassian.net","email":"u@e","api_token":"jtk-tok","default_project":"PROJ"}`
+	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte(body), 0o600))
+
+	v, stdout, _ := newReconcileView()
+	r, err := detectAndReconcile(v, jtkPath,
+		filepath.Join(tmp, "cfl.yml"),
+		filepath.Join(tmp, "shared.yml"),
+		"", "", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "https://acme.atlassian.net", r.prefill.URL)
+	testutil.Equal(t, "jtk-tok", r.prefill.APIToken)
+	testutil.Equal(t, "PROJ", r.prefill.DefaultProject)
+	testutil.Equal(t, []string{jtkPath}, r.consumedLegacies)
+	if !strings.Contains(stdout.String(), "Migrating existing jtk config") {
+		t.Errorf("expected migration message; got: %s", stdout.String())
+	}
+}
+
+func TestReconcile_FlagOverridesPrefill(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	v, _, _ := newReconcileView()
+
+	r, err := detectAndReconcile(v,
+		filepath.Join(tmp, "jtk.json"),
+		filepath.Join(tmp, "cfl.yml"),
+		filepath.Join(tmp, "shared.yml"),
+		"https://flag.atlassian.net", "flag@e.com", "flag-tok", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "https://flag.atlassian.net", r.prefill.URL)
+	testutil.Equal(t, "flag-tok", r.prefill.APIToken)
+}
+
+func TestReconcile_CorruptSharedAborts(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	testutil.RequireNoError(t, os.MkdirAll(filepath.Dir(sharedPath), 0o700))
+	testutil.RequireNoError(t, os.WriteFile(sharedPath, []byte("default: : :: ["), 0o600))
+
+	v, _, stderr := newReconcileView()
+	_, err := detectAndReconcile(v,
+		filepath.Join(tmp, "jtk.json"),
+		filepath.Join(tmp, "cfl.yml"),
+		sharedPath,
+		"", "", "", "", "")
+	testutil.RequireError(t, err)
+	if !strings.Contains(stderr.String(), "unreadable") {
+		t.Errorf("expected unreadable warning; got: %s", stderr.String())
+	}
+}
+
+func TestApplyResultToStore_DefaultTarget_PreservesCFLSection(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		CFL: credstore.ToolSection{
+			Section:      credstore.Section{APIToken: "preserved-cfl"},
+			DefaultSpace: "SPACE",
+		},
+	}
+	cfg := &config.Config{
+		URL: "https://acme.atlassian.net", Email: "u@e", APIToken: "jtk-tok",
+		DefaultProject: "PROJ",
+	}
+
+	applyResultToStore(store, cfg, writeDefault)
+
+	testutil.Equal(t, "https://acme.atlassian.net", store.Default.URL)
+	testutil.Equal(t, "jtk-tok", store.Default.APIToken)
+	testutil.Equal(t, "PROJ", store.JTK.DefaultProject)
+	// CFL section preserved.
+	testutil.Equal(t, "preserved-cfl", store.CFL.APIToken)
+	testutil.Equal(t, "SPACE", store.CFL.DefaultSpace)
+}
+
+func TestApplyResultToStore_OverrideTarget(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		Default: credstore.Section{URL: "https://default.atlassian.net", APIToken: "default-tok"},
+	}
+	cfg := &config.Config{URL: "https://jtk.atlassian.net", Email: "u@e", APIToken: "jtk-tok"}
+
+	applyResultToStore(store, cfg, writeJTKOverride)
+
+	testutil.Equal(t, "https://jtk.atlassian.net", store.JTK.URL)
+	testutil.Equal(t, "jtk-tok", store.JTK.APIToken)
+	// Default left alone.
+	testutil.Equal(t, "https://default.atlassian.net", store.Default.URL)
+	testutil.Equal(t, "default-tok", store.Default.APIToken)
+}

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -180,7 +180,34 @@ func TestResultFromMismatch_UseJTK_ClearsStaleCFLOverride(t *testing.T) {
 	testutil.Equal(t, writeDefault, r.target)
 	testutil.Equal(t, "", r.store.CFL.URL)
 	testutil.Equal(t, "", r.store.CFL.APIToken)
+	testutil.Equal(t, "", r.store.JTK.URL)
+	testutil.Equal(t, "", r.store.JTK.APIToken)
 	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
+}
+
+// Symmetric to UseJTK_ClearsStaleCFLOverride: use_cfl also clears
+// both overrides so jtk falls through to the new default.
+func TestResultFromMismatch_UseCFL_ClearsBothOverrides(t *testing.T) {
+	t.Parallel()
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok", DefaultProject: "PROJ"}
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
+	v, _, _ := newReconcileView()
+	store := &credstore.Store{
+		JTK: credstore.ToolSection{
+			Section:        credstore.Section{URL: "https://stale-jtk.atlassian.net", APIToken: "stale-jtk"},
+			DefaultProject: "STALE",
+		},
+		CFL: credstore.ToolSection{
+			Section: credstore.Section{URL: "https://stale-cfl.atlassian.net", APIToken: "stale-cfl"},
+		},
+	}
+	r := resultFromMismatch(jtk, cfl, "use_cfl", store, v, "", "", "", "", "")
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "", r.store.JTK.URL)
+	testutil.Equal(t, "", r.store.JTK.APIToken)
+	testutil.Equal(t, "", r.store.CFL.URL)
+	testutil.Equal(t, "", r.store.CFL.APIToken)
+	testutil.Equal(t, "STALE", r.store.JTK.DefaultProject) // per-tool default survives
 }
 
 func TestResultFromMismatch_UseCFL_PreservesJTKDefaults(t *testing.T) {

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -176,6 +176,7 @@ func TestResultFromMismatch_KeepDifferent(t *testing.T) {
 	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", Email: "u@e", APIToken: "jtk-tok"}
 	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", Email: "u@e", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
 	v, stdout, _ := newReconcileView()
+	jtk.DefaultProject = "PROJ"
 	r := resultFromMismatch(jtk, cfl, "keep_different", &credstore.Store{}, v, "", "", "", "", "")
 	// jtk creds → JTK override; cfl creds → CFL override; default empty.
 	testutil.Equal(t, writeJTKOverride, r.target)
@@ -183,8 +184,10 @@ func TestResultFromMismatch_KeepDifferent(t *testing.T) {
 	testutil.Equal(t, "", r.store.Default.APIToken)
 	testutil.Equal(t, "https://jtk.atlassian.net", r.store.JTK.URL)
 	testutil.Equal(t, "jtk-tok", r.store.JTK.APIToken)
+	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
 	testutil.Equal(t, "https://cfl.atlassian.net", r.store.CFL.URL)
 	testutil.Equal(t, "cfl-tok", r.store.CFL.APIToken)
+	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
 	if !strings.Contains(stdout.String(), "Keeping per-tool credentials") {
 		t.Errorf("expected keep-different note; got: %s", stdout.String())
 	}

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -265,3 +265,68 @@ func TestMismatchDescription_EducationalText(t *testing.T) {
 		}
 	}
 }
+
+func TestReconcile_BothLegaciesMatch_AutoMigrates(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte(
+		`{"url":"https://acme.atlassian.net","email":"u@e","api_token":"tok","default_project":"PROJ"}`), 0o600))
+	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte(
+		"url: https://acme.atlassian.net/wiki\nemail: u@e\napi_token: tok\ndefault_space: SPACE\n"), 0o600))
+
+	v, stdout, _ := newReconcileView()
+	r, err := detectAndReconcile(v, jtkPath, cflPath,
+		filepath.Join(tmp, "shared.yml"),
+		"", "", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "tok", r.prefill.APIToken)
+	// cfl's per-tool defaults preserved on the store.
+	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
+	if !strings.Contains(stdout.String(), "Found matching jtk and cfl credentials") {
+		t.Errorf("expected matched-legacy message; got: %s", stdout.String())
+	}
+}
+
+func TestReconcile_CorruptJTKLegacyAborts(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte("{not json"), 0o600))
+
+	v, _, stderr := newReconcileView()
+	_, err := detectAndReconcile(v, jtkPath,
+		filepath.Join(tmp, "cfl.yml"),
+		filepath.Join(tmp, "shared.yml"),
+		"", "", "", "", "")
+	testutil.RequireError(t, err)
+
+	body, ferr := os.ReadFile(jtkPath)
+	testutil.RequireNoError(t, ferr)
+	testutil.Equal(t, "{not json", string(body))
+
+	if !strings.Contains(stderr.String(), "unreadable") {
+		t.Errorf("expected unreadable warning; got: %s", stderr.String())
+	}
+}
+
+func TestReconcile_CorruptCFLLegacyDowngradesToWarning(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte("url: : :: ["), 0o600))
+
+	v, stdout, _ := newReconcileView()
+	r, err := detectAndReconcile(v,
+		filepath.Join(tmp, "jtk.json"),
+		cflPath,
+		filepath.Join(tmp, "shared.yml"),
+		"", "", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.NotNil(t, r)
+	if !strings.Contains(stdout.String(), "ignoring") {
+		t.Errorf("expected ignore note for sibling-corrupt; got: %s", stdout.String())
+	}
+}

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -177,8 +177,12 @@ func TestResultFromMismatch_KeepDifferent(t *testing.T) {
 	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", Email: "u@e", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
 	v, stdout, _ := newReconcileView()
 	r := resultFromMismatch(jtk, cfl, "keep_different", &credstore.Store{}, v, "", "", "", "", "")
-	testutil.Equal(t, "https://jtk.atlassian.net", r.store.Default.URL)
-	testutil.Equal(t, "jtk-tok", r.store.Default.APIToken)
+	// jtk creds → JTK override; cfl creds → CFL override; default empty.
+	testutil.Equal(t, writeJTKOverride, r.target)
+	testutil.Equal(t, "", r.store.Default.URL)
+	testutil.Equal(t, "", r.store.Default.APIToken)
+	testutil.Equal(t, "https://jtk.atlassian.net", r.store.JTK.URL)
+	testutil.Equal(t, "jtk-tok", r.store.JTK.APIToken)
 	testutil.Equal(t, "https://cfl.atlassian.net", r.store.CFL.URL)
 	testutil.Equal(t, "cfl-tok", r.store.CFL.APIToken)
 	if !strings.Contains(stdout.String(), "Keeping per-tool credentials") {

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -185,3 +185,65 @@ func TestResultFromMismatch_KeepDifferent(t *testing.T) {
 		t.Errorf("expected keep-different note; got: %s", stdout.String())
 	}
 }
+
+func TestResultFromSharedNoOverride_ReuseYes(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		Default: credstore.Section{
+			URL:      "https://acme.atlassian.net",
+			Email:    "u@e",
+			APIToken: "shared-tok",
+		},
+		JTK: credstore.ToolSection{DefaultProject: "EXISTING"},
+	}
+	r := resultFromSharedNoOverride(store, true, "", "", "", "", "")
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "shared-tok", r.prefill.APIToken)
+	testutil.Equal(t, "EXISTING", r.prefill.DefaultProject)
+	testutil.Equal(t, true, r.affectsSibling)
+}
+
+func TestResultFromSharedNoOverride_ReuseNo_FreshForm(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		Default: credstore.Section{URL: "https://x", APIToken: "shared-tok"},
+		JTK:     credstore.ToolSection{DefaultProject: "EXISTING"},
+	}
+	r := resultFromSharedNoOverride(store, false, "", "", "", "", "")
+	testutil.Equal(t, writeJTKOverride, r.target)
+	testutil.Equal(t, "", r.prefill.APIToken)
+	testutil.Equal(t, "EXISTING", r.prefill.DefaultProject)
+	testutil.Equal(t, false, r.affectsSibling)
+}
+
+func TestResultFromSharedWithOverride(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{
+		Default: credstore.Section{URL: "https://default", APIToken: "default-tok"},
+		JTK: credstore.ToolSection{
+			Section:        credstore.Section{URL: "https://jtk-override", APIToken: "jtk-tok"},
+			DefaultProject: "PROJ",
+		},
+	}
+	r := resultFromSharedWithOverride(store, "", "", "", "", "")
+	testutil.Equal(t, writeJTKOverride, r.target)
+	testutil.Equal(t, "jtk-tok", r.prefill.APIToken)
+	testutil.Equal(t, "PROJ", r.prefill.DefaultProject)
+	testutil.Equal(t, false, r.affectsSibling)
+}
+
+func TestResultFromSiblingLegacy_PreservesCFLDefaults(t *testing.T) {
+	t.Parallel()
+	cfl := &credstore.LegacyCreds{
+		Path:         "/cfl.yml",
+		URL:          "https://x",
+		Email:        "u@e",
+		APIToken:     "cfl-tok",
+		DefaultSpace: "SPACE",
+		OutputFormat: "json",
+	}
+	store := &credstore.Store{}
+	r := resultFromSiblingLegacy(cfl, store, true, "", "", "", "", "")
+	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
+	testutil.Equal(t, "json", r.store.CFL.OutputFormat)
+}

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -161,6 +161,28 @@ func TestResultFromMismatch_UseJTK(t *testing.T) {
 	testutil.Equal(t, "PROJ", r.prefill.DefaultProject)
 }
 
+// TestResultFromMismatch_UseJTK_ClearsStaleCFLOverride pins the
+// daemon-r3 fix: prior keep_different override on cfl must be cleared
+// when the user picks use_jtk, so cfl resolves to the new default
+// rather than the stale cfl override.
+func TestResultFromMismatch_UseJTK_ClearsStaleCFLOverride(t *testing.T) {
+	t.Parallel()
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok"}
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
+	v, _, _ := newReconcileView()
+	store := &credstore.Store{
+		CFL: credstore.ToolSection{
+			Section:      credstore.Section{URL: "https://stale.atlassian.net", APIToken: "stale-tok"},
+			DefaultSpace: "SPACE", // per-tool default must survive
+		},
+	}
+	r := resultFromMismatch(jtk, cfl, "use_jtk", store, v, "", "", "", "", "")
+	testutil.Equal(t, writeDefault, r.target)
+	testutil.Equal(t, "", r.store.CFL.URL)
+	testutil.Equal(t, "", r.store.CFL.APIToken)
+	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
+}
+
 func TestResultFromMismatch_UseCFL_PreservesJTKDefaults(t *testing.T) {
 	t.Parallel()
 	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok", DefaultProject: "PROJ"}

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -134,3 +134,54 @@ func TestApplyResultToStore_OverrideTarget(t *testing.T) {
 	testutil.Equal(t, "https://default.atlassian.net", store.Default.URL)
 	testutil.Equal(t, "default-tok", store.Default.APIToken)
 }
+
+func TestResultFromSiblingLegacy_ReuseYes(t *testing.T) {
+	t.Parallel()
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://acme.atlassian.net/wiki", Email: "u@e", APIToken: "cfl-tok"}
+	r := resultFromSiblingLegacy(cfl, &credstore.Store{}, true, "", "", "", "", "")
+	testutil.Equal(t, "cfl-tok", r.prefill.APIToken)
+	testutil.Equal(t, []string{"/cfl.yml"}, r.consumedLegacies)
+}
+
+func TestResultFromSiblingLegacy_ReuseNo(t *testing.T) {
+	t.Parallel()
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", APIToken: "cfl-tok"}
+	r := resultFromSiblingLegacy(cfl, &credstore.Store{}, false, "", "", "", "", "")
+	testutil.Equal(t, "", r.prefill.APIToken)
+	testutil.Equal(t, 0, len(r.consumedLegacies))
+}
+
+func TestResultFromMismatch_UseJTK(t *testing.T) {
+	t.Parallel()
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok", DefaultProject: "PROJ"}
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
+	v, _, _ := newReconcileView()
+	r := resultFromMismatch(jtk, cfl, "use_jtk", &credstore.Store{}, v, "", "", "", "", "")
+	testutil.Equal(t, "jtk-tok", r.prefill.APIToken)
+	testutil.Equal(t, "PROJ", r.prefill.DefaultProject)
+}
+
+func TestResultFromMismatch_UseCFL_PreservesJTKDefaults(t *testing.T) {
+	t.Parallel()
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok", DefaultProject: "PROJ"}
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
+	v, _, _ := newReconcileView()
+	r := resultFromMismatch(jtk, cfl, "use_cfl", &credstore.Store{}, v, "", "", "", "", "")
+	testutil.Equal(t, "cfl-tok", r.prefill.APIToken) // cfl creds chosen
+	testutil.Equal(t, "PROJ", r.prefill.DefaultProject) // jtk's default_project preserved
+}
+
+func TestResultFromMismatch_KeepDifferent(t *testing.T) {
+	t.Parallel()
+	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", Email: "u@e", APIToken: "jtk-tok"}
+	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", Email: "u@e", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
+	v, stdout, _ := newReconcileView()
+	r := resultFromMismatch(jtk, cfl, "keep_different", &credstore.Store{}, v, "", "", "", "", "")
+	testutil.Equal(t, "https://jtk.atlassian.net", r.store.Default.URL)
+	testutil.Equal(t, "jtk-tok", r.store.Default.APIToken)
+	testutil.Equal(t, "https://cfl.atlassian.net", r.store.CFL.URL)
+	testutil.Equal(t, "cfl-tok", r.store.CFL.APIToken)
+	if !strings.Contains(stdout.String(), "Keeping per-tool credentials") {
+		t.Errorf("expected keep-different note; got: %s", stdout.String())
+	}
+}

--- a/tools/jtk/internal/config/config.go
+++ b/tools/jtk/internal/config/config.go
@@ -13,16 +13,28 @@ import (
 	"github.com/open-cli-collective/atlassian-go/url"
 )
 
-// loadShared returns the shared credential store, or an empty Store
-// on any read/parse error. Accessors silently fall through on corrupt
-// shared store, mirroring the legacy-file behavior in this file. Init
-// loads credstore directly via credstore.Load to surface corruption.
+// loadShared returns the shared credential store. Accessors can't
+// propagate errors, so on corrupt shared store we warn once on stderr
+// (so the user sees something is wrong) and fall through to legacy
+// reads. Init has a separate code path that surfaces corruption as a
+// hard error and refuses to clobber the file.
 func loadShared() *credstore.Store {
 	s, err := credstore.Load(credstore.DefaultPath())
 	if err != nil {
+		warnCorruptSharedOnce(err)
 		return &credstore.Store{}
 	}
 	return s
+}
+
+var corruptWarnEmitted = false
+
+func warnCorruptSharedOnce(err error) {
+	if corruptWarnEmitted {
+		return
+	}
+	corruptWarnEmitted = true
+	fmt.Fprintf(os.Stderr, "warning: shared credential store is unreadable (%v); falling back to per-tool config. Run `jtk init` to fix.\n", err)
 }
 
 // jtkSection returns the resolved Section for jtk merged from default

--- a/tools/jtk/internal/config/config.go
+++ b/tools/jtk/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/open-cli-collective/atlassian-go/auth"
 	"github.com/open-cli-collective/atlassian-go/credstore"
@@ -27,14 +28,12 @@ func loadShared() *credstore.Store {
 	return s
 }
 
-var corruptWarnEmitted = false
+var corruptSharedWarnOnce sync.Once
 
 func warnCorruptSharedOnce(err error) {
-	if corruptWarnEmitted {
-		return
-	}
-	corruptWarnEmitted = true
-	fmt.Fprintf(os.Stderr, "warning: shared credential store is unreadable (%v); falling back to per-tool config. Run `jtk init` to fix.\n", err)
+	corruptSharedWarnOnce.Do(func() {
+		fmt.Fprintf(os.Stderr, "warning: shared credential store is unreadable (%v); falling back to per-tool config. Run `jtk init` to fix.\n", err)
+	})
 }
 
 // jtkSection returns the resolved Section for jtk merged from default

--- a/tools/jtk/internal/config/config.go
+++ b/tools/jtk/internal/config/config.go
@@ -9,8 +9,33 @@ import (
 	"path/filepath"
 
 	"github.com/open-cli-collective/atlassian-go/auth"
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/url"
 )
+
+// loadShared returns the shared credential store, or an empty Store
+// on any read/parse error. Accessors silently fall through on corrupt
+// shared store, mirroring the legacy-file behavior in this file. Init
+// loads credstore directly via credstore.Load to surface corruption.
+func loadShared() *credstore.Store {
+	s, err := credstore.Load(credstore.DefaultPath())
+	if err != nil {
+		return &credstore.Store{}
+	}
+	return s
+}
+
+// jtkSection returns the resolved Section for jtk merged from default
+// and the jtk override.
+func jtkSection() credstore.Section {
+	return loadShared().Resolve(credstore.ToolJTK)
+}
+
+// jtkSectionWithSource returns the resolved value and source for one
+// field of the jtk section.
+func jtkSectionWithSource(field string) (string, credstore.Source) {
+	return loadShared().ResolveWithSource(credstore.ToolJTK, field)
+}
 
 const (
 	configDirName  = "jira-ticket-cli"
@@ -101,12 +126,15 @@ func Clear() error {
 }
 
 // GetURL returns the Jira URL from config or environment.
-// Precedence: JIRA_URL → ATLASSIAN_URL → config url → JIRA_DOMAIN (legacy) → config domain (legacy)
+// Precedence: JIRA_URL → ATLASSIAN_URL → shared jtk override → shared default → legacy config url → JIRA_DOMAIN → legacy config domain.
 func GetURL() string {
 	if v := os.Getenv("JIRA_URL"); v != "" {
 		return url.NormalizeURL(v)
 	}
 	if v := os.Getenv("ATLASSIAN_URL"); v != "" {
+		return url.NormalizeURL(v)
+	}
+	if v := jtkSection().URL; v != "" {
 		return url.NormalizeURL(v)
 	}
 	cfg, err := Load()
@@ -140,12 +168,15 @@ func GetDomain() string {
 }
 
 // GetEmail returns the email from config or environment.
-// Precedence: JIRA_EMAIL → ATLASSIAN_EMAIL → config email
+// Precedence: JIRA_EMAIL → ATLASSIAN_EMAIL → shared jtk override → shared default → legacy config email.
 func GetEmail() string {
 	if v := os.Getenv("JIRA_EMAIL"); v != "" {
 		return v
 	}
 	if v := os.Getenv("ATLASSIAN_EMAIL"); v != "" {
+		return v
+	}
+	if v := jtkSection().Email; v != "" {
 		return v
 	}
 	cfg, err := Load()
@@ -156,12 +187,15 @@ func GetEmail() string {
 }
 
 // GetAPIToken returns the API token from config or environment.
-// Precedence: JIRA_API_TOKEN → ATLASSIAN_API_TOKEN → config api_token
+// Precedence: JIRA_API_TOKEN → ATLASSIAN_API_TOKEN → shared jtk override → shared default → legacy config api_token.
 func GetAPIToken() string {
 	if v := os.Getenv("JIRA_API_TOKEN"); v != "" {
 		return v
 	}
 	if v := os.Getenv("ATLASSIAN_API_TOKEN"); v != "" {
+		return v
+	}
+	if v := jtkSection().APIToken; v != "" {
 		return v
 	}
 	cfg, err := Load()
@@ -190,7 +224,7 @@ func GetAuthMethod() string {
 }
 
 // GetAuthMethodWithSource returns the auth method and its source.
-// Precedence: JIRA_AUTH_METHOD → ATLASSIAN_AUTH_METHOD → config auth_method → "basic"
+// Precedence: JIRA_AUTH_METHOD → ATLASSIAN_AUTH_METHOD → shared jtk override → shared default → legacy config auth_method → "basic"
 // Invalid values are skipped and fall through to the next source.
 // Validation happens at entry points (api.New, init --auth-method) not here.
 func GetAuthMethodWithSource() (value, source string) {
@@ -203,6 +237,9 @@ func GetAuthMethodWithSource() (value, source string) {
 		if auth.ValidateAuthMethod(v) == nil {
 			return v, "env (ATLASSIAN_AUTH_METHOD)"
 		}
+	}
+	if v, src := jtkSectionWithSource("auth_method"); v != "" && auth.ValidateAuthMethod(v) == nil {
+		return v, string(src)
 	}
 	cfg, err := Load()
 	if err != nil {
@@ -224,13 +261,16 @@ func GetCloudID() string {
 }
 
 // GetCloudIDWithSource returns the Cloud ID and its source.
-// Precedence: JIRA_CLOUD_ID → ATLASSIAN_CLOUD_ID → config cloud_id
+// Precedence: JIRA_CLOUD_ID → ATLASSIAN_CLOUD_ID → shared jtk override → shared default → legacy config cloud_id.
 func GetCloudIDWithSource() (value, source string) {
 	if v := os.Getenv("JIRA_CLOUD_ID"); v != "" {
 		return v, "env (JIRA_CLOUD_ID)"
 	}
 	if v := os.Getenv("ATLASSIAN_CLOUD_ID"); v != "" {
 		return v, "env (ATLASSIAN_CLOUD_ID)"
+	}
+	if v, src := jtkSectionWithSource("cloud_id"); v != "" {
+		return v, string(src)
 	}
 	cfg, err := Load()
 	if err != nil {
@@ -243,9 +283,12 @@ func GetCloudIDWithSource() (value, source string) {
 }
 
 // GetDefaultProject returns the default project from config or environment.
-// Precedence: JIRA_DEFAULT_PROJECT → config default_project
+// Precedence: JIRA_DEFAULT_PROJECT → shared jtk.default_project → legacy config default_project.
 func GetDefaultProject() string {
 	if v := os.Getenv("JIRA_DEFAULT_PROJECT"); v != "" {
+		return v
+	}
+	if v := loadShared().JTK.DefaultProject; v != "" {
 		return v
 	}
 	cfg, err := Load()

--- a/tools/jtk/internal/config/config_test.go
+++ b/tools/jtk/internal/config/config_test.go
@@ -611,3 +611,51 @@ func TestSharedStore_AuthMethodWithSource(t *testing.T) {
 	testutil.Equal(t, "bearer", value)
 	testutil.Equal(t, string(credstore.SourceDefault), source)
 }
+
+func TestSharedStore_FullPrecedenceChain(t *testing.T) {
+	tempDir, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Layer 1 (lowest): legacy file.
+	cfg := &Config{URL: "https://legacy.atlassian.net", APIToken: "legacy-tok"}
+	testutil.RequireNoError(t, Save(cfg))
+
+	// Layer 2: shared default.
+	sharedPath := filepath.Join(tempDir, "atlassian-cli", "config.yml")
+	store := &credstore.Store{
+		Default: credstore.Section{URL: "https://shared.atlassian.net", APIToken: "shared-tok"},
+	}
+	testutil.RequireNoError(t, store.Save(sharedPath))
+	testutil.Equal(t, "https://shared.atlassian.net", GetURL()) // shared default wins over legacy
+
+	// Layer 3: jtk override beats default.
+	store.JTK.Section = credstore.Section{APIToken: "jtk-tok"}
+	testutil.RequireNoError(t, store.Save(sharedPath))
+	testutil.Equal(t, "jtk-tok", GetAPIToken())
+
+	// Layer 4: ATLASSIAN_* env beats shared.
+	t.Setenv("ATLASSIAN_API_TOKEN", "atlassian-env-tok")
+	testutil.Equal(t, "atlassian-env-tok", GetAPIToken())
+
+	// Layer 5: JIRA_* env beats ATLASSIAN_*.
+	t.Setenv("JIRA_API_TOKEN", "jira-env-tok")
+	testutil.Equal(t, "jira-env-tok", GetAPIToken())
+}
+
+func TestSharedStore_CorruptDoesNotBlockAccessors(t *testing.T) {
+	tempDir, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Corrupt shared store.
+	sharedPath := filepath.Join(tempDir, "atlassian-cli", "config.yml")
+	testutil.RequireNoError(t, os.MkdirAll(filepath.Dir(sharedPath), 0o700))
+	testutil.RequireNoError(t, os.WriteFile(sharedPath, []byte("default: : :: ["), 0o600))
+
+	// Legacy still works.
+	cfg := &Config{URL: "https://legacy.atlassian.net", Email: "u@e", APIToken: "tok"}
+	testutil.RequireNoError(t, Save(cfg))
+
+	// Accessor returns legacy value despite corrupt shared.
+	testutil.Equal(t, "https://legacy.atlassian.net", GetURL())
+	testutil.Equal(t, "tok", GetAPIToken())
+}

--- a/tools/jtk/internal/config/config_test.go
+++ b/tools/jtk/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/open-cli-collective/atlassian-go/url"
 )
@@ -527,4 +528,86 @@ func TestGetURL_FullPrecedenceChain(t *testing.T) {
 	// JIRA_URL takes precedence over ATLASSIAN_URL
 	t.Setenv("JIRA_URL", "https://jira-url.atlassian.net")
 	testutil.Equal(t, GetURL(), "https://jira-url.atlassian.net")
+}
+
+func TestSharedStore_FillsURLBetweenEnvAndLegacy(t *testing.T) {
+	tempDir, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Seed shared store with a URL.
+	sharedPath := filepath.Join(tempDir, "atlassian-cli", "config.yml")
+	store := &credstore.Store{
+		Default: credstore.Section{URL: "https://shared.atlassian.net"},
+	}
+	testutil.RequireNoError(t, store.Save(sharedPath))
+
+	// No legacy file, no env vars → shared default wins.
+	testutil.Equal(t, "https://shared.atlassian.net", GetURL())
+
+	// Env var beats shared.
+	t.Setenv("ATLASSIAN_URL", "https://env.atlassian.net")
+	testutil.Equal(t, "https://env.atlassian.net", GetURL())
+}
+
+func TestSharedStore_JTKOverrideBeatsDefault(t *testing.T) {
+	tempDir, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	sharedPath := filepath.Join(tempDir, "atlassian-cli", "config.yml")
+	store := &credstore.Store{
+		Default: credstore.Section{
+			URL:      "https://shared.atlassian.net",
+			APIToken: "default-tok",
+		},
+		JTK: credstore.ToolSection{
+			Section: credstore.Section{APIToken: "jtk-tok"},
+		},
+	}
+	testutil.RequireNoError(t, store.Save(sharedPath))
+
+	testutil.Equal(t, "jtk-tok", GetAPIToken())
+}
+
+func TestSharedStore_LegacyWinsWhenSharedAbsent(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	cfg := &Config{
+		URL:      "https://legacy.atlassian.net",
+		Email:    "legacy@example.com",
+		APIToken: "legacy-tok",
+	}
+	testutil.RequireNoError(t, Save(cfg))
+	testutil.Equal(t, "https://legacy.atlassian.net", GetURL())
+	testutil.Equal(t, "legacy-tok", GetAPIToken())
+}
+
+func TestSharedStore_DefaultProject(t *testing.T) {
+	tempDir, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	sharedPath := filepath.Join(tempDir, "atlassian-cli", "config.yml")
+	store := &credstore.Store{
+		JTK: credstore.ToolSection{DefaultProject: "MON"},
+	}
+	testutil.RequireNoError(t, store.Save(sharedPath))
+
+	testutil.Equal(t, "MON", GetDefaultProject())
+	t.Setenv("JIRA_DEFAULT_PROJECT", "ENV")
+	testutil.Equal(t, "ENV", GetDefaultProject())
+}
+
+func TestSharedStore_AuthMethodWithSource(t *testing.T) {
+	tempDir, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	sharedPath := filepath.Join(tempDir, "atlassian-cli", "config.yml")
+	store := &credstore.Store{
+		Default: credstore.Section{AuthMethod: "bearer"},
+	}
+	testutil.RequireNoError(t, store.Save(sharedPath))
+
+	value, source := GetAuthMethodWithSource()
+	testutil.Equal(t, "bearer", value)
+	testutil.Equal(t, string(credstore.SourceDefault), source)
 }


### PR DESCRIPTION
## Summary

- New `shared/credstore` package writes `~/.config/atlassian-cli/config.yml`. One Atlassian token, both tools.
- `cfl init` and `jtk init` detect existing legacy files plus the shared store, then prompt or auto-migrate. When the two tools' legacy files have different tokens, the reconciliation flow educates the user that one token usually works for both products.
- Loader precedence: tool env > `ATLASSIAN_*` env > shared tool override > shared default > legacy file. Per-field merge — partial overrides don't shadow defaults.
- Corrupt files refuse to overwrite. Atomic `Save` (temp+rename, cleanup on failure).

Closes #354

## Test plan

- [x] `go test ./shared/credstore/...` (46 cases incl. corrupt, partial overrides, atomic save, URL normalization)
- [x] `go test ./tools/cfl/...` and `./tools/jtk/...` (3111 total passing across 57 packages)
- [x] `make lint` clean for new code (2 pre-existing govet items in `shared/testutil` from Feb 2026 are not introduced here)
- [ ] Manual smoke against a real Atlassian tenant — deferred (no test instance handy; merging on the documented test coverage)

## Out of scope (follow-ups)

The plan also covered `config show` source attribution for shared sections and `config clear --shared` / `--tool-creds` flag scopes (Phase 4.5 in the plan). Those are independent UX improvements; the shared store itself works without them and the loader already honors all the new sources. I deferred them so the issue's actual request — sibling-aware init — ships in a focused PR.