### PR TITLE
fix!: collapse the keyring to a single shared api_token [MON-5326]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,9 @@ Note: there is **no `api_token:` field** — the secret is in the keyring.
 The `cfl`/`jtk` sections may still carry non-secret per-tool overrides
 (`url`, `email`, `auth_method`, `cloud_id`); per-field merge applies.
 
-Keyring bundle: fixed ref `atlassian-cli/default`, keys `api_token`
-(shared default), `cfl_api_token`, `jtk_api_token` (per-tool overrides).
+Keyring bundle: fixed ref `atlassian-cli/default`, exactly one key
+`api_token` shared by cfl and jtk (Secret-Handling Standard §1.11.10:
+one key per logical credential — there are no per-tool override keys).
 Backend selection is env-only (`ATLASSIAN_CLI_KEYRING_BACKEND`); leave it
 unset to auto-select the OS keyring, or set it to `file` for the opt-in
 encrypted-file backend. The file-backend passphrase comes from
@@ -155,17 +156,20 @@ passphrase can never share stdin with a piped token.
 
 1. Tool-specific env (`CFL_API_TOKEN` / `JIRA_API_TOKEN`)
 2. `ATLASSIAN_API_TOKEN` env
-3. Keyring per-tool key (`cfl_api_token` / `jtk_api_token`)
-4. Keyring shared `api_token`
+3. Keyring shared `api_token`
 
 Non-secret fields keep their previous precedence (env → shared store
 override → shared default → legacy file).
 
 **One-time auto-migration:** the first API/`test`/`init` invocation that
 actually opens the keyring moves any pre-existing plaintext token (shared
-`config.yml` *or* a legacy per-tool file) into the keyring and scrubs the
-plaintext in place, printing a one-line notice. Legacy non-secret files
-keep working; init still detects/reconciles them. **Caveat:** when an
+`config.yml` *or* a legacy per-tool file) — and any deprecated per-tool
+keyring key left by an older build (B3 upgrade path) — into the single
+`api_token` and scrubs the plaintext in place, printing a one-line
+notice. If the collected sources hold **more than one distinct token**
+the migration fails loud, names every source (never the value), and
+mutates nothing — it never precedence-picks a secret winner. Legacy
+non-secret files keep working; init still detects/reconciles them. **Caveat:** when an
 API-token env var is set it wins outright and the keyring is not opened,
 so migration is deferred until an invocation actually needs the keyring
 (`init`/`set-credential`, or a command run without the env var). A user
@@ -176,10 +180,10 @@ override, so a read path is never forced to mutate disk behind it.
 **Non-interactive ingress:** `cfl set-credential` / `jtk set-credential`
 read a token from stdin or `--from-env VAR` and store it in the keyring
 (never echoed). `config show` reports token presence + source + keyring
-backend only (never the value). `config clear` removes the tool's
-resolved key (warning when it is the shared `api_token` that the sibling
-also uses); `config clear --all` removes the whole bundle plus the
-non-secret config file.
+backend only (never the value). `config clear` removes the single shared
+`api_token` (warning that the sibling tool loses access too, since both
+resolve the same key); `config clear --all` removes the whole bundle
+(including any deprecated per-tool keys) plus the non-secret config file.
 
 ## Git History
 

