### PR TITLE
feat(cfl): support `--file -` to read page body from stdin

### DIFF
--- a/tools/cfl/internal/cmd/page/create.go
+++ b/tools/cfl/internal/cmd/page/create.go
@@ -40,7 +40,7 @@ By default, pages are created using the cloud editor format (ADF).
 Use --legacy to create pages in the legacy editor format.
 
 Content can be provided via:
-- --file flag to read from a file
+- --file flag to read from a file (use --file - to read from stdin)
 - Standard input (pipe content)
 - Interactive editor (default, or with --editor flag)
 
@@ -64,6 +64,9 @@ Content format:
 
   # Create from stdin (markdown)
   echo "# Hello World" | cfl page create -s DEV -t "My Page"
+
+  # Create from stdin via explicit --file - (e.g. piping HTML as storage)
+  echo "<p>Hello</p>" | cfl page create -s DEV -t "My Page" --file - --storage
 
   # Create from stdin with legacy format (XHTML)
   echo "<p>Hello</p>" | cfl page create -s DEV -t "My Page" --no-markdown --legacy
@@ -106,8 +109,9 @@ Content format:
 
 func runCreate(ctx context.Context, opts *createOptions) error {
 	// Validate file exists before making any network calls so we fail
-	// fast on bad input without needing config or API access.
-	if opts.file != "" {
+	// fast on bad input without needing config or API access. "-" means
+	// stdin, which has no path to stat.
+	if opts.file != "" && opts.file != "-" {
 		if _, err := os.Stat(opts.file); err != nil {
 			return fmt.Errorf("reading file: %w", err)
 		}
@@ -224,6 +228,14 @@ func getContent(opts *createOptions) (string, bool, error) {
 			}
 		}
 		return true
+	}
+
+	if opts.file == "-" {
+		data, err := io.ReadAll(stdinReader(opts.Options))
+		if err != nil {
+			return "", false, fmt.Errorf("reading stdin: %w", err)
+		}
+		return string(data), useMarkdown(""), nil
 	}
 
 	if opts.file != "" {

--- a/tools/cfl/internal/cmd/page/create_test.go
+++ b/tools/cfl/internal/cmd/page/create_test.go
@@ -823,3 +823,115 @@ func TestRunCreate_WhitespaceOnlyFile(t *testing.T) {
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "page content cannot be empty")
 }
+
+// mockCreateBodyServer returns a server capturing the create request body.
+func mockCreateBodyServer(t *testing.T, received *map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, received)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id": "99999", "title": "Test", "version": {"number": 1}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// "--file -" reads the body from stdin; the early os.Stat guard must not
+// treat "-" as a path (it would ENOENT).
+func TestRunCreate_FileDash_Stdin_ADF(t *testing.T) {
+	t.Parallel()
+	var receivedBody map[string]any
+	server := mockCreateBodyServer(t, &receivedBody)
+	defer server.Close()
+
+	rootOpts := newCreateTestRootOptions()
+	rootOpts.Stdin = strings.NewReader("# Hello\n\nThis is **bold** text.")
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &createOptions{
+		Options: rootOpts,
+		space:   "DEV",
+		title:   "Test Page",
+		file:    "-",
+	}
+
+	err := runCreate(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+
+	bodyMap := receivedBody["body"].(map[string]any)
+	adfMap := bodyMap["atlas_doc_format"].(map[string]any)
+	content := adfMap["value"].(string)
+	testutil.Contains(t, content, `"type":"doc"`)
+	testutil.Contains(t, content, `"type":"heading"`)
+	testutil.Contains(t, content, `"type":"strong"`)
+}
+
+// "--file - --storage" pipes raw storage XHTML through unchanged.
+func TestRunCreate_FileDash_Stdin_Storage(t *testing.T) {
+	t.Parallel()
+	var receivedBody map[string]any
+	server := mockCreateBodyServer(t, &receivedBody)
+	defer server.Close()
+
+	rootOpts := newCreateTestRootOptions()
+	rootOpts.Stdin = strings.NewReader(`<p>Storage content</p>`)
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	useMd := false
+	opts := &createOptions{
+		Options:  rootOpts,
+		space:    "DEV",
+		title:    "Test Page",
+		file:     "-",
+		storage:  true,
+		markdown: &useMd,
+	}
+
+	err := runCreate(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+
+	bodyMap := receivedBody["body"].(map[string]any)
+	storageMap := bodyMap["storage"].(map[string]any)
+	testutil.Equal(t, "<p>Storage content</p>", storageMap["value"].(string))
+	testutil.Nil(t, bodyMap["atlas_doc_format"])
+}
+
+// "--file - --no-markdown" passes raw ADF JSON through to atlas_doc_format
+// unconverted (the shape INT-425's create_page(format="adf") relies on).
+func TestRunCreate_FileDash_Stdin_NoMarkdown_ADF(t *testing.T) {
+	t.Parallel()
+	var receivedBody map[string]any
+	server := mockCreateBodyServer(t, &receivedBody)
+	defer server.Close()
+
+	adf := `{"type":"doc","version":1,"content":[]}`
+	rootOpts := newCreateTestRootOptions()
+	rootOpts.Stdin = strings.NewReader(adf)
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	useMd := false
+	opts := &createOptions{
+		Options:  rootOpts,
+		space:    "DEV",
+		title:    "Test Page",
+		file:     "-",
+		markdown: &useMd,
+	}
+
+	err := runCreate(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+
+	bodyMap := receivedBody["body"].(map[string]any)
+	adfMap := bodyMap["atlas_doc_format"].(map[string]any)
+	testutil.Equal(t, adf, adfMap["value"].(string))
+}

--- a/tools/cfl/internal/cmd/page/create_test.go
+++ b/tools/cfl/internal/cmd/page/create_test.go
@@ -960,3 +960,34 @@ func TestRunCreate_FileDash_EmptyStdin(t *testing.T) {
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "page content cannot be empty")
 }
+
+// "--file - --legacy" converts markdown stdin to storage XHTML.
+func TestRunCreate_FileDash_Stdin_Legacy(t *testing.T) {
+	t.Parallel()
+	var receivedBody map[string]any
+	server := mockCreateBodyServer(t, &receivedBody)
+	defer server.Close()
+
+	rootOpts := newCreateTestRootOptions()
+	rootOpts.Stdin = strings.NewReader("# Hello\n\nThis is **bold** text.")
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &createOptions{
+		Options: rootOpts,
+		space:   "DEV",
+		title:   "Test Page",
+		file:    "-",
+		legacy:  true,
+	}
+
+	err := runCreate(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+
+	bodyMap := receivedBody["body"].(map[string]any)
+	storageMap := bodyMap["storage"].(map[string]any)
+	content := storageMap["value"].(string)
+	testutil.Contains(t, content, "<h1")
+	testutil.Contains(t, content, "<strong>bold</strong>")
+	testutil.Nil(t, bodyMap["atlas_doc_format"])
+}

--- a/tools/cfl/internal/cmd/page/create_test.go
+++ b/tools/cfl/internal/cmd/page/create_test.go
@@ -935,3 +935,28 @@ func TestRunCreate_FileDash_Stdin_NoMarkdown_ADF(t *testing.T) {
 	adfMap := bodyMap["atlas_doc_format"].(map[string]any)
 	testutil.Equal(t, adf, adfMap["value"].(string))
 }
+
+// "--file -" with empty stdin still hits the empty-content guard
+// (symmetric with TestRunEdit_FileDash_EmptyStdin).
+func TestRunCreate_FileDash_EmptyStdin(t *testing.T) {
+	t.Parallel()
+	var receivedBody map[string]any
+	server := mockCreateBodyServer(t, &receivedBody)
+	defer server.Close()
+
+	rootOpts := newCreateTestRootOptions()
+	rootOpts.Stdin = strings.NewReader("")
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &createOptions{
+		Options: rootOpts,
+		space:   "DEV",
+		title:   "Test Page",
+		file:    "-",
+	}
+
+	err := runCreate(context.Background(), opts)
+	testutil.RequireError(t, err)
+	testutil.Contains(t, err.Error(), "page content cannot be empty")
+}

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -41,7 +41,7 @@ By default, pages are updated using the cloud editor format (ADF).
 Use --legacy to update pages in the legacy editor format.
 
 Content can be provided via:
-- --file flag to read from a file
+- --file flag to read from a file (use --file - to read from stdin)
 - Standard input (pipe content)
 - Interactive editor (default, or with --editor flag)
 
@@ -62,6 +62,9 @@ Content format:
 
   # Update page content from stdin
   echo "# Updated Content" | cfl page edit 12345
+
+  # Update from stdin via explicit --file - (e.g. piping HTML as storage)
+  echo "<p>Updated</p>" | cfl page edit 12345 --file - --storage
 
   # Update page title only
   cfl page edit 12345 --title "New Title"
@@ -110,8 +113,9 @@ Content format:
 
 func runEdit(ctx context.Context, opts *editOptions) error {
 	// Validate file exists before making any network calls so we fail
-	// fast on bad input without needing config or API access.
-	if opts.file != "" {
+	// fast on bad input without needing config or API access. "-" means
+	// stdin, which has no path to stat.
+	if opts.file != "" && opts.file != "-" {
 		if _, err := os.Stat(opts.file); err != nil {
 			return fmt.Errorf("reading file: %w", err)
 		}
@@ -279,6 +283,14 @@ func getEditContent(opts *editOptions, existingPage *api.Page) (string, bool, er
 			}
 		}
 		return true
+	}
+
+	if opts.file == "-" {
+		data, err := io.ReadAll(stdinReader(opts.Options))
+		if err != nil {
+			return "", false, fmt.Errorf("reading stdin: %w", err)
+		}
+		return string(data), useMarkdown(""), nil
 	}
 
 	if opts.file != "" {

--- a/tools/cfl/internal/cmd/page/edit_test.go
+++ b/tools/cfl/internal/cmd/page/edit_test.go
@@ -1661,20 +1661,8 @@ func TestRunEdit_FileDash_Stdin_NoMarkdown_ADF(t *testing.T) {
 // "--file -" with empty stdin still hits the empty-content guard.
 func TestRunEdit_FileDash_EmptyStdin(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{
-				"id": "12345",
-				"title": "Test",
-				"version": {"number": 1},
-				"body": {"storage": {"value": "<p>Old</p>"}},
-				"_links": {"webui": "/pages/12345"}
-			}`))
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
+	var receivedBody map[string]any
+	server := mockEditBodyServer(t, &receivedBody)
 	defer server.Close()
 
 	rootOpts := newEditTestRootOptions()
@@ -1690,4 +1678,33 @@ func TestRunEdit_FileDash_EmptyStdin(t *testing.T) {
 	err := runEdit(context.Background(), opts)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "page content cannot be empty")
+}
+
+// "--file - --legacy" converts markdown stdin to storage XHTML.
+func TestRunEdit_FileDash_Stdin_Legacy(t *testing.T) {
+	t.Parallel()
+	var receivedBody map[string]any
+	server := mockEditBodyServer(t, &receivedBody)
+	defer server.Close()
+
+	rootOpts := newEditTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+	rootOpts.Stdin = strings.NewReader("# Heading\n\nSome **bold** text.")
+	opts := &editOptions{
+		Options: rootOpts,
+		pageID:  "12345",
+		file:    "-",
+		legacy:  true,
+	}
+
+	err := runEdit(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+
+	bodyMap := receivedBody["body"].(map[string]any)
+	storageMap := bodyMap["storage"].(map[string]any)
+	content := storageMap["value"].(string)
+	testutil.Contains(t, content, "<h1")
+	testutil.Contains(t, content, "<strong>bold</strong>")
+	testutil.Nil(t, bodyMap["atlas_doc_format"])
 }

--- a/tools/cfl/internal/cmd/page/edit_test.go
+++ b/tools/cfl/internal/cmd/page/edit_test.go
@@ -1539,3 +1539,155 @@ func TestRunEdit_ADFPage_NewContent(t *testing.T) {
 	adfMap := bodyMap["atlas_doc_format"].(map[string]any)
 	testutil.Contains(t, adfMap["value"].(string), "Updated Content")
 }
+
+// mockEditBodyServer returns a server serving an existing page on GET and
+// capturing the PUT update body.
+func mockEditBodyServer(t *testing.T, received *map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 1},
+				"body": {"storage": {"value": "<p>Old</p>"}},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		case "PUT":
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, received)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 2},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// "--file -" reads the edit body from stdin; the early os.Stat guard must
+// not treat "-" as a path.
+func TestRunEdit_FileDash_Stdin_ADF(t *testing.T) {
+	t.Parallel()
+	var receivedBody map[string]any
+	server := mockEditBodyServer(t, &receivedBody)
+	defer server.Close()
+
+	rootOpts := newEditTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+	rootOpts.Stdin = strings.NewReader("# Heading\n\nSome **bold** text.")
+	opts := &editOptions{
+		Options: rootOpts,
+		pageID:  "12345",
+		file:    "-",
+	}
+
+	err := runEdit(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+
+	bodyMap := receivedBody["body"].(map[string]any)
+	adfMap := bodyMap["atlas_doc_format"].(map[string]any)
+	content := adfMap["value"].(string)
+	testutil.Contains(t, content, `"type":"doc"`)
+	testutil.Contains(t, content, `"type":"heading"`)
+	testutil.Contains(t, content, `"type":"strong"`)
+}
+
+// "--file - --storage" pipes raw storage XHTML through unchanged.
+func TestRunEdit_FileDash_Stdin_Storage(t *testing.T) {
+	t.Parallel()
+	var receivedBody map[string]any
+	server := mockEditBodyServer(t, &receivedBody)
+	defer server.Close()
+
+	rootOpts := newEditTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+	rootOpts.Stdin = strings.NewReader(`<p>Updated storage</p>`)
+	useMd := false
+	opts := &editOptions{
+		Options:  rootOpts,
+		pageID:   "12345",
+		file:     "-",
+		storage:  true,
+		markdown: &useMd,
+	}
+
+	err := runEdit(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+
+	bodyMap := receivedBody["body"].(map[string]any)
+	storageMap := bodyMap["storage"].(map[string]any)
+	testutil.Equal(t, "<p>Updated storage</p>", storageMap["value"].(string))
+	testutil.Nil(t, bodyMap["atlas_doc_format"])
+}
+
+// "--file - --no-markdown" passes raw ADF JSON through to atlas_doc_format
+// unconverted (the shape INT-425's edit_page(format="adf") relies on).
+func TestRunEdit_FileDash_Stdin_NoMarkdown_ADF(t *testing.T) {
+	t.Parallel()
+	var receivedBody map[string]any
+	server := mockEditBodyServer(t, &receivedBody)
+	defer server.Close()
+
+	adf := `{"type":"doc","version":1,"content":[]}`
+	rootOpts := newEditTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+	rootOpts.Stdin = strings.NewReader(adf)
+	useMd := false
+	opts := &editOptions{
+		Options:  rootOpts,
+		pageID:   "12345",
+		file:     "-",
+		markdown: &useMd,
+	}
+
+	err := runEdit(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+
+	bodyMap := receivedBody["body"].(map[string]any)
+	adfMap := bodyMap["atlas_doc_format"].(map[string]any)
+	testutil.Equal(t, adf, adfMap["value"].(string))
+}
+
+// "--file -" with empty stdin still hits the empty-content guard.
+func TestRunEdit_FileDash_EmptyStdin(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"id": "12345",
+				"title": "Test",
+				"version": {"number": 1},
+				"body": {"storage": {"value": "<p>Old</p>"}},
+				"_links": {"webui": "/pages/12345"}
+			}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	rootOpts := newEditTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+	rootOpts.Stdin = strings.NewReader("")
+	opts := &editOptions{
+		Options: rootOpts,
+		pageID:  "12345",
+		file:    "-",
+	}
+
+	err := runEdit(context.Background(), opts)
+	testutil.RequireError(t, err)
+	testutil.Contains(t, err.Error(), "page content cannot be empty")
+}

--- a/tools/cfl/internal/cmd/page/page.go
+++ b/tools/cfl/internal/cmd/page/page.go
@@ -2,10 +2,22 @@
 package page
 
 import (
+	"io"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
+
+// stdinReader returns the reader to use for `--file -` content. Tests inject
+// a reader via root.Options.Stdin; in production it defaults to os.Stdin.
+func stdinReader(o *root.Options) io.Reader {
+	if o != nil && o.Stdin != nil {
+		return o.Stdin
+	}
+	return os.Stdin
+}
 
 // Register adds page commands to the root command.
 func Register(rootCmd *cobra.Command, opts *root.Options) {


### PR DESCRIPTION
## Summary

`cfl page create` and `cfl page edit` already read piped stdin (the `os.Stdin` char-device fallthrough in `getContent`/`getEditContent`), but the canonical `--file -` idiom failed: the fail-fast `os.Stat(opts.file)` guard and the `os.ReadFile(opts.file)` path both ENOENT on `-`.

This special-cases `-` in those two spots for **both** commands, reading through `root.Options.Stdin` (a tiny shared `stdinReader` helper) so the path is unit-testable. Markdown / storage / ADF selection (`--no-markdown`/`--storage`/`--legacy`) is unchanged and composes with `-`.

Enables callers that can't share a filesystem with the cfl subprocess (e.g. a remote MCP wrapper) to stream a body via stdin:
```
pandoc -t html doc.md | cfl page edit 12345 --file - --storage
```

## Changes
- `page.go`: 4-line `stdinReader(*root.Options)` resolver (Options.Stdin in tests, os.Stdin in prod).
- `create.go` / `edit.go`: skip `os.Stat` for `-`; read stdin for `-` in the content path; help text + one example each.
- `create_test.go` / `edit_test.go`: `--file -` cases — markdown→ADF default, `--storage` passthrough, `--no-markdown` raw-ADF passthrough (symmetric create/edit), edit empty-stdin guard.

## Scope
- `--body <string>` intentionally **out of scope** (the pipe path already covers it; ticket marks it nice-to-have).
- Pre-existing unrelated lint finding in `internal/config/config_test.go:460` (gosec false-positive on a test token) is **not** touched.

## Verification
From `tools/cfl/`: `make build` ✓ · `go test -race ./...` → 999 passed ✓ · `golangci-lint run ./internal/cmd/page/...` → clean ✓

[INT-424]
Closes #363