### PR TITLE
feat(jtk): support --status on issues update via transitions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,14 @@ jtk projects create --key PROJ --name "My Project" --lead <account-id>
 jtk projects update PROJ --name "New Name"
 jtk projects delete PROJ
 
-# Transitions
+# Workflow status (typical)
+jtk issues update PROJ-123 --status "Done"
+
+# Transitions API (advanced: pick a specific transition by ID, set
+# fields-on-transition, or disambiguate when multiple transitions land on
+# the same target status)
 jtk transitions list PROJ-123
-jtk transitions do PROJ-123 "Done"
+jtk transitions do PROJ-123 51
 
 # Comments
 jtk comments list PROJ-123

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -361,8 +361,9 @@ jtk issues update PROJ-123 --description "Updated description" --field labels=ur
 # Unassign an issue
 jtk issues update PROJ-123 --assignee none
 
-# Change workflow status (routes to the transitions API under the hood)
-jtk issues update PROJ-123 --status Done
+# Change workflow status (routes to the transitions API under the hood).
+# Quote multi-word status names: --status "In Progress"
+jtk issues update PROJ-123 --status "Done"
 
 # Multi-value fields: repeat --field with the same key to accumulate values
 jtk issues update PROJ-123 --field customfield_10050=Option1 --field customfield_10050=Option2

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -361,6 +361,9 @@ jtk issues update PROJ-123 --description "Updated description" --field labels=ur
 # Unassign an issue
 jtk issues update PROJ-123 --assignee none
 
+# Change workflow status (routes to the transitions API under the hood)
+jtk issues update PROJ-123 --status Done
+
 # Multi-value fields: repeat --field with the same key to accumulate values
 jtk issues update PROJ-123 --field customfield_10050=Option1 --field customfield_10050=Option2
 ```
@@ -372,6 +375,7 @@ jtk issues update PROJ-123 --field customfield_10050=Option1 --field customfield
 | `--parent` | | | Parent issue key (epic or parent issue) |
 | `--assignee` | `-a` | | Assignee (account ID, email, display name, `"me"`, or `"none"` to unassign) |
 | `--type` | `-t` | | New issue type (uses Jira Cloud bulk move API) |
+| `--status` | | | New workflow status (uses Jira transitions API; resolved before any writes) |
 | `--field` | `-f` | | Field to update in `key=value` format (can be repeated; repeating the same key accumulates values for multi-select fields) |
 
 **Arguments:**
@@ -686,7 +690,11 @@ jtk transitions list PROJ-123 --id
 
 ### `jtk transitions do <issue-key> <transition>`
 
-Perform a transition on an issue.
+Perform a transition on an issue. For ordinary status changes, prefer
+`jtk issues update <key> --status <name>` — it hides the Jira API split.
+Reach for `transitions do` when you need to disambiguate multiple
+transitions to the same target status, set fields-on-transition, or pick
+a transition by ID.
 
 **Aliases:** `jtk transition do`, `jtk tr do`
 

--- a/tools/jtk/api/transitions.go
+++ b/tools/jtk/api/transitions.go
@@ -67,3 +67,18 @@ func FindTransitionByName(transitions []Transition, name string) *Transition {
 	}
 	return nil
 }
+
+// FindTransitionsByStatus returns all transitions whose target status name
+// matches statusName (case-insensitive). Returns an empty slice when none
+// match. Callers are responsible for handling ambiguity when more than one
+// transition lands on the same target status.
+func FindTransitionsByStatus(transitions []Transition, statusName string) []Transition {
+	nameLower := strings.ToLower(statusName)
+	var matches []Transition
+	for _, t := range transitions {
+		if strings.ToLower(t.To.Name) == nameLower {
+			matches = append(matches, t)
+		}
+	}
+	return matches
+}

--- a/tools/jtk/api/transitions_test.go
+++ b/tools/jtk/api/transitions_test.go
@@ -75,6 +75,44 @@ func TestFindTransitionByName_NilSlice(t *testing.T) {
 	testutil.Nil(t, result)
 }
 
+func TestFindTransitionsByStatus(t *testing.T) {
+	t.Parallel()
+	transitions := []Transition{
+		{ID: "11", Name: "Start", To: Status{Name: "In Progress"}},
+		{ID: "21", Name: "Resume", To: Status{Name: "In Progress"}},
+		{ID: "31", Name: "Complete", To: Status{Name: "Done"}},
+	}
+
+	tests := []struct {
+		name       string
+		statusName string
+		wantIDs    []string
+	}{
+		{"exact single match", "Done", []string{"31"}},
+		{"case-insensitive single match", "done", []string{"31"}},
+		{"multiple matches", "In Progress", []string{"11", "21"}},
+		{"no match", "Closed", nil},
+		{"empty input", "", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FindTransitionsByStatus(transitions, tt.statusName)
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("got %d matches, want %d", len(got), len(tt.wantIDs))
+			}
+			for i, want := range tt.wantIDs {
+				testutil.Equal(t, got[i].ID, want)
+			}
+		})
+	}
+}
+
+func TestFindTransitionsByStatus_EmptyAndNil(t *testing.T) {
+	testutil.Equal(t, len(FindTransitionsByStatus([]Transition{}, "Done")), 0)
+	testutil.Equal(t, len(FindTransitionsByStatus(nil, "Done")), 0)
+}
+
 func TestClient_GetTransitions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testutil.Contains(t, r.URL.Path, "/issue/PROJ-123/transitions")

--- a/tools/jtk/integration-tests.md
+++ b/tools/jtk/integration-tests.md
@@ -663,6 +663,108 @@ Run these steps in order. Each step depends on the previous.
    jtk issues delete $MV_ISSUE --force
    ```
 