--- a/shared/credstore/credstore_test.go
+++ b/shared/credstore/credstore_test.go
@@ -169,7 +169,7 @@ func TestResolveWithSource(t *testing.T) {
 
 // HasUsableConfig is NON-secret completeness only — the token lives in
 // the keyring, so it is intentionally NOT part of this check (callers
-// compose it with keyring.HasTokenForTool).
+// compose it with keyring.HasToken).
 func TestHasUsableConfig(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/shared/credtest/credtest.go
+++ b/shared/credtest/credtest.go
@@ -22,7 +22,13 @@ import (
 // pre-migration "B3 upgrade" state — a user upgraded through the per-tool
 // build and holds only these — so credtest reaches the bundle through the
 // same cli-common credstore the keyring package uses, opened with the
-// superset allowlist. These literals must track keyring's deprecatedKeys.
+// superset allowlist.
+//
+// These mirror keyring.deprecatedKeys (unexported there). Duplication is
+// acceptable because the set is FROZEN historical state: it is exactly
+// the keys the B3 build wrote, and the whole point of MON-5326 is that
+// no new per-tool keys will ever be added — so there is nothing to drift
+// toward. Authority lives in shared/keyring/migrate.go.
 var deprecatedBundleKeys = []string{"cfl_api_token", "jtk_api_token"} //nolint:gosec // G101: bundle key names, not credentials
 
 // openBundle opens the canonical atlassian-cli bundle directly via

--- a/shared/credtest/credtest.go
+++ b/shared/credtest/credtest.go
@@ -31,6 +31,14 @@ var deprecatedBundleKeys = []string{"cfl_api_token", "jtk_api_token"} //nolint:g
 // Hermetic configures. Test-harness only.
 func openBundle(t *testing.T) (*cccredstore.Store, string) {
 	t.Helper()
+	// Hermetic precondition guard: opening a BackendFile store with no
+	// passphrase rooted in the REAL HOME would read/write real keyring
+	// state silently. Fail loud if the caller skipped credtest.Hermetic
+	// (which sets the backend + passphrase + isolates HOME/XDG).
+	if os.Getenv(keyring.BackendEnvVar) != "file" || os.Getenv("ATLASSIAN_CLI_KEYRING_PASSPHRASE") == "" {
+		t.Fatalf("credtest: call credtest.Hermetic(t) before SeedDeprecatedKey/BundleKeys " +
+			"(file backend + passphrase + isolated HOME must be set first)")
+	}
 	service, profile, err := cccredstore.ParseRef(keyring.Ref)
 	if err != nil {
 		t.Fatalf("credtest: ParseRef(%q): %v", keyring.Ref, err)

--- a/shared/credtest/credtest.go
+++ b/shared/credtest/credtest.go
@@ -7,10 +7,81 @@
 package credtest
 
 import (
+	"os"
+	"sort"
 	"testing"
+
+	cccredstore "github.com/open-cli-collective/cli-common/credstore"
 
 	"github.com/open-cli-collective/atlassian-go/keyring"
 )
+
+// deprecatedBundleKeys are the removed per-tool override keys. Production
+// keyring exposes neither the names nor a writer for them (by design:
+// SetToken refuses non-allowlisted keys). Tests still need to fabricate
+// pre-migration "B3 upgrade" state — a user upgraded through the per-tool
+// build and holds only these — so credtest reaches the bundle through the
+// same cli-common credstore the keyring package uses, opened with the
+// superset allowlist. These literals must track keyring's deprecatedKeys.
+var deprecatedBundleKeys = []string{"cfl_api_token", "jtk_api_token"} //nolint:gosec // G101: bundle key names, not credentials
+
+// openBundle opens the canonical atlassian-cli bundle directly via
+// cli-common credstore with the superset allowlist (api_token + the two
+// deprecated keys), honoring the same file backend + passphrase env that
+// Hermetic configures. Test-harness only.
+func openBundle(t *testing.T) (*cccredstore.Store, string) {
+	t.Helper()
+	service, profile, err := cccredstore.ParseRef(keyring.Ref)
+	if err != nil {
+		t.Fatalf("credtest: ParseRef(%q): %v", keyring.Ref, err)
+	}
+	cs, err := cccredstore.Open(service, &cccredstore.Options{
+		AllowedKeys:   append([]string{keyring.KeyAPIToken}, deprecatedBundleKeys...),
+		ConfigBackend: cccredstore.BackendFile,
+		FilePassphrase: func() (string, error) {
+			return os.Getenv("ATLASSIAN_CLI_KEYRING_PASSPHRASE"), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("credtest: open bundle: %v", err)
+	}
+	return cs, profile
+}
+
+// SeedDeprecatedKey writes a removed per-tool override key directly into
+// the bundle, standing in for B3 upgrade residue (plaintext already
+// scrubbed, only the old keyring key left). Production refuses to write
+// these, so the fixture goes through the underlying credstore.
+func SeedDeprecatedKey(t *testing.T, key, token string) {
+	t.Helper()
+	cs, profile := openBundle(t)
+	defer func() { _ = cs.Close() }()
+	if err := cs.Set(profile, key, token, cccredstore.WithOverwrite()); err != nil {
+		t.Fatalf("credtest.SeedDeprecatedKey(%s): %v", key, err)
+	}
+}
+
+// BundleKeys returns the EXACT set of bundle keys that currently hold a
+// value — api_token plus the deprecated per-tool keys — sorted. §1.11.11
+// conformance asserts against this: a healthy bundle is exactly
+// {api_token}; a cleared bundle is exactly empty.
+func BundleKeys(t *testing.T) []string {
+	t.Helper()
+	cs, profile := openBundle(t)
+	defer func() { _ = cs.Close() }()
+	var present []string
+	for _, k := range append([]string{keyring.KeyAPIToken}, deprecatedBundleKeys...) {
+		ok, err := cs.Exists(profile, k)
+		if err != nil {
+			t.Fatalf("credtest.BundleKeys: exists %s: %v", k, err)
+		}
+		if ok {
+			present = append(present, k)
+		}
+	}
+	sort.Strings(present)
+	return present
+}
 
 // tokenEnvVars are every API-token env var that would otherwise override
 // the keyring at runtime; cleared so tests exercise the keyring path.
@@ -44,12 +115,13 @@ func Hermetic(t *testing.T) string {
 	return dir
 }
 
-// SeedToken stores a token under key in the hermetic keyring (the same
+// SeedToken stores the shared api_token in the hermetic keyring (the same
 // file backend Hermetic configures). Use it to set up "token already in
-// the keyring" scenarios without going through init.
-func SeedToken(t *testing.T, key, token string) {
+// the keyring" scenarios without going through init. There is one key per
+// logical credential (§1.11.10), so no key argument.
+func SeedToken(t *testing.T, token string) {
 	t.Helper()
-	if err := keyring.PersistToken(key, token); err != nil {
-		t.Fatalf("credtest.SeedToken(%q): %v", key, err)
+	if err := keyring.PersistToken(token); err != nil {
+		t.Fatalf("credtest.SeedToken: %v", err)
 	}
 }

--- a/shared/keyring/clear.go
+++ b/shared/keyring/clear.go
@@ -25,10 +25,6 @@ type ClearPlan struct {
 	// jtk and cfl.
 	ToolKey string
 
-	// SharedDefault is true whenever ToolKey is set: api_token is the one
-	// shared key, so clearing it always de-authenticates the sibling too.
-	SharedDefault bool
-
 	// ExistingKeys are all bundle keys currently holding a value (the
 	// --all blast radius). Empty when the keyring could not be opened.
 	ExistingKeys []string
@@ -104,7 +100,6 @@ func PlanClear(tool string, all bool) (ClearPlan, *Store, error) {
 	for _, e := range existing {
 		if e == KeyAPIToken {
 			p.ToolKey = KeyAPIToken
-			p.SharedDefault = true
 			break
 		}
 	}

--- a/shared/keyring/clear.go
+++ b/shared/keyring/clear.go
@@ -19,13 +19,14 @@ import (
 type ClearPlan struct {
 	Ref string
 
-	// ToolKey is the single key a default (non --all) clear deletes for
-	// this tool: its override (<tool>_api_token) if that key exists,
-	// otherwise the shared api_token if THAT exists, otherwise "".
+	// ToolKey is the single key a default (non --all) clear deletes: the
+	// shared api_token if it exists, otherwise "". There is one key per
+	// logical credential (§1.11.10) — deleting it de-authenticates BOTH
+	// jtk and cfl.
 	ToolKey string
 
-	// SharedDefault is true when ToolKey == api_token — deleting it also
-	// de-authenticates the sibling tool.
+	// SharedDefault is true whenever ToolKey is set: api_token is the one
+	// shared key, so clearing it always de-authenticates the sibling too.
 	SharedDefault bool
 
 	// ExistingKeys are all bundle keys currently holding a value (the
@@ -63,7 +64,11 @@ type ClearPlan struct {
 // store is closed internally and nil is returned, so the rule is simply
 // "Close it iff it is non-nil" — never both close-internally and
 // transfer.
-func PlanClear(tool string) (ClearPlan, *Store, error) {
+// all selects the superset allowlist (incl. residual deprecated per-tool
+// keys) so `config clear --all` can delete B3 leftovers — the supported
+// recovery path after a divergent-deprecated migration conflict. A
+// default (non-all) clear uses the strict single-key allowlist.
+func PlanClear(tool string, all bool) (ClearPlan, *Store, error) {
 	p := ClearPlan{Ref: Ref}
 
 	for _, name := range envVarsFor(tool) {
@@ -80,7 +85,11 @@ func PlanClear(tool string) (ClearPlan, *Store, error) {
 		}
 	}
 
-	s, err := OpenNoMigrate()
+	open := OpenNoMigrate
+	if all {
+		open = OpenForClearAll
+	}
+	s, err := open()
 	if err != nil {
 		return p, nil, err
 	}
@@ -92,19 +101,12 @@ func PlanClear(tool string) (ClearPlan, *Store, error) {
 	}
 	p.ExistingKeys = existing
 
-	has := func(k string) bool {
-		for _, e := range existing {
-			if e == k {
-				return true
-			}
+	for _, e := range existing {
+		if e == KeyAPIToken {
+			p.ToolKey = KeyAPIToken
+			p.SharedDefault = true
+			break
 		}
-		return false
-	}
-	if ok := KeyFor(tool); ok != "" && has(ok) {
-		p.ToolKey = ok
-	} else if has(KeyAPIToken) {
-		p.ToolKey = KeyAPIToken
-		p.SharedDefault = true
 	}
 
 	return p, s, nil

--- a/shared/keyring/info.go
+++ b/shared/keyring/info.go
@@ -51,7 +51,7 @@ func InspectForTool(tool string) (Info, error) {
 	if info.TokenSource == string(SourceEnv) {
 		return info, nil
 	}
-	v, tokSrc, gerr := resolveFromStore(s, tool)
+	v, tokSrc, gerr := resolveFromStore(s)
 	if gerr != nil {
 		return info, gerr
 	}

--- a/shared/keyring/keyring.go
+++ b/shared/keyring/keyring.go
@@ -146,8 +146,19 @@ func (s *Store) get(key string) (string, bool, error) {
 	return v, true, nil
 }
 
-// SetToken stores a token under an allowlisted key (ingress / migration).
+// SetToken stores a token under an allowlisted key (explicit ingress:
+// PersistToken / SetCredential). Ingress is an intentional user action,
+// so it overwrites any existing value.
 func (s *Store) SetToken(key, val string) error {
+	return s.setToken(key, val, true)
+}
+
+// setToken is the single guarded write chokepoint. With overwrite=false a
+// value created between a caller's read and this write surfaces as
+// cccredstore.ErrExists instead of being silently clobbered — the §1.8
+// migration relies on this so a concurrent writer can never make it
+// re-introduce "pick a winner".
+func (s *Store) setToken(key, val string, overwrite bool) error {
 	// Enforce the allowlist at the lowest write chokepoint: SetCredential
 	// validates earlier (better message), but PersistToken (init) and any
 	// future caller reach the keyring only through here, so the security
@@ -162,7 +173,11 @@ func (s *Store) SetToken(key, val string) error {
 	if val == "" {
 		return fmt.Errorf("refusing to store an empty value at %s/%s", s.ref, key)
 	}
-	if err := s.cs.Set(s.profile, key, val, cccredstore.WithOverwrite()); err != nil {
+	opts := []cccredstore.SetOpt{}
+	if overwrite {
+		opts = append(opts, cccredstore.WithOverwrite())
+	}
+	if err := s.cs.Set(s.profile, key, val, opts...); err != nil {
 		return fmt.Errorf("store %s at %s: %w", key, s.ref, err)
 	}
 	return nil

--- a/shared/keyring/keyring.go
+++ b/shared/keyring/keyring.go
@@ -26,12 +26,20 @@ type Store struct {
 	service string
 	profile string
 	ref     string
+	allow   []string // effective allowlist this handle was opened with
 }
 
 // Open opens the fixed shared ref and runs the one-time §1.8 migration
 // (used by API commands, `config test`, and `init`). A legacy-vs-keyring
 // effective-value conflict surfaces here as a hard error.
 func Open() (*Store, error) { return open(false, true) }
+
+// OpenForClearAll opens the bundle WITHOUT migration but with the
+// migration/superset allowlist (so `config clear --all` can delete any
+// residual deprecated per-tool key — the supported recovery path when a
+// divergent-deprecated state made migration fail loud). Runtime and
+// OpenNoMigrate keep the strict single-key allowlist (§1.11.11).
+func OpenForClearAll() (*Store, error) { return openWithAllow(false, false, migrationAllowedKeys) }
 
 // (There is intentionally no exported overwrite-migration entry point:
 // no user-facing `--overwrite` command exists, so the open(overwrite=…)
@@ -43,7 +51,18 @@ func Open() (*Store, error) { return open(false, true) }
 func OpenNoMigrate() (*Store, error) { return open(false, false) }
 
 func open(overwrite, runMigration bool) (*Store, error) {
-	s, err := openRef(Ref)
+	// The migration path needs to read and delete the deprecated per-tool
+	// keys (B3 upgrade), so it opens with the superset allowlist;
+	// non-migrating opens stay strict single-key (§1.11.11).
+	allow := allowedKeys
+	if runMigration {
+		allow = migrationAllowedKeys
+	}
+	return openWithAllow(overwrite, runMigration, allow)
+}
+
+func openWithAllow(overwrite, runMigration bool, allow []string) (*Store, error) {
+	s, err := openRef(Ref, allow)
 	if err != nil {
 		return nil, err
 	}
@@ -61,15 +80,15 @@ func open(overwrite, runMigration bool) (*Store, error) {
 // the ref is a compile-time constant — there is no caller-supplied ref
 // in the fixed-ref architecture.
 func openCanonical() (*Store, error) {
-	return openRef(Ref)
+	return openRef(Ref, allowedKeys)
 }
 
-func openRef(ref string) (*Store, error) {
+func openRef(ref string, allow []string) (*Store, error) {
 	service, profile, err := cccredstore.ParseRef(ref)
 	if err != nil {
 		return nil, fmt.Errorf("invalid credential ref %q: %w", ref, err)
 	}
-	opts := &cccredstore.Options{AllowedKeys: allowedKeys}
+	opts := &cccredstore.Options{AllowedKeys: allow}
 	switch b := strings.TrimSpace(os.Getenv(BackendEnvVar)); b {
 	case "":
 		// Auto-select per §1.4 (credstore decides; fail-closed on Linux).
@@ -90,7 +109,7 @@ func openRef(ref string) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Store{cs: cs, service: service, profile: profile, ref: ref}, nil
+	return &Store{cs: cs, service: service, profile: profile, ref: ref, allow: allow}, nil
 }
 
 // Close releases the backing store. Safe on a nil receiver.
@@ -108,19 +127,10 @@ func (s *Store) Service() string { return s.service }
 // Backend reports the credstore backend and how it was selected (§1.6).
 func (s *Store) Backend() (cccredstore.Backend, cccredstore.Source) { return s.cs.Backend() }
 
-// Token returns the effective token for tool: the per-tool override key if
-// present, else the shared default key. Keyring errors propagate (never
-// folded into "absent").
-func (s *Store) Token(tool string) (string, bool, error) {
-	if k := KeyFor(tool); k != "" {
-		v, ok, err := s.get(k)
-		if err != nil {
-			return "", false, err
-		}
-		if ok {
-			return v, true, nil
-		}
-	}
+// Token returns the shared api_token. One key per logical credential
+// (§1.11.10): jtk and cfl resolve the same key. Keyring errors propagate
+// (never folded into "absent").
+func (s *Store) Token() (string, bool, error) {
 	return s.get(KeyAPIToken)
 }
 
@@ -148,8 +158,7 @@ func (s *Store) SetToken(key, val string) error {
 			key, s.ref, strings.Join(allowedKeys, ", "))
 	}
 	// Reject empty values for ALL ingress paths (SetCredential already
-	// trims+rejects; this also covers PersistToken). An empty per-tool
-	// override would make Token() silently fall back to the shared key.
+	// trims+rejects; this also covers PersistToken).
 	if val == "" {
 		return fmt.Errorf("refusing to store an empty value at %s/%s", s.ref, key)
 	}
@@ -189,7 +198,7 @@ func (s *Store) DeleteToken(key string) error {
 // (never the env-first resolver: env cannot be cleared).
 func (s *Store) ExistingKeys() ([]string, error) {
 	var out []string
-	for _, k := range allowedKeys {
+	for _, k := range s.allow {
 		ok, err := s.cs.Exists(s.profile, k)
 		if err != nil {
 			return nil, fmt.Errorf("check %s at %s: %w", k, s.ref, err)
@@ -213,7 +222,7 @@ func (s *Store) ClearBundle() error {
 // holds the token, so there is no io.Reader to read from). No migration
 // runs: init calls EnsureMigrated up front, so the §1.8 source is already
 // resolved before the new token is written.
-func PersistToken(key, token string) (err error) {
+func PersistToken(token string) (err error) {
 	s, err := openCanonical()
 	if err != nil {
 		return err
@@ -221,85 +230,27 @@ func PersistToken(key, token string) (err error) {
 	// Surface the Close error on this WRITE path: the encrypted-file
 	// backend may flush/sync on Close, so a swallowed Close error after a
 	// "successful" SetToken could mean the token was never durably
-	// written. Read-only callers (HasTokenForTool, EnsureMigrated) keep
-	// the cheap discard — there a Close error changes nothing.
+	// written. Read-only callers (HasToken, EnsureMigrated) keep the
+	// cheap discard — there a Close error changes nothing.
 	defer func() {
 		if cerr := s.Close(); cerr != nil && err == nil {
 			err = fmt.Errorf("persist token: close keyring %s: %w", s.ref, cerr)
 		}
 	}()
-	return s.SetToken(key, token)
+	return s.SetToken(KeyAPIToken, token)
 }
 
-// PersistTokenForTool stores token under the key matching init's write
-// target and keeps resolution consistent with that choice. The per-tool
-// override key (cfl_api_token / jtk_api_token) outranks the shared
-// api_token in resolveFromStore, so when init writes the shared default
-// (override=false) any pre-existing per-tool override for THIS tool would
-// silently shadow the value the user just saved (e.g. a prior
-// `set-credential --key cfl_api_token` or token-only legacy divergence).
-// Writing the default therefore also deletes this tool's override key so
-// the tool actually resolves the token init persisted. The sibling's
-// override is independent and left untouched. override=true writes the
-// per-tool key directly (already highest precedence — no cleanup needed).
-func PersistTokenForTool(tool string, override bool, token string) (err error) {
-	s, err := openCanonical()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if cerr := s.Close(); cerr != nil && err == nil {
-			err = fmt.Errorf("persist token: close keyring %s: %w", s.ref, cerr)
-		}
-	}()
-	if override {
-		return s.SetToken(KeyFor(tool), token)
-	}
-	if err := s.SetToken(KeyAPIToken, token); err != nil {
-		return err
-	}
-	return s.DeleteToken(KeyFor(tool))
-}
-
-// PersistUnifiedToken stores token as the shared api_token and removes
-// BOTH per-tool override keys. It backs init's explicit mismatch choice
-// "use <tool>'s credentials for both tools": the user asked for one token
-// across cfl and jtk, so any per-tool override (either tool's) must go or
-// it would keep shadowing api_token in resolveFromStore and silently
-// leave that tool on its old token. Unlike PersistTokenForTool's
-// default-write path, the sibling override is intentionally cleared here
-// because the action is an explicit cross-tool unify, not a normal save.
-func PersistUnifiedToken(token string) (err error) {
-	s, err := openCanonical()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if cerr := s.Close(); cerr != nil && err == nil {
-			err = fmt.Errorf("persist token: close keyring %s: %w", s.ref, cerr)
-		}
-	}()
-	if err := s.SetToken(KeyAPIToken, token); err != nil {
-		return err
-	}
-	if err := s.DeleteToken(KeyFor(ToolCFL)); err != nil {
-		return err
-	}
-	return s.DeleteToken(KeyFor(ToolJTK))
-}
-
-// HasTokenForTool reports whether a keyring token is already present for
-// tool (its override key, else the shared default) WITHOUT running the
-// migration or consulting env. Used by `init` detection to compose
-// readiness with credstore.HasUsableConfig. A genuine keyring error is
-// surfaced, never folded into false.
-func HasTokenForTool(tool string) (bool, error) {
+// HasToken reports whether the shared api_token is already present in the
+// keyring WITHOUT running the migration or consulting env. Used by `init`
+// detection to compose readiness with credstore.HasUsableConfig. A
+// genuine keyring error is surfaced, never folded into false.
+func HasToken() (bool, error) {
 	s, err := OpenNoMigrate()
 	if err != nil {
 		return false, err
 	}
 	defer func() { _ = s.Close() }()
-	_, ok, err := s.Token(tool)
+	_, ok, err := s.Token()
 	return ok, err
 }
 

--- a/shared/keyring/keyring.go
+++ b/shared/keyring/keyring.go
@@ -164,6 +164,13 @@ func (s *Store) setToken(key, val string, overwrite bool) error {
 	// future caller reach the keyring only through here, so the security
 	// boundary for "what may be stored under the fixed ref" lives in one
 	// place rather than relying on each caller to re-check.
+	// Intentional asymmetry: writes are ALWAYS restricted to the strict
+	// conforming set (allowedKeys = {api_token}), never s.allow — even on
+	// a store opened with migrationAllowedKeys. That wider allowlist only
+	// exists so the migration / clear-all can READ and DELETE the
+	// deprecated per-tool keys to clean them up; nothing may ever WRITE a
+	// deprecated key back (§1.11.11). ExistingKeys/DeleteToken use s.allow
+	// (read/delete the residue); setToken stays strict (no resurrection).
 	if !slices.Contains(allowedKeys, key) {
 		return fmt.Errorf("refusing to store under non-allowlisted key %q at %s (allowed: %s)",
 			key, s.ref, strings.Join(allowedKeys, ", "))

--- a/shared/keyring/keyring_e2e_test.go
+++ b/shared/keyring/keyring_e2e_test.go
@@ -81,6 +81,21 @@ func seedDeprecatedKey(t *testing.T, key, val string) {
 	}
 }
 
+// seedRawAPIToken writes api_token WITHOUT running the migration (via
+// the no-migrate clear-all store), to stand up a "token already in the
+// keyring" precondition for conflict tests.
+func seedRawAPIToken(t *testing.T, val string) {
+	t.Helper()
+	s, err := OpenForClearAll()
+	if err != nil {
+		t.Fatalf("OpenForClearAll: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if err := s.cs.Set(s.profile, KeyAPIToken, val, cccredstore.WithOverwrite()); err != nil {
+		t.Fatalf("seed api_token: %v", err)
+	}
+}
+
 func wantKeys(t *testing.T, got []string, want ...string) {
 	t.Helper()
 	sort.Strings(want)
@@ -116,6 +131,19 @@ func TestSetCredential_StdinAndEnv(t *testing.T) {
 		t.Fatalf("SetCredential(env): %v", err)
 	}
 	wantKeys(t, bundleKeys(t), KeyAPIToken)
+	// Ingress overwrites: the value must actually be replaced, not just
+	// "key still present" (guards a regression to no-overwrite ingress).
+	got2, ok2, err2 := func() (string, bool, error) {
+		s, e := OpenNoMigrate()
+		if e != nil {
+			return "", false, e
+		}
+		defer func() { _ = s.Close() }()
+		return s.Token()
+	}()
+	if err2 != nil || !ok2 || got2 != "env-"+secret {
+		t.Fatalf("--from-env must overwrite the stored value: got=%q ok=%v err=%v", got2, ok2, err2)
+	}
 }
 
 func TestSetCredential_Rejections(t *testing.T) {
@@ -369,6 +397,14 @@ func TestMigration_B3UpgradeFixture_DivergentDeprecatedKeys_Conflict(t *testing.
 	if _, ok, _ := s.Token(); ok {
 		t.Fatal("conflict must not write api_token")
 	}
+
+	// Stably reproducible: a second run must fail the same way (the
+	// no-mutation + stable-error pair, independent of map iteration
+	// order). State must still be untouched.
+	if err2 := EnsureMigrated(); !errors.Is(err2, ErrMigrationConflict) {
+		t.Fatalf("conflict must be stable on re-run, got: %v", err2)
+	}
+	wantKeys(t, bundleKeys(t), "cfl_api_token", "jtk_api_token")
 }
 
 // §1.11.11: after a default `config clear` the (single-key) bundle is
@@ -553,5 +589,207 @@ func TestResolveToken_CorruptSharedConfig_DegradesGracefully(t *testing.T) {
 	}
 	if strings.Contains(string(out), secret) {
 		t.Fatal("warning text leaked the secret")
+	}
+}
+
+// writeLegacyDefault writes a pre-migration shared config.yml with one
+// plaintext default api_token (credstore.Save strips tokens, so the
+// fixture is hand-written).
+func writeLegacyDefault(t *testing.T, dir, token string) string {
+	t.Helper()
+	p := filepath.Join(dir, "atlassian-cli", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p,
+		[]byte("default:\n  url: https://acme.atlassian.net\n  api_token: "+token+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// Concurrent-writer race, IDENTICAL value: a writer sets api_token to the
+// same value between phase-1 read and phase-2 write. The no-overwrite
+// write hits ErrExists; re-resolve sees an equal value → benign,
+// migration completes (plaintext scrubbed), nothing clobbered.
+func TestMigration_ConcurrentWriter_IdenticalValue_Benign(t *testing.T) {
+	dir := hermetic(t)
+	shared := writeLegacyDefault(t, dir, secret)
+
+	migrationApplyHook = func(s *Store) {
+		if err := s.cs.Set(s.profile, KeyAPIToken, secret, cccredstore.WithOverwrite()); err != nil {
+			t.Fatalf("race-seed api_token: %v", err)
+		}
+	}
+	t.Cleanup(func() { migrationApplyHook = nil })
+
+	if err := EnsureMigrated(); err != nil {
+		t.Fatalf("identical concurrent value must be benign, got: %v", err)
+	}
+	s, err := OpenNoMigrate()
+	if err != nil {
+		t.Fatalf("OpenNoMigrate: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if v, ok, _ := s.Token(); !ok || v != secret {
+		t.Fatalf("api_token: got=%q ok=%v", v, ok)
+	}
+	wantKeys(t, bundleKeys(t), KeyAPIToken)
+	raw, _ := os.ReadFile(shared) //nolint:gosec // G304: test reads its own temp file
+	if strings.Contains(string(raw), "api_token") {
+		t.Fatalf("plaintext should still be scrubbed on the benign path:\n%s", raw)
+	}
+}
+
+// Concurrent-writer race, DIVERGENT value: a writer sets api_token to a
+// DIFFERENT value mid-migration. The no-overwrite write hits ErrExists;
+// re-resolve sees a different value → hard conflict naming the keyring
+// value, the racer's token is NOT clobbered, and no plaintext is scrubbed.
+func TestMigration_ConcurrentWriter_DivergentValue_ConflictNoClobber(t *testing.T) {
+	dir := hermetic(t)
+	srcTok := "SRC-" + secret
+	raceTok := "RACE-" + secret
+	shared := writeLegacyDefault(t, dir, srcTok)
+
+	migrationApplyHook = func(s *Store) {
+		if err := s.cs.Set(s.profile, KeyAPIToken, raceTok, cccredstore.WithOverwrite()); err != nil {
+			t.Fatalf("race-seed api_token: %v", err)
+		}
+	}
+	t.Cleanup(func() { migrationApplyHook = nil })
+
+	err := EnsureMigrated()
+	if !errors.Is(err, ErrMigrationConflict) {
+		t.Fatalf("divergent concurrent value must conflict, got: %v", err)
+	}
+	msg := err.Error()
+	if strings.Contains(msg, srcTok) || strings.Contains(msg, raceTok) {
+		t.Fatalf("conflict error leaked a secret value: %s", msg)
+	}
+	if !strings.Contains(msg, shared) || !strings.Contains(msg, KeyAPIToken) {
+		t.Fatalf("conflict must name the source path AND the keyring api_token: %s", msg)
+	}
+	// The racer's token survives (never silently clobbered).
+	s, oerr := OpenNoMigrate()
+	if oerr != nil {
+		t.Fatalf("OpenNoMigrate: %v", oerr)
+	}
+	defer func() { _ = s.Close() }()
+	if v, ok, _ := s.Token(); !ok || v != raceTok {
+		t.Fatalf("racer api_token must be intact; got=%q ok=%v", v, ok)
+	}
+	raw, _ := os.ReadFile(shared) //nolint:gosec // G304: test reads its own temp file
+	if !strings.Contains(string(raw), "api_token") {
+		t.Fatalf("conflict must NOT scrub the source:\n%s", raw)
+	}
+}
+
+// A pre-existing keyring api_token that disagrees with a single legacy
+// source: the conflict message must name the keyring api_token as a
+// disagreeing party (not read as "divergence across" one source), no
+// mutation occurs, and no secret leaks.
+func TestMigration_ExistingAPIToken_NamedInConflict(t *testing.T) {
+	dir := hermetic(t)
+	existing := "EXISTING-" + secret
+	legacy := "LEGACY-" + secret
+	seedRawAPIToken(t, existing)
+	shared := writeLegacyDefault(t, dir, legacy)
+
+	err := EnsureMigrated()
+	if !errors.Is(err, ErrMigrationConflict) {
+		t.Fatalf("want ErrMigrationConflict, got %v", err)
+	}
+	msg := err.Error()
+	if strings.Contains(msg, existing) || strings.Contains(msg, legacy) {
+		t.Fatalf("conflict error leaked a secret value: %s", msg)
+	}
+	if !strings.Contains(msg, shared) || !strings.Contains(msg, KeyAPIToken) || !strings.Contains(msg, Ref) {
+		t.Fatalf("conflict must name the legacy path, api_token, and ref: %s", msg)
+	}
+	// No mutation: existing keyring value intact, plaintext not scrubbed.
+	s, oerr := OpenNoMigrate()
+	if oerr != nil {
+		t.Fatalf("OpenNoMigrate: %v", oerr)
+	}
+	defer func() { _ = s.Close() }()
+	if v, _, _ := s.Token(); v != existing {
+		t.Fatalf("existing api_token must be untouched; got %q", v)
+	}
+	raw, _ := os.ReadFile(shared) //nolint:gosec // G304: test reads its own temp file
+	if !strings.Contains(string(raw), "api_token") {
+		t.Fatalf("conflict must NOT scrub the source:\n%s", raw)
+	}
+}
+
+// Realistic B3 upgrade: a deprecated keyring key AND a plaintext file
+// both hold the SAME token → collapse to api_token, delete the
+// deprecated key, scrub the plaintext, all in one run; bundle exactly
+// {api_token}.
+func TestMigration_DeprecatedKeyAndPlaintext_SameValue_Collapses(t *testing.T) {
+	dir := hermetic(t)
+	seedDeprecatedKey(t, "jtk_api_token", secret)
+	shared := writeLegacyDefault(t, dir, secret)
+
+	if err := EnsureMigrated(); err != nil {
+		t.Fatalf("EnsureMigrated: %v", err)
+	}
+	s, err := OpenNoMigrate()
+	if err != nil {
+		t.Fatalf("OpenNoMigrate: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if v, ok, _ := s.Token(); !ok || v != secret {
+		t.Fatalf("api_token: got=%q ok=%v", v, ok)
+	}
+	wantKeys(t, bundleKeys(t), KeyAPIToken)
+	raw, _ := os.ReadFile(shared) //nolint:gosec // G304: test reads its own temp file
+	if strings.Contains(string(raw), "api_token") {
+		t.Fatalf("plaintext not scrubbed:\n%s", raw)
+	}
+}
+
+// B3 upgrade where the deprecated keyring key and the plaintext file
+// DISAGREE → hard conflict, nothing mutated.
+func TestMigration_DeprecatedKeyAndPlaintext_Divergent_Conflict(t *testing.T) {
+	dir := hermetic(t)
+	seedDeprecatedKey(t, "jtk_api_token", "DEP-"+secret)
+	shared := writeLegacyDefault(t, dir, "PLAIN-"+secret)
+
+	err := EnsureMigrated()
+	if !errors.Is(err, ErrMigrationConflict) {
+		t.Fatalf("want ErrMigrationConflict, got %v", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("conflict error leaked a secret value: %s", err)
+	}
+	wantKeys(t, bundleKeys(t), "jtk_api_token") // deprecated key untouched
+	raw, _ := os.ReadFile(shared)               //nolint:gosec // G304: test reads its own temp file
+	if !strings.Contains(string(raw), "api_token") {
+		t.Fatalf("conflict must NOT scrub the source:\n%s", raw)
+	}
+}
+
+// The overwrite=true apply path (no production caller today, but
+// reachable code): an explicit-overwrite migration replaces an existing
+// api_token with the single legacy source value and scrubs plaintext.
+func TestMigrateOverwrite_ApplyReplacesExisting(t *testing.T) {
+	dir := hermetic(t)
+	seedRawAPIToken(t, "OLD-"+secret)
+	shared := writeLegacyDefault(t, dir, "NEW-"+secret)
+
+	s, err := OpenForClearAll() // migrationAllowedKeys, no auto-migrate
+	if err != nil {
+		t.Fatalf("OpenForClearAll: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if err := migrateLegacyOverwrite(s, true); err != nil {
+		t.Fatalf("overwrite migration: %v", err)
+	}
+	if v, ok, _ := s.Token(); !ok || v != "NEW-"+secret {
+		t.Fatalf("overwrite must replace the existing token; got=%q ok=%v", v, ok)
+	}
+	raw, _ := os.ReadFile(shared) //nolint:gosec // G304: test reads its own temp file
+	if strings.Contains(string(raw), "api_token") {
+		t.Fatalf("overwrite path must still scrub plaintext:\n%s", raw)
 	}
 }

--- a/shared/keyring/keyring_e2e_test.go
+++ b/shared/keyring/keyring_e2e_test.go
@@ -395,6 +395,32 @@ func TestClear_BundleEmptyAfterClear(t *testing.T) {
 	wantKeys(t, bundleKeys(t)) // empty
 }
 
+// §1.8 recovery path: a user left with only deprecated per-tool keyring
+// keys whose values diverge cannot migrate (hard conflict). The
+// documented escape hatch is `config clear --all` — it must wipe the
+// WHOLE bundle, deprecated keys included, leaving it exactly empty so a
+// clean set-credential can follow.
+func TestClearAll_RemovesDeprecatedKeys(t *testing.T) {
+	hermetic(t)
+	seedDeprecatedKey(t, "cfl_api_token", "CFL-"+secret)
+	seedDeprecatedKey(t, "jtk_api_token", "JTK-"+secret)
+	wantKeys(t, bundleKeys(t), "cfl_api_token", "jtk_api_token") // precondition
+
+	_, store, perr := PlanClear(ToolCFL, true)
+	if perr != nil {
+		t.Fatalf("PlanClear: %v", perr)
+	}
+	defer func() { _ = store.Close() }()
+	cleared, err := ClearAll(store)
+	if err != nil {
+		t.Fatalf("ClearAll: %v", err)
+	}
+	if !cleared {
+		t.Fatal("ClearAll must report the bundle cleared")
+	}
+	wantKeys(t, bundleKeys(t)) // exactly empty — deprecated keys gone
+}
+
 // ClearAll must FAIL LOUD (naming the path) when a surviving legacy file
 // is unparseable — never claim success while plaintext may remain — AND,
 // because the plaintext scrub runs before the bundle clear, the keyring

--- a/shared/keyring/keyring_e2e_test.go
+++ b/shared/keyring/keyring_e2e_test.go
@@ -2,10 +2,14 @@ package keyring
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+
+	cccredstore "github.com/open-cli-collective/cli-common/credstore"
 
 	"github.com/open-cli-collective/atlassian-go/credstore"
 )
@@ -34,11 +38,62 @@ func hermetic(t *testing.T) string {
 //nolint:gosec // G101: test fixture string, not a real credential
 const secret = "TOK-pqrSTU-suffix" // distinctive so a leak is unmistakable
 
+// bundleKeys returns the EXACT set of bundle keys that currently hold a
+// value, across the conforming key (api_token) AND the deprecated B3 keys,
+// sorted. §1.11.11 conformance asserts against this: a healthy bundle is
+// exactly {api_token}; a cleared bundle is exactly empty; no deprecated
+// per-tool key may survive a migration.
+func bundleKeys(t *testing.T) []string {
+	t.Helper()
+	s, err := OpenForClearAll() // migrationAllowedKeys: sees deprecated keys too
+	if err != nil {
+		t.Fatalf("OpenForClearAll: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	var present []string
+	for _, k := range append([]string{KeyAPIToken}, deprecatedKeys...) {
+		ok, herr := s.HasToken(k)
+		if herr != nil {
+			t.Fatalf("HasToken(%s): %v", k, herr)
+		}
+		if ok {
+			present = append(present, k)
+		}
+	}
+	sort.Strings(present)
+	return present
+}
+
+// seedDeprecatedKey writes a removed per-tool key directly into the
+// bundle to stand in for B3 upgrade state. SetToken refuses non-allowlist
+// keys by design, so the fixture goes through the underlying credstore
+// (opened with migrationAllowedKeys) — exactly the residue this
+// migration's deprecated-key cleanup must absorb.
+func seedDeprecatedKey(t *testing.T, key, val string) {
+	t.Helper()
+	s, err := OpenForClearAll()
+	if err != nil {
+		t.Fatalf("OpenForClearAll: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if err := s.cs.Set(s.profile, key, val, cccredstore.WithOverwrite()); err != nil {
+		t.Fatalf("seed deprecated key %s: %v", key, err)
+	}
+}
+
+func wantKeys(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("bundle key set = %v, want exactly %v", got, want)
+	}
+}
+
 func TestSetCredential_StdinAndEnv(t *testing.T) {
 	hermetic(t)
 
 	// stdin path: trims surrounding whitespace.
-	if err := SetCredential(strings.NewReader("  "+secret+"\n"), KeyAPIToken, ""); err != nil {
+	if err := SetCredential(strings.NewReader("  "+secret+"\n"), ""); err != nil {
 		t.Fatalf("SetCredential(stdin): %v", err)
 	}
 	got, ok, err := func() (string, bool, error) {
@@ -47,33 +102,33 @@ func TestSetCredential_StdinAndEnv(t *testing.T) {
 			return "", false, e
 		}
 		defer func() { _ = s.Close() }()
-		return s.Token(ToolCFL)
+		return s.Token()
 	}()
 	if err != nil || !ok || got != secret {
 		t.Fatalf("stored token mismatch: got=%q ok=%v err=%v", got, ok, err)
 	}
+	// §1.11.11: a single shared key, nothing else.
+	wantKeys(t, bundleKeys(t), KeyAPIToken)
 
-	// --from-env path.
+	// --from-env path overwrites the same single key.
 	t.Setenv("MY_SECRET_VAR", "env-"+secret)
-	if err := SetCredential(nil, KeyJTKAPIToken, "MY_SECRET_VAR"); err != nil {
+	if err := SetCredential(nil, "MY_SECRET_VAR"); err != nil {
 		t.Fatalf("SetCredential(env): %v", err)
 	}
+	wantKeys(t, bundleKeys(t), KeyAPIToken)
 }
 
 func TestSetCredential_Rejections(t *testing.T) {
 	hermetic(t)
 
-	if err := SetCredential(strings.NewReader("   \n"), KeyAPIToken, ""); err == nil {
+	if err := SetCredential(strings.NewReader("   \n"), ""); err == nil {
 		t.Fatal("expected error for empty token")
 	}
-	if err := SetCredential(strings.NewReader("x"), "bogus_key", ""); err == nil {
-		t.Fatal("expected error for unknown key")
-	}
-	if err := SetCredential(nil, KeyAPIToken, "DEFINITELY_UNSET_VAR"); err == nil {
+	if err := SetCredential(nil, "DEFINITELY_UNSET_VAR"); err == nil {
 		t.Fatal("expected error for unset env var")
 	}
 	// nil reader + no env var must be a normal error, never a panic.
-	if err := SetCredential(nil, KeyAPIToken, ""); err == nil {
+	if err := SetCredential(nil, ""); err == nil {
 		t.Fatal("expected error for nil stdin and no --from-env")
 	}
 }
@@ -99,16 +154,17 @@ func TestMigration_EndToEnd_ScrubAndSignal(t *testing.T) {
 		t.Fatalf("EnsureMigrated: %v", err)
 	}
 
-	// Token is now in the keyring.
+	// Token is now in the single shared keyring key, and nothing else.
 	s, err := OpenNoMigrate()
 	if err != nil {
 		t.Fatalf("OpenNoMigrate: %v", err)
 	}
 	defer func() { _ = s.Close() }()
-	tok, ok, err := s.get(KeyAPIToken)
+	tok, ok, err := s.Token()
 	if err != nil || !ok || tok != secret {
 		t.Fatalf("keyring token: got=%q ok=%v err=%v", tok, ok, err)
 	}
+	wantKeys(t, bundleKeys(t), KeyAPIToken)
 
 	// Plaintext file scrubbed (non-secret fields preserved).
 	raw, err := os.ReadFile(sharedPath) //nolint:gosec // G304: test reads its own temp file
@@ -144,10 +200,11 @@ func TestMigration_EndToEnd_ScrubAndSignal(t *testing.T) {
 	}
 }
 
-// End-to-end: legacy per-tool plaintext files (cfl yaml + jtk json) with
-// NO shared default migrate to their own override keys, are scrubbed in
-// place, and the migration is idempotent regardless of tool order.
-func TestMigration_LegacyFiles_ScrubAndIdempotent(t *testing.T) {
+// Amended §1.8: two legacy per-tool plaintext files (cfl yml + jtk json)
+// holding the SAME token, with no shared default, collapse onto the
+// single shared api_token (no per-tool keys), are scrubbed in place, and
+// the migration is idempotent.
+func TestMigration_DuplicateLegacy_CollapsesToSingleKey(t *testing.T) {
 	hermetic(t)
 
 	cflPath := credstore.LegacyCFLPath()
@@ -158,13 +215,12 @@ func TestMigration_LegacyFiles_ScrubAndIdempotent(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(jtkPath), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	cflTok, jtkTok := "CFL-"+secret, "JTK-"+secret
 	if err := os.WriteFile(cflPath,
-		[]byte("url: https://acme.atlassian.net\nemail: c@e\napi_token: "+cflTok+"\n"), 0o600); err != nil {
+		[]byte("url: https://acme.atlassian.net\nemail: c@e\napi_token: "+secret+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(jtkPath,
-		[]byte(`{"url":"https://acme.atlassian.net","email":"j@e","api_token":"`+jtkTok+`"}`), 0o600); err != nil {
+		[]byte(`{"url":"https://acme.atlassian.net","email":"j@e","api_token":"`+secret+`"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -177,14 +233,10 @@ func TestMigration_LegacyFiles_ScrubAndIdempotent(t *testing.T) {
 		t.Fatalf("OpenNoMigrate: %v", err)
 	}
 	defer func() { _ = s.Close() }()
-
-	// No shared default → each legacy file maps to its own override key.
-	if v, ok, _ := s.get(KeyCFLAPIToken); !ok || v != cflTok {
-		t.Fatalf("cfl_api_token: got=%q ok=%v", v, ok)
+	if v, ok, _ := s.Token(); !ok || v != secret {
+		t.Fatalf("api_token: got=%q ok=%v", v, ok)
 	}
-	if v, ok, _ := s.get(KeyJTKAPIToken); !ok || v != jtkTok {
-		t.Fatalf("jtk_api_token: got=%q ok=%v", v, ok)
-	}
+	wantKeys(t, bundleKeys(t), KeyAPIToken)
 
 	for _, p := range []string{cflPath, jtkPath} {
 		raw, rerr := os.ReadFile(p) //nolint:gosec // G304: test reads its own temp file
@@ -196,11 +248,151 @@ func TestMigration_LegacyFiles_ScrubAndIdempotent(t *testing.T) {
 		}
 	}
 
-	// Idempotent across re-run (cfl-first / jtk-first order is internal
-	// to gatherEffective; a second pass must be a silent no-op).
 	if err := EnsureMigrated(); err != nil {
 		t.Fatalf("second EnsureMigrated must be idempotent: %v", err)
 	}
+}
+
+// Amended §1.8: divergent plaintext sources (shared default vs a legacy
+// per-tool file) is a HARD conflict — the migration never precedence-picks
+// a secret winner. Two-phase guarantee: nothing is written and NO source
+// is scrubbed; the error names every location and never the value.
+func TestMigration_DivergentSources_ConflictNoMutation(t *testing.T) {
+	dir := hermetic(t)
+	sharedPath := filepath.Join(dir, "atlassian-cli", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(sharedPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	defTok := "DEFAULT-" + secret
+	legTok := "LEGACY-" + secret
+	if err := os.WriteFile(sharedPath,
+		[]byte("default:\n  url: https://acme.atlassian.net\n  api_token: "+defTok+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cflPath := credstore.LegacyCFLPath()
+	if err := os.MkdirAll(filepath.Dir(cflPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cflPath,
+		[]byte("url: https://acme.atlassian.net\napi_token: "+legTok+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := EnsureMigrated()
+	if !errors.Is(err, ErrMigrationConflict) {
+		t.Fatalf("want ErrMigrationConflict, got %v", err)
+	}
+	msg := err.Error()
+	if strings.Contains(msg, defTok) || strings.Contains(msg, legTok) {
+		t.Fatalf("conflict error leaked a secret value: %s", msg)
+	}
+	if !strings.Contains(msg, sharedPath) || !strings.Contains(msg, cflPath) {
+		t.Fatalf("conflict error must name every source location: %s", msg)
+	}
+
+	// Two-phase: no source mutated, nothing written to the keyring.
+	for _, p := range []string{sharedPath, cflPath} {
+		raw, rerr := os.ReadFile(p) //nolint:gosec // G304: test reads its own temp file
+		if rerr != nil {
+			t.Fatal(rerr)
+		}
+		if !strings.Contains(string(raw), "api_token") {
+			t.Fatalf("conflict must NOT scrub %s:\n%s", p, raw)
+		}
+	}
+	wantKeys(t, bundleKeys(t)) // empty: nothing written
+}
+
+// B3 upgrade fixture: a user upgraded through the per-tool-key build and
+// holds ONLY deprecated keyring keys (plaintext already scrubbed), both
+// with the same value. The migration must consolidate onto api_token,
+// delete BOTH deprecated keys, fire the signal, and leave the bundle
+// exactly {api_token}. Without this, S1's key-set collapse would silently
+// de-authenticate these users.
+func TestMigration_B3UpgradeFixture_DeprecatedKeysOnly(t *testing.T) {
+	hermetic(t)
+	seedDeprecatedKey(t, "cfl_api_token", secret)
+	seedDeprecatedKey(t, "jtk_api_token", secret)
+	wantKeys(t, bundleKeys(t), "cfl_api_token", "jtk_api_token") // precondition
+
+	if err := EnsureMigrated(); err != nil {
+		t.Fatalf("EnsureMigrated: %v", err)
+	}
+
+	s, err := OpenNoMigrate()
+	if err != nil {
+		t.Fatalf("OpenNoMigrate: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if v, ok, _ := s.Token(); !ok || v != secret {
+		t.Fatalf("api_token: got=%q ok=%v", v, ok)
+	}
+	wantKeys(t, bundleKeys(t), KeyAPIToken) // deprecated keys gone
+
+	var buf bytes.Buffer
+	FlushMigrationNotice(&buf)
+	if buf.Len() == 0 {
+		t.Fatal("expected a migration notice for the B3 upgrade path")
+	}
+	if strings.Contains(buf.String(), secret) {
+		t.Fatalf("migration notice leaked the secret: %s", buf.String())
+	}
+
+	if err := EnsureMigrated(); err != nil {
+		t.Fatalf("second EnsureMigrated must be idempotent: %v", err)
+	}
+}
+
+// B3 upgrade fixture, divergent: the two deprecated keys disagree. Same
+// hard-conflict rule — never precedence-pick — and the two-phase
+// guarantee means NEITHER deprecated key is deleted and api_token is not
+// written.
+func TestMigration_B3UpgradeFixture_DivergentDeprecatedKeys_Conflict(t *testing.T) {
+	hermetic(t)
+	seedDeprecatedKey(t, "cfl_api_token", "CFL-"+secret)
+	seedDeprecatedKey(t, "jtk_api_token", "JTK-"+secret)
+
+	err := EnsureMigrated()
+	if !errors.Is(err, ErrMigrationConflict) {
+		t.Fatalf("want ErrMigrationConflict, got %v", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("conflict error leaked a secret value: %s", err)
+	}
+	// Two-phase: nothing deleted, nothing written.
+	wantKeys(t, bundleKeys(t), "cfl_api_token", "jtk_api_token")
+	s, oerr := OpenNoMigrate()
+	if oerr != nil {
+		t.Fatalf("OpenNoMigrate: %v", oerr)
+	}
+	defer func() { _ = s.Close() }()
+	if _, ok, _ := s.Token(); ok {
+		t.Fatal("conflict must not write api_token")
+	}
+}
+
+// §1.11.11: after a default `config clear` the (single-key) bundle is
+// exactly empty, and `config clear --all` on an already-clean bundle is a
+// no-op that also leaves it empty.
+func TestClear_BundleEmptyAfterClear(t *testing.T) {
+	hermetic(t)
+	if err := SetCredential(strings.NewReader(secret), ""); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	wantKeys(t, bundleKeys(t), KeyAPIToken)
+
+	plan, store, err := PlanClear(ToolCFL, false)
+	if err != nil {
+		t.Fatalf("PlanClear: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	if plan.ToolKey != KeyAPIToken {
+		t.Fatalf("default clear should target api_token; got %q", plan.ToolKey)
+	}
+	if err := store.DeleteToken(plan.ToolKey); err != nil {
+		t.Fatalf("DeleteToken: %v", err)
+	}
+	wantKeys(t, bundleKeys(t)) // empty
 }
 
 // ClearAll must FAIL LOUD (naming the path) when a surviving legacy file
@@ -209,7 +401,7 @@ func TestMigration_LegacyFiles_ScrubAndIdempotent(t *testing.T) {
 // token must survive the failure (the safer, recoverable state).
 func TestClearAll_FailsLoudOnUnparseableLegacy(t *testing.T) {
 	hermetic(t)
-	if err := SetCredential(strings.NewReader(secret), KeyAPIToken, ""); err != nil {
+	if err := SetCredential(strings.NewReader(secret), ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	cflPath := credstore.LegacyCFLPath()
@@ -221,7 +413,7 @@ func TestClearAll_FailsLoudOnUnparseableLegacy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	plan, store, perr := PlanClear(ToolCFL)
+	_, store, perr := PlanClear(ToolCFL, true)
 	if perr != nil {
 		t.Fatalf("PlanClear: %v", perr)
 	}
@@ -229,7 +421,6 @@ func TestClearAll_FailsLoudOnUnparseableLegacy(t *testing.T) {
 		t.Fatal("PlanClear must return an open store on success")
 	}
 	defer func() { _ = store.Close() }()
-	_ = plan
 
 	cleared, err := ClearAll(store)
 	if err == nil {
@@ -258,61 +449,11 @@ func TestClearAll_FailsLoudOnUnparseableLegacy(t *testing.T) {
 	}
 }
 
-// A legacy token shadowed by a non-empty shared default is scrub-only:
-// no override key written, and (since nothing was relocated to a NEW
-// key beyond the default) the file is still scrubbed.
-func TestMigration_ShadowedLegacy_ScrubOnly(t *testing.T) {
-	dir := hermetic(t)
-	sharedPath := filepath.Join(dir, "atlassian-cli", "config.yml")
-	if err := os.MkdirAll(filepath.Dir(sharedPath), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(sharedPath,
-		[]byte("default:\n  url: https://acme.atlassian.net\n  api_token: DEFAULT-"+secret+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	cflPath := credstore.LegacyCFLPath()
-	if err := os.MkdirAll(filepath.Dir(cflPath), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(cflPath,
-		[]byte("url: https://acme.atlassian.net\napi_token: SHADOWED-"+secret+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := EnsureMigrated(); err != nil {
-		t.Fatalf("EnsureMigrated: %v", err)
-	}
-	s, err := OpenNoMigrate()
-	if err != nil {
-		t.Fatalf("OpenNoMigrate: %v", err)
-	}
-	defer func() { _ = s.Close() }()
-
-	if _, ok, _ := s.get(KeyCFLAPIToken); ok {
-		t.Fatal("shadowed legacy value must NOT be written to cfl_api_token")
-	}
-	if v, ok, _ := s.get(KeyAPIToken); !ok || v != "DEFAULT-"+secret {
-		t.Fatalf("api_token: got=%q ok=%v", v, ok)
-	}
-	// Both plaintext sources scrubbed even though the legacy file's value
-	// was dead data.
-	for _, p := range []string{sharedPath, cflPath} {
-		raw, rerr := os.ReadFile(p) //nolint:gosec // G304: test reads its own temp file
-		if rerr != nil {
-			t.Fatal(rerr)
-		}
-		if strings.Contains(string(raw), secret) {
-			t.Fatalf("%s not scrubbed:\n%s", p, raw)
-		}
-	}
-}
-
 // InspectForTool must report presence/source/backend without ever
 // returning the token value.
 func TestInspectForTool_NoValue(t *testing.T) {
 	hermetic(t)
-	if err := SetCredential(strings.NewReader(secret), KeyAPIToken, ""); err != nil {
+	if err := SetCredential(strings.NewReader(secret), ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	info, err := InspectForTool(ToolCFL)
@@ -340,7 +481,7 @@ func TestInspectForTool_NoValue(t *testing.T) {
 // one-shot guard), with no secret in the warning text.
 func TestResolveToken_CorruptSharedConfig_DegradesGracefully(t *testing.T) {
 	dir := hermetic(t)
-	if err := SetCredential(strings.NewReader(secret), KeyAPIToken, ""); err != nil {
+	if err := SetCredential(strings.NewReader(secret), ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	sharedPath := filepath.Join(dir, "atlassian-cli", "config.yml")
@@ -386,92 +527,5 @@ func TestResolveToken_CorruptSharedConfig_DegradesGracefully(t *testing.T) {
 	}
 	if strings.Contains(string(out), secret) {
 		t.Fatal("warning text leaked the secret")
-	}
-}
-
-// A pre-existing per-tool override key outranks api_token in
-// resolveFromStore. When init writes the shared default it must drop that
-// override, otherwise the tool keeps resolving the stale override token
-// the user just replaced. PersistTokenForTool owns that invariant.
-func TestPersistTokenForTool_DefaultWriteClearsStaleOverride(t *testing.T) {
-	hermetic(t)
-
-	const stale = "OLD-cfl-override-token"
-	if err := PersistTokenForTool(credstore.ToolCFL, true, stale); err != nil {
-		t.Fatalf("seed cfl override: %v", err)
-	}
-	if tok, _, err := ResolveTokenNoMigrate(credstore.ToolCFL); err != nil || tok != stale {
-		t.Fatalf("precondition: cfl should resolve the override; got %q err=%v", tok, err)
-	}
-
-	// init reuses the shared default → write api_token. The stale
-	// cfl_api_token must be removed so cfl resolves the new value.
-	if err := PersistTokenForTool(credstore.ToolCFL, false, secret); err != nil {
-		t.Fatalf("PersistTokenForTool(default): %v", err)
-	}
-	if tok, src, err := ResolveTokenNoMigrate(credstore.ToolCFL); err != nil || tok != secret || src != SourceKeyAPI {
-		t.Fatalf("cfl must resolve the saved api_token, not the stale override; got %q src=%q err=%v", tok, src, err)
-	}
-
-	s, err := OpenNoMigrate()
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	defer func() { _ = s.Close() }()
-	if ok, herr := s.HasToken(KeyFor(credstore.ToolCFL)); herr != nil || ok {
-		t.Fatalf("cfl override key must be gone after a default write; present=%v err=%v", ok, herr)
-	}
-
-	// Sibling override is independent and must survive a cfl default write.
-	if err := PersistTokenForTool(credstore.ToolJTK, true, "jtk-only"); err != nil {
-		t.Fatalf("seed jtk override: %v", err)
-	}
-	if err := PersistTokenForTool(credstore.ToolCFL, false, secret); err != nil {
-		t.Fatalf("re-write cfl default: %v", err)
-	}
-	if tok, _, err := ResolveTokenNoMigrate(credstore.ToolJTK); err != nil || tok != "jtk-only" {
-		t.Fatalf("jtk override must be untouched by a cfl default write; got %q err=%v", tok, err)
-	}
-}
-
-// The mismatch "use X for both tools" choice must actually unify: after
-// PersistUnifiedToken both tools resolve the one api_token and neither
-// per-tool override remains to shadow it. This is the explicit cross-tool
-// action where, unlike a normal default write, the sibling override is
-// also cleared.
-func TestPersistUnifiedToken_BothToolsResolveSharedAndOverridesGone(t *testing.T) {
-	hermetic(t)
-
-	// Post-migration steady state of two divergent legacy files: each
-	// tool's old token sits under its own per-tool key.
-	if err := PersistTokenForTool(credstore.ToolCFL, true, "cfl-old"); err != nil {
-		t.Fatalf("seed cfl override: %v", err)
-	}
-	if err := PersistTokenForTool(credstore.ToolJTK, true, "jtk-old"); err != nil {
-		t.Fatalf("seed jtk override: %v", err)
-	}
-
-	// User chose "use jtk for both": jtk's token is persisted as the
-	// shared default and both overrides are wiped.
-	if err := PersistUnifiedToken("jtk-old"); err != nil {
-		t.Fatalf("PersistUnifiedToken: %v", err)
-	}
-
-	for _, tool := range []string{credstore.ToolCFL, credstore.ToolJTK} {
-		tok, src, err := ResolveTokenNoMigrate(tool)
-		if err != nil || tok != "jtk-old" || src != SourceKeyAPI {
-			t.Fatalf("%s must resolve the unified api_token; got %q src=%q err=%v", tool, tok, src, err)
-		}
-	}
-
-	s, err := OpenNoMigrate()
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	defer func() { _ = s.Close() }()
-	for _, k := range []string{KeyFor(credstore.ToolCFL), KeyFor(credstore.ToolJTK)} {
-		if ok, herr := s.HasToken(k); herr != nil || ok {
-			t.Fatalf("override key %s must be gone after unify; present=%v err=%v", k, ok, herr)
-		}
 	}
 }

--- a/shared/keyring/keyring_e2e_test.go
+++ b/shared/keyring/keyring_e2e_test.go
@@ -639,6 +639,16 @@ func TestMigration_ConcurrentWriter_IdenticalValue_Benign(t *testing.T) {
 	if strings.Contains(string(raw), "api_token") {
 		t.Fatalf("plaintext should still be scrubbed on the benign path:\n%s", raw)
 	}
+	// The consolidation is effective this run → the one-time notice
+	// fires (and never leaks the secret), even on the benign race path.
+	var nb bytes.Buffer
+	FlushMigrationNotice(&nb)
+	if nb.Len() == 0 {
+		t.Fatal("benign concurrent migration must still emit the notice")
+	}
+	if strings.Contains(nb.String(), secret) {
+		t.Fatalf("notice leaked the secret: %s", nb.String())
+	}
 }
 
 // Concurrent-writer race, DIVERGENT value: a writer sets api_token to a

--- a/shared/keyring/migrate.go
+++ b/shared/keyring/migrate.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	cccredstore "github.com/open-cli-collective/cli-common/credstore"
+
 	"github.com/open-cli-collective/atlassian-go/credstore"
 )
 
@@ -43,7 +45,7 @@ var deprecatedKeys = []string{"cfl_api_token", "jtk_api_token"} //nolint:gosec /
 var migrationAllowedKeys = append(append([]string{}, allowedKeys...), deprecatedKeys...)
 
 // ErrMigrationConflict is the stable identity for a §1.8 conflict.
-var ErrMigrationConflict = errors.New("keyring: legacy plaintext API token conflicts with the existing keyring value")
+var ErrMigrationConflict = errors.New("keyring: API token migration sources disagree")
 
 func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 	// ---- Phase 1: collect (no mutation) ----------------------------------
@@ -111,16 +113,41 @@ func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 	// ---- Phase 1: detect (pure) ------------------------------------------
 	plan, conflictLocs := planMigration(curAPI, srcLoc, overwrite)
 	if len(conflictLocs) > 0 {
+		// When an api_token already exists it is one of the disagreeing
+		// parties (source-vs-existing, or "and the keyring value too" in a
+		// multi-source split) — name it so the message isn't "divergence
+		// across" a single source.
+		if curAPI != "" {
+			conflictLocs = append(conflictLocs, "keyring "+KeyAPIToken+" ("+s.ref+")")
+			sort.Strings(conflictLocs)
+		}
 		return conflictError(conflictLocs, s.ref)
 	}
 
 	// ---- Phase 2: apply (only reached with zero conflicts) ---------------
 	changed := false
 	if plan.write {
-		if err := s.SetToken(KeyAPIToken, plan.value); err != nil {
+		switch err := s.setToken(KeyAPIToken, plan.value, overwrite); {
+		case err == nil:
+			changed = true
+		case !overwrite && errors.Is(err, cccredstore.ErrExists):
+			// A concurrent writer set api_token between the phase-1 read
+			// and now. Re-resolve and apply the same no-precedence rule:
+			// an identical value is benign (fall through to cleanup); any
+			// difference is a conflict naming the now-present keyring
+			// value — never silently clobber it.
+			cur, _, gerr := s.get(KeyAPIToken)
+			if gerr != nil {
+				return gerr
+			}
+			if cur != plan.value {
+				return conflictError(
+					append(sortedLocs(srcLoc), "keyring "+KeyAPIToken+" ("+s.ref+")"),
+					s.ref)
+			}
+		default:
 			return err
 		}
-		changed = true
 	}
 	for _, dk := range deprecatedKeys {
 		if _, ok := depPresent[dk]; ok {

--- a/shared/keyring/migrate.go
+++ b/shared/keyring/migrate.go
@@ -173,12 +173,14 @@ func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 			return err
 		}
 	}
+	removedDeprecated := false
 	for _, dk := range deprecatedKeys {
 		if _, ok := depPresent[dk]; ok {
 			if err := s.DeleteToken(dk); err != nil {
 				return fmt.Errorf("migrated to keyring %s but could not remove deprecated key %s: %w", s.ref, dk, err)
 			}
 			changed = true
+			removedDeprecated = true
 		}
 	}
 	if anyPlaintext {
@@ -199,9 +201,20 @@ func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 	}
 
 	if changed {
+		var cleaned string
+		switch {
+		case anyPlaintext && removedDeprecated:
+			cleaned = "; the legacy plaintext copy and deprecated per-tool keyring keys were removed"
+		case anyPlaintext:
+			cleaned = "; the legacy plaintext copy was removed"
+		case removedDeprecated:
+			cleaned = "; deprecated per-tool keyring keys were removed"
+		default:
+			cleaned = "" // benign concurrent path: nothing left to clean
+		}
 		recordMigration(fmt.Sprintf(
-			"atlassian-cli: consolidated the API token into the OS keyring %s (%s); any plaintext copy and deprecated per-tool keys were removed",
-			s.ref, KeyAPIToken))
+			"atlassian-cli: consolidated the API token into the OS keyring %s (%s)%s",
+			s.ref, KeyAPIToken, cleaned))
 	}
 	return nil
 }

--- a/shared/keyring/migrate.go
+++ b/shared/keyring/migrate.go
@@ -210,7 +210,12 @@ func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 		case removedDeprecated:
 			cleaned = "; deprecated per-tool keyring keys were removed"
 		default:
-			cleaned = "" // benign concurrent path: nothing left to clean
+			// Defensive only: changed=true with plan.write set implies a
+			// non-empty srcLoc, and every srcLoc source is either plaintext
+			// (anyPlaintext) or a deprecated key (removedDeprecated) — so
+			// this is unreachable today. Kept so a future source kind can't
+			// silently print a wrong cleanup clause.
+			cleaned = ""
 		}
 		recordMigration(fmt.Sprintf(
 			"atlassian-cli: consolidated the API token into the OS keyring %s (%s)%s",

--- a/shared/keyring/migrate.go
+++ b/shared/keyring/migrate.go
@@ -7,41 +7,46 @@ import (
 	"sort"
 	"strings"
 
-	cccredstore "github.com/open-cli-collective/cli-common/credstore"
-
 	"github.com/open-cli-collective/atlassian-go/credstore"
 )
 
-// One-time §1.8 migration (§2.x analog). The access secret is the
-// Atlassian api_token. Sources of a legacy plaintext token, in today's
-// persisted precedence (env is never persisted; the shared Store outranks
-// a legacy per-tool file):
+// One-time §1.8 migration. The access secret is the Atlassian api_token,
+// and there is exactly ONE keyring key for it (§1.11.10): jtk and cfl
+// share `api_token`. This migration unifies every legacy source onto that
+// one key:
 //
-//   - shared config.yml: Store.Default / Store.CFL / Store.JTK .APIToken
-//   - legacy cfl file (~/.config/cfl/config.yml)
-//   - legacy jtk file (os.UserConfigDir()/jira-ticket-cli/config.json)
+//   - legacy plaintext: shared config.yml (Default/CFL/JTK .APIToken) and
+//     the legacy per-tool files (cfl yml, jtk json);
+//   - deprecated keyring keys cfl_api_token / jtk_api_token left by an
+//     earlier build (B3 upgrade path: a user may hold ONLY these, with
+//     plaintext already scrubbed).
 //
-// The migrated value per scope is that scope's CURRENT EFFECTIVE token:
-//
-//   - api_token      <- Store.Default.APIToken
-//   - cfl_api_token  <- cfl's own-scope effective token, written ONLY when
-//     it is a genuine override (differs from the effective default and its
-//     source outranks the default). A legacy cfl FILE value shadowed by a
-//     non-empty shared Store value is dead data: scrubbed, never written,
-//     never a conflict. A value equal to the effective default is
-//     cleanup-only (no override key — writing it would pin cfl off future
-//     default changes).
-//   - jtk_api_token  <- symmetric.
-//
-// All plaintext token bytes are scrubbed afterwards (shared config.yml AND
-// the legacy files), whether or not they were written to a key. The only
-// fail-loud is a genuine EFFECTIVE value disagreeing with an existing
-// keyring value (cross-tool idempotency: equal => silent no-op + scrub).
+// Behavior (amended §1.8): collect every non-empty migration-source value;
+// if more than one DISTINCT value exists across all sources it is a hard
+// conflict (fail loud, name every source, never print a secret, never
+// precedence-pick). With exactly one distinct value it is compared to any
+// existing `api_token`: absent → write; equal → no-op; different →
+// conflict unless overwrite. All plaintext is scrubbed and both
+// deprecated keyring keys deleted afterwards. The whole thing is
+// strictly two-phase: collect + detect (pure, no mutation) THEN apply, so
+// a failed migration leaves every source untouched.
+
+// deprecatedKeys are the removed per-tool override keys. They are NOT in
+// allowedKeys (the §1.11.11 conforming bundle is exactly {api_token});
+// they exist only so this one-time migration and `config clear --all`
+// can read/delete residual B3 state. The migration store is opened with
+// migrationAllowedKeys so credstore permits Delete of these.
+var deprecatedKeys = []string{"cfl_api_token", "jtk_api_token"} //nolint:gosec // G101: bundle key names, not credentials
+
+// migrationAllowedKeys = allowedKeys ∪ deprecatedKeys. Used only by the
+// migration open and OpenForClearAll; runtime / OpenNoMigrate stay strict.
+var migrationAllowedKeys = append(append([]string{}, allowedKeys...), deprecatedKeys...)
 
 // ErrMigrationConflict is the stable identity for a §1.8 conflict.
 var ErrMigrationConflict = errors.New("keyring: legacy plaintext API token conflicts with the existing keyring value")
 
 func migrateLegacyOverwrite(s *Store, overwrite bool) error {
+	// ---- Phase 1: collect (no mutation) ----------------------------------
 	sharedPath := credstore.DefaultPath()
 	store, err := credstore.Load(sharedPath)
 	if err != nil {
@@ -60,77 +65,146 @@ func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 		return deferLegacyLoadErr(errJ)
 	}
 
-	want, locs, anyPlaintext := gatherEffective(store, legacyCFL, legacyJTK)
+	// Existing target value (NOT a migration source — it is the target).
+	curAPI, _, err := s.get(KeyAPIToken)
+	if err != nil {
+		return err
+	}
 
-	// Current keyring values for the allowlist.
-	current := map[string]string{}
-	for _, k := range allowedKeys {
-		if v, ok, gerr := s.get(k); gerr != nil {
+	// Migration sources: value -> sorted, de-duplicated locations.
+	srcLoc := map[string]map[string]struct{}{}
+	add := func(val, loc string) {
+		if val == "" {
+			return
+		}
+		if srcLoc[val] == nil {
+			srcLoc[val] = map[string]struct{}{}
+		}
+		srcLoc[val][loc] = struct{}{}
+	}
+	add(store.Default.APIToken, "shared config default ("+sharedPath+")")
+	add(store.CFL.APIToken, "shared cfl override ("+sharedPath+")")
+	add(store.JTK.APIToken, "shared jtk override ("+sharedPath+")")
+	if legacyCFL != nil {
+		add(legacyCFL.APIToken, "legacy cfl config ("+legacyCFL.Path+")")
+	}
+	if legacyJTK != nil {
+		add(legacyJTK.APIToken, "legacy jtk config ("+legacyJTK.Path+")")
+	}
+	depPresent := map[string]string{} // key -> value, for deletion in phase 2
+	for _, dk := range deprecatedKeys {
+		v, ok, gerr := s.get(dk)
+		if gerr != nil {
 			return gerr
-		} else if ok {
-			current[k] = v
+		}
+		if ok {
+			depPresent[dk] = v
+			add(v, "keyring deprecated key "+dk+" ("+s.ref+")")
 		}
 	}
 
-	toWrite, conflicts := planWrites(want, current, overwrite)
-	if len(conflicts) > 0 {
-		return conflictError(conflicts, locs, s.ref)
+	anyPlaintext := store.Default.APIToken != "" || store.CFL.APIToken != "" ||
+		store.JTK.APIToken != "" ||
+		(legacyCFL != nil && legacyCFL.APIToken != "") ||
+		(legacyJTK != nil && legacyJTK.APIToken != "")
+
+	// ---- Phase 1: detect (pure) ------------------------------------------
+	plan, conflictLocs := planMigration(curAPI, srcLoc, overwrite)
+	if len(conflictLocs) > 0 {
+		return conflictError(conflictLocs, s.ref)
 	}
 
-	if len(toWrite) > 0 {
-		// Only force-overwrite on the explicit overwrite path. On the
-		// normal path planWrites already excluded every key that exists
-		// with a different value (those are fail-loud conflicts); writing
-		// without WithOverwrite keeps that contract even against a key
-		// that appeared between the preflight read and here (TOCTOU) —
-		// the backend errors instead of silently clobbering it.
-		var opts []cccredstore.SetOpt
-		if overwrite {
-			opts = append(opts, cccredstore.WithOverwrite())
+	// ---- Phase 2: apply (only reached with zero conflicts) ---------------
+	changed := false
+	if plan.write {
+		if err := s.SetToken(KeyAPIToken, plan.value); err != nil {
+			return err
 		}
-		if _, err := s.cs.SetBundle(s.profile, toWrite, opts...); err != nil {
-			return fmt.Errorf("migrate API token to keyring %s: %w", s.ref, err)
+		changed = true
+	}
+	for _, dk := range deprecatedKeys {
+		if _, ok := depPresent[dk]; ok {
+			if err := s.DeleteToken(dk); err != nil {
+				return fmt.Errorf("migrated to keyring %s but could not remove deprecated key %s: %w", s.ref, dk, err)
+			}
+			changed = true
 		}
+	}
+	if anyPlaintext {
+		if err := scrubSharedStore(store, sharedPath); err != nil {
+			return fmt.Errorf("migrated to keyring %s but could not scrub %s: %w", s.ref, sharedPath, err)
+		}
+		if legacyCFL != nil && legacyCFL.APIToken != "" {
+			if err := scrubLegacyFile(cflPath); err != nil {
+				return fmt.Errorf("migrated to keyring %s but could not scrub %s: %w", s.ref, cflPath, err)
+			}
+		}
+		if legacyJTK != nil && legacyJTK.APIToken != "" {
+			if err := scrubLegacyFile(jtkPath); err != nil {
+				return fmt.Errorf("migrated to keyring %s but could not scrub %s: %w", s.ref, jtkPath, err)
+			}
+		}
+		changed = true
 	}
 
-	if !anyPlaintext {
-		return nil // steady state — nothing legacy on disk
-	}
-
-	// Scrub every plaintext source (whether or not it fed a key). Failure
-	// here is real: we wrote the keyring but could not remove the
-	// plaintext — surface it so the user knows the secret still lingers.
-	if err := scrubSharedStore(store, sharedPath); err != nil {
-		return fmt.Errorf("migrated to keyring %s but could not scrub %s: %w", s.ref, sharedPath, err)
-	}
-	// Scrub the legacy files via the SAME generic map round-trip
-	// `config clear` uses (scrubLegacyFile): it deletes only api_token
-	// and preserves every other key verbatim — including fields a user
-	// hand-added or a future schema introduces. A hardcoded
-	// field-allowlist rewrite would silently drop those during this
-	// one-time, irreversible migration.
-	if legacyCFL != nil && legacyCFL.APIToken != "" {
-		if err := scrubLegacyFile(cflPath); err != nil {
-			return fmt.Errorf("migrated to keyring %s but could not scrub %s: %w", s.ref, cflPath, err)
-		}
-	}
-	if legacyJTK != nil && legacyJTK.APIToken != "" {
-		if err := scrubLegacyFile(jtkPath); err != nil {
-			return fmt.Errorf("migrated to keyring %s but could not scrub %s: %w", s.ref, jtkPath, err)
-		}
-	}
-
-	if len(toWrite) > 0 {
-		keys := make([]string, 0, len(toWrite))
-		for k := range toWrite {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
+	if changed {
 		recordMigration(fmt.Sprintf(
-			"atlassian-cli: migrated the API token (%s) into the OS keyring %s; the plaintext copy was removed",
-			strings.Join(keys, ", "), s.ref))
+			"atlassian-cli: consolidated the API token into the OS keyring %s (%s); any plaintext copy and deprecated per-tool keys were removed",
+			s.ref, KeyAPIToken))
 	}
 	return nil
+}
+
+// migrationPlan is the pure decision: whether to write api_token and to
+// what value. Deletes/scrubs are unconditional in phase 2 (idempotent);
+// only the write is value-dependent.
+type migrationPlan struct {
+	write bool
+	value string
+}
+
+// planMigration is the pure §1.8 resolver over the collected sources.
+//   - >1 distinct source value           → conflict (every location).
+//   - exactly 1 distinct value v:
+//     curAPI == ""        → write v
+//     curAPI == v         → no write (cleanup/scrub only)
+//     curAPI != v         → conflict, unless overwrite (then write v)
+//   - 0 sources                           → no write (nothing to migrate)
+//
+// overwrite resolves source-vs-api_token ONLY; it never resolves a
+// >1-distinct-source conflict.
+func planMigration(curAPI string, srcLoc map[string]map[string]struct{}, overwrite bool) (migrationPlan, []string) {
+	if len(srcLoc) > 1 {
+		return migrationPlan{}, sortedLocs(srcLoc)
+	}
+	if len(srcLoc) == 0 {
+		return migrationPlan{}, nil
+	}
+	var v string
+	for val := range srcLoc {
+		v = val
+	}
+	switch {
+	case curAPI == "":
+		return migrationPlan{write: true, value: v}, nil
+	case curAPI == v:
+		return migrationPlan{}, nil
+	case overwrite:
+		return migrationPlan{write: true, value: v}, nil
+	default:
+		return migrationPlan{}, sortedLocs(srcLoc)
+	}
+}
+
+func sortedLocs(srcLoc map[string]map[string]struct{}) []string {
+	var locs []string
+	for _, set := range srcLoc {
+		for l := range set {
+			locs = append(locs, l)
+		}
+	}
+	sort.Strings(locs)
+	return locs
 }
 
 // deferLegacyLoadErr classifies ANY legacy-file load failure as
@@ -147,112 +221,14 @@ func deferLegacyLoadErr(err error) error {
 	return fmt.Errorf("%w: %w", credstore.ErrCorruptStore, err)
 }
 
-// gatherEffective computes the genuine per-scope key writes, a non-secret
-// location string per key (for conflict messages), and whether ANY
-// plaintext token existed anywhere (drives scrub even when every value is
-// shadowed/cleanup-only).
-func gatherEffective(store *credstore.Store, lc, lj *credstore.LegacyCreds) (want, locs map[string]string, anyPlaintext bool) {
-	want = map[string]string{}
-	locs = map[string]string{}
-
-	// Location strings name the concrete plaintext file so a conflict
-	// error tells the user exactly which file still holds a secret to
-	// remove/scrub — no separate diagnostic step.
-	sharedPath := credstore.DefaultPath()
-
-	effDefault := store.Default.APIToken
-	if effDefault != "" {
-		want[KeyAPIToken] = effDefault
-		locs[KeyAPIToken] = "shared config default (" + sharedPath + ")"
-	}
-
-	lcTok, ljTok := "", ""
-	lcPath, ljPath := "", ""
-	if lc != nil {
-		lcTok = lc.APIToken
-		lcPath = lc.Path
-	}
-	if lj != nil {
-		ljTok = lj.APIToken
-		ljPath = lj.Path
-	}
-	if effDefault != "" || store.CFL.APIToken != "" || store.JTK.APIToken != "" ||
-		lcTok != "" || ljTok != "" {
-		anyPlaintext = true
-	}
-
-	// cfl/jtk own-scope token under today's precedence, EXCLUDING the
-	// shared default (the default is its own key). The shared Store
-	// override outranks the legacy file, so a legacy-file value is only
-	// reachable when the Store override is empty AND no default shadows it.
-	cflOwn, cflLoc := firstNonEmptyLoc(
-		store.CFL.APIToken, "shared cfl override ("+sharedPath+")",
-		shadowed(lcTok, effDefault), "legacy cfl config ("+lcPath+")")
-	jtkOwn, jtkLoc := firstNonEmptyLoc(
-		store.JTK.APIToken, "shared jtk override ("+sharedPath+")",
-		shadowed(ljTok, effDefault), "legacy jtk config ("+ljPath+")")
-
-	if cflOwn != "" && cflOwn != effDefault {
-		want[KeyCFLAPIToken] = cflOwn
-		locs[KeyCFLAPIToken] = cflLoc
-	}
-	if jtkOwn != "" && jtkOwn != effDefault {
-		want[KeyJTKAPIToken] = jtkOwn
-		locs[KeyJTKAPIToken] = jtkLoc
-	}
-	return want, locs, anyPlaintext
-}
-
-// shadowed returns "" when a non-empty higher-precedence default exists
-// (the legacy-file value is dead data); otherwise it returns the value.
-func shadowed(legacyFileTok, effDefault string) string {
-	if effDefault != "" {
-		return ""
-	}
-	return legacyFileTok
-}
-
-func firstNonEmptyLoc(a, aLoc, b, bLoc string) (string, string) {
-	if a != "" {
-		return a, aLoc
-	}
-	if b != "" {
-		return b, bLoc
-	}
-	return "", ""
-}
-
-// planWrites is the pure §1.8 resolver: equal current value => idempotent
-// skip; differing current value => conflict (unless overwrite). Returns
-// only the keys to actually SetBundle.
-func planWrites(want, current map[string]string, overwrite bool) (toWrite map[string]string, conflicts []string) {
-	toWrite = map[string]string{}
-	for k, v := range want {
-		cur, present := current[k]
-		switch {
-		case !present:
-			toWrite[k] = v
-		case cur == v:
-			// already migrated — idempotent no-op (still scrub plaintext)
-		case overwrite:
-			toWrite[k] = v
-		default:
-			conflicts = append(conflicts, k)
-		}
-	}
-	sort.Strings(conflicts)
-	return toWrite, conflicts
-}
-
-// conflictError names the conflicting keys and their non-secret legacy
-// locations plus the keyring ref — never a value (§1.12).
-func conflictError(conflictKeys []string, locs map[string]string, ref string) error {
-	parts := make([]string, 0, len(conflictKeys))
-	for _, k := range conflictKeys {
-		parts = append(parts, fmt.Sprintf("%s (legacy %s vs keyring %s/%s)", k, locs[k], ref, k))
-	}
-	return fmt.Errorf("%w: %s; resolve by clearing one side (`config clear`, or remove/scrub the legacy plaintext file) then re-running",
-		ErrMigrationConflict, strings.Join(parts, ", "))
+// conflictError names every conflicting source location plus the keyring
+// ref — never a value (§1.12) — and points at the supported recovery
+// path now that per-tool `--key` is gone.
+func conflictError(locs []string, ref string) error {
+	return fmt.Errorf("%w: divergent API token values across %s; the migration will not pick a winner. "+
+		"Resolve by removing/scrubbing all but one source (or `config clear --all` then `set-credential` to start clean, "+
+		"or delete the conflicting entry from the OS keychain), then re-run. Keyring ref: %s",
+		ErrMigrationConflict, strings.Join(locs, ", "), ref)
 }
 
 // ---- plaintext scrub ------------------------------------------------------

--- a/shared/keyring/migrate.go
+++ b/shared/keyring/migrate.go
@@ -44,12 +44,18 @@ var deprecatedKeys = []string{"cfl_api_token", "jtk_api_token"} //nolint:gosec /
 // migration open and OpenForClearAll; runtime / OpenNoMigrate stay strict.
 var migrationAllowedKeys = append(append([]string{}, allowedKeys...), deprecatedKeys...)
 
-// migrationApplyHook is a white-box test seam (nil in production),
-// invoked once (with the in-flight store) after phase-1 detect and
-// before the phase-2 write — the only point at which a test can
-// deterministically simulate a concurrent api_token writer racing the
-// migration, writing through the SAME open handle (a second open would
-// lock-conflict on the file backend).
+// migrationApplyHook is a TEST-ONLY white-box seam (always nil in
+// production; the nil guard means zero production behavior). It cannot
+// live in a _test.go file because migrateLegacyOverwrite — production
+// code — references it. It is invoked once (with the in-flight store)
+// after phase-1 detect and before the phase-2 write: the only point at
+// which a test can deterministically simulate a concurrent api_token
+// writer racing the migration, writing through the SAME open handle (a
+// second open would lock-conflict on the file backend).
+//
+// It has no mutex by design: it MUST never be set from a parallel test.
+// The tests that set it use the hermetic harness (t.Setenv), which is
+// already incompatible with t.Parallel(), so this holds structurally.
 var migrationApplyHook func(s *Store)
 
 // ErrMigrationConflict is the stable identity for a §1.8 conflict.
@@ -159,6 +165,10 @@ func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 					append(sortedLocs(srcLoc), "keyring "+KeyAPIToken+" ("+s.ref+")"),
 					s.ref)
 			}
+			// Identical value: the racer committed exactly what we would
+			// have. The §1.8 consolidation IS effective this run (the
+			// notice should fire even with nothing left to scrub/delete).
+			changed = true
 		default:
 			return err
 		}

--- a/shared/keyring/migrate.go
+++ b/shared/keyring/migrate.go
@@ -44,6 +44,14 @@ var deprecatedKeys = []string{"cfl_api_token", "jtk_api_token"} //nolint:gosec /
 // migration open and OpenForClearAll; runtime / OpenNoMigrate stay strict.
 var migrationAllowedKeys = append(append([]string{}, allowedKeys...), deprecatedKeys...)
 
+// migrationApplyHook is a white-box test seam (nil in production),
+// invoked once (with the in-flight store) after phase-1 detect and
+// before the phase-2 write — the only point at which a test can
+// deterministically simulate a concurrent api_token writer racing the
+// migration, writing through the SAME open handle (a second open would
+// lock-conflict on the file backend).
+var migrationApplyHook func(s *Store)
+
 // ErrMigrationConflict is the stable identity for a §1.8 conflict.
 var ErrMigrationConflict = errors.New("keyring: API token migration sources disagree")
 
@@ -125,6 +133,12 @@ func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 	}
 
 	// ---- Phase 2: apply (only reached with zero conflicts) ---------------
+	// Test seam: lets a white-box test create api_token AFTER phase-1's
+	// read but BEFORE the write, deterministically exercising the
+	// concurrent-writer ErrExists reconciliation below. nil in production.
+	if migrationApplyHook != nil {
+		migrationApplyHook(s)
+	}
 	changed := false
 	if plan.write {
 		switch err := s.setToken(KeyAPIToken, plan.value, overwrite); {

--- a/shared/keyring/migrate_test.go
+++ b/shared/keyring/migrate_test.go
@@ -1,176 +1,93 @@
 package keyring
 
 import (
+	"errors"
+	"sort"
 	"strings"
 	"testing"
-
-	"github.com/open-cli-collective/atlassian-go/credstore"
 )
 
-// planWrites is the pure §1.8 resolver. The matrix below is the explicit
-// list from the plan: idempotent equals, fail-loud differs, overwrite.
-func TestPlanWrites_Matrix(t *testing.T) {
+// src builds the {value -> location-set} map planMigration consumes.
+func src(pairs ...[2]string) map[string]map[string]struct{} {
+	m := map[string]map[string]struct{}{}
+	for _, p := range pairs {
+		val, loc := p[0], p[1]
+		if m[val] == nil {
+			m[val] = map[string]struct{}{}
+		}
+		m[val][loc] = struct{}{}
+	}
+	return m
+}
+
+func TestPlanMigration(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name      string
-		want      map[string]string
-		current   map[string]string
+		curAPI    string
+		srcLoc    map[string]map[string]struct{}
 		overwrite bool
-		wantWrite map[string]string
-		wantConf  []string
+		wantWrite bool
+		wantVal   string
+		wantConf  bool
 	}{
-		{
-			name:      "empty",
-			want:      map[string]string{},
-			current:   map[string]string{},
-			wantWrite: map[string]string{},
-		},
-		{
-			name:      "fresh write (absent in keyring)",
-			want:      map[string]string{KeyAPIToken: "t"},
-			current:   map[string]string{},
-			wantWrite: map[string]string{KeyAPIToken: "t"},
-		},
-		{
-			name:      "equal value is idempotent no-op",
-			want:      map[string]string{KeyAPIToken: "t"},
-			current:   map[string]string{KeyAPIToken: "t"},
-			wantWrite: map[string]string{},
-		},
-		{
-			name:     "different value is a fail-loud conflict",
-			want:     map[string]string{KeyAPIToken: "new"},
-			current:  map[string]string{KeyAPIToken: "old"},
-			wantConf: []string{KeyAPIToken},
-		},
-		{
-			name:      "overwrite forces a differing value",
-			want:      map[string]string{KeyAPIToken: "new"},
-			current:   map[string]string{KeyAPIToken: "old"},
-			overwrite: true,
-			wantWrite: map[string]string{KeyAPIToken: "new"},
-		},
-		{
-			name:      "multi-key: one fresh, one equal, one conflict",
-			want:      map[string]string{KeyAPIToken: "a", KeyCFLAPIToken: "b", KeyJTKAPIToken: "c"},
-			current:   map[string]string{KeyCFLAPIToken: "b", KeyJTKAPIToken: "x"},
-			wantWrite: map[string]string{KeyAPIToken: "a"},
-			wantConf:  []string{KeyJTKAPIToken},
-		},
+		{name: "nothing to migrate", srcLoc: src()},
+		{name: "single source, api_token absent -> write",
+			srcLoc: src([2]string{"T", "legacy cfl"}), wantWrite: true, wantVal: "T"},
+		{name: "single source equals existing api_token -> no-op (cleanup only)",
+			curAPI: "T", srcLoc: src([2]string{"T", "legacy cfl"})},
+		{name: "single source differs from api_token -> conflict",
+			curAPI: "OLD", srcLoc: src([2]string{"NEW", "legacy cfl"}), wantConf: true},
+		{name: "single source differs, --overwrite resolves",
+			curAPI: "OLD", srcLoc: src([2]string{"NEW", "legacy cfl"}), overwrite: true,
+			wantWrite: true, wantVal: "NEW"},
+		{name: "two distinct sources -> hard conflict",
+			srcLoc:   src([2]string{"A", "legacy cfl"}, [2]string{"B", "legacy jtk"}),
+			wantConf: true},
+		{name: "two distinct sources, --overwrite still conflicts (never picks)",
+			srcLoc:    src([2]string{"A", "legacy cfl"}, [2]string{"B", "keyring deprecated key cfl_api_token"}),
+			overwrite: true, wantConf: true},
+		{name: "same value from many sources collapses to one -> write",
+			srcLoc:    src([2]string{"S", "shared default"}, [2]string{"S", "legacy jtk"}),
+			wantWrite: true, wantVal: "S"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			gotWrite, gotConf := planWrites(tc.want, tc.current, tc.overwrite)
-			if len(gotWrite) != len(tc.wantWrite) {
-				t.Fatalf("toWrite=%v want %v", gotWrite, tc.wantWrite)
+			plan, conflicts := planMigration(tc.curAPI, tc.srcLoc, tc.overwrite)
+			if (len(conflicts) > 0) != tc.wantConf {
+				t.Fatalf("conflict=%v, want %v (locs=%v)", len(conflicts) > 0, tc.wantConf, conflicts)
 			}
-			for k, v := range tc.wantWrite {
-				if gotWrite[k] != v {
-					t.Fatalf("toWrite[%s]=%q want %q", k, gotWrite[k], v)
-				}
+			if plan.write != tc.wantWrite {
+				t.Fatalf("write=%v, want %v", plan.write, tc.wantWrite)
 			}
-			if strings.Join(gotConf, ",") != strings.Join(tc.wantConf, ",") {
-				t.Fatalf("conflicts=%v want %v", gotConf, tc.wantConf)
+			if plan.write && plan.value != tc.wantVal {
+				t.Fatalf("value=%q, want %q", plan.value, tc.wantVal)
+			}
+			// Plan-then-apply invariant: a conflict must never also
+			// request a write (no mutation when the picture is ambiguous).
+			if tc.wantConf && plan.write {
+				t.Fatal("conflict must not also request a write")
 			}
 		})
 	}
 }
 
-func lc(path, tok string) *credstore.LegacyCreds {
-	return &credstore.LegacyCreds{Path: path, APIToken: tok}
-}
-
-// gatherEffective maps today's persisted precedence to per-scope keys.
-func TestGatherEffective_Mapping(t *testing.T) {
-	t.Parallel()
-
-	t.Run("empty everywhere", func(t *testing.T) {
-		t.Parallel()
-		want, _, any := gatherEffective(&credstore.Store{}, nil, nil)
-		if len(want) != 0 || any {
-			t.Fatalf("want empty, anyPlaintext=false; got %v %v", want, any)
-		}
-	})
-
-	t.Run("shared default only", func(t *testing.T) {
-		t.Parallel()
-		st := &credstore.Store{Default: credstore.Section{APIToken: "D"}}
-		want, _, any := gatherEffective(st, nil, nil)
-		if want[KeyAPIToken] != "D" || len(want) != 1 || !any {
-			t.Fatalf("got %v any=%v", want, any)
-		}
-	})
-
-	t.Run("cfl legacy file only -> cfl override (no default shadows it)", func(t *testing.T) {
-		t.Parallel()
-		want, _, any := gatherEffective(&credstore.Store{}, lc("/cfl", "C"), nil)
-		if want[KeyCFLAPIToken] != "C" || !any {
-			t.Fatalf("got %v any=%v", want, any)
-		}
-	})
-
-	t.Run("jtk legacy file only -> jtk override", func(t *testing.T) {
-		t.Parallel()
-		want, _, _ := gatherEffective(&credstore.Store{}, nil, lc("/jtk", "J"))
-		if want[KeyJTKAPIToken] != "J" {
-			t.Fatalf("got %v", want)
-		}
-	})
-
-	t.Run("shared Store.CFL override differing from default is a real override", func(t *testing.T) {
-		t.Parallel()
-		st := &credstore.Store{
-			Default: credstore.Section{APIToken: "D"},
-			CFL:     credstore.ToolSection{Section: credstore.Section{APIToken: "C"}},
-		}
-		want, _, _ := gatherEffective(st, nil, nil)
-		if want[KeyAPIToken] != "D" || want[KeyCFLAPIToken] != "C" {
-			t.Fatalf("got %v", want)
-		}
-	})
-
-	t.Run("legacy cfl file shadowed by shared default is scrub-only", func(t *testing.T) {
-		t.Parallel()
-		st := &credstore.Store{Default: credstore.Section{APIToken: "D"}}
-		want, _, any := gatherEffective(st, lc("/cfl", "shadowed"), nil)
-		if _, ok := want[KeyCFLAPIToken]; ok {
-			t.Fatalf("shadowed legacy must not be written: %v", want)
-		}
-		if want[KeyAPIToken] != "D" || !any {
-			t.Fatalf("got %v any=%v (anyPlaintext must be true so the dead file is scrubbed)", want, any)
-		}
-	})
-
-	t.Run("tool value equal to effective default is cleanup-only", func(t *testing.T) {
-		t.Parallel()
-		st := &credstore.Store{
-			Default: credstore.Section{APIToken: "D"},
-			CFL:     credstore.ToolSection{Section: credstore.Section{APIToken: "D"}},
-		}
-		want, _, _ := gatherEffective(st, nil, nil)
-		if _, ok := want[KeyCFLAPIToken]; ok {
-			t.Fatalf("equal-to-default must not pin an override: %v", want)
-		}
-	})
-}
-
-// conflictError must name keys + non-secret locations + ref, never the
-// secret value (§1.12).
+// conflictError names every source location and never the secret value.
 func TestConflictError_NoSecretLeak(t *testing.T) {
 	t.Parallel()
-	err := conflictError(
-		[]string{KeyAPIToken},
-		//nolint:gosec // G101: a non-secret location label, not a credential
-		map[string]string{KeyAPIToken: "shared config default"},
-		Ref,
-	)
-	msg := err.Error()
-	if strings.Contains(msg, "SUPER-SECRET") {
-		t.Fatalf("conflict error leaked a value: %s", msg)
+	const secretVal = "TOK-do-not-leak" //nolint:gosec // G101: test fixture string, not a real credential
+	locs := []string{"legacy cfl config (/x/cfl.yml)", "keyring deprecated key jtk_api_token (atlassian-cli/default)"}
+	sort.Strings(locs)
+	err := conflictError(locs, "atlassian-cli/default")
+	if !errors.Is(err, ErrMigrationConflict) {
+		t.Fatalf("want ErrMigrationConflict, got %v", err)
 	}
-	if !strings.Contains(msg, KeyAPIToken) || !strings.Contains(msg, Ref) {
-		t.Fatalf("conflict error missing key/ref: %s", msg)
+	msg := err.Error()
+	if !strings.Contains(msg, "legacy cfl config (/x/cfl.yml)") || !strings.Contains(msg, "jtk_api_token") {
+		t.Fatalf("conflict error must name every source location: %q", msg)
+	}
+	if strings.Contains(msg, secretVal) {
+		t.Fatal("conflict error leaked the secret value")
 	}
 }

--- a/shared/keyring/ref.go
+++ b/shared/keyring/ref.go
@@ -26,29 +26,19 @@ const (
 	// string-split by hand.
 	Ref = Service + "/" + Profile
 
-	// KeyAPIToken is the shared/default API token bundle key.
+	// KeyAPIToken is the single shared API token bundle key. There is
+	// one key per logical credential (Secret-Handling Standard §1.11.10);
+	// jtk and cfl resolve the same api_token. There are no per-tool
+	// override keys.
 	KeyAPIToken = "api_token" //nolint:gosec // G101: a bundle key name, not a credential
-	// KeyCFLAPIToken / KeyJTKAPIToken are the per-tool override keys.
-	KeyCFLAPIToken = "cfl_api_token" //nolint:gosec // G101: a bundle key name, not a credential
-	KeyJTKAPIToken = "jtk_api_token" //nolint:gosec // G101: a bundle key name, not a credential
 
-	// ToolCFL / ToolJTK identify the calling tool for per-tool resolution.
+	// ToolCFL / ToolJTK identify the calling tool for the unchanged
+	// per-tool env-var selection only (§ envVarsFor); the keyring key is
+	// shared regardless of tool.
 	ToolCFL = "cfl"
 	ToolJTK = "jtk"
 )
 
-// allowedKeys is the §1.5.2 allowlist: exactly the three token keys.
-var allowedKeys = []string{KeyAPIToken, KeyCFLAPIToken, KeyJTKAPIToken}
-
-// KeyFor returns the per-tool override key for a tool, or "" for an
-// unknown tool (callers fall back to KeyAPIToken).
-func KeyFor(tool string) string {
-	switch tool {
-	case ToolCFL:
-		return KeyCFLAPIToken
-	case ToolJTK:
-		return KeyJTKAPIToken
-	default:
-		return ""
-	}
-}
+// allowedKeys is the §1.5.2 allowlist and the §1.11.11 conforming bundle
+// key set: exactly the one shared token key.
+var allowedKeys = []string{KeyAPIToken}

--- a/shared/keyring/resolve.go
+++ b/shared/keyring/resolve.go
@@ -56,8 +56,6 @@ const (
 	SourceNone   TokenSource = "unset"
 	SourceEnv    TokenSource = "environment"
 	SourceKeyAPI TokenSource = "keyring (api_token)"
-	SourceKeyCFL TokenSource = "keyring (cfl_api_token)"
-	SourceKeyJTK TokenSource = "keyring (jtk_api_token)"
 )
 
 // envVarsFor returns the ordered API-token env vars for a tool: the
@@ -83,17 +81,6 @@ func envToken(tool string) (string, bool) {
 	return "", false
 }
 
-func sourceForKey(tool string) TokenSource {
-	switch KeyFor(tool) {
-	case KeyCFLAPIToken:
-		return SourceKeyCFL
-	case KeyJTKAPIToken:
-		return SourceKeyJTK
-	default:
-		return SourceKeyAPI
-	}
-}
-
 // ResolveToken is the RUNTIME token resolver (API commands, `config test`,
 // `init` credential need): env wins; otherwise the keyring is opened with
 // the one-time §1.8 migration (Open) and the effective key is read. Env
@@ -117,12 +104,12 @@ func ResolveToken(tool string) (string, TokenSource, error) {
 				return "", SourceNone, nerr
 			}
 			defer func() { _ = ns.Close() }()
-			return resolveFromStore(ns, tool)
+			return resolveFromStore(ns)
 		}
 		return "", SourceNone, err
 	}
 	defer func() { _ = s.Close() }()
-	return resolveFromStore(s, tool)
+	return resolveFromStore(s)
 }
 
 // ResolveTokenNoMigrate is the DIAGNOSTIC resolver (`config show` source
@@ -137,19 +124,12 @@ func ResolveTokenNoMigrate(tool string) (string, TokenSource, error) {
 		return "", SourceNone, err
 	}
 	defer func() { _ = s.Close() }()
-	return resolveFromStore(s, tool)
+	return resolveFromStore(s)
 }
 
-func resolveFromStore(s *Store, tool string) (string, TokenSource, error) {
-	// Per-tool override key first, then the shared default — surfacing the
-	// real source for the diagnostic column.
-	if k := KeyFor(tool); k != "" {
-		if v, ok, err := s.get(k); err != nil {
-			return "", SourceNone, err
-		} else if ok {
-			return v, sourceForKey(tool), nil
-		}
-	}
+// resolveFromStore reads the single shared api_token. One key per logical
+// credential (§1.11.10): jtk and cfl resolve the same key.
+func resolveFromStore(s *Store) (string, TokenSource, error) {
 	if v, ok, err := s.get(KeyAPIToken); err != nil {
 		return "", SourceNone, err
 	} else if ok {

--- a/shared/keyring/setcredential.go
+++ b/shared/keyring/setcredential.go
@@ -5,28 +5,22 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"slices"
 	"strings"
 )
 
 // SetCredential is the §Ingress write logic, kept here (a pure library)
 // so each tool only needs a thin cobra wrapper — shared/ never imports
 // cobra. It reads the token from envVar (when non-empty) else from in,
-// trims surrounding whitespace, refuses an empty value, validates the
-// key against the bundle allowlist, and stores it in the one canonical
-// shared bundle (the ref is a compile-time constant — there is no
-// user-facing ref: runtime resolution, migration, show, and clear all
-// target the same bundle, so storing elsewhere would be unreadable).
+// trims surrounding whitespace, refuses an empty value, and stores it as
+// the single shared api_token in the one canonical bundle (the ref is a
+// compile-time constant and there is one key per logical credential —
+// §1.11.10 — so there is no key or ref to choose: runtime resolution,
+// migration, show, and clear all target the same bundle).
 //
 // The token is never echoed: it is read, trimmed, and written; no caller
 // branch logs or returns it. The one-time §1.8 migration runs first so a
 // pre-existing legacy token cannot later collide.
-func SetCredential(in io.Reader, key, envVar string) (err error) {
-	if !slices.Contains(allowedKeys, key) {
-		return fmt.Errorf("unknown credential key %q (allowed: %s)",
-			key, strings.Join(allowedKeys, ", "))
-	}
-
+func SetCredential(in io.Reader, envVar string) (err error) {
 	var raw string
 	if strings.TrimSpace(envVar) != "" {
 		v, ok := os.LookupEnv(envVar)
@@ -67,5 +61,5 @@ func SetCredential(in io.Reader, key, envVar string) (err error) {
 			err = fmt.Errorf("set-credential: close keyring %s: %w", s.ref, cerr)
 		}
 	}()
-	return s.SetToken(key, token)
+	return s.SetToken(KeyAPIToken, token)
 }

--- a/tools/cfl/CLAUDE.md
+++ b/tools/cfl/CLAUDE.md
@@ -142,7 +142,7 @@ Variables are checked in precedence order (first match wins):
 |---------|------------|
 | URL | `CFL_URL` → `ATLASSIAN_URL` → shared `cfl` override → shared `default` → legacy config |
 | Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → shared `cfl` → shared `default` → legacy |
-| API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `cfl_api_token` → keyring `api_token` (OS keyring, **not** the config file) |
+| API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `api_token` (single shared key; OS keyring, **not** the config file) |
 | Default Space | `CFL_DEFAULT_SPACE` → shared `cfl.default_space` → legacy |
 | Auth Method | `CFL_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `cfl` → shared `default` → legacy → `"basic"` |
 | Cloud ID | `CFL_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `cfl` → shared `default` → legacy |

--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -550,10 +550,10 @@ cfl config test
 
 #### `cfl config clear`
 
-Remove cfl's resolved token key from the OS keyring (`cfl_api_token` if a
-cfl override exists, otherwise the shared `api_token` — you are warned
-when clearing the shared key, since jtk also uses it). `--all` removes the
-entire shared bundle plus the non-secret config file and scrubs any
+Remove the single shared `api_token` from the OS keyring — you are warned
+that jtk loses access too, since both tools resolve the same key. `--all`
+removes the entire shared bundle (including any deprecated per-tool keys
+left by an older build) plus the non-secret config file and scrubs any
 surviving legacy plaintext files; `--all` still cleans the plaintext
 artifacts even when the keyring itself cannot be opened (the recovery
 path).
@@ -820,7 +820,7 @@ Environment variables override file-based config. Variables are checked in order
 |---------|-------------------------------|
 | URL | `CFL_URL` → `ATLASSIAN_URL` → shared `cfl` override → shared `default` → legacy file |
 | Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → shared `cfl` → shared `default` → legacy |
-| API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `cfl_api_token` → keyring `api_token` (OS keyring, never a plaintext file) |
+| API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `api_token` (single shared key; OS keyring, never a plaintext file) |
 | Default Space | `CFL_DEFAULT_SPACE` → shared `cfl.default_space` → legacy |
 | Auth Method | `CFL_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared → legacy → `basic` |
 | Cloud ID | `CFL_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared → legacy |

--- a/tools/cfl/cmd/cfl/main_test.go
+++ b/tools/cfl/cmd/cfl/main_test.go
@@ -12,19 +12,28 @@ import (
 	"github.com/open-cli-collective/atlassian-go/credtest"
 )
 
-// unreachableURL binds an ephemeral port and immediately closes it, so a
-// dial to the returned URL is refused fast and deterministically on any
-// host (unlike port 9, which a running discard service would accept and
-// stall).
+// unreachableURL returns a URL whose dial fails fast and
+// deterministically on any host: the listener stays bound for the test's
+// lifetime (no close-then-rebind TOCTOU) but every accepted connection is
+// closed immediately, so the HTTP client gets an instant EOF/reset
+// instead of a port-9-style stall or a spurious success.
 func unreachableURL(t *testing.T) string {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	addr := l.Addr().String()
-	_ = l.Close()
-	return "http://" + addr
+	go func() {
+		for {
+			c, aerr := l.Accept()
+			if aerr != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	t.Cleanup(func() { _ = l.Close() })
+	return "http://" + l.Addr().String()
 }
 
 // §1.11.6 acceptance: these tests invoke the REAL cfl entrypoint (this

--- a/tools/cfl/cmd/cfl/main_test.go
+++ b/tools/cfl/cmd/cfl/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +11,21 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/credtest"
 )
+
+// unreachableURL binds an ephemeral port and immediately closes it, so a
+// dial to the returned URL is refused fast and deterministically on any
+// host (unlike port 9, which a running discard service would accept and
+// stall).
+func unreachableURL(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+	return "http://" + addr
+}
 
 // §1.11.6 acceptance: these tests invoke the REAL cfl entrypoint (this
 // package's main(), re-executed as a subprocess) on a migrating
@@ -119,8 +135,8 @@ func TestEntrypoint_PlaintextMigration_Exit0(t *testing.T) {
 // flushes the notice to stderr before os.Exit.
 func TestEntrypoint_Migration_SurvivesNonZeroExit(t *testing.T) {
 	dir := credtest.Hermetic(t)
-	// Port 9 (discard) refuses fast → `me` fails after migration ran.
-	writeLegacyShared(t, dir, "http://127.0.0.1:9", legacyTok)
+	// Closed ephemeral port → `me` fails fast after migration ran.
+	writeLegacyShared(t, dir, unreachableURL(t), legacyTok)
 
 	stderr, code := runCLI(t, dir, "", "me")
 	if code == 0 {

--- a/tools/cfl/cmd/cfl/main_test.go
+++ b/tools/cfl/cmd/cfl/main_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/credtest"
+)
+
+// §1.11.6 acceptance: these tests invoke the REAL cfl entrypoint (this
+// package's main(), re-executed as a subprocess) on a migrating
+// invocation and assert the one-time §1.8 notice reaches stderr —
+// crucially even when the command then exits non-zero, since main()
+// flushes the notice before os.Exit. They also pin §1.11.11: after a
+// successful migration the keyring bundle key set is exactly {api_token}
+// (no deprecated per-tool keys survive), including the B3 upgrade path.
+//
+// `_migration` JSON signal is not applicable for atlassian-cli command
+// paths today (no command emits a structured migration envelope), so it
+// is intentionally not asserted here.
+
+// migrationLine is the stable substring recordMigration writes; it never
+// contains the secret (asserted below).
+const migrationLine = "consolidated the API token into the OS keyring"
+
+// entrypointEnv re-execs this test binary as the real cfl CLI.
+const entrypointEnv = "CFL_ENTRYPOINT_TEST"
+
+func TestMain(m *testing.M) {
+	if os.Getenv(entrypointEnv) == "1" {
+		// Subprocess: behave exactly as the installed cfl binary. main()
+		// reads os.Args (the CLI args we exec with) and calls os.Exit, so
+		// the testing framework's flag parsing is never reached.
+		main()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+// runCLI re-execs the test binary as cfl with args, in a hermetic
+// HOME/XDG rooted at dir and the encrypted-file keyring backend. It
+// returns stderr and the process exit code.
+func runCLI(t *testing.T, dir string, stdin string, args ...string) (stderr string, code int) {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := exec.Command(exe, args...) //nolint:gosec // G204: exe is this test binary
+	cmd.Env = append(os.Environ(),
+		entrypointEnv+"=1",
+		"HOME="+dir,
+		"XDG_CONFIG_HOME="+dir,
+		"ATLASSIAN_CLI_KEYRING_BACKEND=file",
+		"ATLASSIAN_CLI_KEYRING_PASSPHRASE=credtest-passphrase",
+		// Token/URL env must not shadow the keyring or the fixture file.
+		"ATLASSIAN_API_TOKEN=", "CFL_API_TOKEN=", "JIRA_API_TOKEN=",
+		"ATLASSIAN_URL=", "CFL_URL=",
+	)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	var errBuf bytes.Buffer
+	cmd.Stdout = &bytes.Buffer{}
+	cmd.Stderr = &errBuf
+	_ = cmd.Run()
+	return errBuf.String(), cmd.ProcessState.ExitCode()
+}
+
+func writeLegacyShared(t *testing.T, dir, url, token string) string {
+	t.Helper()
+	p := filepath.Join(dir, "atlassian-cli", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "default:\n  url: " + url + "\n  email: u@e\n  api_token: " + token + "\n"
+	if err := os.WriteFile(p, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+//nolint:gosec // G101: test fixture token, not a real credential
+const legacyTok = "LEGACY-entrypoint-TOK"
+
+// Plaintext migration via the real entrypoint, exit 0: set-credential
+// opens the keyring (running the §1.8 migration on the seeded legacy
+// plaintext), the notice reaches stderr, the plaintext is scrubbed, and
+// the bundle is exactly {api_token}.
+func TestEntrypoint_PlaintextMigration_Exit0(t *testing.T) {
+	dir := credtest.Hermetic(t)
+	shared := writeLegacyShared(t, dir, "https://acme.atlassian.net", legacyTok)
+
+	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n", "set-credential")
+	if code != 0 {
+		t.Fatalf("set-credential should exit 0; got %d\nstderr:\n%s", code, stderr)
+	}
+	if !strings.Contains(stderr, migrationLine) {
+		t.Fatalf("migration notice missing from stderr:\n%s", stderr)
+	}
+	if strings.Contains(stderr, legacyTok) {
+		t.Fatalf("stderr leaked the secret: %s", stderr)
+	}
+	if got := credtest.BundleKeys(t); strings.Join(got, ",") != "api_token" {
+		t.Fatalf("§1.11.11: bundle key set = %v, want exactly [api_token]", got)
+	}
+	raw, _ := os.ReadFile(shared) //nolint:gosec // G304: test reads its own temp file
+	if strings.Contains(string(raw), "api_token") {
+		t.Fatalf("legacy plaintext not scrubbed:\n%s", raw)
+	}
+}
+
+// The migration signal must survive a non-zero exit: a migrating
+// invocation whose subsequent command fails (unreachable URL) still
+// flushes the notice to stderr before os.Exit.
+func TestEntrypoint_Migration_SurvivesNonZeroExit(t *testing.T) {
+	dir := credtest.Hermetic(t)
+	// Port 9 (discard) refuses fast → `me` fails after migration ran.
+	writeLegacyShared(t, dir, "http://127.0.0.1:9", legacyTok)
+
+	stderr, code := runCLI(t, dir, "", "me")
+	if code == 0 {
+		t.Fatalf("me against an unreachable URL must exit non-zero\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, migrationLine) {
+		t.Fatalf("migration notice must be flushed BEFORE the non-zero exit:\n%s", stderr)
+	}
+	if strings.Contains(stderr, legacyTok) {
+		t.Fatalf("stderr leaked the secret: %s", stderr)
+	}
+}
+
+// B3 upgrade fixture via the real entrypoint: a user holding ONLY the
+// deprecated per-tool keyring keys (no plaintext) is consolidated onto
+// the single api_token, the deprecated keys are deleted, and the bundle
+// is exactly {api_token}.
+func TestEntrypoint_B3UpgradeFixture_DeprecatedKeysOnly(t *testing.T) {
+	dir := credtest.Hermetic(t)
+	credtest.SeedDeprecatedKey(t, "cfl_api_token", legacyTok)
+	credtest.SeedDeprecatedKey(t, "jtk_api_token", legacyTok)
+
+	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n", "set-credential")
+	if code != 0 {
+		t.Fatalf("set-credential should exit 0; got %d\nstderr:\n%s", code, stderr)
+	}
+	if !strings.Contains(stderr, migrationLine) {
+		t.Fatalf("B3 upgrade must emit the migration notice:\n%s", stderr)
+	}
+	if got := credtest.BundleKeys(t); strings.Join(got, ",") != "api_token" {
+		t.Fatalf("§1.11.11: B3 upgrade must leave exactly [api_token]; got %v", got)
+	}
+}

--- a/tools/cfl/cmd/cfl/main_test.go
+++ b/tools/cfl/cmd/cfl/main_test.go
@@ -92,7 +92,13 @@ func runCLI(t *testing.T, dir string, stdin string, args ...string) (stderr stri
 	var errBuf bytes.Buffer
 	cmd.Stdout = &bytes.Buffer{}
 	cmd.Stderr = &errBuf
-	_ = cmd.Run()
+	runErr := cmd.Run()
+	// A nil ProcessState means the subprocess never started (exec
+	// failure) — a test-infra error, not a CLI exit. Fail loud rather
+	// than panic in ExitCode().
+	if cmd.ProcessState == nil {
+		t.Fatalf("subprocess did not start: %v", runErr)
+	}
 	return errBuf.String(), cmd.ProcessState.ExitCode()
 }
 

--- a/tools/cfl/internal/cmd/configcmd/clear.go
+++ b/tools/cfl/internal/cmd/configcmd/clear.go
@@ -140,10 +140,10 @@ func runClear(opts *clearOptions) error {
 	}
 
 	_, _ = fmt.Fprintf(opts.Stderr, "This will delete key %q from keyring %s.\n", plan.ToolKey, plan.Ref)
-	if plan.SharedDefault {
-		_, _ = fmt.Fprintln(opts.Stderr,
-			"Warning: this is the SHARED token (api_token). jtk will also lose access (cfl and jtk resolve the same key).")
-	}
+	// One key per logical credential (§1.11.10): the only deletable key
+	// is the shared api_token, so clearing it always deauths the sibling.
+	_, _ = fmt.Fprintln(opts.Stderr,
+		"Warning: this is the SHARED token (api_token). jtk will also lose access (cfl and jtk resolve the same key).")
 	ok, cerr := confirm("Proceed?")
 	if cerr != nil {
 		return cerr

--- a/tools/cfl/internal/cmd/configcmd/clear.go
+++ b/tools/cfl/internal/cmd/configcmd/clear.go
@@ -66,7 +66,7 @@ func runClear(opts *clearOptions) error {
 	// store the delete/clear step reuses (no second passphrase prompt).
 	// The env + plaintext-file fields are populated even when the keyring
 	// cannot be opened, so `--all` can still clean plaintext artifacts.
-	plan, store, err := keyring.PlanClear(credstore.ToolCFL)
+	plan, store, err := keyring.PlanClear(credstore.ToolCFL, opts.all)
 	if store != nil {
 		defer func() { _ = store.Close() }()
 	}

--- a/tools/cfl/internal/cmd/configcmd/clear.go
+++ b/tools/cfl/internal/cmd/configcmd/clear.go
@@ -32,10 +32,9 @@ func newClearCmd(opts *root.Options) *cobra.Command {
 		Short: "Clear the stored Atlassian API token from the OS keyring",
 		Long: `Remove the stored API token from the OS keyring.
 
-By default this deletes only the key cfl resolves to: cfl_api_token if a
-cfl-specific override exists, otherwise the shared api_token (which jtk
-also uses — you will be warned). The exact ref and key are previewed
-before deletion.
+By default this deletes the single shared api_token (cfl and jtk
+resolve the same key, so jtk also loses access — you will be warned).
+The exact ref and key are previewed before deletion.
 
 Use --all to remove the ENTIRE shared bundle plus the shared non-secret
 config file and scrub any surviving legacy plaintext files.
@@ -143,7 +142,7 @@ func runClear(opts *clearOptions) error {
 	_, _ = fmt.Fprintf(opts.Stderr, "This will delete key %q from keyring %s.\n", plan.ToolKey, plan.Ref)
 	if plan.SharedDefault {
 		_, _ = fmt.Fprintln(opts.Stderr,
-			"Warning: this is the SHARED token (api_token). jtk will also lose access. Use a cfl_api_token override if you want cfl-only credentials.")
+			"Warning: this is the SHARED token (api_token). jtk will also lose access (cfl and jtk resolve the same key).")
 	}
 	ok, cerr := confirm("Proceed?")
 	if cerr != nil {

--- a/tools/cfl/internal/cmd/configcmd/clear_test.go
+++ b/tools/cfl/internal/cmd/configcmd/clear_test.go
@@ -63,6 +63,9 @@ func TestRunClear_DeletesSharedKey_Confirmed(t *testing.T) {
 	// the single shared api_token and warns the sibling loses access.
 	testutil.False(t, tokenPresent(t, keyring.KeyAPIToken))
 	testutil.Contains(t, errBuf.String(), "jtk will also lose access")
+	// Removed per-tool override keys must never be advised again.
+	testutil.NotContains(t, errBuf.String(), "cfl_api_token")
+	testutil.NotContains(t, errBuf.String(), "override")
 }
 
 func TestRunClear_Cancelled(t *testing.T) {

--- a/tools/cfl/internal/cmd/configcmd/clear_test.go
+++ b/tools/cfl/internal/cmd/configcmd/clear_test.go
@@ -66,6 +66,9 @@ func TestRunClear_DeletesSharedKey_Confirmed(t *testing.T) {
 	// Removed per-tool override keys must never be advised again.
 	testutil.NotContains(t, errBuf.String(), "cfl_api_token")
 	testutil.NotContains(t, errBuf.String(), "override")
+	// §1.11.11 via the REAL command flow: exactly empty (no stray
+	// deprecated key survives a default clear).
+	testutil.Equal(t, 0, len(credtest.BundleKeys(t)))
 }
 
 func TestRunClear_Cancelled(t *testing.T) {

--- a/tools/cfl/internal/cmd/configcmd/clear_test.go
+++ b/tools/cfl/internal/cmd/configcmd/clear_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -43,7 +42,7 @@ func TestRunClear_NothingToClear(t *testing.T) {
 
 func TestRunClear_DeletesSharedKey_WithForce(t *testing.T) {
 	credtest.Hermetic(t)
-	credtest.SeedToken(t, keyring.KeyAPIToken, "shared-secret")
+	credtest.SeedToken(t, "shared-secret")
 
 	opts, _, errBuf := newClearOpts(true, "")
 	testutil.RequireNoError(t, runClear(opts))
@@ -53,23 +52,22 @@ func TestRunClear_DeletesSharedKey_WithForce(t *testing.T) {
 	testutil.Contains(t, errBuf.String(), "jtk will also lose access")
 }
 
-func TestRunClear_DeletesCFLOverride_Confirmed(t *testing.T) {
+func TestRunClear_DeletesSharedKey_Confirmed(t *testing.T) {
 	credtest.Hermetic(t)
-	credtest.SeedToken(t, keyring.KeyAPIToken, "shared-secret")
-	credtest.SeedToken(t, keyring.KeyFor(credstore.ToolCFL), "cfl-secret")
+	credtest.SeedToken(t, "shared-secret")
 
 	opts, _, errBuf := newClearOpts(false, "y\n")
 	testutil.RequireNoError(t, runClear(opts))
 
-	// Only cfl's override is removed; the shared default survives.
-	testutil.False(t, tokenPresent(t, keyring.KeyFor(credstore.ToolCFL)))
-	testutil.True(t, tokenPresent(t, keyring.KeyAPIToken))
-	testutil.Contains(t, errBuf.String(), "cfl_api_token")
+	// One key per logical credential (§1.11.10): a confirmed clear removes
+	// the single shared api_token and warns the sibling loses access.
+	testutil.False(t, tokenPresent(t, keyring.KeyAPIToken))
+	testutil.Contains(t, errBuf.String(), "jtk will also lose access")
 }
 
 func TestRunClear_Cancelled(t *testing.T) {
 	credtest.Hermetic(t)
-	credtest.SeedToken(t, keyring.KeyAPIToken, "shared-secret")
+	credtest.SeedToken(t, "shared-secret")
 
 	opts, _, _ := newClearOpts(false, "n\n")
 	testutil.RequireNoError(t, runClear(opts))
@@ -79,7 +77,7 @@ func TestRunClear_Cancelled(t *testing.T) {
 
 func TestRunClear_All(t *testing.T) {
 	xdg := credtest.Hermetic(t)
-	credtest.SeedToken(t, keyring.KeyAPIToken, "shared-secret")
+	credtest.SeedToken(t, "shared-secret")
 
 	sharedPath := filepath.Join(xdg, "atlassian-cli", "config.yml")
 	testutil.RequireNoError(t, os.MkdirAll(filepath.Dir(sharedPath), 0o700))

--- a/tools/cfl/internal/cmd/configcmd/show_test.go
+++ b/tools/cfl/internal/cmd/configcmd/show_test.go
@@ -15,7 +15,7 @@ import (
 // the token value (or any slice of it), even with a token configured.
 func TestRunShow_TokenPresenceNoLeak(t *testing.T) {
 	credtest.Hermetic(t)
-	credtest.SeedToken(t, keyring.KeyAPIToken, "SUPER-SECRET-show-token")
+	credtest.SeedToken(t, "SUPER-SECRET-show-token")
 
 	out, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
 	opts := &root.Options{Output: "table", NoColor: true, Stdout: out, Stderr: errBuf}

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -114,22 +114,15 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	cfg := result.prefill
 
 	// The up-front EnsureMigrated relocates any legacy plaintext token into
-	// the keyring and scrubs the file, so detectAndReconcile (which reads
-	// the now-scrubbed legacy/config files) leaves prefill.APIToken empty
-	// even though the token still exists. Backfill it from the keyring so a
-	// returning user isn't forced to re-enter a token that was just
-	// migrated. For an explicit "use X for both tools" mismatch choice,
-	// resolve the CHOSEN tool's token (migration moved each differing
-	// legacy token to its own per-tool key), not the current tool's, so
-	// the unify uses the token the user picked. NoMigrate: migration
-	// already ran above. Value stays password-masked in the form (same
-	// ingress as before); never displayed.
+	// the single shared keyring api_token and scrubs the file, so
+	// detectAndReconcile (which reads the now-scrubbed legacy/config files)
+	// leaves prefill.APIToken empty even though the token still exists.
+	// Backfill it from the keyring so a returning user isn't forced to
+	// re-enter a token that was just migrated. NoMigrate: migration already
+	// ran above. Value stays password-masked in the form (same ingress as
+	// before); never displayed.
 	if cfg.APIToken == "" {
-		backfillTool := credstore.ToolCFL
-		if result.unifyBoth && result.unifySource != "" {
-			backfillTool = result.unifySource
-		}
-		if tok, _, terr := keyring.ResolveTokenNoMigrate(backfillTool); terr == nil {
+		if tok, _, terr := keyring.ResolveTokenNoMigrate(credstore.ToolCFL); terr == nil {
 			cfg.APIToken = tok
 		}
 	}
@@ -305,19 +298,10 @@ func finalizeInit(
 	}
 
 	// The token never lands in the plaintext store (Save strips it) — it
-	// goes to the OS keyring under the key matching the write target
-	// (shared default → api_token; cfl override → cfl_api_token), clearing
-	// any stale per-tool override that would otherwise shadow a default
-	// write so the tool resolves exactly what was just saved. An explicit
-	// "use X for both tools" mismatch choice unifies: api_token + clear
-	// BOTH overrides so the sibling switches too.
-	persist := func() error {
-		if result.unifyBoth {
-			return keyring.PersistUnifiedToken(cfg.APIToken)
-		}
-		return keyring.PersistTokenForTool(credstore.ToolCFL, result.target == writeCFLOverride, cfg.APIToken)
-	}
-	if err := persist(); err != nil {
+	// goes to the OS keyring under the single shared api_token (§1.11.10:
+	// one key for both jtk and cfl; the reconcile write-target governs
+	// only NON-secret placement, untouched here).
+	if err := keyring.PersistToken(cfg.APIToken); err != nil {
 		v.Error("Saved the non-secret config to %s, but could not store the API token in the keyring: %v", sharedPath, err)
 		v.Error("Recover by storing just the token (no need to re-run init): `cfl set-credential` (reads stdin or --from-env VAR).")
 		return err

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -162,8 +162,11 @@ func TestFinalizeInit_WritesToCorrectSection(t *testing.T) {
 		target  writeTarget
 		wantKey string
 	}{
+		// One key per logical credential (§1.11.10): the token always
+		// lands under the single shared api_token; writeTarget governs
+		// only NON-secret placement (default vs cfl section).
 		{"default", writeDefault, keyring.KeyAPIToken},
-		{"cfl_override", writeCFLOverride, keyring.KeyFor(credstore.ToolCFL)},
+		{"cfl_override", writeCFLOverride, keyring.KeyAPIToken},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -20,7 +20,7 @@ func hasUsableCreds(store *credstore.Store, tool string) (bool, error) {
 	if !store.HasUsableConfig(tool) {
 		return false, nil
 	}
-	return keyring.HasTokenForTool(tool)
+	return keyring.HasToken()
 }
 
 // writeTarget tells the post-form save logic which section of the
@@ -49,14 +49,6 @@ type reconcileResult struct {
 	// is currently reading from. Set when reuse=yes was chosen on a
 	// shared store that already had usable creds.
 	affectsSibling bool
-	// unifyBoth is set by the explicit mismatch choice "use <tool>'s
-	// credentials for both tools". It tells the save path to persist the
-	// chosen token as the shared api_token AND clear BOTH per-tool
-	// override keys, so neither tool stays shadowed on its old token.
-	// unifySource is the tool whose token was chosen (credstore.ToolCFL /
-	// ToolJTK); the command layer resolves THAT tool's keyring token.
-	unifyBoth   bool
-	unifySource string
 }
 
 // detectAndReconcile decides what to do given whatever configs already
@@ -278,20 +270,18 @@ func resultFromMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds, choice stri
 		store.CFL.Section = credstore.Section{}
 		store.JTK.Section = credstore.Section{}
 		var cfg *config.Config
-		chosenTool := credstore.ToolCFL
 		if choice == "use_cfl" {
 			cfg = configFromLegacy(cflLegacy)
 		} else {
 			cfg = configFromLegacy(jtkLegacy)
 			cfg.DefaultSpace = cflLegacy.DefaultSpace
 			cfg.OutputFormat = cflLegacy.OutputFormat
-			chosenTool = credstore.ToolJTK
 		}
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-		// Signal the cross-tool unify; the command layer (init.go) does the
-		// keyring resolve+persist. reconcile.go stays keyring-free so it
-		// remains unit-testable without OS-keychain isolation.
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed, unifyBoth: true, unifySource: chosenTool}
+		// Non-secret connection reconcile only. The token is now a single
+		// shared key: divergent legacy tokens are caught by the keyring
+		// migration (fail-loud §1.8), not chosen here.
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
 	case "keep_different":
 		// Both tools land in their override sections so the split is
 		// stable: store.Default stays empty, cfl reads its override,

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -315,10 +315,6 @@ func TestResultFromMismatch_UseCFL_ClearsStaleJTKOverride(t *testing.T) {
 	testutil.Equal(t, "", r.store.CFL.URL)
 	testutil.Equal(t, "", r.store.CFL.APIToken)
 	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
-	// Signals the command layer to unify on cfl's keyring token and clear
-	// both per-tool override keys.
-	testutil.Equal(t, true, r.unifyBoth)
-	testutil.Equal(t, credstore.ToolCFL, r.unifySource)
 }
 
 // Symmetric to UseCFL_ClearsStaleJTKOverride: use_jtk also clears
@@ -344,8 +340,6 @@ func TestResultFromMismatch_UseJTK_ClearsBothOverrides(t *testing.T) {
 	testutil.Equal(t, "", r.store.JTK.URL)
 	testutil.Equal(t, "", r.store.JTK.APIToken)
 	testutil.Equal(t, "STALE", r.store.CFL.DefaultSpace) // per-tool default survives
-	testutil.Equal(t, true, r.unifyBoth)
-	testutil.Equal(t, credstore.ToolJTK, r.unifySource) // unify on jtk's token
 }
 
 func TestResultFromMismatch_UseJTK_PreservesCFLDefaults(t *testing.T) {
@@ -377,9 +371,6 @@ func TestResultFromMismatch_KeepDifferent(t *testing.T) {
 	testutil.Equal(t, "jtk-tok", r.store.JTK.APIToken)
 	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
 	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
-	// keep_different keeps per-tool overrides — it is NOT a unify action.
-	testutil.Equal(t, false, r.unifyBoth)
-	testutil.Equal(t, "", r.unifySource)
 	if !strings.Contains(stdout.String(), "Keeping per-tool credentials") {
 		t.Errorf("expected keep-different note; got: %s", stdout.String())
 	}

--- a/tools/cfl/internal/cmd/setcredential/setcredential.go
+++ b/tools/cfl/internal/cmd/setcredential/setcredential.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
@@ -16,7 +15,7 @@ import (
 
 // Register adds the set-credential command to the root command.
 func Register(rootCmd *cobra.Command, opts *root.Options) {
-	var fromEnv, key string
+	var fromEnv string
 
 	cmd := &cobra.Command{
 		Use:   "set-credential",
@@ -24,23 +23,15 @@ func Register(rootCmd *cobra.Command, opts *root.Options) {
 		Long: `Store the Atlassian API token in the OS keyring (non-interactive).
 
 The token is read from stdin, or from an environment variable with
---from-env. It is never echoed. The default key (api_token) is the
-shared token used by both cfl and jtk; use --key cfl_api_token to set a
-cfl-only override. This command cannot write jtk's override key (cfl
-would never read it) — use jtk set-credential for that.`,
+--from-env. It is never echoed. There is one shared token (api_token)
+used by both cfl and jtk.`,
 		Example: `  # From a secrets manager, into the shared bundle
   op read op://vault/atlassian/token | cfl set-credential
 
-  # From an environment variable, cfl-only override
-  cfl set-credential --from-env CFL_API_TOKEN --key cfl_api_token`,
+  # From an environment variable
+  cfl set-credential --from-env CFL_API_TOKEN`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			// Restrict to keys cfl actually resolves — writing the
-			// sibling's override key would store a token cfl never reads.
-			if key != keyring.KeyAPIToken && key != keyring.KeyFor(credstore.ToolCFL) {
-				return fmt.Errorf("invalid --key %q for cfl (allowed: %s, %s)",
-					key, keyring.KeyAPIToken, keyring.KeyFor(credstore.ToolCFL))
-			}
-			if err := keyring.SetCredential(opts.Stdin, key, fromEnv); err != nil {
+			if err := keyring.SetCredential(opts.Stdin, fromEnv); err != nil {
 				return err
 			}
 			_, _ = fmt.Fprintln(opts.Stderr, "API token stored in the OS keyring.")
@@ -49,7 +40,6 @@ would never read it) — use jtk set-credential for that.`,
 	}
 
 	cmd.Flags().StringVar(&fromEnv, "from-env", "", "Read the token from this environment variable instead of stdin")
-	cmd.Flags().StringVar(&key, "key", keyring.KeyAPIToken, "Bundle key: api_token (shared) or cfl_api_token (cfl-only override)")
 
 	rootCmd.AddCommand(cmd)
 }

--- a/tools/cfl/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/cfl/internal/cmd/setcredential/setcredential_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -31,26 +30,8 @@ func TestSetCredential_StdinStoresToKeyring(t *testing.T) {
 	s, err := keyring.OpenNoMigrate()
 	testutil.RequireNoError(t, err)
 	defer func() { _ = s.Close() }()
-	got, ok, err := s.Token(credstore.ToolCFL)
+	got, ok, err := s.Token()
 	testutil.RequireNoError(t, err)
 	testutil.True(t, ok)
 	testutil.Equal(t, "cfl-wrapper-token", got)
-}
-
-// cfl must refuse the sibling's override key (storing it would leave a
-// token cfl never resolves).
-func TestSetCredential_RejectsSiblingKey(t *testing.T) {
-	credtest.Hermetic(t)
-
-	opts := &root.Options{
-		Stdin:  strings.NewReader("x\n"),
-		Stdout: &bytes.Buffer{},
-		Stderr: &bytes.Buffer{},
-	}
-	rootCmd := &cobra.Command{Use: "cfl"}
-	Register(rootCmd, opts)
-	rootCmd.SetArgs([]string{"set-credential", "--key", keyring.KeyJTKAPIToken})
-	if err := rootCmd.Execute(); err == nil {
-		t.Fatal("expected cfl set-credential --key jtk_api_token to be rejected")
-	}
 }

--- a/tools/jtk/CLAUDE.md
+++ b/tools/jtk/CLAUDE.md
@@ -181,7 +181,7 @@ Variables are checked in precedence order (first match wins):
 |---------|------------|
 | URL | `JIRA_URL` → `ATLASSIAN_URL` → shared `jtk` override → shared `default` → legacy config → `JIRA_DOMAIN` |
 | Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → shared `jtk` → shared `default` → legacy |
-| API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `jtk_api_token` → keyring `api_token` (OS keyring, **not** the config file) |
+| API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `api_token` (single shared key; OS keyring, **not** the config file) |
 | Default Project | `JIRA_DEFAULT_PROJECT` → shared `jtk.default_project` → legacy |
 | Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `jtk` → shared `default` → legacy → `"basic"` |
 | Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `jtk` → shared `default` → legacy |

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -1629,7 +1629,7 @@ token non-interactively: `jtk set-credential` (reads stdin or
 
 Legacy per-tool config keeps working indefinitely (Linux: `~/.config/jira-ticket-cli/config.json`; macOS: `~/Library/Application Support/jira-ticket-cli/config.json`). The first command auto-migrates any pre-existing plaintext token into the keyring and scrubs the plaintext in place.
 
-Run `jtk config show` to inspect the resolved values, including the keyring ref, backend, and whether a token is configured (the token value itself is never displayed). Token/keyring reporting is authoritative; the non-secret rows reflect env + the legacy per-tool file only, so a value set solely in the shared store appears as "-" there even though jtk uses it at runtime. `jtk config clear` removes the tool's resolved key; `jtk config clear --all` removes the whole bundle plus the non-secret config file.
+Run `jtk config show` to inspect the resolved values, including the keyring ref, backend, and whether a token is configured (the token value itself is never displayed). Token/keyring reporting is authoritative; the non-secret rows reflect env + the legacy per-tool file only, so a value set solely in the shared store appears as "-" there even though jtk uses it at runtime. `jtk config clear` removes the single shared `api_token` (warning that cfl loses access too, since both tools resolve the same key); `jtk config clear --all` removes the whole bundle (including any deprecated per-tool keys) plus the non-secret config file.
 
 ### Environment Variables
 
@@ -1639,7 +1639,7 @@ Environment variables override file-based config. Variables are checked in order
 |---------|-------------------------------|
 | URL | `JIRA_URL` → `ATLASSIAN_URL` → shared `jtk` override → shared `default` → legacy → `JIRA_DOMAIN` |
 | Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → shared `jtk` → shared `default` → legacy |
-| API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `jtk_api_token` → keyring `api_token` (OS keyring, never a plaintext file) |
+| API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `api_token` (single shared key; OS keyring, never a plaintext file) |
 | Default Project | `JIRA_DEFAULT_PROJECT` → shared `jtk.default_project` → legacy |
 | Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared → legacy → `basic` |
 | Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared → legacy |

--- a/tools/jtk/cmd/jtk/main_test.go
+++ b/tools/jtk/cmd/jtk/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +11,21 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/credtest"
 )
+
+// unreachableURL binds an ephemeral port and immediately closes it, so a
+// dial to the returned URL is refused fast and deterministically on any
+// host (unlike port 9, which a running discard service would accept and
+// stall).
+func unreachableURL(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+	return "http://" + addr
+}
 
 // §1.11.6 acceptance: these tests invoke the REAL jtk entrypoint (this
 // package's main(), re-executed as a subprocess) on a migrating
@@ -103,7 +119,8 @@ func TestEntrypoint_PlaintextMigration_Exit0(t *testing.T) {
 
 func TestEntrypoint_Migration_SurvivesNonZeroExit(t *testing.T) {
 	dir := credtest.Hermetic(t)
-	writeLegacyShared(t, dir, "http://127.0.0.1:9", legacyTok)
+	// Closed ephemeral port → `me` fails fast after migration ran.
+	writeLegacyShared(t, dir, unreachableURL(t), legacyTok)
 
 	stderr, code := runCLI(t, dir, "", "me")
 	if code == 0 {

--- a/tools/jtk/cmd/jtk/main_test.go
+++ b/tools/jtk/cmd/jtk/main_test.go
@@ -12,19 +12,28 @@ import (
 	"github.com/open-cli-collective/atlassian-go/credtest"
 )
 
-// unreachableURL binds an ephemeral port and immediately closes it, so a
-// dial to the returned URL is refused fast and deterministically on any
-// host (unlike port 9, which a running discard service would accept and
-// stall).
+// unreachableURL returns a URL whose dial fails fast and
+// deterministically on any host: the listener stays bound for the test's
+// lifetime (no close-then-rebind TOCTOU) but every accepted connection is
+// closed immediately, so the HTTP client gets an instant EOF/reset
+// instead of a port-9-style stall or a spurious success.
 func unreachableURL(t *testing.T) string {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	addr := l.Addr().String()
-	_ = l.Close()
-	return "http://" + addr
+	go func() {
+		for {
+			c, aerr := l.Accept()
+			if aerr != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	t.Cleanup(func() { _ = l.Close() })
+	return "http://" + l.Addr().String()
 }
 
 // §1.11.6 acceptance: these tests invoke the REAL jtk entrypoint (this

--- a/tools/jtk/cmd/jtk/main_test.go
+++ b/tools/jtk/cmd/jtk/main_test.go
@@ -83,7 +83,13 @@ func runCLI(t *testing.T, dir string, stdin string, args ...string) (stderr stri
 	var errBuf bytes.Buffer
 	cmd.Stdout = &bytes.Buffer{}
 	cmd.Stderr = &errBuf
-	_ = cmd.Run()
+	runErr := cmd.Run()
+	// A nil ProcessState means the subprocess never started (exec
+	// failure) — a test-infra error, not a CLI exit. Fail loud rather
+	// than panic in ExitCode().
+	if cmd.ProcessState == nil {
+		t.Fatalf("subprocess did not start: %v", runErr)
+	}
 	return errBuf.String(), cmd.ProcessState.ExitCode()
 }
 

--- a/tools/jtk/cmd/jtk/main_test.go
+++ b/tools/jtk/cmd/jtk/main_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/credtest"
+)
+
+// §1.11.6 acceptance: these tests invoke the REAL jtk entrypoint (this
+// package's main(), re-executed as a subprocess) on a migrating
+// invocation and assert the one-time §1.8 notice reaches stderr —
+// crucially even when the command then exits non-zero, since main()
+// flushes the notice before os.Exit. They also pin §1.11.11: after a
+// successful migration the keyring bundle key set is exactly {api_token}
+// (no deprecated per-tool keys survive), including the B3 upgrade path.
+//
+// `_migration` JSON signal is not applicable for atlassian-cli command
+// paths today (no command emits a structured migration envelope), so it
+// is intentionally not asserted here.
+
+const migrationLine = "consolidated the API token into the OS keyring"
+
+const entrypointEnv = "JTK_ENTRYPOINT_TEST"
+
+func TestMain(m *testing.M) {
+	if os.Getenv(entrypointEnv) == "1" {
+		// Subprocess: behave exactly as the installed jtk binary.
+		main()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func runCLI(t *testing.T, dir string, stdin string, args ...string) (stderr string, code int) {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := exec.Command(exe, args...) //nolint:gosec // G204: exe is this test binary
+	cmd.Env = append(os.Environ(),
+		entrypointEnv+"=1",
+		"HOME="+dir,
+		"XDG_CONFIG_HOME="+dir,
+		"ATLASSIAN_CLI_KEYRING_BACKEND=file",
+		"ATLASSIAN_CLI_KEYRING_PASSPHRASE=credtest-passphrase",
+		"ATLASSIAN_API_TOKEN=", "JIRA_API_TOKEN=", "CFL_API_TOKEN=",
+		"ATLASSIAN_URL=", "JIRA_URL=",
+	)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	var errBuf bytes.Buffer
+	cmd.Stdout = &bytes.Buffer{}
+	cmd.Stderr = &errBuf
+	_ = cmd.Run()
+	return errBuf.String(), cmd.ProcessState.ExitCode()
+}
+
+func writeLegacyShared(t *testing.T, dir, url, token string) string {
+	t.Helper()
+	p := filepath.Join(dir, "atlassian-cli", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "default:\n  url: " + url + "\n  email: u@e\n  api_token: " + token + "\n"
+	if err := os.WriteFile(p, []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+//nolint:gosec // G101: test fixture token, not a real credential
+const legacyTok = "LEGACY-entrypoint-TOK"
+
+func TestEntrypoint_PlaintextMigration_Exit0(t *testing.T) {
+	dir := credtest.Hermetic(t)
+	shared := writeLegacyShared(t, dir, "https://acme.atlassian.net", legacyTok)
+
+	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n", "set-credential")
+	if code != 0 {
+		t.Fatalf("set-credential should exit 0; got %d\nstderr:\n%s", code, stderr)
+	}
+	if !strings.Contains(stderr, migrationLine) {
+		t.Fatalf("migration notice missing from stderr:\n%s", stderr)
+	}
+	if strings.Contains(stderr, legacyTok) {
+		t.Fatalf("stderr leaked the secret: %s", stderr)
+	}
+	if got := credtest.BundleKeys(t); strings.Join(got, ",") != "api_token" {
+		t.Fatalf("§1.11.11: bundle key set = %v, want exactly [api_token]", got)
+	}
+	raw, _ := os.ReadFile(shared) //nolint:gosec // G304: test reads its own temp file
+	if strings.Contains(string(raw), "api_token") {
+		t.Fatalf("legacy plaintext not scrubbed:\n%s", raw)
+	}
+}
+
+func TestEntrypoint_Migration_SurvivesNonZeroExit(t *testing.T) {
+	dir := credtest.Hermetic(t)
+	writeLegacyShared(t, dir, "http://127.0.0.1:9", legacyTok)
+
+	stderr, code := runCLI(t, dir, "", "me")
+	if code == 0 {
+		t.Fatalf("me against an unreachable URL must exit non-zero\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, migrationLine) {
+		t.Fatalf("migration notice must be flushed BEFORE the non-zero exit:\n%s", stderr)
+	}
+	if strings.Contains(stderr, legacyTok) {
+		t.Fatalf("stderr leaked the secret: %s", stderr)
+	}
+}
+
+func TestEntrypoint_B3UpgradeFixture_DeprecatedKeysOnly(t *testing.T) {
+	dir := credtest.Hermetic(t)
+	credtest.SeedDeprecatedKey(t, "cfl_api_token", legacyTok)
+	credtest.SeedDeprecatedKey(t, "jtk_api_token", legacyTok)
+
+	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n", "set-credential")
+	if code != 0 {
+		t.Fatalf("set-credential should exit 0; got %d\nstderr:\n%s", code, stderr)
+	}
+	if !strings.Contains(stderr, migrationLine) {
+		t.Fatalf("B3 upgrade must emit the migration notice:\n%s", stderr)
+	}
+	if got := credtest.BundleKeys(t); strings.Join(got, ",") != "api_token" {
+		t.Fatalf("§1.11.11: B3 upgrade must leave exactly [api_token]; got %v", got)
+	}
+}

--- a/tools/jtk/internal/cmd/configcmd/configcmd.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd.go
@@ -196,10 +196,10 @@ func runClear(ctx context.Context, opts *clearOptions) error {
 	}
 
 	fmt.Fprintf(opts.Stderr, "This will delete key %q from keyring %s.\n", plan.ToolKey, plan.Ref)
-	if plan.SharedDefault {
-		fmt.Fprintln(opts.Stderr,
-			"Warning: this is the SHARED token (api_token). cfl will also lose access (jtk and cfl resolve the same key).")
-	}
+	// One key per logical credential (§1.11.10): the only deletable key
+	// is the shared api_token, so clearing it always deauths the sibling.
+	fmt.Fprintln(opts.Stderr,
+		"Warning: this is the SHARED token (api_token). cfl will also lose access (jtk and cfl resolve the same key).")
 	ok, cerr := confirm("Proceed?")
 	if cerr != nil {
 		return cerr

--- a/tools/jtk/internal/cmd/configcmd/configcmd.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd.go
@@ -86,10 +86,9 @@ func newClearCmd(opts *root.Options) *cobra.Command {
 		Short: "Clear the stored Atlassian API token from the OS keyring",
 		Long: `Remove the stored API token from the OS keyring.
 
-By default this deletes only the key jtk resolves to: jtk_api_token if a
-jtk-specific override exists, otherwise the shared api_token (which cfl
-also uses — you will be warned). The exact ref and key are previewed
-before deletion.
+By default this deletes the single shared api_token (jtk and cfl
+resolve the same key, so cfl also loses access — you will be warned).
+The exact ref and key are previewed before deletion.
 
 Use --all to remove the ENTIRE shared bundle plus the shared non-secret
 config file and scrub any surviving legacy plaintext files.
@@ -199,7 +198,7 @@ func runClear(ctx context.Context, opts *clearOptions) error {
 	fmt.Fprintf(opts.Stderr, "This will delete key %q from keyring %s.\n", plan.ToolKey, plan.Ref)
 	if plan.SharedDefault {
 		fmt.Fprintln(opts.Stderr,
-			"Warning: this is the SHARED token (api_token). cfl will also lose access. Use a jtk_api_token override if you want jtk-only credentials.")
+			"Warning: this is the SHARED token (api_token). cfl will also lose access (jtk and cfl resolve the same key).")
 	}
 	ok, cerr := confirm("Proceed?")
 	if cerr != nil {

--- a/tools/jtk/internal/cmd/configcmd/configcmd.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd.go
@@ -122,7 +122,7 @@ func runClear(ctx context.Context, opts *clearOptions) error {
 	// store the delete/clear step reuses (no second passphrase prompt).
 	// The env + plaintext-file fields are populated even when the keyring
 	// cannot be opened, so `--all` can still clean plaintext artifacts.
-	plan, store, err := keyring.PlanClear(credstore.ToolJTK)
+	plan, store, err := keyring.PlanClear(credstore.ToolJTK, opts.all)
 	if store != nil {
 		defer func() { _ = store.Close() }()
 	}

--- a/tools/jtk/internal/cmd/configcmd/configcmd_test.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd_test.go
@@ -195,6 +195,9 @@ func TestRunClear_DeletesSharedKey_Confirmed(t *testing.T) {
 	// Removed per-tool override keys must never be advised again.
 	testutil.NotContains(t, errBuf.String(), "jtk_api_token")
 	testutil.NotContains(t, errBuf.String(), "override")
+	// §1.11.11 via the REAL command flow: exactly empty (no stray
+	// deprecated key survives a default clear).
+	testutil.Equal(t, 0, len(credtest.BundleKeys(t)))
 }
 
 func TestRunClear_Cancelled(t *testing.T) {

--- a/tools/jtk/internal/cmd/configcmd/configcmd_test.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -53,7 +52,7 @@ func TestShowCmd_TableOutput(t *testing.T) {
 
 func TestRunClear_All(t *testing.T) {
 	xdg := credtest.Hermetic(t)
-	credtest.SeedToken(t, keyring.KeyAPIToken, "shared-secret")
+	credtest.SeedToken(t, "shared-secret")
 
 	sharedPath := filepath.Join(xdg, "atlassian-cli", "config.yml")
 	testutil.RequireNoError(t, os.MkdirAll(filepath.Dir(sharedPath), 0o700))
@@ -186,7 +185,7 @@ func jtkTokenPresent(t *testing.T, key string) bool {
 
 func TestRunClear_DeletesSharedKey_Confirmed(t *testing.T) {
 	credtest.Hermetic(t)
-	credtest.SeedToken(t, keyring.KeyAPIToken, "shared-secret")
+	credtest.SeedToken(t, "shared-secret")
 
 	opts, _, errBuf := newClearOpts(t, false, "y\n")
 	testutil.RequireNoError(t, runClear(context.Background(), opts))
@@ -197,7 +196,7 @@ func TestRunClear_DeletesSharedKey_Confirmed(t *testing.T) {
 
 func TestRunClear_Cancelled(t *testing.T) {
 	credtest.Hermetic(t)
-	credtest.SeedToken(t, keyring.KeyAPIToken, "shared-secret")
+	credtest.SeedToken(t, "shared-secret")
 
 	opts, _, _ := newClearOpts(t, false, "n\n")
 	testutil.RequireNoError(t, runClear(context.Background(), opts))
@@ -205,17 +204,16 @@ func TestRunClear_Cancelled(t *testing.T) {
 	testutil.True(t, jtkTokenPresent(t, keyring.KeyAPIToken))
 }
 
-func TestRunClear_Force_DeletesJTKOverride(t *testing.T) {
+func TestRunClear_Force_DeletesSharedKey(t *testing.T) {
 	credtest.Hermetic(t)
-	credtest.SeedToken(t, keyring.KeyAPIToken, "shared-secret")
-	credtest.SeedToken(t, keyring.KeyFor(credstore.ToolJTK), "jtk-secret")
+	credtest.SeedToken(t, "shared-secret")
 
 	opts, _, _ := newClearOpts(t, true, "")
 	testutil.RequireNoError(t, runClear(context.Background(), opts))
 
-	// Only jtk's override key is removed; the shared default survives.
-	testutil.False(t, jtkTokenPresent(t, keyring.KeyFor(credstore.ToolJTK)))
-	testutil.True(t, jtkTokenPresent(t, keyring.KeyAPIToken))
+	// One key per logical credential (§1.11.10): the force path deletes
+	// the single shared api_token without prompting.
+	testutil.False(t, jtkTokenPresent(t, keyring.KeyAPIToken))
 }
 
 func TestRunClear_NothingToClear(t *testing.T) {

--- a/tools/jtk/internal/cmd/configcmd/configcmd_test.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd_test.go
@@ -192,6 +192,9 @@ func TestRunClear_DeletesSharedKey_Confirmed(t *testing.T) {
 
 	testutil.False(t, jtkTokenPresent(t, keyring.KeyAPIToken))
 	testutil.Contains(t, errBuf.String(), "cfl will also lose access")
+	// Removed per-tool override keys must never be advised again.
+	testutil.NotContains(t, errBuf.String(), "jtk_api_token")
+	testutil.NotContains(t, errBuf.String(), "override")
 }
 
 func TestRunClear_Cancelled(t *testing.T) {

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -99,22 +99,15 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	cfg := result.prefill
 
 	// The up-front EnsureMigrated relocates any legacy plaintext token into
-	// the keyring and scrubs the file, so detectAndReconcile (which reads
-	// the now-scrubbed legacy/config files) leaves prefill.APIToken empty
-	// even though the token still exists. Backfill it from the keyring so a
-	// returning user isn't forced to re-enter a token that was just
-	// migrated. For an explicit "use X for both tools" mismatch choice,
-	// resolve the CHOSEN tool's token (migration moved each differing
-	// legacy token to its own per-tool key), not the current tool's, so
-	// the unify uses the token the user picked. NoMigrate: migration
-	// already ran above. Value stays password-masked in the form (same
-	// ingress as before); never displayed.
+	// the single shared keyring api_token and scrubs the file, so
+	// detectAndReconcile (which reads the now-scrubbed legacy/config files)
+	// leaves prefill.APIToken empty even though the token still exists.
+	// Backfill it from the keyring so a returning user isn't forced to
+	// re-enter a token that was just migrated. NoMigrate: migration already
+	// ran above. Value stays password-masked in the form (same ingress as
+	// before); never displayed.
 	if cfg.APIToken == "" {
-		backfillTool := credstore.ToolJTK
-		if result.unifyBoth && result.unifySource != "" {
-			backfillTool = result.unifySource
-		}
-		if tok, _, terr := keyring.ResolveTokenNoMigrate(backfillTool); terr == nil {
+		if tok, _, terr := keyring.ResolveTokenNoMigrate(credstore.ToolJTK); terr == nil {
 			cfg.APIToken = tok
 		}
 	}
@@ -279,19 +272,10 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	}
 
 	// The token never lands in the plaintext store (Save strips it) — it
-	// goes to the OS keyring under the key matching the write target
-	// (shared default → api_token; jtk override → jtk_api_token), clearing
-	// any stale per-tool override that would otherwise shadow a default
-	// write so the tool resolves exactly what was just saved. An explicit
-	// "use X for both tools" mismatch choice unifies: api_token + clear
-	// BOTH overrides so the sibling switches too.
-	persist := func() error {
-		if result.unifyBoth {
-			return keyring.PersistUnifiedToken(cfg.APIToken)
-		}
-		return keyring.PersistTokenForTool(credstore.ToolJTK, result.target == writeJTKOverride, cfg.APIToken)
-	}
-	if err := persist(); err != nil {
+	// goes to the OS keyring under the single shared api_token (§1.11.10:
+	// one key for both jtk and cfl; the reconcile write-target governs
+	// only NON-secret placement, untouched here).
+	if err := keyring.PersistToken(cfg.APIToken); err != nil {
 		v.Error("Saved the non-secret config to %s, but could not store the API token in the keyring: %v", sharedPath, err)
 		v.Error("Recover by storing just the token (no need to re-run init): `jtk set-credential` (reads stdin or --from-env VAR).")
 		return err

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -20,7 +20,7 @@ func hasUsableCreds(store *credstore.Store, tool string) (bool, error) {
 	if !store.HasUsableConfig(tool) {
 		return false, nil
 	}
-	return keyring.HasTokenForTool(tool)
+	return keyring.HasToken()
 }
 
 // writeTarget tells the post-form save logic which section of the
@@ -42,14 +42,6 @@ type reconcileResult struct {
 	// is currently reading from. Set when reuse=yes was chosen on a
 	// shared store that already had usable creds.
 	affectsSibling bool
-	// unifyBoth is set by the explicit mismatch choice "use <tool>'s
-	// credentials for both tools". It tells the save path to persist the
-	// chosen token as the shared api_token AND clear BOTH per-tool
-	// override keys, so neither tool stays shadowed on its old token.
-	// unifySource is the tool whose token was chosen (credstore.ToolCFL /
-	// ToolJTK); the command layer resolves THAT tool's keyring token.
-	unifyBoth   bool
-	unifySource string
 }
 
 // detectAndReconcile is jtk's mirror of cfl init's reconciliation
@@ -255,19 +247,17 @@ func resultFromMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds, choice stri
 		store.JTK.Section = credstore.Section{}
 		store.CFL.Section = credstore.Section{}
 		var cfg *config.Config
-		chosenTool := credstore.ToolJTK
 		if choice == "use_jtk" {
 			cfg = configFromLegacy(jtkLegacy)
 		} else {
 			cfg = configFromLegacy(cflLegacy)
 			cfg.DefaultProject = jtkLegacy.DefaultProject
-			chosenTool = credstore.ToolCFL
 		}
 		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-		// Signal the cross-tool unify; the command layer (initcmd.go) does
-		// the keyring resolve+persist. reconcile.go stays keyring-free so
-		// it remains unit-testable without OS-keychain isolation.
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed, unifyBoth: true, unifySource: chosenTool}
+		// Non-secret connection reconcile only. The token is now a single
+		// shared key: divergent legacy tokens are caught by the keyring
+		// migration (fail-loud §1.8), not chosen here.
+		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
 	case "keep_different":
 		// Both tools land in their override sections so the split is
 		// stable: store.Default stays empty, jtk reads its override,

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -183,10 +183,6 @@ func TestResultFromMismatch_UseJTK_ClearsStaleCFLOverride(t *testing.T) {
 	testutil.Equal(t, "", r.store.JTK.URL)
 	testutil.Equal(t, "", r.store.JTK.APIToken)
 	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
-	// Signals the command layer to unify on jtk's keyring token and clear
-	// both per-tool override keys.
-	testutil.Equal(t, true, r.unifyBoth)
-	testutil.Equal(t, credstore.ToolJTK, r.unifySource)
 }
 
 // Symmetric to UseJTK_ClearsStaleCFLOverride: use_cfl also clears
@@ -212,8 +208,6 @@ func TestResultFromMismatch_UseCFL_ClearsBothOverrides(t *testing.T) {
 	testutil.Equal(t, "", r.store.CFL.URL)
 	testutil.Equal(t, "", r.store.CFL.APIToken)
 	testutil.Equal(t, "STALE", r.store.JTK.DefaultProject) // per-tool default survives
-	testutil.Equal(t, true, r.unifyBoth)
-	testutil.Equal(t, credstore.ToolCFL, r.unifySource) // unify on cfl's token
 }
 
 func TestResultFromMismatch_UseCFL_PreservesJTKDefaults(t *testing.T) {
@@ -243,9 +237,6 @@ func TestResultFromMismatch_KeepDifferent(t *testing.T) {
 	testutil.Equal(t, "https://cfl.atlassian.net", r.store.CFL.URL)
 	testutil.Equal(t, "cfl-tok", r.store.CFL.APIToken)
 	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
-	// keep_different keeps per-tool overrides — it is NOT a unify action.
-	testutil.Equal(t, false, r.unifyBoth)
-	testutil.Equal(t, "", r.unifySource)
 	if !strings.Contains(stdout.String(), "Keeping per-tool credentials") {
 		t.Errorf("expected keep-different note; got: %s", stdout.String())
 	}

--- a/tools/jtk/internal/cmd/setcredential/setcredential.go
+++ b/tools/jtk/internal/cmd/setcredential/setcredential.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
@@ -16,7 +15,7 @@ import (
 
 // Register adds the set-credential command to the root command.
 func Register(rootCmd *cobra.Command, opts *root.Options) {
-	var fromEnv, key string
+	var fromEnv string
 
 	cmd := &cobra.Command{
 		Use:   "set-credential",
@@ -24,23 +23,15 @@ func Register(rootCmd *cobra.Command, opts *root.Options) {
 		Long: `Store the Atlassian API token in the OS keyring (non-interactive).
 
 The token is read from stdin, or from an environment variable with
---from-env. It is never echoed. The default key (api_token) is the
-shared token used by both jtk and cfl; use --key jtk_api_token to set a
-jtk-only override. This command cannot write cfl's override key (jtk
-would never read it) — use cfl set-credential for that.`,
+--from-env. It is never echoed. There is one shared token (api_token)
+used by both jtk and cfl.`,
 		Example: `  # From a secrets manager, into the shared bundle
   op read op://vault/atlassian/token | jtk set-credential
 
-  # From an environment variable, jtk-only override
-  jtk set-credential --from-env JIRA_API_TOKEN --key jtk_api_token`,
+  # From an environment variable
+  jtk set-credential --from-env JIRA_API_TOKEN`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			// Restrict to keys jtk actually resolves — writing the
-			// sibling's override key would store a token jtk never reads.
-			if key != keyring.KeyAPIToken && key != keyring.KeyFor(credstore.ToolJTK) {
-				return fmt.Errorf("invalid --key %q for jtk (allowed: %s, %s)",
-					key, keyring.KeyAPIToken, keyring.KeyFor(credstore.ToolJTK))
-			}
-			if err := keyring.SetCredential(opts.Stdin, key, fromEnv); err != nil {
+			if err := keyring.SetCredential(opts.Stdin, fromEnv); err != nil {
 				return err
 			}
 			_, _ = fmt.Fprintln(opts.Stderr, "API token stored in the OS keyring.")
@@ -49,7 +40,6 @@ would never read it) — use cfl set-credential for that.`,
 	}
 
 	cmd.Flags().StringVar(&fromEnv, "from-env", "", "Read the token from this environment variable instead of stdin")
-	cmd.Flags().StringVar(&key, "key", keyring.KeyAPIToken, "Bundle key: api_token (shared) or jtk_api_token (jtk-only override)")
 
 	rootCmd.AddCommand(cmd)
 }

--- a/tools/jtk/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/jtk/internal/cmd/setcredential/setcredential_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -25,32 +24,14 @@ func TestSetCredential_StdinStoresToKeyring(t *testing.T) {
 	}
 	rootCmd := &cobra.Command{Use: "jtk"}
 	Register(rootCmd, opts)
-	rootCmd.SetArgs([]string{"set-credential", "--key", keyring.KeyJTKAPIToken})
+	rootCmd.SetArgs([]string{"set-credential"})
 	testutil.RequireNoError(t, rootCmd.Execute())
 
 	s, err := keyring.OpenNoMigrate()
 	testutil.RequireNoError(t, err)
 	defer func() { _ = s.Close() }()
-	got, ok, err := s.Token(credstore.ToolJTK)
+	got, ok, err := s.Token()
 	testutil.RequireNoError(t, err)
 	testutil.True(t, ok)
 	testutil.Equal(t, "jtk-wrapper-token", got)
-}
-
-// jtk must refuse the sibling's override key (storing it would leave a
-// token jtk never resolves).
-func TestSetCredential_RejectsSiblingKey(t *testing.T) {
-	credtest.Hermetic(t)
-
-	opts := &root.Options{
-		Stdin:  strings.NewReader("x\n"),
-		Stdout: &bytes.Buffer{},
-		Stderr: &bytes.Buffer{},
-	}
-	rootCmd := &cobra.Command{Use: "jtk"}
-	Register(rootCmd, opts)
-	rootCmd.SetArgs([]string{"set-credential", "--key", keyring.KeyCFLAPIToken})
-	if err := rootCmd.Execute(); err == nil {
-		t.Fatal("expected jtk set-credential --key cfl_api_token to be rejected")
-	}
 }

--- a/tools/jtk/internal/config/config_test.go
+++ b/tools/jtk/internal/config/config_test.go
@@ -260,7 +260,7 @@ func TestGetAPIToken_EnvOverride(t *testing.T) {
 	testutil.Equal(t, GetAPIToken(), "")
 
 	// Keyring is the store of truth.
-	testutil.RequireNoError(t, keyring.PersistToken(keyring.KeyAPIToken, "kr-token"))
+	testutil.RequireNoError(t, keyring.PersistToken("kr-token"))
 	testutil.Equal(t, GetAPIToken(), "kr-token")
 
 	// Env outranks the keyring.
@@ -291,7 +291,7 @@ func TestIsConfigured(t *testing.T) {
 	testutil.False(t, IsConfigured())
 
 	// Token in the keyring completes it.
-	testutil.RequireNoError(t, keyring.PersistToken(keyring.KeyAPIToken, "kr-token"))
+	testutil.RequireNoError(t, keyring.PersistToken("kr-token"))
 	testutil.True(t, IsConfigured())
 }
 
@@ -306,7 +306,7 @@ func TestIsConfigured_LegacyDomain(t *testing.T) {
 	}
 	err := Save(cfg)
 	testutil.RequireNoError(t, err)
-	testutil.RequireNoError(t, keyring.PersistToken(keyring.KeyAPIToken, "kr-token"))
+	testutil.RequireNoError(t, keyring.PersistToken("kr-token"))
 	testutil.True(t, IsConfigured())
 }
 
@@ -563,22 +563,6 @@ func TestSharedStore_FillsURLBetweenEnvAndLegacy(t *testing.T) {
 	testutil.Equal(t, "https://env.atlassian.net", GetURL())
 }
 
-func TestSharedStore_JTKOverrideBeatsDefault(t *testing.T) {
-	tempDir, cleanup := setupTestConfig(t)
-	defer cleanup()
-
-	sharedPath := filepath.Join(tempDir, "atlassian-cli", "config.yml")
-	store := &credstore.Store{
-		Default: credstore.Section{URL: "https://shared.atlassian.net"},
-	}
-	testutil.RequireNoError(t, store.Save(sharedPath))
-
-	// The per-tool override now lives in the KEYRING, not the YAML store.
-	testutil.RequireNoError(t, keyring.PersistToken(keyring.KeyAPIToken, "default-tok"))
-	testutil.RequireNoError(t, keyring.PersistToken(keyring.KeyFor(credstore.ToolJTK), "jtk-tok"))
-	testutil.Equal(t, "jtk-tok", GetAPIToken())
-}
-
 func TestSharedStore_LegacyWinsWhenSharedAbsent(t *testing.T) {
 	_, cleanup := setupTestConfig(t)
 	defer cleanup()
@@ -642,11 +626,10 @@ func TestSharedStore_FullPrecedenceChain(t *testing.T) {
 	testutil.Equal(t, "https://shared.atlassian.net", GetURL()) // shared default wins over legacy
 
 	// Token precedence is keyring-based (not the YAML store/legacy):
-	// shared default key, then the jtk override key, then env.
-	testutil.RequireNoError(t, keyring.PersistToken(keyring.KeyAPIToken, "shared-tok"))
+	// the single shared api_token key, then env. There is one key per
+	// logical credential (§1.11.10) — no per-tool keyring override.
+	testutil.RequireNoError(t, keyring.PersistToken("shared-tok"))
 	testutil.Equal(t, "shared-tok", GetAPIToken())
-	testutil.RequireNoError(t, keyring.PersistToken(keyring.KeyFor(credstore.ToolJTK), "jtk-tok"))
-	testutil.Equal(t, "jtk-tok", GetAPIToken())
 
 	// Layer 4: ATLASSIAN_* env beats the keyring.
 	t.Setenv("ATLASSIAN_API_TOKEN", "atlassian-env-tok")

--- a/tools/jtk/internal/config/source_test.go
+++ b/tools/jtk/internal/config/source_test.go
@@ -109,7 +109,7 @@ func TestTokenResolution_EnvAndKeyring(t *testing.T) {
 	testutil.False(t, r.TokenConfigured)
 
 	// Seeded into the keyring under the shared default key.
-	testutil.RequireNoError(t, keyring.PersistToken(keyring.KeyAPIToken, "kr-token"))
+	testutil.RequireNoError(t, keyring.PersistToken("kr-token"))
 	r = GetValuesWithSources()
 	testutil.True(t, r.TokenConfigured)
 	testutil.Equal(t, r.TokenSource, string(keyring.SourceKeyAPI))


### PR DESCRIPTION
## Summary

Brings atlassian-cli into conformance with the Secret-Handling Standard
§2.2 + §1.11.10/§1.11.11: **one key per logical credential**. The keyring
bundle now holds exactly `api_token`, shared by `cfl` and `jtk`. The
per-tool override keys, the `set-credential --key` flag, and the
token-unify reconcile machinery are removed.

Token-collapse only. Per-tool **non-secret** overrides
(url/email/auth_method/cloud_id) are intentionally out of scope and
tracked separately in MON-5328 / #368.

## What changed

- **Resolver**: tool/shared env var → single shared keyring `api_token`.
  No per-tool keyring precedence.
- **§1.8 migration** rewritten as strictly two-phase (collect+detect is
  pure, then apply). It now also absorbs deprecated per-tool keyring
  keys left by the B3 build (upgrade path). **>1 distinct token across
  all sources fails loud, names every source, prints no secret, and
  mutates nothing** — never precedence-picks a secret winner. One
  distinct value → written, deprecated keys deleted, plaintext scrubbed.
- **`config clear`** deletes the single shared key (warns the sibling
  loses access); `--all` removes the whole bundle (incl. deprecated
  keys) plus the non-secret config file.
- **Dead code removed**: `PersistTokenForTool`, `PersistUnifiedToken`,
  `HasTokenForTool`, `KeyFor`, `unifyBoth`/`unifySource`, and the
  per-tool mismatch "use X for both tools" token branch. Non-secret
  reconcile (including `keep_different` per-tool sections) is unchanged.

## Tests

- Amended §1.8 conflict/collapse matrix; B3 deprecated-key upgrade
  fixture; two-phase no-mutation-on-conflict guarantees.
- New §1.11.6 real-entrypoint acceptance (re-exec'd `main()`): the
  migration notice reaches stderr **even before a non-zero exit**.
- §1.11.11 exact bundle-key-set assertions (`{api_token}`; empty after
  clear) across set-credential / migration / clear / B3 upgrade.
- Pure reconcile/migration helpers stay keyring-free; hermetic
  file-backend harness (no OS keychain in CI).
- Net diff: 36 files, +1006 / −921. All three modules green: gofmt,
  `go vet`, `go test -race`, `go mod tidy` no-drift, golangci-lint.

## Breaking change

The bundle key set is now exactly `{api_token}`. `cfl_api_token` /
`jtk_api_token` are no longer written or resolved (the one-time
migration consolidates pre-existing ones, failing loud on divergence).
`set-credential --key` is removed. `cfl` and `jtk` always share one
token. Existing single-token users are unaffected; B3 per-tool-key
users are auto-consolidated on first keyring open.

Closes #367
[MON-5326]