+### `--status` sub-block (issues update routes to transitions API)
+
+> Validates that `jtk issues update --status <name>` performs a workflow
+> transition under the hood. The sub-block creates a dedicated issue so it
+> can finish in any status without interfering with later steps.
+
+1. **Create a fresh issue for status testing:**
+   ```bash
+   STATUS_ISSUE=$(jtk issues create -p $PROJECT -t $ISSUE_TYPE -s "[Test] Status Update" --id)
+   echo $STATUS_ISSUE
+   ```
+   Expected: A new issue key. Capture it as `$STATUS_ISSUE`.
+
+2. **Discover available target statuses for the issue:**
+   ```bash
+   jtk transitions list $STATUS_ISSUE
+   ```
+   Expected: Table of available transitions with `ID | NAME | TO_STATUS`.
+   Pick a target status name → `$STATUS_TARGET` (e.g., `In Progress`).
+   Pick a second target status → `$STATUS_SECOND` (e.g., `Done`).
+
+3. **Transition by status name (happy path):**
+   ```bash
+   jtk issues update $STATUS_ISSUE --status "$STATUS_TARGET"
+   ```
+   Expected: Full issue detail block; STATUS row shows `$STATUS_TARGET`.
+
+4. **Re-run the same transition (already-current short-circuit):**
+   ```bash
+   jtk issues update $STATUS_ISSUE --status "$STATUS_TARGET"
+   ```
+   Expected: stderr advisory `status is already $STATUS_TARGET` and exit 0.
+   No errors, no extra output on stdout.
+
+5. **Combine `--status` with `--summary`:**
+   ```bash
+   jtk issues update $STATUS_ISSUE \
+     --summary "[Test] Status Update (combined)" \
+     --status "$STATUS_SECOND"
+   ```
+   Expected: Full issue detail block with the new summary AND the new
+   status. (PUT before POST internally.)
+
+6. **`--id` mode + transition:**
+   ```bash
+   jtk transitions list $STATUS_ISSUE   # pick another available status -> $STATUS_THIRD
+   jtk issues update $STATUS_ISSUE --status "$STATUS_THIRD" --id
+   ```
+   Expected: Issue key only on stdout, no advisory. `jtk issues get $STATUS_ISSUE`
+   should confirm the status changed.
+
+7. **`--id` mode + already-current (no advisory in ID mode):**
+   ```bash
+   jtk issues update $STATUS_ISSUE --status "$STATUS_THIRD" --id
+   ```
+   Expected: Issue key on stdout, nothing on stderr, exit 0.
+
+7b. **Ambiguous status (multiple transitions to the same target status):**
+
+   Some workflows have more than one transition leading to the same target
+   status (e.g. two different paths to `Done`). Inspect the transitions list
+   from step 2; if any `TO_STATUS` appears on more than one row, pick that
+   name as `$STATUS_AMBIGUOUS` and run:
+   ```bash
+   jtk issues update $STATUS_ISSUE --status "$STATUS_AMBIGUOUS"
+   ```
+   Expected: stderr error `multiple transitions land on status '$STATUS_AMBIGUOUS'`,
+   followed by a candidates list with IDs, and a `jtk transitions do <key> <id>`
+   recommendation. Exit non-zero. No state change.
+
+   Also verify that preflight blocks combined writes:
+   ```bash
+   jtk issues update $STATUS_ISSUE \
+     --summary "[Test] should not apply" \
+     --status "$STATUS_AMBIGUOUS"
+   ```
+   Then `jtk issues get $STATUS_ISSUE` confirms the summary did NOT change.
+
+   If no workflow on the test project has ambiguous transitions, skip this step.
+
+8. **Invalid status name (not in the available transitions):**
+   ```bash
+   jtk issues update $STATUS_ISSUE --status "Definitely Not A Real Status"
+   ```
+   Expected: stderr error `no transition to status 'Definitely Not A Real Status' is currently available on this issue`
+   followed by an `Available target statuses:` list. Exit code non-zero.
+   No state change on the issue.
+
+9. **Preflight failure does not write summary:**
+   ```bash
+   jtk issues update $STATUS_ISSUE \
+     --summary "[Test] should not be applied" \
+     --status "Definitely Not A Real Status"
+   ```
+   Expected: Same error as step 8. `jtk issues get $STATUS_ISSUE` confirms
+   the summary was NOT changed.
+
+10. **Cleanup:**
+    ```bash
+    jtk issues delete $STATUS_ISSUE --force
+    ```
+
 ### Error cases
 
 | # | Command | Expected Output |

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -51,8 +51,8 @@ preceding field edit must be performed as a separate command.`,
   # Change issue type
   jtk issues update PROJ-123 --type Story
 
-  # Change workflow status
-  jtk issues update PROJ-123 --status Done
+  # Change workflow status (quote multi-word names: --status "In Progress")
+  jtk issues update PROJ-123 --status "Done"
 
   # Move issue under a different parent/epic
   jtk issues update PROJ-123 --parent PROJ-100

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -25,6 +25,7 @@ func newUpdateCmd(opts *root.Options) *cobra.Command {
 	var parent string
 	var assignee string
 	var issueType string
+	var status string
 	var fields []string
 
 	cmd := &cobra.Command{
@@ -33,7 +34,14 @@ func newUpdateCmd(opts *root.Options) *cobra.Command {
 		Long: `Update fields on an existing Jira issue.
 
 To change the issue type, use --type. This uses the Jira Cloud bulk move API
-transparently (since the standard update API does not support type changes).`,
+transparently (since the standard update API does not support type changes).
+
+To change the workflow status, use --status. This resolves the matching
+transition against the issue's current workflow and POSTs to the transitions
+endpoint. If multiple transitions land on the same target status, run
+` + "`jtk transitions do <key> <id>`" + ` instead. ` + "`--status`" + ` is resolved before any
+writes; condition-based transitions that become available only after a
+preceding field edit must be performed as a separate command.`,
 		Example: `  # Update summary
   jtk issues update PROJ-123 --summary "New summary"
 
@@ -42,6 +50,9 @@ transparently (since the standard update API does not support type changes).`,
 
   # Change issue type
   jtk issues update PROJ-123 --type Story
+
+  # Change workflow status
+  jtk issues update PROJ-123 --status Done
 
   # Move issue under a different parent/epic
   jtk issues update PROJ-123 --parent PROJ-100
@@ -56,7 +67,7 @@ transparently (since the standard update API does not support type changes).`,
   jtk issues update PROJ-123 --field priority=High --field "Story Points"=5`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUpdate(cmd.Context(), opts, args[0], summary, description, parent, assignee, issueType, fields)
+			return runUpdate(cmd.Context(), opts, args[0], summary, description, parent, assignee, issueType, status, fields)
 		},
 	}
 
@@ -65,20 +76,39 @@ transparently (since the standard update API does not support type changes).`,
 	cmd.Flags().StringVar(&parent, "parent", "", "Parent issue key (epic or parent issue)")
 	cmd.Flags().StringVarP(&assignee, "assignee", "a", "", "Assignee (account ID, email, or \"me\")")
 	cmd.Flags().StringVarP(&issueType, "type", "t", "", "New issue type (uses bulk move API)")
+	cmd.Flags().StringVar(&status, "status", "", "New workflow status (uses transitions API)")
 	cmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "Fields to update (key=value)")
 
 	return cmd
 }
 
-func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, description, parent, assignee, issueType string, fieldArgs []string) error {
+// statusChange describes the result of preflight-resolving a --status request.
+type statusChange struct {
+	isNoop       bool   // current status already equals requested
+	transitionID string // empty when isNoop
+	targetStatus string // resolved To.Name; used by mutation.ModelContainsStatus
+}
+
+func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, description, parent, assignee, issueType, status string, fieldArgs []string) error {
 	// Validate that at least one field is being updated before making API calls
-	if summary == "" && description == "" && parent == "" && assignee == "" && issueType == "" && len(fieldArgs) == 0 {
+	if summary == "" && description == "" && parent == "" && assignee == "" && issueType == "" && status == "" && len(fieldArgs) == 0 {
 		return fmt.Errorf("no fields specified to update")
 	}
 
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
+	}
+
+	// Preflight: resolve --status against the issue's *current* workflow before
+	// any writes. This lets us reject ambiguous/invalid status names without
+	// having partially mutated the issue.
+	var sc statusChange
+	if status != "" {
+		sc, err = resolveStatusChange(ctx, client, opts, issueKey, status)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Handle type change via the move API
@@ -148,13 +178,41 @@ func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, descr
 		req = api.BuildUpdateRequest(fields)
 	}
 
+	// Status-only no-op short-circuit: nothing else to write, status already
+	// matches. In ID-only mode we still emit the key (machine-parseable
+	// output); otherwise emit a stderr advisory.
+	if status != "" && sc.isNoop && req == nil && issueType == "" {
+		if opts.EmitIDOnly() {
+			return jtkpresent.EmitIDs(opts, []string{issueKey})
+		}
+		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentStatusAlreadyCurrent(status))
+	}
+
+	doTransition := func(ctx context.Context) error {
+		if status == "" || sc.isNoop {
+			return nil
+		}
+		return client.DoTransition(ctx, issueKey, sc.transitionID, nil)
+	}
+
 	if opts.EmitIDOnly() {
 		if req != nil {
 			if err := client.UpdateIssue(ctx, issueKey, req); err != nil {
 				return err
 			}
 		}
+		if err := doTransition(ctx); err != nil {
+			return err
+		}
 		return jtkpresent.EmitIDs(opts, []string{issueKey})
+	}
+
+	var isFresh func(*present.OutputModel) bool
+	if status != "" && !sc.isNoop {
+		target := sc.targetStatus
+		isFresh = func(m *present.OutputModel) bool {
+			return mutation.ModelContainsStatus(m, target)
+		}
 	}
 
 	return mutation.WriteAndPresent(ctx, opts, mutation.Config{
@@ -163,6 +221,9 @@ func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, descr
 				if err := client.UpdateIssue(ctx, issueKey, req); err != nil {
 					return "", err
 				}
+			}
+			if err := doTransition(ctx); err != nil {
+				return "", err
 			}
 			return issueKey, nil
 		},
@@ -175,10 +236,43 @@ func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, descr
 				issue, client.IssueURL(id), opts.IsExtended(), opts.IsFullText(),
 			), nil
 		},
+		IsFresh: isFresh,
 		Fallback: func(id string) *present.OutputModel {
 			return jtkpresent.IssuePresenter{}.PresentUpdated(id)
 		},
 	})
+}
+
+// resolveStatusChange preflights a --status request: it fetches the issue and
+// (if a transition is needed) the available transitions, then classifies the
+// outcome. On user-facing errors (no matching transition, ambiguous match) it
+// emits the error via the presenter and returns root.ErrAlreadyReported so
+// the caller does not double-print.
+func resolveStatusChange(ctx context.Context, client *api.Client, opts *root.Options, issueKey, status string) (statusChange, error) {
+	issue, err := client.GetIssue(ctx, issueKey)
+	if err != nil {
+		return statusChange{}, fmt.Errorf("failed to get issue: %w", err)
+	}
+	if issue.Fields.Status != nil && strings.EqualFold(issue.Fields.Status.Name, status) {
+		return statusChange{isNoop: true, targetStatus: issue.Fields.Status.Name}, nil
+	}
+
+	transitions, err := client.GetTransitions(ctx, issueKey)
+	if err != nil {
+		return statusChange{}, fmt.Errorf("failed to get transitions: %w", err)
+	}
+
+	matches := api.FindTransitionsByStatus(transitions, status)
+	switch len(matches) {
+	case 0:
+		_ = jtkpresent.Emit(opts, jtkpresent.TransitionPresenter{}.PresentStatusNotFound(status, transitions))
+		return statusChange{}, root.ErrAlreadyReported
+	case 1:
+		return statusChange{transitionID: matches[0].ID, targetStatus: matches[0].To.Name}, nil
+	default:
+		_ = jtkpresent.Emit(opts, jtkpresent.TransitionPresenter{}.PresentStatusAmbiguous(issueKey, status, matches))
+		return statusChange{}, root.ErrAlreadyReported
+	}
 }
 
 // changeIssueType performs the type change via the bulk move API.

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -83,9 +83,11 @@ preceding field edit must be performed as a separate command.`,
 }
 
 // statusChange describes the result of preflight-resolving a --status request.
+// It is only populated when --status was requested; an empty value should not
+// be interpreted as a noop.
 type statusChange struct {
 	isNoop       bool   // current status already equals requested
-	transitionID string // empty when isNoop
+	transitionID string // populated when isNoop is false and a transition was resolved
 	targetStatus string // resolved To.Name; used by mutation.ModelContainsStatus
 }
 
@@ -253,7 +255,10 @@ func resolveStatusChange(ctx context.Context, client *api.Client, opts *root.Opt
 	if err != nil {
 		return statusChange{}, fmt.Errorf("failed to get issue: %w", err)
 	}
-	if issue.Fields.Status != nil && strings.EqualFold(issue.Fields.Status.Name, status) {
+	if issue.Fields.Status == nil {
+		return statusChange{}, fmt.Errorf("issue %s has no current status; cannot resolve --status", issueKey)
+	}
+	if strings.EqualFold(issue.Fields.Status.Name, status) {
 		return statusChange{isNoop: true, targetStatus: issue.Fields.Status.Name}, nil
 	}
 

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -185,7 +185,7 @@ func runUpdate(ctx context.Context, opts *root.Options, issueKey, summary, descr
 		if opts.EmitIDOnly() {
 			return jtkpresent.EmitIDs(opts, []string{issueKey})
 		}
-		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentStatusAlreadyCurrent(status))
+		return jtkpresent.Emit(opts, jtkpresent.IssuePresenter{}.PresentStatusAlreadyCurrent(sc.targetStatus))
 	}
 
 	doTransition := func(ctx context.Context) error {

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -686,12 +686,21 @@ func newStatusServer(t *testing.T, cfg statusServerConfig) (*httptest.Server, *s
 		switch {
 		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "GET":
 			rec.getIssueCalls++
+			// After a successful transition POST the issue reflects the new
+			// status, so subsequent GETs return it. This lets the IsFresh
+			// contract actually be tested rather than always reading the
+			// pre-write status. Only safe when there is a single transition
+			// (unambiguous target).
+			currentStatus := cfg.currentStatus
+			if rec.postTransition > 0 && cfg.postTransitionErr == 0 && len(cfg.transitions) == 1 {
+				currentStatus = cfg.transitions[0].To.Name
+			}
 			issue := map[string]any{
 				"key": "PROJ-123",
 				"id":  "10001",
 				"fields": map[string]any{
 					"summary":   "Test",
-					"status":    map[string]any{"name": cfg.currentStatus},
+					"status":    map[string]any{"name": currentStatus},
 					"project":   map[string]any{"key": "PROJ"},
 					"issuetype": map[string]any{"id": "10001", "name": "Task"},
 				},
@@ -751,6 +760,57 @@ func TestRunUpdate_StatusOnly_HappyPath(t *testing.T) {
 	testutil.RequireNoError(t, json.Unmarshal(rec.transitionBody, &body))
 	testutil.Equal(t, body.Transition.ID, "31")
 	testutil.Contains(t, stdout.String(), "PROJ-123")
+	// Freshness: post-write fetch must surface the new status, not the
+	// pre-write one. (newStatusServer flips the status after a successful POST.)
+	testutil.Contains(t, stdout.String(), "Done")
+}
+
+// TestRunUpdate_Status_FreshnessRetries proves IsFresh is wired to the
+// resolved target status. The first post-write fetch returns the stale status
+// ("To Do") and subsequent fetches return the fresh status ("Done"). With
+// IsFresh correctly wired, the renderer retries past the stale read and
+// emits a model that contains "Done". Without it, the first stale model
+// would be emitted immediately and "To Do" would appear in stdout.
+func TestRunUpdate_Status_FreshnessRetries(t *testing.T) {
+	var (
+		postCount int
+		getCount  int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "GET":
+			getCount++
+			// First GET is the preflight; second is the first post-write fetch
+			// (stale); third+ are the freshness retries (fresh).
+			status := "To Do"
+			if postCount > 0 && getCount > 2 {
+				status = "Done"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"key": "PROJ-123",
+				"fields": map[string]any{
+					"status":  map[string]any{"name": status},
+					"project": map[string]any{"key": "PROJ"},
+				},
+			})
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123/transitions" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{Transitions: []api.Transition{
+				{ID: "31", Name: "Complete", To: api.Status{Name: "Done"}},
+			}})
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123/transitions" && r.Method == "POST":
+			postCount++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	opts, stdout, _ := newOptsForServer(t, srv.URL)
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "", "Done", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, postCount, 1)
+	testutil.Contains(t, stdout.String(), "Done")
 }
 
 func TestRunUpdate_StatusOnly_AlreadyCurrent(t *testing.T) {
@@ -909,4 +969,129 @@ func TestRunUpdate_Status_IDOnly_AlreadyCurrent_EmitsKeyNoAdvisory(t *testing.T)
 	testutil.Equal(t, rec.getTransitions, 0)
 	testutil.Equal(t, stdout.String(), "PROJ-123\n")
 	testutil.Equal(t, stderr.String(), "")
+}
+
+// TestRunUpdate_TypeAndStatus_HappyPath exercises the riskiest combinable
+// path: --status is resolved against the issue's pre-move workflow, then the
+// type change runs (bulk-move API), then the pre-move transition POST runs.
+// Documented contract: the pre-move transition ID is what gets POSTed.
+func TestRunUpdate_TypeAndStatus_HappyPath(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("issuetypes", "24h", map[string][]api.IssueType{
+		"PROJ": {
+			{ID: "10000", Name: "Epic"},
+			{ID: "10001", Name: "Task"},
+		},
+	}))
+	var (
+		moveCalled       bool
+		transitionPosted bool
+		transitionBody   []byte
+		order            []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"key": "PROJ-123",
+				"id":  "10001",
+				"fields": map[string]any{
+					"status":    map[string]any{"name": "To Do"},
+					"project":   map[string]any{"key": "PROJ"},
+					"issuetype": map[string]any{"id": "10000", "name": "Epic"},
+				},
+			})
+		case r.URL.Path == "/rest/api/3/project/PROJ" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(struct {
+				IssueTypes []api.IssueType `json:"issueTypes"`
+			}{IssueTypes: []api.IssueType{{ID: "10001", Name: "Task"}}})
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123/transitions" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{Transitions: []api.Transition{
+				{ID: "31", Name: "Complete", To: api.Status{Name: "Done"}},
+			}})
+		case r.URL.Path == "/rest/api/3/bulk/issues/move" && r.Method == "POST":
+			order = append(order, "MOVE")
+			moveCalled = true
+			_ = json.NewEncoder(w).Encode(api.MoveIssuesResponse{TaskID: "task-1"})
+		case r.URL.Path == "/rest/api/3/bulk/queue/task-1" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(api.MoveTaskStatus{
+				TaskID: "task-1", Status: "COMPLETE", Progress: 100,
+				Result: &api.MoveTaskResult{Successful: []string{"PROJ-123"}},
+			})
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123/transitions" && r.Method == "POST":
+			order = append(order, "TRANSITION")
+			transitionPosted = true
+			transitionBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	opts, _, _ := newOptsForServer(t, srv.URL)
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "Task", "Done", nil)
+	testutil.RequireNoError(t, err)
+	testutil.True(t, moveCalled, "bulk move must be called")
+	testutil.True(t, transitionPosted, "transition POST must follow the move")
+	testutil.Equal(t, len(order), 2)
+	testutil.Equal(t, order[0], "MOVE")
+	testutil.Equal(t, order[1], "TRANSITION")
+
+	var body api.TransitionRequest
+	testutil.RequireNoError(t, json.Unmarshal(transitionBody, &body))
+	testutil.Equal(t, body.Transition.ID, "31")
+}
+
+// TestRunUpdate_TypeAndStatus_TransitionPostFailsAfterMove documents the
+// non-rollback contract: if the pre-move transition becomes invalid after the
+// type change (e.g. the new workflow doesn't have it), the type change is
+// already done and the transition error is surfaced.
+func TestRunUpdate_TypeAndStatus_TransitionPostFailsAfterMove(t *testing.T) {
+	seedCacheForIssues(t)
+	testutil.RequireNoError(t, cache.WriteResource("issuetypes", "24h", map[string][]api.IssueType{
+		"PROJ": {{ID: "10001", Name: "Task"}},
+	}))
+	var moveCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"key": "PROJ-123",
+				"fields": map[string]any{
+					"status":    map[string]any{"name": "To Do"},
+					"project":   map[string]any{"key": "PROJ"},
+					"issuetype": map[string]any{"id": "10000", "name": "Epic"},
+				},
+			})
+		case r.URL.Path == "/rest/api/3/project/PROJ" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(struct {
+				IssueTypes []api.IssueType `json:"issueTypes"`
+			}{IssueTypes: []api.IssueType{{ID: "10001", Name: "Task"}}})
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123/transitions" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{Transitions: []api.Transition{
+				{ID: "31", Name: "Complete", To: api.Status{Name: "Done"}},
+			}})
+		case r.URL.Path == "/rest/api/3/bulk/issues/move" && r.Method == "POST":
+			moveCalled = true
+			_ = json.NewEncoder(w).Encode(api.MoveIssuesResponse{TaskID: "task-1"})
+		case r.URL.Path == "/rest/api/3/bulk/queue/task-1" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(api.MoveTaskStatus{
+				TaskID: "task-1", Status: "COMPLETE", Progress: 100,
+				Result: &api.MoveTaskResult{Successful: []string{"PROJ-123"}},
+			})
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123/transitions" && r.Method == "POST":
+			// New workflow rejects the pre-move transition.
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"errorMessages":["transition not valid"]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	opts, _, _ := newOptsForServer(t, srv.URL)
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "Task", "Done", nil)
+	testutil.Error(t, err)
+	testutil.True(t, moveCalled, "type change happened before the transition failed (non-rollback)")
 }

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -45,7 +46,7 @@ func TestRunUpdate_RequestBodyNoDoubleQuoting(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(context.Background(), opts, "PROJ-123", "Updated summary", "Updated description", "", "", "", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-123", "Updated summary", "Updated description", "", "", "", "", nil)
 	testutil.RequireNoError(t, err)
 
 	testutil.NotEmpty(t, capturedBody)
@@ -168,7 +169,7 @@ func TestRunUpdate_TypeChange(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "Task", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "Task", "", nil)
 	testutil.RequireNoError(t, err)
 	testutil.True(t, moveCompleted, "should have called the move API")
 
@@ -222,7 +223,7 @@ func TestRunUpdate_TypeAlreadyCorrect(t *testing.T) {
 	// Should succeed without calling move API since it's already the right type.
 	// The silent changeIssueType returns nil (no-op), then WriteAndPresent
 	// re-fetches and shows post-state detail.
-	err = runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "Task", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "Task", "", nil)
 	testutil.RequireNoError(t, err)
 	testutil.Contains(t, stdout.String(), "PROJ-123")
 }
@@ -254,7 +255,7 @@ func TestRunUpdate_SummaryOnly(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "", "", nil)
 	testutil.RequireNoError(t, err)
 
 	var reqBody map[string]any
@@ -284,7 +285,7 @@ func TestRunUpdate_IDOnly(t *testing.T) {
 	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "", "", nil)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "PROJ-123\n")
 }
@@ -295,7 +296,7 @@ func TestRunUpdate_NoFieldsError(t *testing.T) {
 		Stderr: &bytes.Buffer{},
 	}
 
-	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "", nil)
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "", "", nil)
 	testutil.Error(t, err)
 	testutil.Contains(t, err.Error(), "no fields specified")
 }
@@ -327,7 +328,7 @@ func TestRunUpdate_ParentOnly(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(context.Background(), opts, "PROJ-456", "", "", "PROJ-100", "", "", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-456", "", "", "PROJ-100", "", "", "", nil)
 	testutil.RequireNoError(t, err)
 
 	testutil.NotEmpty(t, capturedBody)
@@ -369,7 +370,7 @@ func TestRunUpdate_ParentWithSummary(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(context.Background(), opts, "PROJ-456", "Updated title", "", "PROJ-200", "", "", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-456", "Updated title", "", "PROJ-200", "", "", "", nil)
 	testutil.RequireNoError(t, err)
 
 	testutil.NotEmpty(t, capturedBody)
@@ -459,7 +460,7 @@ func TestRunUpdate_AssigneeOnly(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(context.Background(), opts, "PROJ-789", "", "", "", "61292e4c4f29230069621c5f", "", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-789", "", "", "", "61292e4c4f29230069621c5f", "", "", nil)
 	testutil.RequireNoError(t, err)
 
 	testutil.NotEmpty(t, capturedBody)
@@ -507,7 +508,7 @@ func TestRunUpdate_AssigneeMe(t *testing.T) {
 	}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(context.Background(), opts, "PROJ-789", "", "", "", "me", "", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-789", "", "", "", "me", "", "", nil)
 	testutil.RequireNoError(t, err)
 
 	testutil.NotEmpty(t, capturedBody)
@@ -602,7 +603,7 @@ func TestRunUpdate_TypeChange_MoveNotFound_ServerDCError(t *testing.T) {
 	opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "Task", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "Task", "", nil)
 	if err == nil {
 		t.Fatal("expected error for Server/DC detection")
 	}
@@ -653,9 +654,259 @@ func TestRunUpdate_TypeChange_PollNotFound_ContinuesFieldUpdates(t *testing.T) {
 	opts := &root.Options{Stdout: &stdout, Stderr: &stderr}
 	opts.SetAPIClient(client)
 
-	err = runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "Task", nil)
+	err = runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "Task", "", nil)
 	testutil.RequireNoError(t, err)
 
 	testutil.Contains(t, stderr.String(), "could not be verified")
 	testutil.True(t, putCalled, "field update PUT should still have been called")
+}
+
+// --- Tests for --status (#358) ----------------------------------------------
+
+// statusServerConfig drives the mock server used by --status tests.
+type statusServerConfig struct {
+	currentStatus     string           // status name returned on the initial issue GET
+	transitions       []api.Transition // transitions returned by GET /transitions
+	transitionsErr    int              // if non-zero, /transitions returns this HTTP status
+	postTransitionErr int              // if non-zero, POST /transitions returns this HTTP status
+}
+
+type statusServerRecord struct {
+	getIssueCalls  int
+	getTransitions int
+	postTransition int
+	putIssue       int
+	transitionBody []byte
+}
+
+func newStatusServer(t *testing.T, cfg statusServerConfig) (*httptest.Server, *statusServerRecord) {
+	t.Helper()
+	rec := &statusServerRecord{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "GET":
+			rec.getIssueCalls++
+			issue := map[string]any{
+				"key": "PROJ-123",
+				"id":  "10001",
+				"fields": map[string]any{
+					"summary":   "Test",
+					"status":    map[string]any{"name": cfg.currentStatus},
+					"project":   map[string]any{"key": "PROJ"},
+					"issuetype": map[string]any{"id": "10001", "name": "Task"},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(issue)
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123/transitions" && r.Method == "GET":
+			rec.getTransitions++
+			if cfg.transitionsErr != 0 {
+				w.WriteHeader(cfg.transitionsErr)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{Transitions: cfg.transitions})
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123/transitions" && r.Method == "POST":
+			rec.postTransition++
+			rec.transitionBody, _ = io.ReadAll(r.Body)
+			if cfg.postTransitionErr != 0 {
+				w.WriteHeader(cfg.postTransitionErr)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "PUT":
+			rec.putIssue++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+func newOptsForServer(t *testing.T, url string) (*root.Options, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	client, err := api.New(api.ClientConfig{URL: url, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	opts := &root.Options{Stdout: stdout, Stderr: stderr}
+	opts.SetAPIClient(client)
+	return opts, stdout, stderr
+}
+
+func TestRunUpdate_StatusOnly_HappyPath(t *testing.T) {
+	srv, rec := newStatusServer(t, statusServerConfig{
+		currentStatus: "To Do",
+		transitions: []api.Transition{
+			{ID: "31", Name: "Complete", To: api.Status{Name: "Done"}},
+		},
+	})
+	opts, stdout, _ := newOptsForServer(t, srv.URL)
+
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "", "Done", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, rec.postTransition, 1)
+	testutil.Equal(t, rec.putIssue, 0)
+
+	var body api.TransitionRequest
+	testutil.RequireNoError(t, json.Unmarshal(rec.transitionBody, &body))
+	testutil.Equal(t, body.Transition.ID, "31")
+	testutil.Contains(t, stdout.String(), "PROJ-123")
+}
+
+func TestRunUpdate_StatusOnly_AlreadyCurrent(t *testing.T) {
+	srv, rec := newStatusServer(t, statusServerConfig{
+		currentStatus: "Done",
+		transitions:   []api.Transition{{ID: "31", Name: "Complete", To: api.Status{Name: "Done"}}},
+	})
+	opts, _, stderr := newOptsForServer(t, srv.URL)
+
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "", "done", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, rec.postTransition, 0)
+	testutil.Equal(t, rec.getTransitions, 0)
+	testutil.Contains(t, stderr.String(), "status is already")
+}
+
+func TestRunUpdate_StatusAndSummary_AlreadyCurrent(t *testing.T) {
+	srv, rec := newStatusServer(t, statusServerConfig{currentStatus: "Done"})
+	opts, _, _ := newOptsForServer(t, srv.URL)
+
+	err := runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "", "Done", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, rec.postTransition, 0)
+	testutil.Equal(t, rec.putIssue, 1)
+}
+
+func TestRunUpdate_Status_NotFound(t *testing.T) {
+	srv, rec := newStatusServer(t, statusServerConfig{
+		currentStatus: "To Do",
+		transitions: []api.Transition{
+			{ID: "11", Name: "Start", To: api.Status{Name: "In Progress"}},
+		},
+	})
+	opts, _, stderr := newOptsForServer(t, srv.URL)
+
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "", "Bogus", nil)
+	testutil.Error(t, err)
+	testutil.True(t, errors.Is(err, root.ErrAlreadyReported), "expected ErrAlreadyReported sentinel")
+	testutil.Equal(t, rec.postTransition, 0)
+	testutil.Equal(t, rec.putIssue, 0)
+	testutil.Contains(t, stderr.String(), "no transition to status 'Bogus'")
+	testutil.Contains(t, stderr.String(), "In Progress")
+}
+
+func TestRunUpdate_Status_NotFound_DoesNotWriteSummary(t *testing.T) {
+	// Preflight failure must not perform any field writes.
+	srv, rec := newStatusServer(t, statusServerConfig{
+		currentStatus: "To Do",
+		transitions: []api.Transition{
+			{ID: "11", Name: "Start", To: api.Status{Name: "In Progress"}},
+		},
+	})
+	opts, _, _ := newOptsForServer(t, srv.URL)
+
+	err := runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "", "Bogus", nil)
+	testutil.Error(t, err)
+	testutil.Equal(t, rec.putIssue, 0)
+}
+
+func TestRunUpdate_Status_Ambiguous(t *testing.T) {
+	srv, rec := newStatusServer(t, statusServerConfig{
+		currentStatus: "To Do",
+		transitions: []api.Transition{
+			{ID: "31", Name: "Resolve", To: api.Status{Name: "Done"}},
+			{ID: "41", Name: "Close", To: api.Status{Name: "Done"}},
+		},
+	})
+	opts, _, stderr := newOptsForServer(t, srv.URL)
+
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "", "Done", nil)
+	testutil.Error(t, err)
+	testutil.True(t, errors.Is(err, root.ErrAlreadyReported))
+	testutil.Equal(t, rec.postTransition, 0)
+	testutil.Contains(t, stderr.String(), "multiple transitions")
+	testutil.Contains(t, stderr.String(), "jtk transitions do PROJ-123")
+}
+
+func TestRunUpdate_StatusAndSummary_HappyPath_OrdersWritesPutBeforePost(t *testing.T) {
+	var order []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"key": "PROJ-123",
+				"fields": map[string]any{
+					"status":  map[string]any{"name": "To Do"},
+					"project": map[string]any{"key": "PROJ"},
+				},
+			})
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123/transitions" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(api.TransitionsResponse{Transitions: []api.Transition{
+				{ID: "31", Name: "Done", To: api.Status{Name: "Done"}},
+			}})
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "PUT":
+			order = append(order, "PUT")
+			w.WriteHeader(http.StatusNoContent)
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123/transitions" && r.Method == "POST":
+			order = append(order, "POST")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	opts, _, _ := newOptsForServer(t, srv.URL)
+	err := runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "", "Done", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, len(order), 2)
+	testutil.Equal(t, order[0], "PUT")
+	testutil.Equal(t, order[1], "POST")
+}
+
+func TestRunUpdate_Status_TransitionPostFailsAfterPut(t *testing.T) {
+	// Documented non-rollback semantics: if the transition POST fails after a
+	// successful field PUT, the PUT stands and the error surfaces.
+	srv, rec := newStatusServer(t, statusServerConfig{
+		currentStatus: "To Do",
+		transitions: []api.Transition{
+			{ID: "31", Name: "Done", To: api.Status{Name: "Done"}},
+		},
+		postTransitionErr: http.StatusInternalServerError,
+	})
+	opts, _, _ := newOptsForServer(t, srv.URL)
+
+	err := runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "", "Done", nil)
+	testutil.Error(t, err)
+	testutil.Equal(t, rec.putIssue, 1)
+	testutil.Equal(t, rec.postTransition, 1)
+}
+
+func TestRunUpdate_Status_IDOnly(t *testing.T) {
+	srv, rec := newStatusServer(t, statusServerConfig{
+		currentStatus: "To Do",
+		transitions: []api.Transition{
+			{ID: "31", Name: "Done", To: api.Status{Name: "Done"}},
+		},
+	})
+	opts, stdout, _ := newOptsForServer(t, srv.URL)
+	opts.IDOnly = true
+
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "", "Done", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, rec.postTransition, 1)
+	testutil.Equal(t, stdout.String(), "PROJ-123\n")
+}
+
+func TestRunUpdate_Status_IDOnly_AlreadyCurrent_EmitsKeyNoAdvisory(t *testing.T) {
+	srv, rec := newStatusServer(t, statusServerConfig{currentStatus: "Done"})
+	opts, stdout, stderr := newOptsForServer(t, srv.URL)
+	opts.IDOnly = true
+
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "", "Done", nil)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, rec.postTransition, 0)
+	testutil.Equal(t, rec.getTransitions, 0)
+	testutil.Equal(t, stdout.String(), "PROJ-123\n")
+	testutil.Equal(t, stderr.String(), "")
 }

--- a/tools/jtk/internal/cmd/issues/update_test.go
+++ b/tools/jtk/internal/cmd/issues/update_test.go
@@ -1095,3 +1095,45 @@ func TestRunUpdate_TypeAndStatus_TransitionPostFailsAfterMove(t *testing.T) {
 	testutil.Error(t, err)
 	testutil.True(t, moveCalled, "type change happened before the transition failed (non-rollback)")
 }
+
+// TestRunUpdate_Status_GetTransitionsError covers the preflight error path
+// where listing transitions fails; no writes should happen and the error
+// must be wrapped so the caller sees "failed to get transitions".
+func TestRunUpdate_Status_GetTransitionsError(t *testing.T) {
+	srv, rec := newStatusServer(t, statusServerConfig{
+		currentStatus:  "To Do",
+		transitionsErr: http.StatusInternalServerError,
+	})
+	opts, _, _ := newOptsForServer(t, srv.URL)
+
+	err := runUpdate(context.Background(), opts, "PROJ-123", "", "", "", "", "", "Done", nil)
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "failed to get transitions")
+	testutil.Equal(t, rec.postTransition, 0)
+	testutil.Equal(t, rec.putIssue, 0)
+}
+
+// TestRunUpdate_Status_GetIssueError covers the preflight error path where
+// the initial issue fetch fails. With --summary also requested, we assert
+// that no field PUT happens — preflight protects field writes.
+func TestRunUpdate_Status_GetIssueError(t *testing.T) {
+	var putCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "GET":
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.URL.Path == "/rest/api/3/issue/PROJ-123" && r.Method == "PUT":
+			putCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	opts, _, _ := newOptsForServer(t, srv.URL)
+	err := runUpdate(context.Background(), opts, "PROJ-123", "New summary", "", "", "", "", "Done", nil)
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "failed to get issue")
+	testutil.False(t, putCalled, "preflight failure must block the field PUT")
+}

--- a/tools/jtk/internal/present/issue.go
+++ b/tools/jtk/internal/present/issue.go
@@ -657,6 +657,19 @@ func (IssuePresenter) PresentTypeAlreadyCurrent(typeName string) *present.Output
 	}
 }
 
+// PresentStatusAlreadyCurrent creates an advisory when status is already current.
+func (IssuePresenter) PresentStatusAlreadyCurrent(statusName string) *present.OutputModel {
+	return &present.OutputModel{
+		Sections: []present.Section{
+			&present.MessageSection{
+				Kind:    present.MessageInfo,
+				Message: fmt.Sprintf("status is already %s", statusName),
+				Stream:  present.StreamStderr,
+			},
+		},
+	}
+}
+
 // --- Empty state methods ---
 
 // PresentEmpty creates an info message for empty issue list.

--- a/tools/jtk/internal/present/issue_test.go
+++ b/tools/jtk/internal/present/issue_test.go
@@ -449,6 +449,21 @@ func TestIssuePresenter_PresentTypeAlreadyCurrent(t *testing.T) {
 	}
 }
 
+func TestIssuePresenter_PresentStatusAlreadyCurrent(t *testing.T) {
+	t.Parallel()
+	model := IssuePresenter{}.PresentStatusAlreadyCurrent("Done")
+	msg := model.Sections[0].(*present.MessageSection)
+	if msg.Kind != present.MessageInfo {
+		t.Errorf("want MessageInfo, got %v", msg.Kind)
+	}
+	if msg.Stream != present.StreamStderr {
+		t.Errorf("want StreamStderr, got %v", msg.Stream)
+	}
+	if msg.Message != "status is already Done" {
+		t.Errorf("unexpected message %q", msg.Message)
+	}
+}
+
 func TestIssuePresenter_PresentTypeFallbackWarning(t *testing.T) {
 	t.Parallel()
 	model := IssuePresenter{}.PresentTypeFallbackWarning("Bug", "MON", "Task")

--- a/tools/jtk/internal/present/transition.go
+++ b/tools/jtk/internal/present/transition.go
@@ -107,6 +107,73 @@ func (TransitionPresenter) PresentEmpty(issueKey string) *present.OutputModel {
 	}
 }
 
+// PresentStatusNotFound creates an error explaining that no available
+// transition lands on the requested target status. It lists the available
+// target statuses to help the user pick a valid one.
+func (TransitionPresenter) PresentStatusNotFound(requested string, available []api.Transition) *present.OutputModel {
+	sections := []present.Section{
+		&present.MessageSection{
+			Kind:    present.MessageError,
+			Message: fmt.Sprintf("no transition to status '%s' is currently available on this issue", requested),
+			Stream:  present.StreamStderr,
+		},
+		&present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: "Available target statuses:",
+			Stream:  present.StreamStderr,
+		},
+	}
+
+	seen := make(map[string]bool, len(available))
+	for _, t := range available {
+		if t.To.Name == "" || seen[strings.ToLower(t.To.Name)] {
+			continue
+		}
+		seen[strings.ToLower(t.To.Name)] = true
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: fmt.Sprintf("  %s", t.To.Name),
+			Stream:  present.StreamStderr,
+		})
+	}
+
+	return &present.OutputModel{Sections: sections}
+}
+
+// PresentStatusAmbiguous creates an error when multiple available transitions
+// land on the same target status. It recommends `jtk transitions do <key> <id>`
+// to pick the intended transition unambiguously.
+func (TransitionPresenter) PresentStatusAmbiguous(issueKey, requested string, candidates []api.Transition) *present.OutputModel {
+	sections := []present.Section{
+		&present.MessageSection{
+			Kind:    present.MessageError,
+			Message: fmt.Sprintf("multiple transitions land on status '%s'", requested),
+			Stream:  present.StreamStderr,
+		},
+		&present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: "Candidates:",
+			Stream:  present.StreamStderr,
+		},
+	}
+
+	for _, t := range candidates {
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: fmt.Sprintf("  %s: %s -> %s", t.ID, t.Name, t.To.Name),
+			Stream:  present.StreamStderr,
+		})
+	}
+
+	sections = append(sections, &present.MessageSection{
+		Kind:    present.MessageInfo,
+		Message: fmt.Sprintf("Pick one with: jtk transitions do %s <id>", issueKey),
+		Stream:  present.StreamStderr,
+	})
+
+	return &present.OutputModel{Sections: sections}
+}
+
 // PresentNotFound creates an error with available transitions as context.
 func (TransitionPresenter) PresentNotFound(name string, available []api.Transition) *present.OutputModel {
 	sections := []present.Section{

--- a/tools/jtk/internal/present/transition.go
+++ b/tools/jtk/internal/present/transition.go
@@ -117,22 +117,33 @@ func (TransitionPresenter) PresentStatusNotFound(requested string, available []a
 			Message: fmt.Sprintf("no transition to status '%s' is currently available on this issue", requested),
 			Stream:  present.StreamStderr,
 		},
-		&present.MessageSection{
-			Kind:    present.MessageInfo,
-			Message: "Available target statuses:",
-			Stream:  present.StreamStderr,
-		},
 	}
 
 	seen := make(map[string]bool, len(available))
+	var statusLines []present.Section
 	for _, t := range available {
 		if t.To.Name == "" || seen[strings.ToLower(t.To.Name)] {
 			continue
 		}
 		seen[strings.ToLower(t.To.Name)] = true
-		sections = append(sections, &present.MessageSection{
+		statusLines = append(statusLines, &present.MessageSection{
 			Kind:    present.MessageInfo,
 			Message: fmt.Sprintf("  %s", t.To.Name),
+			Stream:  present.StreamStderr,
+		})
+	}
+
+	if len(statusLines) > 0 {
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: "Available target statuses:",
+			Stream:  present.StreamStderr,
+		})
+		sections = append(sections, statusLines...)
+	} else {
+		sections = append(sections, &present.MessageSection{
+			Kind:    present.MessageInfo,
+			Message: "No transitions are available on this issue (terminal state).",
 			Stream:  present.StreamStderr,
 		})
 	}

--- a/tools/jtk/internal/present/transition_test.go
+++ b/tools/jtk/internal/present/transition_test.go
@@ -150,3 +150,70 @@ func TestTransitionListSpec_MatchesPresentListHeaders(t *testing.T) {
 		})
 	}
 }
+
+func TestTransitionPresenter_PresentStatusNotFound(t *testing.T) {
+	t.Parallel()
+	transitions := []api.Transition{
+		{ID: "11", Name: "Start", To: api.Status{Name: "In Progress"}},
+		{ID: "21", Name: "Resume", To: api.Status{Name: "In Progress"}},
+		{ID: "31", Name: "Complete", To: api.Status{Name: "Done"}},
+	}
+	model := TransitionPresenter{}.PresentStatusNotFound("Bogus", transitions)
+
+	first := model.Sections[0].(*present.MessageSection)
+	if first.Kind != present.MessageError {
+		t.Errorf("want MessageError, got %v", first.Kind)
+	}
+	if first.Stream != present.StreamStderr {
+		t.Errorf("want StreamStderr, got %v", first.Stream)
+	}
+
+	// Expect dedup: In Progress appears once, Done once -> header + 2 status lines = 4 sections.
+	if len(model.Sections) != 4 {
+		t.Fatalf("want 4 sections (error, header, 2 deduped statuses), got %d", len(model.Sections))
+	}
+
+	statuses := []string{
+		model.Sections[2].(*present.MessageSection).Message,
+		model.Sections[3].(*present.MessageSection).Message,
+	}
+	for _, want := range []string{"In Progress", "Done"} {
+		found := false
+		for _, s := range statuses {
+			if contains(s, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected status %q in output, got %v", want, statuses)
+		}
+	}
+}
+
+func TestTransitionPresenter_PresentStatusAmbiguous(t *testing.T) {
+	t.Parallel()
+	candidates := []api.Transition{
+		{ID: "31", Name: "Resolve", To: api.Status{Name: "Done"}},
+		{ID: "41", Name: "Close", To: api.Status{Name: "Done"}},
+	}
+	model := TransitionPresenter{}.PresentStatusAmbiguous("PROJ-123", "Done", candidates)
+
+	first := model.Sections[0].(*present.MessageSection)
+	if first.Kind != present.MessageError {
+		t.Errorf("want MessageError, got %v", first.Kind)
+	}
+	last := model.Sections[len(model.Sections)-1].(*present.MessageSection)
+	if !contains(last.Message, "jtk transitions do PROJ-123") {
+		t.Errorf("expected recommendation with issue key, got %q", last.Message)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Adds `--status <name>` to `jtk issues update`; resolves the matching transition by target status name and POSTs to the transitions endpoint under the hood.
- Preflights `--status` so invalid/ambiguous names error before any field writes happen.
- Already-current → stderr advisory (silent in `--id` mode); combinable with `--summary`/`--type`/`--field`/etc.

Closes #358

## Test plan

- [x] Unit: `FindTransitionsByStatus` (match, case-insensitive, multi, none, empty, nil)
- [x] Unit: `--status` happy path, already-current, already-current+summary, not-found (with and without summary), ambiguous, status+summary ordering (PUT before POST), transition POST fails after PUT, `--id` happy path, `--id` already-current
- [x] Unit: presenter snapshots for `PresentStatusAlreadyCurrent`, `PresentStatusNotFound`, `PresentStatusAmbiguous`
- [x] `make test` green, `golangci-lint run` clean
- [ ] Manual smoke: `jtk issues update <key> --status "In Progress"` (post-merge against a real Jira)