### PR TITLE
fix!: drop per-tool non-secret credential overrides (§2.2) [MON-5328]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,14 @@ jtk:
 ```
 
 Note: there is **no `api_token:` field** — the secret is in the keyring.
-The `cfl`/`jtk` sections may still carry non-secret per-tool overrides
-(`url`, `email`, `auth_method`, `cloud_id`); per-field merge applies.
+Per §2.2 (MON-5328) the `cfl`/`jtk` sections carry **only** non-secret
+per-tool defaults (`default_space`, `default_project`,
+`output_format`); they may **not** override connection fields
+(`url`/`email`/`auth_method`/`cloud_id`). Connection is single-sourced
+from `default` (env still overrides at runtime). A pre-MON-5328 file
+with per-tool connection fields is read once by the migration; if those
+diverge from `default`, `init` fails loud (naming every source + field,
+no value) instead of precedence-picking.
 
 Keyring bundle: fixed ref `atlassian-cli/default`, exactly one key
 `api_token` shared by cfl and jtk (Secret-Handling Standard §1.11.10:

--- a/shared/credstore/conn_apply.go
+++ b/shared/credstore/conn_apply.go
@@ -40,6 +40,23 @@ func effectiveConn(def, sec SharedLegacyConn) ConnProfile {
 	}
 }
 
+// ConnEqualsSection reports whether a resolved ConnProfile resolves to
+// the same connection as a Section. Used to decide whether folding
+// `chosen` into the shared default actually CHANGES anything: an init
+// re-run that resolves to the connection already on disk is a no-op for
+// the sibling tool and must not trigger the "save affects sibling"
+// confirmation. Compares in canonical space (canonConn) — `chosen` is
+// normalized + basic-materialized by the detector while the on-disk
+// Section is raw, so a naive field compare would false-diff implicit vs
+// explicit basic and never suppress the prompt. Pure, secret-free
+// (Section.APIToken is not compared — ConnProfile has no token field by
+// construction).
+func ConnEqualsSection(c ConnProfile, s Section) bool {
+	return canonConn(c) == canonConn(ConnProfile{
+		URL: s.URL, Email: s.Email, AuthMethod: s.AuthMethod, CloudID: s.CloudID,
+	})
+}
+
 // sharedConnHasField reports whether a raw pre-MON-5328 per-tool section
 // set ANY connection field of its own. A per-tool section with none is
 // "no opinion": it must NOT contribute a phantom candidate (effectiveConn
@@ -55,6 +72,14 @@ func sharedConnHasField(s SharedLegacyConn) bool {
 // ONLY when that per-tool section actually set a connection field of its
 // own — and the legacy cfl/jtk files. Tool-agnostic: the candidate set
 // is the same whichever tool runs init.
+//
+// `def` and `proj` are two reads of the SAME shared file (the canonical
+// Store and its pre-MON-5328 projection). They are not read atomically;
+// this is sound for a single-user CLI where init is the only writer and
+// is not run concurrently with itself. A concurrent external rewrite
+// between the two reads could surface a spurious divergence — which
+// fails loud and is recoverable by re-running init, never a silent
+// mispick.
 func ConnCandidates(
 	sharedPath string,
 	def Section,

--- a/shared/credstore/conn_apply.go
+++ b/shared/credstore/conn_apply.go
@@ -1,0 +1,125 @@
+package credstore
+
+import (
+	"errors"
+	"sort"
+	"strings"
+)
+
+// This file holds the tool-agnostic apply-layer glue for the §2.2
+// (MON-5328) single-source connection model: building the named
+// candidate set for DetectConnDivergence and rendering the fail-loud
+// error. It lived duplicated verbatim in both tools' reconcile.go;
+// centralized here (next to the detector) so a fix lands once. Pure and
+// secret-free — no token field, no IO, no keyring.
+
+func legacyConn(l *LegacyCreds) ConnProfile {
+	return ConnProfile{URL: l.URL, Email: l.Email, AuthMethod: l.AuthMethod, CloudID: l.CloudID}
+}
+
+// hasConn reports whether a profile carries any connection field.
+func hasConn(c ConnProfile) bool {
+	return c.URL != "" || c.Email != "" || c.AuthMethod != "" || c.CloudID != ""
+}
+
+// effectiveConn merges a pre-MON-5328 per-tool section over default
+// (the old per-field-merge semantics) so the detector compares what the
+// tool actually USED to resolve.
+func effectiveConn(def, sec SharedLegacyConn) ConnProfile {
+	pick := func(o, d string) string {
+		if o != "" {
+			return o
+		}
+		return d
+	}
+	return ConnProfile{
+		URL:        pick(sec.URL, def.URL),
+		Email:      pick(sec.Email, def.Email),
+		AuthMethod: pick(sec.AuthMethod, def.AuthMethod),
+		CloudID:    pick(sec.CloudID, def.CloudID),
+	}
+}
+
+// sharedConnHasField reports whether a raw pre-MON-5328 per-tool section
+// set ANY connection field of its own. A per-tool section with none is
+// "no opinion": it must NOT contribute a phantom candidate (effectiveConn
+// would otherwise echo the default's values under a `cfl`/`jtk` label
+// and pollute conflict messages).
+func sharedConnHasField(s SharedLegacyConn) bool {
+	return s.URL != "" || s.Email != "" || s.AuthMethod != "" || s.CloudID != ""
+}
+
+// ConnCandidates assembles the origin-labeled connection candidate set
+// for DetectConnDivergence: the shared `default`, the pre-MON-5328
+// per-tool sections AS effective overrides (default ⊕ section) — but
+// ONLY when that per-tool section actually set a connection field of its
+// own — and the legacy cfl/jtk files. Tool-agnostic: the candidate set
+// is the same whichever tool runs init.
+func ConnCandidates(
+	sharedPath string,
+	def Section,
+	proj *SharedLegacyProjection,
+	cflLegacy, jtkLegacy *LegacyCreds,
+) []NamedConn {
+	var out []NamedConn
+	add := func(label, section, path string, c ConnProfile) {
+		if !hasConn(c) {
+			return
+		}
+		out = append(out, NamedConn{Label: label, Section: section, Path: path, Conn: c})
+	}
+	add("shared config", "default", sharedPath, ConnProfile{
+		URL: def.URL, Email: def.Email, AuthMethod: def.AuthMethod, CloudID: def.CloudID,
+	})
+	if proj != nil {
+		if sharedConnHasField(proj.CFL) {
+			add("shared config", "cfl", sharedPath, effectiveConn(proj.Default, proj.CFL))
+		}
+		if sharedConnHasField(proj.JTK) {
+			add("shared config", "jtk", sharedPath, effectiveConn(proj.Default, proj.JTK))
+		}
+	}
+	if cflLegacy != nil {
+		add("legacy cfl config", "", cflLegacy.Path, legacyConn(cflLegacy))
+	}
+	if jtkLegacy != nil {
+		add("legacy jtk config", "", jtkLegacy.Path, legacyConn(jtkLegacy))
+	}
+	return out
+}
+
+// ConnConflictError renders the §2.2 fail-loud message: every
+// conflicting field with its source descriptors (no values, §1.12) and
+// a remediation listing every distinct candidate file PATH. Paths come
+// from the structured NamedConn set (never re-parsed out of formatted
+// descriptor strings — a path may contain '(') and are sorted
+// (deterministic across re-runs).
+func ConnConflictError(conflicts []ConnConflict, candidates []NamedConn, tool string) error {
+	pathSet := map[string]struct{}{}
+	for _, c := range candidates {
+		if c.Path != "" {
+			pathSet[c.Path] = struct{}{}
+		}
+	}
+	paths := make([]string, 0, len(pathSet))
+	for p := range pathSet {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	var b strings.Builder
+	b.WriteString("connection config diverges across sources; init will not pick a winner. Conflicts:\n")
+	for _, c := range conflicts {
+		b.WriteString("  - ")
+		b.WriteString(c.Field)
+		b.WriteString(": ")
+		b.WriteString(strings.Join(c.Sources, ", "))
+		b.WriteString("\n")
+	}
+	b.WriteString("Resolve by editing/removing all but one connection in: ")
+	b.WriteString(strings.Join(paths, ", "))
+	b.WriteString(" — then re-run ")
+	b.WriteString(tool)
+	b.WriteString(" init. (No values shown; secrets live only in the OS keyring.)")
+	return errors.New(b.String())
+}

--- a/shared/credstore/conndivergence.go
+++ b/shared/credstore/conndivergence.go
@@ -1,0 +1,152 @@
+package credstore
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/open-cli-collective/atlassian-go/auth"
+)
+
+// ConnProfile is the NON-secret connection projection the §2.2 /
+// MON-5328 divergence detector works over. It deliberately has NO token
+// field: the detector is secret-free by construction (never
+// credstore.Section, which carries APIToken), so a pure, keyring/IO-free
+// helper can never leak a credential.
+type ConnProfile struct {
+	URL        string
+	Email      string
+	AuthMethod string
+	CloudID    string
+}
+
+// NamedConn is one origin-labeled connection candidate fed to the
+// detector. Section labels the sub-key for the fail-loud message
+// (default/cfl/jtk share one file, so a path alone is ambiguous); Path
+// is the file the user edits to resolve a conflict.
+type NamedConn struct {
+	Label   string // e.g. "shared config", "legacy cfl config"
+	Section string // "default" | "cfl" | "jtk" | "" (legacy single-section files)
+	Path    string // file path for the remediation hint
+	Conn    ConnProfile
+}
+
+// ConnConflict names ONE diverging connection field — the field plus the
+// contributing source descriptors ("<label> <section>.<field> (<path>)"),
+// NEVER the values (§1.12).
+type ConnConflict struct {
+	Field   string
+	Sources []string
+}
+
+// canonURL / canonScalar normalize so textually-different-but-equivalent
+// values don't false-conflict.
+func canonURL(s string) string    { return NormalizeBaseURL(strings.TrimSpace(s)) }
+func canonScalar(s string) string { return strings.TrimSpace(s) }
+
+// usableBasic reports whether a source is, on its own, a complete basic
+// connection (url+email) with no explicit non-basic auth. Such a source
+// materializes an IMPLICIT auth_method=basic for conflict detection, so
+// an implicit-basic `default` correctly conflicts with an explicit
+// bearer per-tool/legacy source instead of silently unioning to bearer.
+func usableBasic(c ConnProfile) bool {
+	am := strings.ToLower(canonScalar(c.AuthMethod))
+	return canonURL(c.URL) != "" && canonScalar(c.Email) != "" &&
+		(am == "" || am == auth.AuthMethodBasic)
+}
+
+// effectiveAuth is the auth_method a source contributes to detection:
+// an explicit value as-is; else implicit "basic" only if the source is a
+// usable basic connection; else "" (no opinion — a fragmentary source
+// like cloud_id-only must not vote an auth method).
+func effectiveAuth(c ConnProfile) string {
+	if am := strings.ToLower(canonScalar(c.AuthMethod)); am != "" {
+		return am
+	}
+	if usableBasic(c) {
+		return auth.AuthMethodBasic
+	}
+	return ""
+}
+
+// fieldVal is the canonical value a source contributes for field, or ""
+// for "no opinion" (absent → does not participate; never a competing
+// value, so a partial `default` stays compatible with a fuller source).
+func fieldVal(c ConnProfile, field string) string {
+	switch field {
+	case "url":
+		return canonURL(c.URL)
+	case "email":
+		return canonScalar(c.Email)
+	case "auth_method":
+		return effectiveAuth(c)
+	case "cloud_id":
+		return canonScalar(c.CloudID)
+	}
+	return ""
+}
+
+func sourceDesc(n NamedConn, field string) string {
+	key := field
+	if n.Section != "" {
+		key = n.Section + "." + field
+	}
+	if n.Path != "" {
+		return n.Label + " " + key + " (" + n.Path + ")"
+	}
+	return n.Label + " " + key
+}
+
+// DetectConnDivergence is the pure §2.2/MON-5328 connection resolver
+// over the full named candidate set. Field-wise UNION (not whole-profile
+// collapse): for each of url/email/auth_method/cloud_id independently it
+// collects the distinct non-empty canonical values; a field with ≥2
+// distinct values is a conflict (named, no values); a field with exactly
+// one agreed value is folded into chosen. An all-empty/fragmentary
+// source contributes nothing it has no opinion on, so a partial default
+// is compatible with a fuller legacy source. If no conflicts and the
+// resolved auth_method is still empty, it materializes basic (the
+// codebase-wide default). Pure: no IO, no keyring, no secret.
+func DetectConnDivergence(sources []NamedConn) (chosen ConnProfile, conflicts []ConnConflict) {
+	fields := []string{"url", "email", "auth_method", "cloud_id"}
+	resolved := map[string]string{}
+	for _, field := range fields {
+		seen := map[string][]string{} // canonical value -> source descriptors
+		var order []string
+		for _, src := range sources {
+			v := fieldVal(src.Conn, field)
+			if v == "" {
+				continue
+			}
+			if _, ok := seen[v]; !ok {
+				order = append(order, v)
+			}
+			seen[v] = append(seen[v], sourceDesc(src, field))
+		}
+		switch len(order) {
+		case 0:
+			// no opinion anywhere
+		case 1:
+			resolved[field] = order[0]
+		default:
+			var descs []string
+			for _, v := range order {
+				descs = append(descs, seen[v]...)
+			}
+			sort.Strings(descs)
+			conflicts = append(conflicts, ConnConflict{Field: field, Sources: descs})
+		}
+	}
+	if len(conflicts) > 0 {
+		return ConnProfile{}, conflicts
+	}
+	chosen = ConnProfile{
+		URL:        resolved["url"],
+		Email:      resolved["email"],
+		AuthMethod: resolved["auth_method"],
+		CloudID:    resolved["cloud_id"],
+	}
+	if chosen.AuthMethod == "" {
+		chosen.AuthMethod = auth.AuthMethodBasic
+	}
+	return chosen, nil
+}

--- a/shared/credstore/conndivergence.go
+++ b/shared/credstore/conndivergence.go
@@ -85,6 +85,27 @@ func fieldVal(c ConnProfile, field string) string {
 	return ""
 }
 
+// canonConn is the fully-resolved single-source normal form: the same
+// canonicalization DetectConnDivergence applies (url/email/cloud_id
+// canonical, auth_method via effectiveAuth) plus the basic-materialization
+// fallback it does once the union is otherwise resolved. Comparing two
+// profiles via canonConn answers "do these resolve to the same
+// connection?" without false-diffing raw-vs-normalized — e.g. an
+// on-disk default that omits auth_method must compare EQUAL to a
+// detector `chosen` that materialized it to basic.
+func canonConn(c ConnProfile) ConnProfile {
+	am := effectiveAuth(c)
+	if am == "" {
+		am = auth.AuthMethodBasic
+	}
+	return ConnProfile{
+		URL:        canonURL(c.URL),
+		Email:      canonScalar(c.Email),
+		AuthMethod: am,
+		CloudID:    canonScalar(c.CloudID),
+	}
+}
+
 func sourceDesc(n NamedConn, field string) string {
 	key := field
 	if n.Section != "" {

--- a/shared/credstore/conndivergence_test.go
+++ b/shared/credstore/conndivergence_test.go
@@ -110,6 +110,19 @@ func TestDetectConnDivergence(t *testing.T) {
 		testutil.Equal(t, "cid", got.CloudID)
 	})
 
+	t.Run("explicit basic + implicit basic agree -> no conflict", func(t *testing.T) {
+		t.Parallel()
+		// usableBasic must not only PREVENT silent bearer-union; an
+		// explicit `basic` and an implicit-basic (url+email, no auth)
+		// source must canonically AGREE (the positive direction).
+		got, conf := DetectConnDivergence([]NamedConn{
+			nc("shared config", "default", "/c.yml", ConnProfile{URL: "https://acme.atlassian.net", Email: "u@e", AuthMethod: "basic"}),
+			nc("legacy cfl config", "", "/cfl.yml", ConnProfile{URL: "https://acme.atlassian.net", Email: "u@e"}),
+		})
+		testutil.Equal(t, 0, len(conf))
+		testutil.Equal(t, basic, got.AuthMethod)
+	})
+
 	t.Run("all-empty source ignored", func(t *testing.T) {
 		t.Parallel()
 		got, conf := DetectConnDivergence([]NamedConn{

--- a/shared/credstore/conndivergence_test.go
+++ b/shared/credstore/conndivergence_test.go
@@ -1,0 +1,122 @@
+package credstore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func nc(label, section, path string, c ConnProfile) NamedConn {
+	return NamedConn{Label: label, Section: section, Path: path, Conn: c}
+}
+
+// §2.2/MON-5328 detector semantics: field-wise union, conflict iff a
+// canonical field has ≥2 distinct non-empty values; usable-basic
+// materializes implicit basic; fragmentary sources give no auth opinion;
+// partial default is compatible with a fuller source.
+func TestDetectConnDivergence(t *testing.T) {
+	t.Parallel()
+	basic := "basic"
+	bearer := "bearer"
+
+	t.Run("no sources -> empty chosen, basic default", func(t *testing.T) {
+		t.Parallel()
+		got, conf := DetectConnDivergence(nil)
+		testutil.Equal(t, 0, len(conf))
+		testutil.Equal(t, "", got.URL)
+		testutil.Equal(t, basic, got.AuthMethod)
+	})
+
+	t.Run("all equal -> no conflict", func(t *testing.T) {
+		t.Parallel()
+		c := ConnProfile{URL: "https://acme.atlassian.net", Email: "u@e", AuthMethod: basic}
+		got, conf := DetectConnDivergence([]NamedConn{
+			nc("shared config", "default", "/c.yml", c),
+			nc("legacy cfl config", "", "/cfl.yml", c),
+		})
+		testutil.Equal(t, 0, len(conf))
+		testutil.Equal(t, "https://acme.atlassian.net", got.URL)
+	})
+
+	t.Run("canonically equal but textually different -> no conflict", func(t *testing.T) {
+		t.Parallel()
+		got, conf := DetectConnDivergence([]NamedConn{
+			nc("a", "default", "/c.yml", ConnProfile{URL: "https://acme.atlassian.net/wiki/", Email: "u@e"}),
+			nc("b", "", "/cfl.yml", ConnProfile{URL: "https://acme.atlassian.net", Email: " u@e "}),
+		})
+		testutil.Equal(t, 0, len(conf))
+		testutil.Equal(t, "https://acme.atlassian.net", got.URL)
+		testutil.Equal(t, "u@e", got.Email)
+	})
+
+	t.Run("partial default compatible with fuller legacy -> union, no conflict", func(t *testing.T) {
+		t.Parallel()
+		got, conf := DetectConnDivergence([]NamedConn{
+			nc("shared config", "default", "/c.yml", ConnProfile{URL: "https://acme.atlassian.net"}),
+			nc("legacy cfl config", "", "/cfl.yml", ConnProfile{URL: "https://acme.atlassian.net", Email: "u@e"}),
+		})
+		testutil.Equal(t, 0, len(conf))
+		testutil.Equal(t, "https://acme.atlassian.net", got.URL)
+		testutil.Equal(t, "u@e", got.Email) // unioned in from the fuller source
+	})
+
+	t.Run("divergent url -> conflict, no value leak", func(t *testing.T) {
+		t.Parallel()
+		got, conf := DetectConnDivergence([]NamedConn{
+			nc("shared config", "default", "/c.yml", ConnProfile{URL: "https://a.atlassian.net", Email: "u@e"}),
+			nc("legacy cfl config", "", "/cfl.yml", ConnProfile{URL: "https://b.atlassian.net", Email: "u@e"}),
+		})
+		testutil.Equal(t, ConnProfile{}, got)
+		testutil.Equal(t, 1, len(conf))
+		testutil.Equal(t, "url", conf[0].Field)
+		joined := strings.Join(conf[0].Sources, " ")
+		if strings.Contains(joined, "a.atlassian.net") || strings.Contains(joined, "b.atlassian.net") {
+			t.Fatalf("conflict leaked a value: %v", conf[0].Sources)
+		}
+		if !strings.Contains(joined, "shared config default.url (/c.yml)") ||
+			!strings.Contains(joined, "legacy cfl config url (/cfl.yml)") {
+			t.Fatalf("conflict must name source-label section.field (path): %v", conf[0].Sources)
+		}
+	})
+
+	t.Run("implicit-basic default vs explicit-bearer legacy -> conflict", func(t *testing.T) {
+		t.Parallel()
+		_, conf := DetectConnDivergence([]NamedConn{
+			nc("shared config", "default", "/c.yml", ConnProfile{URL: "https://acme.atlassian.net", Email: "u@e"}),
+			nc("legacy jtk config", "", "/jtk.json", ConnProfile{
+				URL: "https://acme.atlassian.net", CloudID: "cid", AuthMethod: bearer,
+			}),
+		})
+		var gotAuth bool
+		for _, c := range conf {
+			if c.Field == "auth_method" {
+				gotAuth = true
+			}
+		}
+		if !gotAuth {
+			t.Fatalf("implicit-basic default must conflict with explicit bearer; conflicts=%v", conf)
+		}
+	})
+
+	t.Run("fragmentary source (cloud_id only) gives no auth opinion", func(t *testing.T) {
+		t.Parallel()
+		got, conf := DetectConnDivergence([]NamedConn{
+			nc("shared config", "default", "/c.yml", ConnProfile{URL: "https://acme.atlassian.net", Email: "u@e"}),
+			nc("legacy cfl config", "", "/cfl.yml", ConnProfile{CloudID: "cid"}),
+		})
+		testutil.Equal(t, 0, len(conf)) // cloud_id-only contributes no auth_method, no conflict
+		testutil.Equal(t, basic, got.AuthMethod)
+		testutil.Equal(t, "cid", got.CloudID)
+	})
+
+	t.Run("all-empty source ignored", func(t *testing.T) {
+		t.Parallel()
+		got, conf := DetectConnDivergence([]NamedConn{
+			nc("shared config", "default", "/c.yml", ConnProfile{URL: "https://acme.atlassian.net", Email: "u@e"}),
+			nc("shared config", "cfl", "/c.yml", ConnProfile{}),
+		})
+		testutil.Equal(t, 0, len(conf))
+		testutil.Equal(t, "https://acme.atlassian.net", got.URL)
+	})
+}

--- a/shared/credstore/credstore.go
+++ b/shared/credstore/credstore.go
@@ -1,16 +1,19 @@
 // Package credstore reads and writes the shared Atlassian NON-SECRET
 // config at ~/.config/atlassian-cli/config.yml. The store has a single
-// "default" section that both cfl and jtk consume, plus optional
-// "cfl" and "jtk" sections that hold per-tool overrides (full or partial).
+// "default" section that both cfl and jtk consume for connection
+// config, plus optional "cfl" and "jtk" sections that hold ONLY
+// non-secret per-tool defaults (default_space/default_project/
+// output_format). Per §2.2 (MON-5328) a per-tool section may NOT
+// override connection credentials — connection is single-sourced from
+// "default" (env still overrides at the caller's runtime layer).
 //
 // The API token is NOT persisted here — it lives in the OS keyring via
 // the sibling shared/keyring package. The codec is intentionally
-// asymmetric: Load still READS a legacy api_token (it is the one-time
-// migration source) but Save NEVER writes one (see Store.MarshalYAML).
-//
-// Field resolution is per-field merge (tool override beats default, any
-// unset field falls through), so a partial override — say, a different
-// cloud_id for cfl — is fully supported.
+// asymmetric: Load still READS a legacy default api_token (it is the
+// one-time migration source) but Save NEVER writes one (see
+// Store.MarshalYAML). Pre-MON-5328 files that still carry per-tool
+// connection/token fields are decoded once by the migration projection
+// (LoadSharedLegacyProjection), never by the canonical Store.
 package credstore
 
 import (
@@ -46,10 +49,14 @@ type Section struct {
 	CloudID    string `yaml:"cloud_id,omitempty"`
 }
 
-// ToolSection embeds Section and adds per-tool defaults that aren't
-// shareable (e.g., default_space is meaningless to jtk).
+// ToolSection holds ONLY the non-secret per-tool defaults. Per §2.2
+// (MON-5328) a per-tool section may NOT override connection credentials
+// (url/email/auth_method/cloud_id) or carry api_token — connection is
+// single-sourced from the shared `default` section (env still overrides
+// at runtime). Legacy files that still carry per-tool connection fields
+// are handled once by the migration projection (see legacy.go), never by
+// this canonical struct.
 type ToolSection struct {
-	Section        `yaml:",inline"`
 	DefaultSpace   string `yaml:"default_space,omitempty"`   // cfl
 	DefaultProject string `yaml:"default_project,omitempty"` // jtk
 	OutputFormat   string `yaml:"output_format,omitempty"`   // cfl
@@ -134,36 +141,18 @@ func (s Store) MarshalYAML() (any, error) {
 	type alias Store
 	c := s
 	c.Default.APIToken = ""
-	c.CFL.APIToken = ""
-	c.JTK.APIToken = ""
+	// Per-tool sections no longer carry api_token (or any connection
+	// field) — the struct can't hold them, so nothing to strip there.
 	return alias(c), nil
 }
 
-func (s *Store) toolSection(tool string) ToolSection {
-	switch tool {
-	case ToolCFL:
-		return s.CFL
-	case ToolJTK:
-		return s.JTK
-	default:
-		return ToolSection{}
-	}
-}
-
-// Resolve returns the effective credentials for tool by merging the
-// tool's override section over default per field. Unset override fields
-// fall through to default; default fields fall through to zero.
-func (s *Store) Resolve(tool string) Section {
-	d := s.Default
-	o := s.toolSection(tool).Section
-	out := Section{
-		URL:        firstNonEmpty(o.URL, d.URL),
-		Email:      firstNonEmpty(o.Email, d.Email),
-		APIToken:   firstNonEmpty(o.APIToken, d.APIToken),
-		AuthMethod: firstNonEmpty(o.AuthMethod, d.AuthMethod),
-		CloudID:    firstNonEmpty(o.CloudID, d.CloudID),
-	}
-	return out
+// Resolve returns the effective credentials for tool. Per §2.2
+// (MON-5328) connection config is single-sourced from `default`; per-tool
+// sections no longer override it, so the tool argument no longer affects
+// the connection result (kept for signature stability — ~every command
+// calls this). Env overrides still apply at the caller's runtime layer.
+func (s *Store) Resolve(_ string) Section {
+	return s.Default
 }
 
 // Source describes where a resolved field came from. Used by
@@ -171,43 +160,31 @@ func (s *Store) Resolve(tool string) Section {
 type Source string
 
 const (
-	SourceUnset       Source = "unset"
-	SourceDefault     Source = "shared default"
-	SourceOverrideCFL Source = "shared cfl override"
-	SourceOverrideJTK Source = "shared jtk override"
+	SourceUnset   Source = "unset"
+	SourceDefault Source = "shared default"
 )
 
 // ResolveWithSource returns the resolved value and where it came from.
-// Field is the YAML field name (url, email, api_token, auth_method, cloud_id).
-func (s *Store) ResolveWithSource(tool, field string) (string, Source) {
-	o := s.toolSection(tool).Section
+// Field is the YAML field name (url, email, api_token, auth_method,
+// cloud_id). Per §2.2 (MON-5328) connection config is single-sourced
+// from `default`, so the only non-unset source is the shared default
+// (the tool argument no longer selects a per-tool override).
+func (s *Store) ResolveWithSource(_, field string) (string, Source) {
 	d := s.Default
-	get := func(sec Section) string {
-		switch field {
-		case "url":
-			return sec.URL
-		case "email":
-			return sec.Email
-		case "api_token":
-			return sec.APIToken
-		case "auth_method":
-			return sec.AuthMethod
-		case "cloud_id":
-			return sec.CloudID
-		}
-		return ""
+	var v string
+	switch field {
+	case "url":
+		v = d.URL
+	case "email":
+		v = d.Email
+	case "api_token":
+		v = d.APIToken
+	case "auth_method":
+		v = d.AuthMethod
+	case "cloud_id":
+		v = d.CloudID
 	}
-	if v := get(o); v != "" {
-		switch tool {
-		case ToolCFL:
-			return v, SourceOverrideCFL
-		case ToolJTK:
-			return v, SourceOverrideJTK
-		default:
-			return v, SourceUnset
-		}
-	}
-	if v := get(d); v != "" {
+	if v != "" {
 		return v, SourceDefault
 	}
 	return "", SourceUnset
@@ -258,13 +235,4 @@ func URLForCFL(base string) string {
 		return ""
 	}
 	return b + "/wiki"
-}
-
-func firstNonEmpty(vals ...string) string {
-	for _, v := range vals {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }

--- a/shared/credstore/credstore_test.go
+++ b/shared/credstore/credstore_test.go
@@ -18,7 +18,7 @@ func TestLoad_AbsentReturnsEmptyStore(t *testing.T) {
 	s, err := Load(filepath.Join(dir, "missing.yml"))
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, "", s.Default.URL)
-	testutil.Equal(t, "", s.CFL.APIToken)
+	testutil.Equal(t, "", s.CFL.DefaultSpace)
 }
 
 func TestLoad_CorruptReturnsErrCorrupt(t *testing.T) {
@@ -44,7 +44,6 @@ func TestSaveLoad_Roundtrip(t *testing.T) {
 			APIToken: "tok",
 		},
 		CFL: ToolSection{
-			Section:      Section{APIToken: "cfl-tok"},
 			DefaultSpace: "MYSPACE",
 		},
 	}
@@ -57,7 +56,6 @@ func TestSaveLoad_Roundtrip(t *testing.T) {
 	// Asymmetric codec: Save never persists the token, so a Save→Load
 	// roundtrip drops it (it now lives in the keyring).
 	testutil.Equal(t, "", out.Default.APIToken)
-	testutil.Equal(t, "", out.CFL.APIToken)
 }
 
 func TestSave_ModeIs0600(t *testing.T) {
@@ -114,7 +112,10 @@ func TestSave_NoLeftoverTempOnFailure(t *testing.T) {
 	}
 }
 
-func TestResolve_PerFieldMergeWithPartialOverride(t *testing.T) {
+// §2.2 (MON-5328): connection is single-sourced from `default`. A
+// per-tool section can no longer override connection fields, so Resolve
+// returns Default regardless of tool.
+func TestResolve_AlwaysReturnsDefault(t *testing.T) {
 	t.Parallel()
 	s := &Store{
 		Default: Section{
@@ -122,16 +123,15 @@ func TestResolve_PerFieldMergeWithPartialOverride(t *testing.T) {
 			Email:    "default@example.com",
 			APIToken: "default-tok",
 		},
-		CFL: ToolSection{
-			Section: Section{APIToken: "cfl-tok"}, // only token override
-		},
+		CFL: ToolSection{DefaultSpace: "SP"},
+		JTK: ToolSection{DefaultProject: "PR"},
 	}
-	got := s.Resolve(ToolCFL)
-	testutil.Equal(t, "https://acme.atlassian.net", got.URL)      // default
-	testutil.Equal(t, "default@example.com", got.Email)           // default
-	testutil.Equal(t, "cfl-tok", got.APIToken)                    // override
-	testutil.Equal(t, "default-tok", s.Default.APIToken)          // default untouched
-	testutil.Equal(t, "default-tok", s.Resolve(ToolJTK).APIToken) // jtk falls through to default
+	for _, tool := range []string{ToolCFL, ToolJTK, "unknown"} {
+		got := s.Resolve(tool)
+		testutil.Equal(t, "https://acme.atlassian.net", got.URL)
+		testutil.Equal(t, "default@example.com", got.Email)
+		testutil.Equal(t, "default-tok", got.APIToken)
+	}
 }
 
 func TestResolve_UnknownToolReturnsDefault(t *testing.T) {
@@ -144,8 +144,8 @@ func TestResolve_UnknownToolReturnsDefault(t *testing.T) {
 func TestResolveWithSource(t *testing.T) {
 	t.Parallel()
 	s := &Store{
-		Default: Section{URL: "https://acme.atlassian.net", Email: "u@e.com"},
-		CFL:     ToolSection{Section: Section{APIToken: "cfl-tok"}},
+		Default: Section{URL: "https://acme.atlassian.net", Email: "u@e.com", APIToken: "def-tok"},
+		CFL:     ToolSection{DefaultSpace: "SP"},
 	}
 	cases := []struct {
 		field     string
@@ -154,7 +154,7 @@ func TestResolveWithSource(t *testing.T) {
 	}{
 		{"url", "https://acme.atlassian.net", SourceDefault},
 		{"email", "u@e.com", SourceDefault},
-		{"api_token", "cfl-tok", SourceOverrideCFL},
+		{"api_token", "def-tok", SourceDefault},
 		{"cloud_id", "", SourceUnset},
 	}
 	for _, tc := range cases {
@@ -197,13 +197,13 @@ func TestHasUsableConfig(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "basic completed by partial override",
+			name: "§2.2: a per-tool section can NOT complete connection",
 			s: &Store{
-				Default: Section{URL: "u"},
-				CFL:     ToolSection{Section: Section{Email: "e"}},
+				Default: Section{URL: "u"}, // missing email
+				CFL:     ToolSection{DefaultSpace: "SP"},
 			},
 			tool: ToolCFL,
-			want: true,
+			want: false, // per-tool no longer supplies email
 		},
 		{
 			name: "bearer needs cloud_id",
@@ -248,8 +248,8 @@ func TestSave_NeverWritesAnyToken(t *testing.T) {
 
 	in := &Store{
 		Default: Section{URL: "u", Email: "e", APIToken: "DEFAULT_SECRET"},
-		CFL:     ToolSection{Section: Section{APIToken: "CFL_SECRET"}, DefaultSpace: "SP"},
-		JTK:     ToolSection{Section: Section{APIToken: "JTK_SECRET"}, DefaultProject: "PR"},
+		CFL:     ToolSection{DefaultSpace: "SP"},
+		JTK:     ToolSection{DefaultProject: "PR"},
 	}
 	if err := in.Save(path); err != nil {
 		t.Fatalf("Save: %v", err)

--- a/shared/credstore/legacy.go
+++ b/shared/credstore/legacy.go
@@ -36,6 +36,52 @@ func (l *LegacyCreds) Section() Section {
 	}
 }
 
+// SharedLegacyConn is one shared-store section's pre-MON-5328
+// connection + token fields. Decoded ONLY by the one-time migration so
+// it can still see legacy per-tool credentials before the stripped
+// schema is written. The canonical Store no longer exposes these — do
+// NOT use for runtime resolution.
+type SharedLegacyConn struct {
+	URL        string `yaml:"url"`
+	Email      string `yaml:"email"`
+	APIToken   string `yaml:"api_token"`
+	AuthMethod string `yaml:"auth_method"`
+	CloudID    string `yaml:"cloud_id"`
+}
+
+// SharedLegacyProjection is the migration-only decode of the shared
+// config.yml retaining the per-tool connection/token fields the
+// canonical Store dropped (§2.2 / MON-5328). Migration-only.
+type SharedLegacyProjection struct {
+	Path    string
+	Default SharedLegacyConn
+	CFL     SharedLegacyConn
+	JTK     SharedLegacyConn
+}
+
+// LoadSharedLegacyProjection decodes path retaining legacy per-tool
+// connection/token fields. Absent file → (nil, nil). Parse failure →
+// ErrCorruptStore (same contract as Load) so callers refuse to clobber
+// an unreadable file.
+func LoadSharedLegacyProjection(path string) (*SharedLegacyProjection, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // CLI tool reading its own config
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%w: reading %s: %s", ErrCorruptStore, path, err.Error())
+	}
+	var raw struct {
+		Default SharedLegacyConn `yaml:"default"`
+		CFL     SharedLegacyConn `yaml:"cfl"`
+		JTK     SharedLegacyConn `yaml:"jtk"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("%w: parsing %s: %s", ErrCorruptStore, path, err.Error())
+	}
+	return &SharedLegacyProjection{Path: path, Default: raw.Default, CFL: raw.CFL, JTK: raw.JTK}, nil
+}
+
 // LegacyCFLPath returns the canonical cfl legacy config path.
 func LegacyCFLPath() string {
 	return tooledPath("cfl", "config.yml")

--- a/shared/credstore/legacy_projection_test.go
+++ b/shared/credstore/legacy_projection_test.go
@@ -60,8 +60,11 @@ func TestLoadSharedLegacyProjection_AbsentAndCorrupt(t *testing.T) {
 
 	bad := filepath.Join(dir, "bad.yml")
 	testutil.RequireNoError(t, os.WriteFile(bad, []byte("default: : :: ["), 0o600))
-	_, err = LoadSharedLegacyProjection(bad)
+	bp, err := LoadSharedLegacyProjection(bad)
 	if !errors.Is(err, ErrCorruptStore) {
 		t.Fatalf("corrupt file must return ErrCorruptStore, got %v", err)
+	}
+	if bp != nil {
+		t.Fatalf("corrupt file must return a nil projection (no half-decoded struct), got %+v", bp)
 	}
 }

--- a/shared/credstore/legacy_projection_test.go
+++ b/shared/credstore/legacy_projection_test.go
@@ -1,0 +1,67 @@
+package credstore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+// The migration projection must still see pre-MON-5328 per-tool
+// connection + token fields the canonical Store no longer decodes —
+// "never destroy evidence before the migration reads it".
+func TestLoadSharedLegacyProjection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	yml := `default:
+  url: https://acme.atlassian.net
+  email: d@e
+  api_token: DEF_TOK
+cfl:
+  url: https://cfl.atlassian.net
+  api_token: CFL_TOK
+  default_space: SP
+jtk:
+  email: j@e
+  api_token: JTK_TOK
+  default_project: PR
+`
+	testutil.RequireNoError(t, os.WriteFile(path, []byte(yml), 0o600))
+
+	p, err := LoadSharedLegacyProjection(path)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "DEF_TOK", p.Default.APIToken)
+	testutil.Equal(t, "https://acme.atlassian.net", p.Default.URL)
+	testutil.Equal(t, "https://cfl.atlassian.net", p.CFL.URL) // canonical Store drops this
+	testutil.Equal(t, "CFL_TOK", p.CFL.APIToken)
+	testutil.Equal(t, "j@e", p.JTK.Email)
+	testutil.Equal(t, "JTK_TOK", p.JTK.APIToken)
+
+	// Canonical Load must NOT expose per-tool connection/token.
+	s, err := Load(path)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "DEF_TOK", s.Default.APIToken) // default still readable (migration source)
+	testutil.Equal(t, "SP", s.CFL.DefaultSpace)      // per-tool non-secret default kept
+	testutil.Equal(t, "PR", s.JTK.DefaultProject)
+}
+
+func TestLoadSharedLegacyProjection_AbsentAndCorrupt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	p, err := LoadSharedLegacyProjection(filepath.Join(dir, "nope.yml"))
+	testutil.RequireNoError(t, err)
+	if p != nil {
+		t.Fatalf("absent file must return nil projection, got %+v", p)
+	}
+
+	bad := filepath.Join(dir, "bad.yml")
+	testutil.RequireNoError(t, os.WriteFile(bad, []byte("default: : :: ["), 0o600))
+	_, err = LoadSharedLegacyProjection(bad)
+	if !errors.Is(err, ErrCorruptStore) {
+		t.Fatalf("corrupt file must return ErrCorruptStore, got %v", err)
+	}
+}

--- a/shared/keyring/migrate.go
+++ b/shared/keyring/migrate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	cccredstore "github.com/open-cli-collective/cli-common/credstore"
+	"gopkg.in/yaml.v3"
 
 	"github.com/open-cli-collective/atlassian-go/credstore"
 )
@@ -64,11 +65,17 @@ var ErrMigrationConflict = errors.New("keyring: API token migration sources disa
 func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 	// ---- Phase 1: collect (no mutation) ----------------------------------
 	sharedPath := credstore.DefaultPath()
-	store, err := credstore.Load(sharedPath)
+	// Migration-only projection: the canonical Store no longer carries
+	// per-tool connection/token fields (§2.2/MON-5328), but the §1.8
+	// token migration must still SEE a legacy per-tool api_token. Absent
+	// file → proj == nil. Parse failure → ErrCorruptStore (callers treat
+	// it as a hard error; never silently overwrite an unreadable file).
+	proj, err := credstore.LoadSharedLegacyProjection(sharedPath)
 	if err != nil {
-		// A corrupt shared store must not be silently overwritten; surface
-		// it (callers treat ErrCorruptStore as a hard error).
 		return err
+	}
+	if proj == nil {
+		proj = &credstore.SharedLegacyProjection{Path: sharedPath}
 	}
 	cflPath := credstore.LegacyCFLPath()
 	jtkPath := credstore.LegacyJTKPath()
@@ -98,9 +105,9 @@ func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 		}
 		srcLoc[val][loc] = struct{}{}
 	}
-	add(store.Default.APIToken, "shared config default ("+sharedPath+")")
-	add(store.CFL.APIToken, "shared cfl override ("+sharedPath+")")
-	add(store.JTK.APIToken, "shared jtk override ("+sharedPath+")")
+	add(proj.Default.APIToken, "shared config default ("+sharedPath+")")
+	add(proj.CFL.APIToken, "shared config cfl.api_token ("+sharedPath+")")
+	add(proj.JTK.APIToken, "shared config jtk.api_token ("+sharedPath+")")
 	if legacyCFL != nil {
 		add(legacyCFL.APIToken, "legacy cfl config ("+legacyCFL.Path+")")
 	}
@@ -119,8 +126,9 @@ func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 		}
 	}
 
-	anyPlaintext := store.Default.APIToken != "" || store.CFL.APIToken != "" ||
-		store.JTK.APIToken != "" ||
+	sharedHadToken := proj.Default.APIToken != "" || proj.CFL.APIToken != "" ||
+		proj.JTK.APIToken != ""
+	anyPlaintext := sharedHadToken ||
 		(legacyCFL != nil && legacyCFL.APIToken != "") ||
 		(legacyJTK != nil && legacyJTK.APIToken != "")
 
@@ -184,8 +192,10 @@ func migrateLegacyOverwrite(s *Store, overwrite bool) error {
 		}
 	}
 	if anyPlaintext {
-		if err := scrubSharedStore(store, sharedPath); err != nil {
-			return fmt.Errorf("migrated to keyring %s but could not scrub %s: %w", s.ref, sharedPath, err)
+		if sharedHadToken {
+			if err := scrubSharedStore(sharedPath); err != nil {
+				return fmt.Errorf("migrated to keyring %s but could not scrub %s: %w", s.ref, sharedPath, err)
+			}
 		}
 		if legacyCFL != nil && legacyCFL.APIToken != "" {
 			if err := scrubLegacyFile(cflPath); err != nil {
@@ -302,20 +312,85 @@ func conflictError(locs []string, ref string) error {
 
 // ---- plaintext scrub ------------------------------------------------------
 
-// scrubSharedStore rewrites the shared config.yml with every api_token
-// removed, preserving all non-secret fields. credstore.Save already omits
-// tokens, so a plain re-save scrubs it; absent file is a no-op.
-func scrubSharedStore(store *credstore.Store, path string) error {
-	if _, err := os.Stat(path); err != nil {
+// scrubSharedStore is a TOKEN-ONLY rewrite of the shared config.yml: it
+// deletes every `api_token` mapping entry (wherever it appears) and
+// preserves all other keys/values verbatim-enough (semantic, not
+// byte-identical — yaml.Node re-emit is not byte-stable). It must NOT
+// round-trip through the canonical Store: post-MON-5328 the struct no
+// longer carries per-tool connection fields, so a Load→Save here would
+// silently strip a user's legacy per-tool url/email/etc on a plain
+// runtime command. Per-tool connection stripping happens at exactly one
+// explicit point (init reconcile/Save, after the divergence detector).
+// Absent file is a no-op. The api_token node is DELETED, never blanked
+// to "" (an empty api_token: would weaken the no-plaintext invariant).
+func scrubSharedStore(path string) error {
+	data, err := os.ReadFile(path) //nolint:gosec // CLI tool scrubbing its own config
+	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
 		return err
 	}
-	store.Default.APIToken = ""
-	store.CFL.APIToken = ""
-	store.JTK.APIToken = ""
-	return store.Save(path)
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if !deleteYAMLKey(&doc, "api_token") {
+		return nil // nothing to scrub — leave the file untouched
+	}
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("re-marshaling %s: %w", path, err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("writing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming %s -> %s: %w", tmp, path, err)
+	}
+	return nil
+}
+
+// deleteYAMLKey recursively removes every mapping entry whose key is
+// `key`, preserving all other nodes. Returns true if anything was
+// removed. Token-only scrub uses it so a single `api_token` anywhere in
+// the document is excised without disturbing sibling keys.
+func deleteYAMLKey(n *yaml.Node, key string) bool {
+	removed := false
+	switch n.Kind {
+	case yaml.DocumentNode:
+		for _, c := range n.Content {
+			if deleteYAMLKey(c, key) {
+				removed = true
+			}
+		}
+	case yaml.MappingNode:
+		kept := make([]*yaml.Node, 0, len(n.Content))
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			k, v := n.Content[i], n.Content[i+1]
+			if k.Value == key {
+				removed = true
+				continue
+			}
+			if deleteYAMLKey(v, key) {
+				removed = true
+			}
+			kept = append(kept, k, v)
+		}
+		n.Content = kept
+	case yaml.SequenceNode:
+		for _, c := range n.Content {
+			if deleteYAMLKey(c, key) {
+				removed = true
+			}
+		}
+	case yaml.ScalarNode, yaml.AliasNode:
+		// Leaf nodes — nothing to recurse into or remove.
+	}
+	return removed
 }
 
 // (Legacy-file scrubbing is the generic, field-preserving scrubLegacyFile

--- a/shared/keyring/migrate_conn_test.go
+++ b/shared/keyring/migrate_conn_test.go
@@ -85,3 +85,64 @@ func TestRuntimeMigration_TokenOnly_PreservesPerToolConn(t *testing.T) {
 		t.Fatalf("runtime scrub dropped default.url:\n%s", got)
 	}
 }
+
+// deleteYAMLKey must excise api_token ANYWHERE — nested mappings and
+// inside sequences — not just top-level sections (the "excise a single
+// api_token anywhere" claim).
+func TestScrubSharedStore_NestedAndSequenceRecursion(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yml")
+	in := "default:\n  url: https://acme.atlassian.net\n  api_token: T0\n" +
+		"nested:\n  inner:\n    api_token: T1\n    keep: yes\n" +
+		"list:\n  - name: a\n    api_token: T2\n  - name: b\n"
+	if err := os.WriteFile(p, []byte(in), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := scrubSharedStore(p); err != nil {
+		t.Fatalf("scrub: %v", err)
+	}
+	raw, _ := os.ReadFile(p) //nolint:gosec // test reads its own temp file
+	got := string(raw)
+	for _, leaked := range []string{"api_token", "T0", "T1", "T2"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("api_token must be excised everywhere (incl. nested/sequence); still has %q:\n%s", leaked, got)
+		}
+	}
+	for _, kept := range []string{"https://acme.atlassian.net", "keep: yes", "name: a", "name: b"} {
+		if !strings.Contains(got, kept) {
+			t.Fatalf("non-token content must be preserved; missing %q:\n%s", kept, got)
+		}
+	}
+}
+
+// No api_token present → scrubSharedStore is a no-op and leaves the file
+// byte-identical (no needless yaml.Node re-emit churn). Absent file is
+// also a no-op; unparseable yaml is a hard error.
+func TestScrubSharedStore_NoopAndError(t *testing.T) {
+	dir := t.TempDir()
+
+	clean := filepath.Join(dir, "clean.yml")
+	body := "default:\n  url: https://acme.atlassian.net\n  email: u@e\n"
+	if err := os.WriteFile(clean, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := scrubSharedStore(clean); err != nil {
+		t.Fatalf("no-op scrub must succeed: %v", err)
+	}
+	raw, _ := os.ReadFile(clean) //nolint:gosec // test reads its own temp file
+	if string(raw) != body {
+		t.Fatalf("token-free file must be byte-identical after scrub:\ngot:\n%s\nwant:\n%s", raw, body)
+	}
+
+	if err := scrubSharedStore(filepath.Join(dir, "absent.yml")); err != nil {
+		t.Fatalf("absent file must be a no-op, got: %v", err)
+	}
+
+	bad := filepath.Join(dir, "bad.yml")
+	if err := os.WriteFile(bad, []byte("default: : :: ["), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := scrubSharedStore(bad); err == nil {
+		t.Fatal("unparseable yaml must be a hard error")
+	}
+}

--- a/shared/keyring/migrate_conn_test.go
+++ b/shared/keyring/migrate_conn_test.go
@@ -1,0 +1,87 @@
+package keyring
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// §2.2/MON-5328 S2 — the runtime keyring token migration must be
+// TOKEN-ONLY and connection-preserving: driving the REAL migrating path
+// (EnsureMigrated → scrubSharedStore) against a pre-strip shared file
+// must (a) move the token into the keyring, (b) DELETE every api_token
+// node (not blank it to ""), and (c) leave legacy per-tool connection
+// fields + non-secret defaults intact on disk — no stripped/whole-profile
+// save on a plain runtime path. Without this, S1's schema strip would
+// silently drop a user's per-tool url/email on the first command.
+func TestRuntimeMigration_TokenOnly_PreservesPerToolConn(t *testing.T) {
+	dir := hermetic(t)
+	path := filepath.Join(dir, "atlassian-cli", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pre := "default:\n" +
+		"  url: https://acme.atlassian.net\n" +
+		"  email: d@e\n" +
+		"  api_token: " + secret + "\n" +
+		"cfl:\n" +
+		"  url: https://cfl.example.net\n" +
+		"  email: c@e\n" +
+		"  default_space: SP\n" +
+		"jtk:\n" +
+		"  api_token: " + secret + "\n" +
+		"  default_project: PR\n"
+	if err := os.WriteFile(path, []byte(pre), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureMigrated(); err != nil {
+		t.Fatalf("EnsureMigrated: %v", err)
+	}
+
+	// (a) token now in the keyring.
+	s, err := OpenNoMigrate()
+	if err != nil {
+		t.Fatalf("OpenNoMigrate: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if v, ok, _ := s.Token(); !ok || v != secret {
+		t.Fatalf("token not migrated to keyring: got=%q ok=%v", v, ok)
+	}
+
+	raw, err := os.ReadFile(path) //nolint:gosec // test reads its own temp file
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(raw)
+
+	// (b) every api_token node DELETED — not present at all, not "" .
+	if strings.Contains(got, "api_token") || strings.Contains(got, secret) {
+		t.Fatalf("scrub must DELETE api_token nodes, file still has it:\n%s", got)
+	}
+
+	// (c) legacy per-tool connection + non-secret defaults preserved
+	// (no stripped/whole-profile save on the runtime path).
+	var doc map[string]map[string]any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if doc["cfl"]["url"] != "https://cfl.example.net" {
+		t.Fatalf("runtime scrub dropped legacy per-tool cfl.url:\n%s", got)
+	}
+	if doc["cfl"]["email"] != "c@e" {
+		t.Fatalf("runtime scrub dropped legacy per-tool cfl.email:\n%s", got)
+	}
+	if doc["cfl"]["default_space"] != "SP" {
+		t.Fatalf("runtime scrub dropped cfl.default_space:\n%s", got)
+	}
+	if doc["jtk"]["default_project"] != "PR" {
+		t.Fatalf("runtime scrub dropped jtk.default_project:\n%s", got)
+	}
+	if doc["default"]["url"] != "https://acme.atlassian.net" {
+		t.Fatalf("runtime scrub dropped default.url:\n%s", got)
+	}
+}

--- a/tools/cfl/CLAUDE.md
+++ b/tools/cfl/CLAUDE.md
@@ -140,14 +140,14 @@ Variables are checked in precedence order (first match wins):
 
 | Setting | Precedence |
 |---------|------------|
-| URL | `CFL_URL` → `ATLASSIAN_URL` → shared `cfl` override → shared `default` → legacy config |
-| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → shared `cfl` → shared `default` → legacy |
+| URL | `CFL_URL` → `ATLASSIAN_URL` → shared `default` → legacy config |
+| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → shared `default` → legacy |
 | API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `api_token` (single shared key; OS keyring, **not** the config file) |
 | Default Space | `CFL_DEFAULT_SPACE` → shared `cfl.default_space` → legacy |
-| Auth Method | `CFL_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `cfl` → shared `default` → legacy → `"basic"` |
-| Cloud ID | `CFL_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `cfl` → shared `default` → legacy |
+| Auth Method | `CFL_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `default` → legacy → `"basic"` |
+| Cloud ID | `CFL_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `default` → legacy |
 
-The "shared" entries refer to the cross-tool credential store at `~/.config/atlassian-cli/config.yml` written by `cfl init` and `jtk init`. The `cfl` section overrides the `default` section per field. Legacy `~/.config/cfl/config.yml` keeps working indefinitely; init migrates it on first run.
+The "shared" entries refer to the cross-tool credential store at `~/.config/atlassian-cli/config.yml` written by `cfl init` and `jtk init`. Per §2.2 (MON-5328) connection config is single-sourced from the `default` section — the `cfl` section carries only non-secret defaults (`default_space`/`output_format`) and may NOT override connection fields. Legacy `~/.config/cfl/config.yml` keeps working indefinitely; init migrates it on first run (failing loud if a pre-MON-5328 per-tool connection diverges from `default`).
 
 Use `ATLASSIAN_*` for shared credentials across cfl and jtk. Use `CFL_*` to override per-tool.
 

--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -818,12 +818,14 @@ Environment variables override file-based config. Variables are checked in order
 
 | Setting | Precedence (highest to lowest) |
 |---------|-------------------------------|
-| URL | `CFL_URL` → `ATLASSIAN_URL` → shared `cfl` override → shared `default` → legacy file |
-| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → shared `cfl` → shared `default` → legacy |
+| URL | `CFL_URL` → `ATLASSIAN_URL` → shared `default` → legacy file |
+| Email | `CFL_EMAIL` → `ATLASSIAN_EMAIL` → shared `default` → legacy |
 | API Token | `CFL_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `api_token` (single shared key; OS keyring, never a plaintext file) |
 | Default Space | `CFL_DEFAULT_SPACE` → shared `cfl.default_space` → legacy |
-| Auth Method | `CFL_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared → legacy → `basic` |
-| Cloud ID | `CFL_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared → legacy |
+| Auth Method | `CFL_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `default` → legacy → `basic` |
+| Cloud ID | `CFL_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `default` → legacy |
+
+Per §2.2 connection config is single-sourced from the shared `default` section — per-tool `cfl:`/`jtk:` sections carry only non-secret defaults and may not override `url`/`email`/`auth_method`/`cloud_id`.
 
 **Shared credentials:** If you use both `cfl` and `jtk` (Jira CLI), set `ATLASSIAN_*` variables once:
 

--- a/tools/cfl/cmd/cfl/main_test.go
+++ b/tools/cfl/cmd/cfl/main_test.go
@@ -185,3 +185,41 @@ func TestEntrypoint_B3UpgradeFixture_DeprecatedKeysOnly(t *testing.T) {
 		t.Fatalf("§1.11.11: B3 upgrade must leave exactly [api_token]; got %v", got)
 	}
 }
+
+// §2.2/MON-5328 detect-before-mutate at the REAL entrypoint: a
+// pre-MON-5328 shared config whose per-tool connection diverges from
+// `default`, plus a plaintext api_token, must make `cfl init` fail loud
+// from detectAndReconcile BEFORE keyring.EnsureMigrated runs — so the
+// token is NOT migrated/scrubbed and the file is untouched. Pins the
+// prior Codex blocker at the runInit level (re-introducing
+// EnsureMigrated-first would fail this test).
+func TestEntrypoint_DivergentInit_NoMutationBeforeFailLoud(t *testing.T) {
+	dir := credtest.Hermetic(t)
+	p := filepath.Join(dir, "atlassian-cli", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pre := "default:\n  url: https://default.atlassian.net\n  email: u@e\n  api_token: PLAINTEXT_TOK\ncfl:\n  url: https://cfl-only.atlassian.net\n"
+	if err := os.WriteFile(p, []byte(pre), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stderr, code := runCLI(t, dir, "", "init", "--no-verify")
+	if code == 0 {
+		t.Fatalf("divergent init must exit non-zero; stderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "cfl.url") {
+		t.Fatalf("must fail loud naming the divergent field/source; stderr:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "cfl-only.atlassian.net") || strings.Contains(stderr, "PLAINTEXT_TOK") {
+		t.Fatalf("fail-loud must not leak values; stderr:\n%s", stderr)
+	}
+	// EnsureMigrated never ran: keyring empty, token still on disk.
+	if got := credtest.BundleKeys(t); len(got) != 0 {
+		t.Fatalf("token must NOT be migrated before the fail-loud; bundle=%v", got)
+	}
+	raw, _ := os.ReadFile(p) //nolint:gosec // test reads its own temp file
+	if !strings.Contains(string(raw), "PLAINTEXT_TOK") || !strings.Contains(string(raw), "cfl-only.atlassian.net") {
+		t.Fatalf("divergent init must mutate NOTHING on disk:\n%s", raw)
+	}
+}

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -292,7 +292,7 @@ func finalizeInit(
 		}
 	}
 
-	applyResultToStore(result.store, cfg, result.target)
+	applyResultToStore(result.store, cfg)
 	if err := result.store.Save(sharedPath); err != nil {
 		return fmt.Errorf("saving shared store: %w", err)
 	}

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -94,18 +94,16 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 		}
 	}
 
-	// Run the one-time §1.8 migration up front so a pre-existing legacy
-	// plaintext token is relocated (and scrubbed) into the keyring before
-	// the user sets a new one — otherwise it could collide later.
-	if err := keyring.EnsureMigrated(); err != nil {
-		v.Error("Could not prepare secure credential storage: %v", err)
-		return err
-	}
-
 	legacyPath := config.DefaultConfigPath()
 	sharedPath := credstore.DefaultPath()
 	jtkLegacyPath := credstore.LegacyJTKPath()
 
+	// §2.2 ordering (MON-5328): detect connection divergence FIRST,
+	// before any mutation. detectAndReconcile reads the pre-migration
+	// projection and fails loud (mutating nothing) if per-tool / legacy
+	// connections diverge. Only once that passes do we run the §1.8
+	// token migration — so a connection conflict can never be preempted
+	// by a token migration/scrub, and a divergent file is never mutated.
 	result, err := detectAndReconcile(v, legacyPath, jtkLegacyPath, sharedPath,
 		prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 	if err != nil {
@@ -113,14 +111,21 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	}
 	cfg := result.prefill
 
-	// The up-front EnsureMigrated relocates any legacy plaintext token into
-	// the single shared keyring api_token and scrubs the file, so
-	// detectAndReconcile (which reads the now-scrubbed legacy/config files)
-	// leaves prefill.APIToken empty even though the token still exists.
-	// Backfill it from the keyring so a returning user isn't forced to
-	// re-enter a token that was just migrated. NoMigrate: migration already
-	// ran above. Value stays password-masked in the form (same ingress as
-	// before); never displayed.
+	// Now the one-time §1.8 token migration: relocate any pre-existing
+	// legacy plaintext token into the single shared keyring api_token
+	// (token-only, connection-preserving scrub) before the user sets a
+	// new one.
+	if err := keyring.EnsureMigrated(); err != nil {
+		v.Error("Could not prepare secure credential storage: %v", err)
+		return err
+	}
+
+	// EnsureMigrated relocated any legacy plaintext token into the
+	// keyring and scrubbed it from disk, so prefill.APIToken is empty
+	// even though the token still exists. Backfill it from the keyring
+	// so a returning user isn't forced to re-enter a just-migrated
+	// token. NoMigrate: migration already ran. Value stays
+	// password-masked in the form; never displayed.
 	if cfg.APIToken == "" {
 		if tok, _, terr := keyring.ResolveTokenNoMigrate(credstore.ToolCFL); terr == nil {
 			cfg.APIToken = tok

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -129,7 +129,7 @@ func TestRunInit_InvalidAuthMethod(t *testing.T) {
 // network call is made.
 
 func newFinalizeReconcileResult() *reconcileResult {
-	return &reconcileResult{store: &credstore.Store{}, target: writeDefault}
+	return &reconcileResult{store: &credstore.Store{}}
 }
 
 func newFinalizeOpts() *root.Options {
@@ -150,68 +150,49 @@ func userResponseServer(t *testing.T, body string, status int) *httptest.Server 
 	}))
 }
 
-// TestFinalizeInit_WritesToCorrectSection verifies the saved YAML
-// routes credentials to the section named by writeTarget. A regression
-// in target selection (e.g. credentials landing in default when an
-// override was intended) would be silently invisible without this
-// readback assertion.
-func TestFinalizeInit_WritesToCorrectSection(t *testing.T) {
-	// credtest.Hermetic uses t.Setenv → no t.Parallel here.
-	cases := []struct {
-		name    string
-		target  writeTarget
-		wantKey string
-	}{
-		// One key per logical credential (§1.11.10): the token always
-		// lands under the single shared api_token; writeTarget governs
-		// only NON-secret placement (default vs cfl section).
-		{"default", writeDefault, keyring.KeyAPIToken},
-		{"cfl_override", writeCFLOverride, keyring.KeyAPIToken},
+// TestFinalizeInit_WritesConnectionToDefault verifies the §2.2
+// (MON-5328) single-source model: connection always lands in the shared
+// `default` section (no per-tool override target), the token NEVER
+// touches the plaintext store (keyring only, single api_token), and the
+// cfl section carries no connection fields.
+func TestFinalizeInit_WritesConnectionToDefault(t *testing.T) {
+	credtest.Hermetic(t) // t.Setenv → no t.Parallel
+	server := userResponseServer(t, `{"accountId":"abc","displayName":"X","email":"x@e"}`, http.StatusOK)
+	defer server.Close()
+	build := func(_ *config.Config) (*api.Client, error) {
+		return api.NewClient(server.URL, "x@e", "tok"), nil
 	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			credtest.Hermetic(t)
-			server := userResponseServer(t, `{"accountId":"abc","displayName":"X","email":"x@e"}`, http.StatusOK)
-			defer server.Close()
-			build := func(_ *config.Config) (*api.Client, error) {
-				return api.NewClient(server.URL, "x@e", "tok"), nil
-			}
-			tmpDir := t.TempDir()
-			configPath := filepath.Join(tmpDir, "config.yml")
-			cfg := &config.Config{URL: server.URL + "/wiki", Email: "x@e", APIToken: "tok"}
-			result := &reconcileResult{store: &credstore.Store{}, target: tc.target}
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	cfg := &config.Config{URL: server.URL + "/wiki", Email: "x@e", APIToken: "tok", DefaultSpace: "SP"}
+	result := &reconcileResult{store: &credstore.Store{}}
 
-			testutil.RequireNoError(t,
-				finalizeInit(context.Background(), newFinalizeOpts(), cfg, result, configPath, false, build))
+	testutil.RequireNoError(t,
+		finalizeInit(context.Background(), newFinalizeOpts(), cfg, result, configPath, false, build))
 
-			loaded, err := credstore.Load(configPath)
-			testutil.RequireNoError(t, err)
+	loaded, err := credstore.Load(configPath)
+	testutil.RequireNoError(t, err)
 
-			var got, leak credstore.Section
-			switch tc.target {
-			case writeDefault:
-				got, leak = loaded.Default, loaded.CFL.Section
-			case writeCFLOverride:
-				got, leak = loaded.CFL.Section, loaded.Default
-			}
-			// The token is NEVER persisted to the plaintext store — it
-			// goes to the keyring under the write-target key.
-			testutil.Equal(t, "", got.APIToken)
-			testutil.Equal(t, "x@e", got.Email)
-			testutil.Equal(t, server.URL, got.URL) // URL normalized: /wiki stripped
-			testutil.Equal(t, "", leak.APIToken)
-			testutil.Equal(t, "", leak.Email)
-			testutil.Equal(t, "", leak.URL)
+	// Connection in default; token never in plaintext.
+	testutil.Equal(t, "", loaded.Default.APIToken)
+	testutil.Equal(t, "x@e", loaded.Default.Email)
+	testutil.Equal(t, server.URL, loaded.Default.URL) // /wiki stripped
+	// cfl section carries only the non-secret default, no connection.
+	testutil.Equal(t, "SP", loaded.CFL.DefaultSpace)
 
-			s, err := keyring.OpenNoMigrate()
-			testutil.RequireNoError(t, err)
-			defer func() { _ = s.Close() }()
-			ok, err := s.HasToken(tc.wantKey)
-			testutil.RequireNoError(t, err)
-			testutil.True(t, ok)
-		})
+	// Raw file must contain no api_token and no per-tool connection key.
+	raw, rerr := os.ReadFile(configPath) //nolint:gosec // test reads its own temp file
+	testutil.RequireNoError(t, rerr)
+	if strings.Contains(string(raw), "api_token") {
+		t.Fatalf("plaintext store must never contain api_token:\n%s", raw)
 	}
+
+	s, err := keyring.OpenNoMigrate()
+	testutil.RequireNoError(t, err)
+	defer func() { _ = s.Close() }()
+	ok, err := s.HasToken(keyring.KeyAPIToken)
+	testutil.RequireNoError(t, err)
+	testutil.True(t, ok)
 }
 
 func TestFinalizeInit_BasicHappyPath(t *testing.T) {

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -3,60 +3,44 @@ package init
 import (
 	"errors"
 	"fmt"
-
-	"github.com/charmbracelet/huh"
+	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/credstore"
-	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/confluence-cli/internal/config"
 )
 
-// hasUsableCreds composes the non-secret config completeness check
-// (credstore) with keyring token presence. The token no longer lives in
-// the shared store, so neither half alone means "already configured".
-func hasUsableCreds(store *credstore.Store, tool string) (bool, error) {
-	if !store.HasUsableConfig(tool) {
-		return false, nil
-	}
-	return keyring.HasToken()
-}
-
-// writeTarget tells the post-form save logic which section of the
-// shared store to write credential edits into. Tool-specific bits
-// (default_space/output_format) always go to the cfl section
-// regardless of target.
-type writeTarget int
-
-const (
-	writeDefault writeTarget = iota
-	writeCFLOverride
-)
-
 // reconcileResult captures everything finalizeInit needs after the
-// detection + prompt phase: a *Config to seed the form, a write target,
-// the shared store the user already had on disk (so save preserves
-// unrelated fields like the jtk section), and the list of legacy
-// files that the user might want to clean up after migration.
+// detection phase: a *Config to seed the form, the shared store the user
+// already had on disk (so save preserves unrelated fields like the jtk
+// section), and the legacy files the user might want to clean up.
+//
+// Per §2.2 (MON-5328) connection config is single-sourced from the
+// shared `default` section — there is no per-tool override and therefore
+// no write-target choice; finalizeInit always writes connection to
+// `default`.
 type reconcileResult struct {
 	prefill          *config.Config
-	target           writeTarget
 	store            *credstore.Store
-	consumedLegacies []string // paths of legacy files actually read into prefill
-	// affectsSibling is true when finalizeInit should confirm before
-	// writing because the save will mutate credentials the sibling tool
-	// is currently reading from. Set when reuse=yes was chosen on a
-	// shared store that already had usable creds.
+	consumedLegacies []string // legacy file paths folded into the result
+	// affectsSibling is true when the save will mutate connection
+	// credentials the sibling tool also reads (always, now that there is
+	// one shared default) AND the store already held usable creds — so
+	// finalizeInit confirms before overwriting a working shared config.
 	affectsSibling bool
 }
 
 // detectAndReconcile decides what to do given whatever configs already
-// exist on disk. It runs whatever interactive prompts are necessary to
-// disambiguate, then returns a deterministic result for finalizeInit.
+// exist on disk. Connection config is single-sourced (§2.2): it gathers
+// every connection candidate (shared default, the pre-MON-5328 shared
+// per-tool sections via the migration projection, and the legacy cfl/jtk
+// files), runs the pure divergence detector, and FAILS LOUD if they
+// disagree (naming every source + field, never a value) rather than
+// precedence-picking. Aligned → the unified connection is folded into
+// the shared default; per-tool non-secret defaults are preserved.
 //
-// Path arguments are injected so tests can point them at a tempdir;
-// production passes the canonical paths.
+// Path arguments are injected so tests can point them at a tempdir.
 func detectAndReconcile(
 	v *view.View,
 	cflLegacyPath, jtkLegacyPath, sharedPath string,
@@ -68,274 +52,210 @@ func detectAndReconcile(
 		v.Error("Refusing to overwrite. Fix or remove the file, then re-run cfl init.")
 		return nil, err
 	}
+	// Migration projection retains the pre-MON-5328 per-tool connection
+	// fields the canonical Store dropped (EnsureMigrated's token-only
+	// scrub preserves them, so they are still readable here).
+	proj, err := credstore.LoadSharedLegacyProjection(sharedPath)
+	if err != nil {
+		v.Error("Shared credential store at %s is unreadable: %v", sharedPath, err)
+		v.Error("Refusing to overwrite. Fix or remove the file, then re-run cfl init.")
+		return nil, err
+	}
+	if proj == nil {
+		proj = &credstore.SharedLegacyProjection{Path: sharedPath}
+	}
 
 	cflLegacy, cflErr := credstore.LoadLegacyCFL(cflLegacyPath)
 	if cflErr != nil {
 		if errors.Is(cflErr, credstore.ErrCorruptStore) {
 			v.Error("Legacy cfl config at %s is unreadable: %v", cflLegacyPath, cflErr)
 			v.Error("Refusing to overwrite. Fix or remove the file, then re-run cfl init.")
-			return nil, cflErr
 		}
 		return nil, cflErr
 	}
 	jtkLegacy, jtkErr := credstore.LoadLegacyJTK(jtkLegacyPath)
 	if jtkErr != nil {
-		// Sibling-corrupt is a warning, not a hard stop — we can still
-		// migrate this tool's data without touching the sibling file.
+		// Sibling-corrupt is a warning, not a hard stop.
 		v.Info("Note: sibling jtk config at %s is unreadable; ignoring. (%v)", jtkLegacyPath, jtkErr)
 		jtkLegacy = nil
 	}
 
-	// Case 1: shared store + keyring already hold usable creds for cfl.
-	usable, err := hasUsableCreds(store, credstore.ToolCFL)
-	if err != nil {
-		return nil, err
-	}
-	if usable {
-		// If the user already has a cfl override, edits go back to the
-		// override; otherwise the user picks default-vs-override.
-		hasOverride := !sectionEmpty(store.CFL.Section)
-		if hasOverride {
-			return resultFromSharedWithOverride(store, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID), nil
-		}
-		var reuse bool
-		err := huh.NewConfirm().
-			Title("Shared Atlassian credentials found").
-			Description(fmt.Sprintf(
-				"%s\n\nReuse these for cfl? (no = set up cfl-specific credentials)",
-				credstore.FormatSection("default", store.Default),
-			)).
-			Affirmative("Reuse").
-			Negative("Set cfl-specific").
-			Value(&reuse).
-			Run()
-		if err != nil {
-			return nil, err
-		}
-		if reuse {
-			v.Info("Note: editing these credentials will also affect jtk (writes go to shared default).")
-		}
-		return resultFromSharedNoOverride(store, reuse, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID), nil
+	// Build the full named connection candidate set and detect
+	// divergence (pure, secret-free, no IO/keyring).
+	candidates := connCandidates(sharedPath, store, proj, cflLegacy, jtkLegacy)
+	chosen, conflicts := credstore.DetectConnDivergence(candidates)
+	if len(conflicts) > 0 {
+		return nil, connConflictError(conflicts)
 	}
 
-	// Case 2: only this tool's legacy exists.
-	if cflLegacy != nil && jtkLegacy == nil {
-		v.Info("Migrating existing cfl config at %s to shared store.", cflLegacy.Path)
-		return resultFromCFLLegacy(cflLegacy, store, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID), nil
+	// Aligned: fold the unified connection into the shared default and
+	// preserve per-tool non-secret defaults (cfl's space/output, jtk's
+	// project) so neither tool loses them on next read.
+	store.Default = credstore.Section{
+		URL:        chosen.URL,
+		Email:      chosen.Email,
+		AuthMethod: chosen.AuthMethod,
+		CloudID:    chosen.CloudID,
 	}
+	consumed := preserveDefaultsAndCollect(store, cflLegacy, jtkLegacy)
 
-	// Case 3: only sibling legacy exists.
-	if cflLegacy == nil && jtkLegacy != nil {
-		var reuse bool
-		err := huh.NewConfirm().
-			Title("Found jtk credentials").
-			Description(fmt.Sprintf(
-				"%s\n\nReuse these for cfl? (Atlassian API tokens are account-wide and usually work across products.)",
-				credstore.FormatSection("jtk", jtkLegacy.Section()),
-			)).
-			Affirmative("Reuse").
-			Negative("Fresh setup").
-			Value(&reuse).
-			Run()
-		if err != nil {
-			return nil, err
-		}
-		return resultFromSiblingLegacy(jtkLegacy, store, reuse, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID), nil
+	// If the shared store already holds a usable connection, editing it
+	// also affects jtk (single shared default) — finalizeInit confirms.
+	// Pure (store.HasUsableConfig only): NO keyring I/O in reconcile (the
+	// B3 leak-regression rule — keyring access lives in the command
+	// layer, never in this pure path).
+	affectsSibling := store.HasUsableConfig(credstore.ToolCFL)
+
+	cfg := configFromConn(chosen)
+	if store.CFL.DefaultSpace != "" {
+		cfg.DefaultSpace = store.CFL.DefaultSpace
 	}
-
-	// Case 4: both legacies exist. Either way, preserve jtk's per-tool
-	// defaults into the store so jtk doesn't lose default_project on
-	// next read.
-	if cflLegacy != nil && jtkLegacy != nil {
-		store.JTK.DefaultProject = jtkLegacy.DefaultProject
-		if credstore.SectionsEqual(cflLegacy.Section(), jtkLegacy.Section()) {
-			v.Info("Found matching cfl and jtk credentials; migrating to shared store.")
-			cfg := configFromLegacy(cflLegacy)
-			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path, jtkLegacy.Path}}, nil
-		}
-		choice, err := promptReconcileMismatch(cflLegacy, jtkLegacy)
-		if err != nil {
-			return nil, err
-		}
-		return resultFromMismatch(cflLegacy, jtkLegacy, choice, store, v, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID), nil
-	}
-
-	// Case 5: nothing on disk anywhere.
-	cfg := &config.Config{}
-	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-	return &reconcileResult{prefill: cfg, target: writeDefault, store: store}, nil
-}
-
-// mismatchDescription is the prompt description for the both-legacies-
-// mismatch reconciliation. Extracted so tests can assert the
-// educational language without driving huh.
-func mismatchDescription(cflLegacy, jtkLegacy *credstore.LegacyCreds) string {
-	return fmt.Sprintf(
-		"%s\n\n%s\n\nNote: Atlassian API tokens are account-wide. One token usually works for both Jira and Confluence.\nManage tokens: https://id.atlassian.com/manage-profile/security/api-tokens",
-		credstore.FormatSection("cfl ("+cflLegacy.Path+")", cflLegacy.Section()),
-		credstore.FormatSection("jtk ("+jtkLegacy.Path+")", jtkLegacy.Section()),
-	)
-}
-
-func promptReconcileMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds) (string, error) {
-	desc := mismatchDescription(cflLegacy, jtkLegacy)
-	var choice string
-	err := huh.NewSelect[string]().
-		Title("Different Atlassian credentials found").
-		Description(desc).
-		Options(
-			huh.NewOption("Use cfl's credentials for both tools", "use_cfl"),
-			huh.NewOption("Use jtk's credentials for both tools", "use_jtk"),
-			huh.NewOption("Keep them different (advanced)", "keep_different"),
-		).
-		Value(&choice).
-		Run()
-	return choice, err
-}
-
-// resultFromCFLLegacy is the post-prompt branch for "only this tool's
-// legacy" — lifted out so tests can drive it without huh.
-func resultFromCFLLegacy(cflLegacy *credstore.LegacyCreds, store *credstore.Store, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
-	cfg := configFromLegacy(cflLegacy)
-	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-	return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{cflLegacy.Path}}
-}
-
-// resultFromSiblingLegacy is the post-prompt branch for "only sibling
-// (jtk) legacy" — `reuse` is what huh returned. Either way, jtk's
-// per-tool defaults (default_project) are preserved into the store so
-// jtk doesn't lose them on next read.
-func resultFromSiblingLegacy(jtkLegacy *credstore.LegacyCreds, store *credstore.Store, reuse bool, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
-	store.JTK.DefaultProject = jtkLegacy.DefaultProject
-	var cfg *config.Config
-	if reuse {
-		cfg = configFromLegacy(jtkLegacy)
-	} else {
-		cfg = &config.Config{}
+	if store.CFL.OutputFormat != "" {
+		cfg.OutputFormat = store.CFL.OutputFormat
 	}
 	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-	consumed := []string{}
-	if reuse {
-		consumed = []string{jtkLegacy.Path}
-	}
-	return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
-}
 
-// resultFromSharedNoOverride is the post-prompt branch for the
-// shared-store-present-no-override case in detectAndReconcile.
-// `reuse` is what huh returned.
-func resultFromSharedNoOverride(store *credstore.Store, reuse bool, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
-	var cfg *config.Config
-	target := writeCFLOverride
-	if reuse {
-		cfg = configFromSection(store.Resolve(credstore.ToolCFL))
-		copyCFLDefaults(cfg, store.CFL)
-		target = writeDefault
-	} else {
-		cfg = &config.Config{}
-		copyCFLDefaults(cfg, store.CFL)
-	}
-	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
 	return &reconcileResult{
-		prefill:        cfg,
-		target:         target,
-		store:          store,
-		affectsSibling: reuse, // reuse=yes writes to default → affects jtk
-	}
+		prefill:          cfg,
+		store:            store,
+		consumedLegacies: consumed,
+		affectsSibling:   affectsSibling,
+	}, nil
 }
 
-// resultFromSharedWithOverride is the (no-prompt) branch when shared
-// store already has a populated cfl override section. Edits land in
-// the override; default isn't touched.
-func resultFromSharedWithOverride(store *credstore.Store, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
-	cfg := configFromSection(store.Resolve(credstore.ToolCFL))
-	copyCFLDefaults(cfg, store.CFL)
-	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-	return &reconcileResult{prefill: cfg, target: writeCFLOverride, store: store}
-}
-
-// resultFromMismatch is the post-prompt branch for "both legacies
-// exist with different creds". `choice` is the huh select value:
-// "use_cfl" | "use_jtk" | "keep_different".
-func resultFromMismatch(cflLegacy, jtkLegacy *credstore.LegacyCreds, choice string, store *credstore.Store, v *view.View, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string) *reconcileResult {
-	consumed := []string{cflLegacy.Path, jtkLegacy.Path}
-	switch choice {
-	case "use_cfl", "use_jtk":
-		// User chose to unify on one tool's creds. Clear both
-		// override Sections so each tool resolves to the new default
-		// rather than a leftover override from a prior keep_different
-		// run. Per-tool defaults (default_space, default_project,
-		// output_format) are preserved.
-		store.CFL.Section = credstore.Section{}
-		store.JTK.Section = credstore.Section{}
-		var cfg *config.Config
-		if choice == "use_cfl" {
-			cfg = configFromLegacy(cflLegacy)
-		} else {
-			cfg = configFromLegacy(jtkLegacy)
-			cfg.DefaultSpace = cflLegacy.DefaultSpace
-			cfg.OutputFormat = cflLegacy.OutputFormat
+// connCandidates assembles the origin-labeled connection sources for the
+// divergence detector: shared default, the pre-MON-5328 shared per-tool
+// sections as effective overrides (default ⊕ section), and the legacy
+// cfl/jtk files. All-empty candidates are skipped (the detector also
+// treats them as "no opinion", but skipping keeps conflict labels tight).
+func connCandidates(
+	sharedPath string,
+	store *credstore.Store,
+	proj *credstore.SharedLegacyProjection,
+	cflLegacy, jtkLegacy *credstore.LegacyCreds,
+) []credstore.NamedConn {
+	var out []credstore.NamedConn
+	add := func(label, section, path string, c credstore.ConnProfile) {
+		if c.URL == "" && c.Email == "" && c.AuthMethod == "" && c.CloudID == "" {
+			return
 		}
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-		// Non-secret connection reconcile only. The token is now a single
-		// shared key: divergent legacy tokens are caught by the keyring
-		// migration (fail-loud §1.8), not chosen here.
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
-	case "keep_different":
-		// Both tools land in their override sections so the split is
-		// stable: store.Default stays empty, cfl reads its override,
-		// jtk reads its override. Save target is writeCFLOverride so
-		// post-form edits stay in the cfl section.
-		store.CFL.Section = cflLegacy.Section()
-		store.CFL.DefaultSpace = cflLegacy.DefaultSpace
-		store.CFL.OutputFormat = cflLegacy.OutputFormat
-		store.JTK.Section = jtkLegacy.Section()
-		cfg := configFromLegacy(cflLegacy)
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-		v.Info("Keeping per-tool credentials. cfl will use cfl's token; jtk will use jtk's token.")
-		return &reconcileResult{prefill: cfg, target: writeCFLOverride, store: store, consumedLegacies: consumed}
+		out = append(out, credstore.NamedConn{Label: label, Section: section, Path: path, Conn: c})
 	}
-	cfg := &config.Config{}
-	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID)
-	return &reconcileResult{prefill: cfg, target: writeDefault, store: store}
+	def := credstore.ConnProfile{
+		URL: store.Default.URL, Email: store.Default.Email,
+		AuthMethod: store.Default.AuthMethod, CloudID: store.Default.CloudID,
+	}
+	add("shared config", "default", sharedPath, def)
+	add("shared config", "cfl", sharedPath, effectiveConn(proj.Default, proj.CFL))
+	add("shared config", "jtk", sharedPath, effectiveConn(proj.Default, proj.JTK))
+	if cflLegacy != nil {
+		add("legacy cfl config", "", cflLegacy.Path, legacyConn(cflLegacy))
+	}
+	if jtkLegacy != nil {
+		add("legacy jtk config", "", jtkLegacy.Path, legacyConn(jtkLegacy))
+	}
+	return out
 }
 
-func sectionEmpty(s credstore.Section) bool {
-	return s.URL == "" && s.Email == "" && s.APIToken == "" && s.AuthMethod == "" && s.CloudID == ""
+// effectiveConn merges a pre-MON-5328 per-tool section over default
+// (the old per-field-merge semantics) so the detector compares what the
+// tool actually USED to resolve.
+func effectiveConn(def, sec credstore.SharedLegacyConn) credstore.ConnProfile {
+	pick := func(o, d string) string {
+		if o != "" {
+			return o
+		}
+		return d
+	}
+	return credstore.ConnProfile{
+		URL:        pick(sec.URL, def.URL),
+		Email:      pick(sec.Email, def.Email),
+		AuthMethod: pick(sec.AuthMethod, def.AuthMethod),
+		CloudID:    pick(sec.CloudID, def.CloudID),
+	}
 }
 
-func configFromSection(s credstore.Section) *config.Config {
+func legacyConn(l *credstore.LegacyCreds) credstore.ConnProfile {
+	return credstore.ConnProfile{
+		URL: l.URL, Email: l.Email, AuthMethod: l.AuthMethod, CloudID: l.CloudID,
+	}
+}
+
+// connConflictError renders the fail-loud message: every conflicting
+// field with every contributing source descriptor
+// (`<label> <section>.<field> (<path>)`), NEVER a value (§1.12), and an
+// actionable remediation pointing at every distinct file.
+func connConflictError(conflicts []credstore.ConnConflict) error {
+	var b strings.Builder
+	b.WriteString("connection config diverges across sources; init will not pick a winner. Conflicts:\n")
+	paths := map[string]struct{}{}
+	for _, c := range conflicts {
+		fmt.Fprintf(&b, "  - %s: %s\n", c.Field, strings.Join(c.Sources, ", "))
+		for _, s := range c.Sources {
+			if i := strings.LastIndex(s, "("); i >= 0 {
+				if j := strings.Index(s[i:], ")"); j > 0 {
+					paths[s[i+1:i+j]] = struct{}{}
+				}
+			}
+		}
+	}
+	b.WriteString("Resolve by editing/removing all but one connection in: ")
+	first := true
+	for p := range paths {
+		if !first {
+			b.WriteString(", ")
+		}
+		b.WriteString(p)
+		first = false
+	}
+	b.WriteString(" — then re-run cfl init. (No values shown; secrets live only in the OS keyring.)")
+	return errors.New(b.String())
+}
+
+// preserveDefaultsAndCollect keeps per-tool non-secret defaults from the
+// pre-strip projection and legacy files, and returns the legacy file
+// paths that contributed a connection (so init can offer to delete them).
+func preserveDefaultsAndCollect(
+	store *credstore.Store,
+	cflLegacy, jtkLegacy *credstore.LegacyCreds,
+) []string {
+	var consumed []string
+	if cflLegacy != nil {
+		if cflLegacy.DefaultSpace != "" {
+			store.CFL.DefaultSpace = cflLegacy.DefaultSpace
+		}
+		if cflLegacy.OutputFormat != "" {
+			store.CFL.OutputFormat = cflLegacy.OutputFormat
+		}
+		if hasConn(legacyConn(cflLegacy)) {
+			consumed = append(consumed, cflLegacy.Path)
+		}
+	}
+	if jtkLegacy != nil {
+		if jtkLegacy.DefaultProject != "" {
+			store.JTK.DefaultProject = jtkLegacy.DefaultProject
+		}
+		if hasConn(legacyConn(jtkLegacy)) {
+			consumed = append(consumed, jtkLegacy.Path)
+		}
+	}
+	return consumed
+}
+
+func hasConn(c credstore.ConnProfile) bool {
+	return c.URL != "" || c.Email != "" || c.AuthMethod != "" || c.CloudID != ""
+}
+
+func configFromConn(c credstore.ConnProfile) *config.Config {
 	cfg := &config.Config{
-		Email:      s.Email,
-		APIToken:   s.APIToken,
-		AuthMethod: s.AuthMethod,
-		CloudID:    s.CloudID,
+		Email:      c.Email,
+		AuthMethod: c.AuthMethod,
+		CloudID:    c.CloudID,
 	}
-	if s.URL != "" {
-		cfg.URL = credstore.URLForCFL(s.URL)
-	}
-	return cfg
-}
-
-func configFromLegacy(l *credstore.LegacyCreds) *config.Config {
-	cfg := configFromSection(l.Section())
-	if l.DefaultSpace != "" {
-		cfg.DefaultSpace = l.DefaultSpace
-	}
-	if l.OutputFormat != "" {
-		cfg.OutputFormat = l.OutputFormat
+	if c.URL != "" {
+		cfg.URL = credstore.URLForCFL(c.URL)
 	}
 	return cfg
-}
-
-func copyCFLDefaults(cfg *config.Config, t credstore.ToolSection) {
-	if t.DefaultSpace != "" {
-		cfg.DefaultSpace = t.DefaultSpace
-	}
-	if t.OutputFormat != "" {
-		cfg.OutputFormat = t.OutputFormat
-	}
 }
 
 func applyFlagOverrides(cfg *config.Config, url, email, authMethod, cloudID string) {
@@ -353,24 +273,16 @@ func applyFlagOverrides(cfg *config.Config, url, email, authMethod, cloudID stri
 	}
 }
 
-// applyResultToStore mutates the shared store so it carries the form's
-// final cfg in the right section. It preserves unrelated existing
-// fields (jtk section, jtk per-tool defaults) and only overwrites a
-// CFL per-tool default when the form actually produced a value, so a
-// freshly-set-up cfl doesn't stomp a previously-saved default_space.
-func applyResultToStore(store *credstore.Store, cfg *config.Config, target writeTarget) {
-	cred := credstore.Section{
+// applyResultToStore writes the form's final cfg into the shared default
+// (connection is single-sourced — §2.2) and preserves/sets the cfl
+// per-tool non-secret defaults. The jtk section and jtk defaults are
+// left untouched.
+func applyResultToStore(store *credstore.Store, cfg *config.Config) {
+	store.Default = credstore.Section{
 		URL:        credstore.NormalizeBaseURL(cfg.URL),
 		Email:      cfg.Email,
-		APIToken:   cfg.APIToken,
 		AuthMethod: cfg.AuthMethod,
 		CloudID:    cfg.CloudID,
-	}
-	switch target {
-	case writeDefault:
-		store.Default = cred
-	case writeCFLOverride:
-		store.CFL.Section = cred
 	}
 	if cfg.DefaultSpace != "" {
 		store.CFL.DefaultSpace = cfg.DefaultSpace

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -90,13 +90,24 @@ func detectAndReconcile(
 	// folding `chosen` in — otherwise a first-time migration from only a
 	// legacy file looks like it is overwriting an already-usable shared
 	// default and the user gets a misleading "Save will affect sibling"
-	// prompt. Pure (store.HasUsableConfig only): NO keyring I/O in
-	// reconcile (the B3 leak-regression rule).
-	affectsSibling := store.HasUsableConfig(credstore.ToolCFL)
+	// prompt. It is true only when the store already held usable creds
+	// AND the resolved connection actually DIFFERS from what is on disk:
+	// re-running `cfl init` without changing the connection is a no-op
+	// for jtk and must not nag (the prior per-tool model only prompted on
+	// an explicit reuse choice; one shared default would otherwise prompt
+	// on every re-init). Pure (HasUsableConfig + value compare only): NO
+	// keyring I/O in reconcile (the B3 leak-regression rule).
+	origDefault := store.Default
+	affectsSibling := store.HasUsableConfig(credstore.ToolCFL) &&
+		!credstore.ConnEqualsSection(chosen, origDefault)
 
 	// Aligned: fold the unified connection into the shared default and
 	// preserve per-tool non-secret defaults (cfl's space/output, jtk's
-	// project) so neither tool loses them on next read.
+	// project) so neither tool loses them on next read. This in-place
+	// write is intentionally redundant with applyResultToStore (which
+	// finalizeInit calls after the form, with the final URL-normalized
+	// values) — result.store.Default is never read between the two, so
+	// the transient pre-normalization state is not observable.
 	store.Default = credstore.Section{
 		URL:        chosen.URL,
 		Email:      chosen.Email,
@@ -122,19 +133,23 @@ func detectAndReconcile(
 	}, nil
 }
 
-// preserveDefaultsAndCollect keeps per-tool non-secret defaults from the
-// pre-strip projection and legacy files, and returns the legacy file
-// paths that contributed a connection (so init can offer to delete them).
+// preserveDefaultsAndCollect fills per-tool non-secret defaults from the
+// legacy files, and returns the legacy file paths that contributed a
+// connection (so init can offer to delete them). Legacy values only fill
+// fields the shared store leaves EMPTY: a value the user already set in
+// the shared store (e.g. via a prior init that changed default_space)
+// must not be silently reverted to a stale legacy value just because the
+// old file still exists. Shared store wins; legacy backfills absent.
 func preserveDefaultsAndCollect(
 	store *credstore.Store,
 	cflLegacy, jtkLegacy *credstore.LegacyCreds,
 ) []string {
 	var consumed []string
 	if cflLegacy != nil {
-		if cflLegacy.DefaultSpace != "" {
+		if store.CFL.DefaultSpace == "" && cflLegacy.DefaultSpace != "" {
 			store.CFL.DefaultSpace = cflLegacy.DefaultSpace
 		}
-		if cflLegacy.OutputFormat != "" {
+		if store.CFL.OutputFormat == "" && cflLegacy.OutputFormat != "" {
 			store.CFL.OutputFormat = cflLegacy.OutputFormat
 		}
 		if legacyHasConn(cflLegacy) {
@@ -142,7 +157,7 @@ func preserveDefaultsAndCollect(
 		}
 	}
 	if jtkLegacy != nil {
-		if jtkLegacy.DefaultProject != "" {
+		if store.JTK.DefaultProject == "" && jtkLegacy.DefaultProject != "" {
 			store.JTK.DefaultProject = jtkLegacy.DefaultProject
 		}
 		if legacyHasConn(jtkLegacy) {

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -88,6 +88,14 @@ func detectAndReconcile(
 		return nil, connConflictError(conflicts)
 	}
 
+	// affectsSibling must be judged on the ORIGINAL loaded store, BEFORE
+	// folding `chosen` in — otherwise a first-time migration from only a
+	// legacy file looks like it is overwriting an already-usable shared
+	// default and the user gets a misleading "Save will affect sibling"
+	// prompt. Pure (store.HasUsableConfig only): NO keyring I/O in
+	// reconcile (the B3 leak-regression rule).
+	affectsSibling := store.HasUsableConfig(credstore.ToolCFL)
+
 	// Aligned: fold the unified connection into the shared default and
 	// preserve per-tool non-secret defaults (cfl's space/output, jtk's
 	// project) so neither tool loses them on next read.
@@ -98,13 +106,6 @@ func detectAndReconcile(
 		CloudID:    chosen.CloudID,
 	}
 	consumed := preserveDefaultsAndCollect(store, cflLegacy, jtkLegacy)
-
-	// If the shared store already holds a usable connection, editing it
-	// also affects jtk (single shared default) — finalizeInit confirms.
-	// Pure (store.HasUsableConfig only): NO keyring I/O in reconcile (the
-	// B3 leak-regression rule — keyring access lives in the command
-	// layer, never in this pure path).
-	affectsSibling := store.HasUsableConfig(credstore.ToolCFL)
 
 	cfg := configFromConn(chosen)
 	if store.CFL.DefaultSpace != "" {

--- a/tools/cfl/internal/cmd/init/reconcile.go
+++ b/tools/cfl/internal/cmd/init/reconcile.go
@@ -2,8 +2,6 @@ package init
 
 import (
 	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/view"
@@ -81,11 +79,11 @@ func detectAndReconcile(
 	}
 
 	// Build the full named connection candidate set and detect
-	// divergence (pure, secret-free, no IO/keyring).
-	candidates := connCandidates(sharedPath, store, proj, cflLegacy, jtkLegacy)
+	// divergence (pure, secret-free, no IO/keyring — shared with jtk).
+	candidates := credstore.ConnCandidates(sharedPath, store.Default, proj, cflLegacy, jtkLegacy)
 	chosen, conflicts := credstore.DetectConnDivergence(candidates)
 	if len(conflicts) > 0 {
-		return nil, connConflictError(conflicts)
+		return nil, credstore.ConnConflictError(conflicts, candidates, "cfl")
 	}
 
 	// affectsSibling must be judged on the ORIGINAL loaded store, BEFORE
@@ -124,95 +122,6 @@ func detectAndReconcile(
 	}, nil
 }
 
-// connCandidates assembles the origin-labeled connection sources for the
-// divergence detector: shared default, the pre-MON-5328 shared per-tool
-// sections as effective overrides (default ⊕ section), and the legacy
-// cfl/jtk files. All-empty candidates are skipped (the detector also
-// treats them as "no opinion", but skipping keeps conflict labels tight).
-func connCandidates(
-	sharedPath string,
-	store *credstore.Store,
-	proj *credstore.SharedLegacyProjection,
-	cflLegacy, jtkLegacy *credstore.LegacyCreds,
-) []credstore.NamedConn {
-	var out []credstore.NamedConn
-	add := func(label, section, path string, c credstore.ConnProfile) {
-		if c.URL == "" && c.Email == "" && c.AuthMethod == "" && c.CloudID == "" {
-			return
-		}
-		out = append(out, credstore.NamedConn{Label: label, Section: section, Path: path, Conn: c})
-	}
-	def := credstore.ConnProfile{
-		URL: store.Default.URL, Email: store.Default.Email,
-		AuthMethod: store.Default.AuthMethod, CloudID: store.Default.CloudID,
-	}
-	add("shared config", "default", sharedPath, def)
-	add("shared config", "cfl", sharedPath, effectiveConn(proj.Default, proj.CFL))
-	add("shared config", "jtk", sharedPath, effectiveConn(proj.Default, proj.JTK))
-	if cflLegacy != nil {
-		add("legacy cfl config", "", cflLegacy.Path, legacyConn(cflLegacy))
-	}
-	if jtkLegacy != nil {
-		add("legacy jtk config", "", jtkLegacy.Path, legacyConn(jtkLegacy))
-	}
-	return out
-}
-
-// effectiveConn merges a pre-MON-5328 per-tool section over default
-// (the old per-field-merge semantics) so the detector compares what the
-// tool actually USED to resolve.
-func effectiveConn(def, sec credstore.SharedLegacyConn) credstore.ConnProfile {
-	pick := func(o, d string) string {
-		if o != "" {
-			return o
-		}
-		return d
-	}
-	return credstore.ConnProfile{
-		URL:        pick(sec.URL, def.URL),
-		Email:      pick(sec.Email, def.Email),
-		AuthMethod: pick(sec.AuthMethod, def.AuthMethod),
-		CloudID:    pick(sec.CloudID, def.CloudID),
-	}
-}
-
-func legacyConn(l *credstore.LegacyCreds) credstore.ConnProfile {
-	return credstore.ConnProfile{
-		URL: l.URL, Email: l.Email, AuthMethod: l.AuthMethod, CloudID: l.CloudID,
-	}
-}
-
-// connConflictError renders the fail-loud message: every conflicting
-// field with every contributing source descriptor
-// (`<label> <section>.<field> (<path>)`), NEVER a value (§1.12), and an
-// actionable remediation pointing at every distinct file.
-func connConflictError(conflicts []credstore.ConnConflict) error {
-	var b strings.Builder
-	b.WriteString("connection config diverges across sources; init will not pick a winner. Conflicts:\n")
-	paths := map[string]struct{}{}
-	for _, c := range conflicts {
-		fmt.Fprintf(&b, "  - %s: %s\n", c.Field, strings.Join(c.Sources, ", "))
-		for _, s := range c.Sources {
-			if i := strings.LastIndex(s, "("); i >= 0 {
-				if j := strings.Index(s[i:], ")"); j > 0 {
-					paths[s[i+1:i+j]] = struct{}{}
-				}
-			}
-		}
-	}
-	b.WriteString("Resolve by editing/removing all but one connection in: ")
-	first := true
-	for p := range paths {
-		if !first {
-			b.WriteString(", ")
-		}
-		b.WriteString(p)
-		first = false
-	}
-	b.WriteString(" — then re-run cfl init. (No values shown; secrets live only in the OS keyring.)")
-	return errors.New(b.String())
-}
-
 // preserveDefaultsAndCollect keeps per-tool non-secret defaults from the
 // pre-strip projection and legacy files, and returns the legacy file
 // paths that contributed a connection (so init can offer to delete them).
@@ -228,7 +137,7 @@ func preserveDefaultsAndCollect(
 		if cflLegacy.OutputFormat != "" {
 			store.CFL.OutputFormat = cflLegacy.OutputFormat
 		}
-		if hasConn(legacyConn(cflLegacy)) {
+		if legacyHasConn(cflLegacy) {
 			consumed = append(consumed, cflLegacy.Path)
 		}
 	}
@@ -236,15 +145,15 @@ func preserveDefaultsAndCollect(
 		if jtkLegacy.DefaultProject != "" {
 			store.JTK.DefaultProject = jtkLegacy.DefaultProject
 		}
-		if hasConn(legacyConn(jtkLegacy)) {
+		if legacyHasConn(jtkLegacy) {
 			consumed = append(consumed, jtkLegacy.Path)
 		}
 	}
 	return consumed
 }
 
-func hasConn(c credstore.ConnProfile) bool {
-	return c.URL != "" || c.Email != "" || c.AuthMethod != "" || c.CloudID != ""
+func legacyHasConn(l *credstore.LegacyCreds) bool {
+	return l.URL != "" || l.Email != "" || l.AuthMethod != "" || l.CloudID != ""
 }
 
 func configFromConn(c credstore.ConnProfile) *config.Config {

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -174,6 +174,37 @@ func TestReconcile_SharedPerToolConnDivergence_FailLoud(t *testing.T) {
 	}
 }
 
+// Pins the prior Codex blocker: detectAndReconcile (which init runs
+// BEFORE keyring.EnsureMigrated) must fail loud AND mutate nothing when
+// a pre-MON-5328 shared config has a divergent per-tool connection plus
+// a plaintext api_token — the file is byte-identical afterwards and the
+// token is never migrated/scrubbed (init returns on this error before
+// EnsureMigrated ever runs).
+func TestReconcile_DivergentWithToken_NoMutation(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	pre := "default:\n  url: https://default.atlassian.net\n  email: u@e\n  api_token: PLAINTEXT_TOK\ncfl:\n  url: https://cfl-only.atlassian.net\n"
+	testutil.RequireNoError(t, os.WriteFile(sharedPath, []byte(pre), 0o600))
+	before, _ := os.ReadFile(sharedPath) //nolint:gosec // test reads its own temp file
+
+	v, _, _ := newReconcileView()
+	_, err := detectAndReconcile(v,
+		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "jtk.json"),
+		sharedPath, "", "", "", "")
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "cfl.url") {
+		t.Fatalf("expected connection divergence; got: %v", err)
+	}
+	after, _ := os.ReadFile(sharedPath) //nolint:gosec // test reads its own temp file
+	if string(before) != string(after) {
+		t.Fatalf("divergent detect must mutate NOTHING; file changed:\n%s", after)
+	}
+	if !strings.Contains(string(after), "PLAINTEXT_TOK") {
+		t.Fatalf("token must NOT be scrubbed on divergence:\n%s", after)
+	}
+}
+
 func TestReconcile_AffectsSibling_WhenSharedUsable(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -96,7 +96,8 @@ func TestReconcile_CorruptCFLLegacyAborts(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	cflPath := filepath.Join(tmp, "cfl.yml")
-	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte(": ::: ["), 0o600))
+	corrupt := []byte(": ::: [")
+	testutil.RequireNoError(t, os.WriteFile(cflPath, corrupt, 0o600))
 	v, _, stderr := newReconcileView()
 	_, err := detectAndReconcile(v, cflPath,
 		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "shared.yml"),
@@ -104,6 +105,13 @@ func TestReconcile_CorruptCFLLegacyAborts(t *testing.T) {
 	testutil.RequireError(t, err)
 	if !strings.Contains(stderr.String(), "unreadable") {
 		t.Errorf("corrupt own-legacy must surface an actionable 'unreadable' message; got: %s", stderr.String())
+	}
+	// Fail-loud must mutate NOTHING: the unreadable file is byte-identical
+	// afterwards (a future refactor that truncates/overwrites before the
+	// early return would otherwise pass undetected).
+	after, _ := os.ReadFile(cflPath) //nolint:gosec // test reads its own temp file
+	if string(after) != string(corrupt) {
+		t.Errorf("corrupt legacy file was mutated by a failed detect; want byte-identical")
 	}
 }
 
@@ -218,7 +226,13 @@ func TestReconcile_DivergentWithToken_NoMutation(t *testing.T) {
 	}
 }
 
-func TestReconcile_AffectsSibling_WhenSharedUsable(t *testing.T) {
+// Re-running init with the connection UNCHANGED must NOT nag about
+// affecting the sibling: the resolved connection is byte-equivalent to
+// the shared default already on disk (implicit-vs-explicit basic and URL
+// normalization are canonicalized away). Pins the §2.2/MON-5328 fix for
+// the daemon-flagged UX regression (one shared default would otherwise
+// prompt on every re-init).
+func TestReconcile_NoNagWhenConnUnchanged(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	sharedPath := filepath.Join(tmp, "shared.yml")
@@ -229,7 +243,48 @@ func TestReconcile_AffectsSibling_WhenSharedUsable(t *testing.T) {
 		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "jtk.json"),
 		sharedPath, "", "", "", "")
 	testutil.RequireNoError(t, err)
+	testutil.Equal(t, false, r.affectsSibling)
+}
+
+// When a usable shared default exists AND the resolved connection
+// actually DIFFERS from it (here a legacy file contributes a cloud_id
+// the default lacked), the save changes what jtk reads, so the sibling
+// confirmation MUST still fire.
+func TestReconcile_NagsWhenResolvedConnDiffers(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	testutil.RequireNoError(t, os.WriteFile(sharedPath,
+		[]byte("default:\n  url: https://acme.atlassian.net\n  email: u@e\n"), 0o600))
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	testutil.RequireNoError(t, os.WriteFile(cflPath,
+		[]byte("url: https://acme.atlassian.net\nemail: u@e\ncloud_id: CID\n"), 0o600))
+	v, _, _ := newReconcileView()
+	r, err := detectAndReconcile(v, cflPath,
+		filepath.Join(tmp, "jtk.json"), sharedPath, "", "", "", "")
+	testutil.RequireNoError(t, err)
 	testutil.Equal(t, true, r.affectsSibling)
+}
+
+// A per-tool default the user already set in the SHARED store must win
+// over a stale value in a still-present legacy file: legacy only
+// backfills fields the shared store leaves empty. Pins the
+// daemon-flagged silent-revert regression in preserveDefaultsAndCollect.
+func TestReconcile_SharedPerToolDefaultWinsOverLegacy(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	testutil.RequireNoError(t, os.WriteFile(sharedPath,
+		[]byte("default:\n  url: https://acme.atlassian.net\n  email: u@e\ncfl:\n  default_space: NEW\n  output_format: json\n"), 0o600))
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	testutil.RequireNoError(t, os.WriteFile(cflPath,
+		[]byte("url: https://acme.atlassian.net\nemail: u@e\ndefault_space: OLD\noutput_format: table\n"), 0o600))
+	v, _, _ := newReconcileView()
+	r, err := detectAndReconcile(v, cflPath,
+		filepath.Join(tmp, "jtk.json"), sharedPath, "", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "NEW", r.store.CFL.DefaultSpace)  // shared store wins
+	testutil.Equal(t, "json", r.store.CFL.OutputFormat) // not reverted to legacy
 }
 
 func TestApplyResultToStore_WritesDefaultAndCFLDefault(t *testing.T) {

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -97,11 +97,14 @@ func TestReconcile_CorruptCFLLegacyAborts(t *testing.T) {
 	tmp := t.TempDir()
 	cflPath := filepath.Join(tmp, "cfl.yml")
 	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte(": ::: ["), 0o600))
-	v, _, _ := newReconcileView()
+	v, _, stderr := newReconcileView()
 	_, err := detectAndReconcile(v, cflPath,
 		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "shared.yml"),
 		"", "", "", "")
 	testutil.RequireError(t, err)
+	if !strings.Contains(stderr.String(), "unreadable") {
+		t.Errorf("corrupt own-legacy must surface an actionable 'unreadable' message; got: %s", stderr.String())
+	}
 }
 
 func TestReconcile_CorruptJTKLegacyDowngradesToWarning(t *testing.T) {

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -57,6 +57,11 @@ func TestReconcile_OnlyCFLLegacy_FoldsIntoDefault(t *testing.T) {
 	testutil.Equal(t, "u@e", r.store.Default.Email)
 	testutil.Equal(t, "SP", r.store.CFL.DefaultSpace)
 	testutil.Equal(t, []string{cflPath}, r.consumedLegacies)
+	// First-time legacy migration: there was NO usable shared default,
+	// so this is not "editing a config the sibling already uses". Pins
+	// the documented pre-fold judgement (a post-fold check would wrongly
+	// see the just-folded connection and report true).
+	testutil.Equal(t, false, r.affectsSibling)
 }
 
 func TestReconcile_FlagOverridesPrefill(t *testing.T) {
@@ -155,6 +160,11 @@ func TestReconcile_DivergentLegacies_FailLoudNoValueLeak(t *testing.T) {
 	}
 	if !strings.Contains(msg, "url:") || !strings.Contains(msg, cflPath) || !strings.Contains(msg, jtkPath) {
 		t.Fatalf("fail-loud must name the field + every source path: %s", msg)
+	}
+	// email is identical across both sources → it must NOT be reported
+	// as a conflict (agreed fields stay folded; only `url` diverges).
+	if strings.Contains(msg, "email:") {
+		t.Fatalf("agreed field must not spuriously conflict: %s", msg)
 	}
 }
 

--- a/tools/cfl/internal/cmd/init/reconcile_test.go
+++ b/tools/cfl/internal/cmd/init/reconcile_test.go
@@ -14,25 +14,8 @@ import (
 	"github.com/open-cli-collective/confluence-cli/internal/config"
 )
 
-type configFixture struct {
-	URL          string
-	Email        string
-	APIToken     string
-	AuthMethod   string
-	CloudID      string
-	DefaultSpace string
-}
-
-func (c configFixture) toConfig() *config.Config {
-	return &config.Config{
-		URL:          c.URL,
-		Email:        c.Email,
-		APIToken:     c.APIToken,
-		AuthMethod:   c.AuthMethod,
-		CloudID:      c.CloudID,
-		DefaultSpace: c.DefaultSpace,
-	}
-}
+// Pure: detectAndReconcile does NO keyring I/O (B3 leak-regression
+// rule), so no hermetic harness is needed here.
 
 func newReconcileView() (*view.View, *bytes.Buffer, *bytes.Buffer) {
 	stdout := &bytes.Buffer{}
@@ -47,83 +30,60 @@ func TestReconcile_NoFilesAnywhere(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	v, _, _ := newReconcileView()
-
 	r, err := detectAndReconcile(v,
-		filepath.Join(tmp, "cfl.yml"),
-		filepath.Join(tmp, "jtk.json"),
-		filepath.Join(tmp, "shared.yml"),
-		"", "", "", "")
+		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "jtk.json"),
+		filepath.Join(tmp, "shared.yml"), "", "", "", "")
 	testutil.RequireNoError(t, err)
 	testutil.NotNil(t, r)
-	testutil.Equal(t, writeDefault, r.target)
 	testutil.Equal(t, "", r.prefill.URL)
-	testutil.Equal(t, 0, len(r.consumedLegacies))
+	testutil.Equal(t, false, r.affectsSibling)
 }
 
-func TestReconcile_OnlyCFLLegacy_AutoMigrates(t *testing.T) {
+func TestReconcile_OnlyCFLLegacy_FoldsIntoDefault(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	cflPath := filepath.Join(tmp, "cfl.yml")
-	body := `url: https://acme.atlassian.net/wiki
-email: u@e.com
-api_token: tok
-default_space: SPACE
-`
-	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte(body), 0o600))
+	testutil.RequireNoError(t, os.WriteFile(cflPath,
+		[]byte("url: https://acme.atlassian.net\nemail: u@e\napi_token: cfl-tok\ndefault_space: SP\n"), 0o600))
 
-	v, stdout, _ := newReconcileView()
+	v, _, _ := newReconcileView()
 	r, err := detectAndReconcile(v, cflPath,
-		filepath.Join(tmp, "jtk.json"),
-		filepath.Join(tmp, "shared.yml"),
+		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "shared.yml"),
 		"", "", "", "")
 	testutil.RequireNoError(t, err)
-	testutil.Equal(t, writeDefault, r.target)
+	// Prefill URL is /wiki-suffixed for cfl; store default is the base.
 	testutil.Equal(t, "https://acme.atlassian.net/wiki", r.prefill.URL)
-	testutil.Equal(t, "tok", r.prefill.APIToken)
-	testutil.Equal(t, "SPACE", r.prefill.DefaultSpace)
+	testutil.Equal(t, "https://acme.atlassian.net", r.store.Default.URL)
+	testutil.Equal(t, "u@e", r.store.Default.Email)
+	testutil.Equal(t, "SP", r.store.CFL.DefaultSpace)
 	testutil.Equal(t, []string{cflPath}, r.consumedLegacies)
-	if !strings.Contains(stdout.String(), "Migrating existing cfl config") {
-		t.Errorf("expected migration message; got: %s", stdout.String())
-	}
 }
 
 func TestReconcile_FlagOverridesPrefill(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	v, _, _ := newReconcileView()
-
 	r, err := detectAndReconcile(v,
-		filepath.Join(tmp, "cfl.yml"),
-		filepath.Join(tmp, "jtk.json"),
+		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "jtk.json"),
 		filepath.Join(tmp, "shared.yml"),
-		"https://flag.atlassian.net", "flag@example.com", "", "")
+		"https://flag.atlassian.net", "flag@e.com", "", "")
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, "https://flag.atlassian.net", r.prefill.URL)
-	testutil.Equal(t, "flag@example.com", r.prefill.Email)
+	testutil.Equal(t, "flag@e.com", r.prefill.Email)
 }
 
 func TestReconcile_CorruptSharedAborts(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	sharedPath := filepath.Join(tmp, "shared.yml")
-	testutil.RequireNoError(t, os.MkdirAll(filepath.Dir(sharedPath), 0o700))
 	testutil.RequireNoError(t, os.WriteFile(sharedPath, []byte("default: : :: ["), 0o600))
-
 	v, _, stderr := newReconcileView()
 	_, err := detectAndReconcile(v,
-		filepath.Join(tmp, "cfl.yml"),
-		filepath.Join(tmp, "jtk.json"),
-		sharedPath,
-		"", "", "", "")
+		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "jtk.json"),
+		sharedPath, "", "", "", "")
 	testutil.RequireError(t, err)
-
-	// The shared file was not modified by detection.
-	body, ferr := os.ReadFile(sharedPath) //nolint:gosec // test-controlled tempdir path
-	testutil.RequireNoError(t, ferr)
-	testutil.Equal(t, "default: : :: [", string(body))
-
 	if !strings.Contains(stderr.String(), "unreadable") {
-		t.Errorf("expected unreadable warning on stderr; got: %s", stderr.String())
+		t.Errorf("expected unreadable warning; got: %s", stderr.String())
 	}
 }
 
@@ -131,336 +91,113 @@ func TestReconcile_CorruptCFLLegacyAborts(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	cflPath := filepath.Join(tmp, "cfl.yml")
-	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte("url: : :: ["), 0o600))
-
-	v, _, stderr := newReconcileView()
+	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte(": ::: ["), 0o600))
+	v, _, _ := newReconcileView()
 	_, err := detectAndReconcile(v, cflPath,
-		filepath.Join(tmp, "jtk.json"),
-		filepath.Join(tmp, "shared.yml"),
+		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "shared.yml"),
 		"", "", "", "")
 	testutil.RequireError(t, err)
-
-	body, ferr := os.ReadFile(cflPath) //nolint:gosec // test-controlled tempdir path
-	testutil.RequireNoError(t, ferr)
-	testutil.Equal(t, "url: : :: [", string(body))
-
-	if !strings.Contains(stderr.String(), "unreadable") {
-		t.Errorf("expected unreadable warning; got: %s", stderr.String())
-	}
 }
 
 func TestReconcile_CorruptJTKLegacyDowngradesToWarning(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	testutil.RequireNoError(t, os.WriteFile(cflPath,
+		[]byte("url: https://acme.atlassian.net\nemail: u@e\napi_token: t\n"), 0o600))
 	jtkPath := filepath.Join(tmp, "jtk.json")
 	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte("{not json"), 0o600))
-
-	v, stdout, _ := newReconcileView()
-	r, err := detectAndReconcile(v,
-		filepath.Join(tmp, "cfl.yml"),
-		jtkPath,
-		filepath.Join(tmp, "shared.yml"),
-		"", "", "", "")
-	testutil.RequireNoError(t, err)
-	testutil.NotNil(t, r)
-	if !strings.Contains(stdout.String(), "ignoring") {
-		t.Errorf("expected ignore note for sibling-corrupt; got: %s", stdout.String())
+	v, stdout, stderr := newReconcileView()
+	r, err := detectAndReconcile(v, cflPath, jtkPath,
+		filepath.Join(tmp, "shared.yml"), "", "", "", "")
+	testutil.RequireNoError(t, err) // sibling-corrupt is a warning
+	testutil.Equal(t, "https://acme.atlassian.net", r.store.Default.URL)
+	if !strings.Contains(stdout.String()+stderr.String(), "sibling jtk config") {
+		t.Errorf("expected sibling-ignored note; got stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
 }
 
-func TestApplyResultToStore_DefaultTarget(t *testing.T) {
-	t.Parallel()
-	store := &credstore.Store{
-		// pre-existing JTK section that we must not stomp
-		JTK: credstore.ToolSection{
-			Section:        credstore.Section{APIToken: "preserved-jtk"},
-			DefaultProject: "PROJ",
-		},
-	}
-	cfg := configFixture{
-		URL: "https://acme.atlassian.net/wiki", Email: "u@e", APIToken: "t",
-		DefaultSpace: "SPACE",
-	}.toConfig()
-
-	applyResultToStore(store, cfg, writeDefault)
-
-	testutil.Equal(t, "https://acme.atlassian.net", store.Default.URL) // base form
-	testutil.Equal(t, "t", store.Default.APIToken)
-	testutil.Equal(t, "SPACE", store.CFL.DefaultSpace)
-	// JTK section preserved.
-	testutil.Equal(t, "preserved-jtk", store.JTK.APIToken)
-	testutil.Equal(t, "PROJ", store.JTK.DefaultProject)
-}
-
-func TestApplyResultToStore_OverrideTarget(t *testing.T) {
-	t.Parallel()
-	store := &credstore.Store{
-		Default: credstore.Section{URL: "https://default.atlassian.net", APIToken: "default-tok"},
-	}
-	cfg := configFixture{
-		URL: "https://cfl.atlassian.net/wiki", Email: "u@e", APIToken: "cfl-tok",
-	}.toConfig()
-
-	applyResultToStore(store, cfg, writeCFLOverride)
-
-	// Override section was written.
-	testutil.Equal(t, "https://cfl.atlassian.net", store.CFL.URL)
-	testutil.Equal(t, "cfl-tok", store.CFL.APIToken)
-	// Default left alone.
-	testutil.Equal(t, "https://default.atlassian.net", store.Default.URL)
-	testutil.Equal(t, "default-tok", store.Default.APIToken)
-}
-
-func TestReconcile_BothLegaciesMatch_AutoMigrates(t *testing.T) {
+func TestReconcile_BothLegaciesAligned_FoldsAndPreservesDefaults(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	cflPath := filepath.Join(tmp, "cfl.yml")
 	jtkPath := filepath.Join(tmp, "jtk.json")
-	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte(
-		"url: https://acme.atlassian.net/wiki\nemail: u@e\napi_token: tok\ndefault_space: SPACE\n"), 0o600))
-	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte(
-		`{"url":"https://acme.atlassian.net","email":"u@e","api_token":"tok","default_project":"PROJ"}`), 0o600))
-
-	v, stdout, _ := newReconcileView()
+	testutil.RequireNoError(t, os.WriteFile(cflPath,
+		[]byte("url: https://acme.atlassian.net\nemail: u@e\napi_token: t\ndefault_space: SP\noutput_format: json\n"), 0o600))
+	testutil.RequireNoError(t, os.WriteFile(jtkPath,
+		[]byte(`{"url":"https://acme.atlassian.net","email":"u@e","api_token":"t","default_project":"PR"}`), 0o600))
+	v, _, _ := newReconcileView()
 	r, err := detectAndReconcile(v, cflPath, jtkPath,
-		filepath.Join(tmp, "shared.yml"),
-		"", "", "", "")
+		filepath.Join(tmp, "shared.yml"), "", "", "", "")
 	testutil.RequireNoError(t, err)
-	testutil.Equal(t, writeDefault, r.target)
-	testutil.Equal(t, "tok", r.prefill.APIToken)
-	// jtk's default_project is preserved on the store even though we
-	// chose cfl as the migration source.
-	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
-	if !strings.Contains(stdout.String(), "Found matching cfl and jtk credentials") {
-		t.Errorf("expected matched-legacy message; got: %s", stdout.String())
-	}
-	testutil.Equal(t, false, r.affectsSibling) // migration, not affecting existing sibling state
+	testutil.Equal(t, "https://acme.atlassian.net", r.store.Default.URL)
+	testutil.Equal(t, "SP", r.store.CFL.DefaultSpace)
+	testutil.Equal(t, "json", r.store.CFL.OutputFormat)
+	testutil.Equal(t, "PR", r.store.JTK.DefaultProject)
 }
 
-func TestSectionsEqual_AuthMethodCanonicalization(t *testing.T) {
+func TestReconcile_DivergentLegacies_FailLoudNoValueLeak(t *testing.T) {
 	t.Parallel()
-	a := credstore.Section{URL: "https://x", Email: "u@e", APIToken: "t"}                      // empty method
-	b := credstore.Section{URL: "https://x", Email: "u@e", APIToken: "t", AuthMethod: "basic"} // explicit
-	if !credstore.SectionsEqual(a, b) {
-		t.Fatalf("empty auth_method should match explicit basic")
-	}
-}
-
-func TestApplyResultToStore_PreservesExistingDefaultSpace(t *testing.T) {
-	t.Parallel()
-	store := &credstore.Store{
-		CFL: credstore.ToolSection{DefaultSpace: "EXISTING"},
-	}
-	cfg := configFixture{URL: "https://x", Email: "u@e", APIToken: "t"}.toConfig() // no DefaultSpace
-	applyResultToStore(store, cfg, writeDefault)
-	testutil.Equal(t, "EXISTING", store.CFL.DefaultSpace) // not stomped
-}
-
-// Post-prompt branch tests — drive each huh-mediated decision by
-// calling the extracted helpers directly so we don't have to fake
-// stdin.
-
-func TestResultFromSiblingLegacy_ReuseYes(t *testing.T) {
-	t.Parallel()
-	jtk := &credstore.LegacyCreds{
-		Path:           "/jtk.json",
-		URL:            "https://acme.atlassian.net",
-		Email:          "u@e",
-		APIToken:       "jtk-tok",
-		DefaultProject: "PROJ",
-	}
-	r := resultFromSiblingLegacy(jtk, &credstore.Store{}, true, "", "", "", "")
-	testutil.Equal(t, "jtk-tok", r.prefill.APIToken)
-	testutil.Equal(t, []string{"/jtk.json"}, r.consumedLegacies)
-}
-
-func TestResultFromSiblingLegacy_ReuseNo(t *testing.T) {
-	t.Parallel()
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", APIToken: "jtk-tok"}
-	r := resultFromSiblingLegacy(jtk, &credstore.Store{}, false, "", "", "", "")
-	testutil.Equal(t, "", r.prefill.APIToken) // fresh setup, no prefill
-	testutil.Equal(t, 0, len(r.consumedLegacies))
-}
-
-func TestResultFromMismatch_UseCFL(t *testing.T) {
-	t.Parallel()
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok", DefaultProject: "PROJ"}
+	tmp := t.TempDir()
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	testutil.RequireNoError(t, os.WriteFile(cflPath,
+		[]byte("url: https://cfl-host.atlassian.net\nemail: u@e\napi_token: t\n"), 0o600))
+	testutil.RequireNoError(t, os.WriteFile(jtkPath,
+		[]byte(`{"url":"https://jtk-host.atlassian.net","email":"u@e","api_token":"t"}`), 0o600))
 	v, _, _ := newReconcileView()
-	r := resultFromMismatch(cfl, jtk, "use_cfl", &credstore.Store{}, v, "", "", "", "")
-	testutil.Equal(t, "cfl-tok", r.prefill.APIToken)
-	testutil.Equal(t, "SPACE", r.prefill.DefaultSpace)
-	testutil.Equal(t, []string{"/cfl.yml", "/jtk.json"}, r.consumedLegacies)
+	_, err := detectAndReconcile(v, cflPath, jtkPath,
+		filepath.Join(tmp, "shared.yml"), "", "", "", "")
+	testutil.RequireError(t, err)
+	msg := err.Error()
+	if strings.Contains(msg, "cfl-host.atlassian.net") || strings.Contains(msg, "jtk-host.atlassian.net") {
+		t.Fatalf("fail-loud must not leak values: %s", msg)
+	}
+	if !strings.Contains(msg, "url:") || !strings.Contains(msg, cflPath) || !strings.Contains(msg, jtkPath) {
+		t.Fatalf("fail-loud must name the field + every source path: %s", msg)
+	}
 }
 
-// TestResultFromMismatch_UseCFL_ClearsStaleJTKOverride pins the
-// daemon-r3 fix: if a prior keep_different run populated
-// store.JTK.Section, switching to use_cfl must clear it so jtk no
-// longer resolves to a stale override that shadows the new default.
-func TestResultFromMismatch_UseCFL_ClearsStaleJTKOverride(t *testing.T) {
+func TestReconcile_SharedPerToolConnDivergence_FailLoud(t *testing.T) {
 	t.Parallel()
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok"}
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	testutil.RequireNoError(t, os.WriteFile(sharedPath,
+		[]byte("default:\n  url: https://default.atlassian.net\n  email: u@e\ncfl:\n  url: https://cfl-only.atlassian.net\n"), 0o600))
 	v, _, _ := newReconcileView()
-	store := &credstore.Store{
-		JTK: credstore.ToolSection{
-			Section:        credstore.Section{URL: "https://stale.atlassian.net", APIToken: "stale-tok"},
-			DefaultProject: "PROJ", // per-tool default must survive
-		},
+	_, err := detectAndReconcile(v,
+		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "jtk.json"),
+		sharedPath, "", "", "", "")
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "cfl.url") {
+		t.Fatalf("must name the shared per-tool section.field: %s", err.Error())
 	}
-	r := resultFromMismatch(cfl, jtk, "use_cfl", store, v, "", "", "", "")
-	testutil.Equal(t, writeDefault, r.target)
-	testutil.Equal(t, "", r.store.JTK.URL)
-	testutil.Equal(t, "", r.store.JTK.APIToken)
-	testutil.Equal(t, "", r.store.CFL.URL)
-	testutil.Equal(t, "", r.store.CFL.APIToken)
-	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
 }
 
-// Symmetric to UseCFL_ClearsStaleJTKOverride: use_jtk also clears
-// both overrides so cfl falls through to the new default.
-func TestResultFromMismatch_UseJTK_ClearsBothOverrides(t *testing.T) {
+func TestReconcile_AffectsSibling_WhenSharedUsable(t *testing.T) {
 	t.Parallel()
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok"}
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	testutil.RequireNoError(t, os.WriteFile(sharedPath,
+		[]byte("default:\n  url: https://acme.atlassian.net\n  email: u@e\n"), 0o600))
 	v, _, _ := newReconcileView()
-	store := &credstore.Store{
-		CFL: credstore.ToolSection{
-			Section:      credstore.Section{URL: "https://stale.atlassian.net", APIToken: "stale-cfl"},
-			DefaultSpace: "STALE",
-		},
-		JTK: credstore.ToolSection{
-			Section: credstore.Section{URL: "https://stale-jtk.atlassian.net", APIToken: "stale-jtk"},
-		},
-	}
-	r := resultFromMismatch(cfl, jtk, "use_jtk", store, v, "", "", "", "")
-	testutil.Equal(t, writeDefault, r.target)
-	testutil.Equal(t, "", r.store.CFL.URL)
-	testutil.Equal(t, "", r.store.CFL.APIToken)
-	testutil.Equal(t, "", r.store.JTK.URL)
-	testutil.Equal(t, "", r.store.JTK.APIToken)
-	testutil.Equal(t, "STALE", r.store.CFL.DefaultSpace) // per-tool default survives
-}
-
-func TestResultFromMismatch_UseJTK_PreservesCFLDefaults(t *testing.T) {
-	t.Parallel()
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok"}
-	v, _, _ := newReconcileView()
-	r := resultFromMismatch(cfl, jtk, "use_jtk", &credstore.Store{}, v, "", "", "", "")
-	testutil.Equal(t, "jtk-tok", r.prefill.APIToken)   // jtk creds chosen
-	testutil.Equal(t, "SPACE", r.prefill.DefaultSpace) // but cfl's default_space preserved
-}
-
-func TestResultFromMismatch_KeepDifferent(t *testing.T) {
-	t.Parallel()
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", Email: "u@e", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", Email: "u@e", APIToken: "jtk-tok"}
-	v, stdout, _ := newReconcileView()
-	store := &credstore.Store{}
-	jtk.DefaultProject = "PROJ"
-	store.JTK.DefaultProject = jtk.DefaultProject // mirrors detectAndReconcile Case 4 preamble
-	r := resultFromMismatch(cfl, jtk, "keep_different", store, v, "", "", "", "")
-	// cfl creds → CFL override; jtk creds → JTK override; default empty.
-	testutil.Equal(t, writeCFLOverride, r.target)
-	testutil.Equal(t, "", r.store.Default.URL)
-	testutil.Equal(t, "", r.store.Default.APIToken)
-	testutil.Equal(t, "https://cfl.atlassian.net", r.store.CFL.URL)
-	testutil.Equal(t, "cfl-tok", r.store.CFL.APIToken)
-	testutil.Equal(t, "https://jtk.atlassian.net", r.store.JTK.URL)
-	testutil.Equal(t, "jtk-tok", r.store.JTK.APIToken)
-	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
-	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
-	if !strings.Contains(stdout.String(), "Keeping per-tool credentials") {
-		t.Errorf("expected keep-different note; got: %s", stdout.String())
-	}
-}
-
-func TestResultFromCFLLegacy_BasicMigration(t *testing.T) {
-	t.Parallel()
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://acme.atlassian.net/wiki", APIToken: "tok"}
-	r := resultFromCFLLegacy(cfl, &credstore.Store{}, "", "", "", "")
-	testutil.Equal(t, writeDefault, r.target)
-	testutil.Equal(t, "tok", r.prefill.APIToken)
-	testutil.Equal(t, []string{"/cfl.yml"}, r.consumedLegacies)
-}
-
-func TestMismatchDescription_EducationalText(t *testing.T) {
-	t.Parallel()
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://x", Email: "u@e", APIToken: "tok"}
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://x", Email: "u@e", APIToken: "different"}
-	desc := mismatchDescription(cfl, jtk)
-	for _, want := range []string{
-		"account-wide",
-		"both Jira and Confluence",
-		"id.atlassian.com/manage-profile",
-		"/cfl.yml",
-		"/jtk.json",
-	} {
-		if !strings.Contains(desc, want) {
-			t.Errorf("expected %q in mismatch description; got:\n%s", want, desc)
-		}
-	}
-}
-
-func TestResultFromSharedNoOverride_ReuseYes(t *testing.T) {
-	t.Parallel()
-	store := &credstore.Store{
-		Default: credstore.Section{
-			URL:      "https://acme.atlassian.net",
-			Email:    "u@e",
-			APIToken: "shared-tok",
-		},
-		CFL: credstore.ToolSection{DefaultSpace: "EXISTING"},
-	}
-	r := resultFromSharedNoOverride(store, true, "", "", "", "")
-	testutil.Equal(t, writeDefault, r.target)
-	testutil.Equal(t, "shared-tok", r.prefill.APIToken)
-	testutil.Equal(t, "EXISTING", r.prefill.DefaultSpace) // carried over
+	r, err := detectAndReconcile(v,
+		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "jtk.json"),
+		sharedPath, "", "", "", "")
+	testutil.RequireNoError(t, err)
 	testutil.Equal(t, true, r.affectsSibling)
 }
 
-func TestResultFromSharedNoOverride_ReuseNo_FreshForm(t *testing.T) {
+func TestApplyResultToStore_WritesDefaultAndCFLDefault(t *testing.T) {
 	t.Parallel()
-	store := &credstore.Store{
-		Default: credstore.Section{URL: "https://x", APIToken: "shared-tok"},
-		CFL:     credstore.ToolSection{DefaultSpace: "EXISTING"},
-	}
-	r := resultFromSharedNoOverride(store, false, "", "", "", "")
-	testutil.Equal(t, writeCFLOverride, r.target)
-	testutil.Equal(t, "", r.prefill.APIToken)             // fresh, not prefilled
-	testutil.Equal(t, "EXISTING", r.prefill.DefaultSpace) // tool defaults still carried so user doesn't retype
-	testutil.Equal(t, false, r.affectsSibling)
-}
-
-func TestResultFromSharedWithOverride(t *testing.T) {
-	t.Parallel()
-	store := &credstore.Store{
-		Default: credstore.Section{URL: "https://default", APIToken: "default-tok"},
-		CFL: credstore.ToolSection{
-			Section:      credstore.Section{URL: "https://cfl-override", APIToken: "cfl-tok"},
-			DefaultSpace: "SPACE",
-		},
-	}
-	r := resultFromSharedWithOverride(store, "", "", "", "")
-	testutil.Equal(t, writeCFLOverride, r.target)
-	testutil.Equal(t, "cfl-tok", r.prefill.APIToken) // override wins
-	testutil.Equal(t, "SPACE", r.prefill.DefaultSpace)
-	testutil.Equal(t, false, r.affectsSibling) // override doesn't affect sibling
-}
-
-func TestResultFromSiblingLegacy_PreservesJTKDefaults(t *testing.T) {
-	t.Parallel()
-	jtk := &credstore.LegacyCreds{
-		Path:           "/jtk.json",
-		URL:            "https://x",
-		Email:          "u@e",
-		APIToken:       "jtk-tok",
-		DefaultProject: "PROJ",
-	}
-	store := &credstore.Store{}
-	r := resultFromSiblingLegacy(jtk, store, true, "", "", "", "")
-	// Even though cfl init is the running tool, jtk's default_project
-	// must survive the migration.
-	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
+	store := &credstore.Store{JTK: credstore.ToolSection{DefaultProject: "KEEP"}}
+	applyResultToStore(store, &config.Config{
+		URL: "https://acme.atlassian.net/wiki", Email: "u@e",
+		AuthMethod: "basic", DefaultSpace: "SP", OutputFormat: "json",
+	})
+	testutil.Equal(t, "https://acme.atlassian.net", store.Default.URL) // /wiki stripped
+	testutil.Equal(t, "u@e", store.Default.Email)
+	testutil.Equal(t, "SP", store.CFL.DefaultSpace)
+	testutil.Equal(t, "json", store.CFL.OutputFormat)
+	testutil.Equal(t, "KEEP", store.JTK.DefaultProject) // sibling untouched
 }

--- a/tools/cfl/internal/config/config.go
+++ b/tools/cfl/internal/config/config.go
@@ -159,10 +159,11 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// LoadFromShared layers credentials from the shared store (default
-// merged with cfl override) on top of the receiver. URLs from the
-// shared store are stored as base; this method appends "/wiki" so the
-// receiver matches cfl's legacy URL convention.
+// LoadFromShared layers connection credentials from the shared store's
+// `default` section (§2.2: single-sourced — no per-tool override) on
+// top of the receiver. URLs from the shared store are stored as base;
+// this method appends "/wiki" so the receiver matches cfl's legacy URL
+// convention.
 func (c *Config) LoadFromShared(s *credstore.Store) {
 	if s == nil {
 		return
@@ -203,10 +204,9 @@ func warnCorruptSharedOnce(err error) {
 // Non-secret fields (url, email, auth_method, cloud_id, default_space,
 // output_format):
 //  1. legacy file (lowest)
-//  2. shared store default
-//  3. shared store cfl override
-//  4. ATLASSIAN_* env
-//  5. CFL_* env (highest)
+//  2. shared store default (§2.2: single-sourced — no per-tool override)
+//  3. ATLASSIAN_* env
+//  4. CFL_* env (highest)
 //
 // The API token is resolved separately and authoritatively via
 // keyring.ResolveToken (env → OS keyring, running the one-time §1.8

--- a/tools/cfl/internal/config/config_test.go
+++ b/tools/cfl/internal/config/config_test.go
@@ -454,17 +454,18 @@ func TestConfig_LoadFromShared(t *testing.T) {
 		testutil.Equal(t, "", cfg.APIToken)
 	})
 
-	t.Run("cfl override does not layer the token", func(t *testing.T) {
+	t.Run("connection comes from default; token never from the store", func(t *testing.T) {
 		t.Parallel()
+		// §2.2 (MON-5328): per-tool sections carry no connection/token;
+		// connection is single-sourced from default and the token lives
+		// only in the keyring.
 		store := &credstore.Store{
 			Default: credstore.Section{
 				URL:      "https://acme.atlassian.net",
 				Email:    "default@example.com",
 				APIToken: "default-tok",
 			},
-			CFL: credstore.ToolSection{
-				Section: credstore.Section{APIToken: "cfl-only-tok"},
-			},
+			CFL: credstore.ToolSection{DefaultSpace: "SP"},
 		}
 		cfg := &Config{}
 		cfg.LoadFromShared(store)

--- a/tools/jtk/CLAUDE.md
+++ b/tools/jtk/CLAUDE.md
@@ -179,14 +179,14 @@ Variables are checked in precedence order (first match wins):
 
 | Setting | Precedence |
 |---------|------------|
-| URL | `JIRA_URL` → `ATLASSIAN_URL` → shared `jtk` override → shared `default` → legacy config → `JIRA_DOMAIN` |
-| Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → shared `jtk` → shared `default` → legacy |
+| URL | `JIRA_URL` → `ATLASSIAN_URL` → shared `default` → legacy config → `JIRA_DOMAIN` |
+| Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → shared `default` → legacy |
 | API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `api_token` (single shared key; OS keyring, **not** the config file) |
 | Default Project | `JIRA_DEFAULT_PROJECT` → shared `jtk.default_project` → legacy |
-| Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `jtk` → shared `default` → legacy → `"basic"` |
-| Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `jtk` → shared `default` → legacy |
+| Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `default` → legacy → `"basic"` |
+| Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `default` → legacy |
 
-The "shared" entries refer to the cross-tool credential store at `~/.config/atlassian-cli/config.yml` written by `jtk init` and `cfl init`. The `jtk` section overrides the `default` section per field. Legacy jtk config (Linux: `~/.config/jira-ticket-cli/config.json`; macOS: `~/Library/Application Support/jira-ticket-cli/config.json`) keeps working indefinitely; init migrates it on first run.
+The "shared" entries refer to the cross-tool credential store at `~/.config/atlassian-cli/config.yml` written by `jtk init` and `cfl init`. Per §2.2 (MON-5328) connection config is single-sourced from the `default` section — the `jtk` section carries only the non-secret `default_project` and may NOT override connection fields. Legacy jtk config (Linux: `~/.config/jira-ticket-cli/config.json`; macOS: `~/Library/Application Support/jira-ticket-cli/config.json`) keeps working indefinitely; init migrates it on first run (failing loud if a pre-MON-5328 per-tool connection diverges from `default`).
 
 Use `ATLASSIAN_*` for shared credentials across jtk and cfl. Use `JIRA_*` to override per-tool.
 

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -1637,12 +1637,14 @@ Environment variables override file-based config. Variables are checked in order
 
 | Setting | Precedence (highest to lowest) |
 |---------|-------------------------------|
-| URL | `JIRA_URL` → `ATLASSIAN_URL` → shared `jtk` override → shared `default` → legacy → `JIRA_DOMAIN` |
-| Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → shared `jtk` → shared `default` → legacy |
+| URL | `JIRA_URL` → `ATLASSIAN_URL` → shared `default` → legacy → `JIRA_DOMAIN` |
+| Email | `JIRA_EMAIL` → `ATLASSIAN_EMAIL` → shared `default` → legacy |
 | API Token | `JIRA_API_TOKEN` → `ATLASSIAN_API_TOKEN` → keyring `api_token` (single shared key; OS keyring, never a plaintext file) |
 | Default Project | `JIRA_DEFAULT_PROJECT` → shared `jtk.default_project` → legacy |
-| Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared → legacy → `basic` |
-| Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared → legacy |
+| Auth Method | `JIRA_AUTH_METHOD` → `ATLASSIAN_AUTH_METHOD` → shared `default` → legacy → `basic` |
+| Cloud ID | `JIRA_CLOUD_ID` → `ATLASSIAN_CLOUD_ID` → shared `default` → legacy |
+
+Per §2.2 connection config is single-sourced from the shared `default` section — per-tool `cfl:`/`jtk:` sections carry only non-secret defaults and may not override `url`/`email`/`auth_method`/`cloud_id`.
 
 **Shared credentials:** If you use both `jtk` and `cfl` (Confluence CLI), set `ATLASSIAN_*` variables once:
 

--- a/tools/jtk/cmd/jtk/main_test.go
+++ b/tools/jtk/cmd/jtk/main_test.go
@@ -165,3 +165,37 @@ func TestEntrypoint_B3UpgradeFixture_DeprecatedKeysOnly(t *testing.T) {
 		t.Fatalf("§1.11.11: B3 upgrade must leave exactly [api_token]; got %v", got)
 	}
 }
+
+// §2.2/MON-5328 detect-before-mutate at the REAL entrypoint (jtk
+// mirror): divergent pre-MON-5328 per-tool connection + plaintext token
+// → `jtk init` fails loud from detectAndReconcile BEFORE
+// keyring.EnsureMigrated; token not migrated/scrubbed, file untouched.
+func TestEntrypoint_DivergentInit_NoMutationBeforeFailLoud(t *testing.T) {
+	dir := credtest.Hermetic(t)
+	p := filepath.Join(dir, "atlassian-cli", "config.yml")
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pre := "default:\n  url: https://default.atlassian.net\n  email: u@e\n  api_token: PLAINTEXT_TOK\njtk:\n  url: https://jtk-only.atlassian.net\n"
+	if err := os.WriteFile(p, []byte(pre), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stderr, code := runCLI(t, dir, "", "init", "--no-verify")
+	if code == 0 {
+		t.Fatalf("divergent init must exit non-zero; stderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "jtk.url") {
+		t.Fatalf("must fail loud naming the divergent field/source; stderr:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "jtk-only.atlassian.net") || strings.Contains(stderr, "PLAINTEXT_TOK") {
+		t.Fatalf("fail-loud must not leak values; stderr:\n%s", stderr)
+	}
+	if got := credtest.BundleKeys(t); len(got) != 0 {
+		t.Fatalf("token must NOT be migrated before the fail-loud; bundle=%v", got)
+	}
+	raw, _ := os.ReadFile(p) //nolint:gosec // test reads its own temp file
+	if !strings.Contains(string(raw), "PLAINTEXT_TOK") || !strings.Contains(string(raw), "jtk-only.atlassian.net") {
+		t.Fatalf("divergent init must mutate NOTHING on disk:\n%s", raw)
+	}
+}

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -79,18 +79,16 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 
 	v := opts.View()
 
-	// Run the one-time §1.8 migration up front so a pre-existing legacy
-	// plaintext token is relocated (and scrubbed) into the keyring before
-	// the user sets a new one — otherwise it could collide later.
-	if err := keyring.EnsureMigrated(); err != nil {
-		v.Error("Could not prepare secure credential storage: %v", err)
-		return err
-	}
-
 	sharedPath := credstore.DefaultPath()
 	jtkLegacyPath := credstore.LegacyJTKPath()
 	cflLegacyPath := credstore.LegacyCFLPath()
 
+	// §2.2 ordering (MON-5328): detect connection divergence FIRST,
+	// before any mutation — detectAndReconcile fails loud (mutating
+	// nothing) on divergent per-tool/legacy connections. Only then run
+	// the §1.8 token migration, so a connection conflict can never be
+	// preempted by a token migration/scrub and a divergent file is never
+	// mutated.
 	result, err := detectAndReconcile(v, jtkLegacyPath, cflLegacyPath, sharedPath,
 		prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
 	if err != nil {
@@ -98,14 +96,18 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	}
 	cfg := result.prefill
 
-	// The up-front EnsureMigrated relocates any legacy plaintext token into
-	// the single shared keyring api_token and scrubs the file, so
-	// detectAndReconcile (which reads the now-scrubbed legacy/config files)
-	// leaves prefill.APIToken empty even though the token still exists.
-	// Backfill it from the keyring so a returning user isn't forced to
-	// re-enter a token that was just migrated. NoMigrate: migration already
-	// ran above. Value stays password-masked in the form (same ingress as
-	// before); never displayed.
+	// Now the one-time §1.8 token migration (token-only,
+	// connection-preserving scrub).
+	if err := keyring.EnsureMigrated(); err != nil {
+		v.Error("Could not prepare secure credential storage: %v", err)
+		return err
+	}
+
+	// EnsureMigrated relocated any legacy plaintext token into the
+	// keyring and scrubbed it from disk, so prefill.APIToken is empty
+	// even though the token still exists. Backfill from the keyring so a
+	// returning user isn't forced to re-enter a just-migrated token.
+	// NoMigrate: migration already ran. Value stays password-masked.
 	if cfg.APIToken == "" {
 		if tok, _, terr := keyring.ResolveTokenNoMigrate(credstore.ToolJTK); terr == nil {
 			cfg.APIToken = tok

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -266,7 +266,7 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	// Save to shared credential store. Per-tool defaults always live in
 	// the jtk section; credential edits go to the section detectAndReconcile
 	// chose (default vs jtk override).
-	applyResultToStore(result.store, cfg, result.target)
+	applyResultToStore(result.store, cfg)
 	if err := result.store.Save(sharedPath); err != nil {
 		return fmt.Errorf("saving shared store: %w", err)
 	}

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -2,8 +2,6 @@ package initcmd
 
 import (
 	"errors"
-	"fmt"
-	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/view"
@@ -68,10 +66,10 @@ func detectAndReconcile(
 		cflLegacy = nil
 	}
 
-	candidates := connCandidates(sharedPath, store, proj, jtkLegacy, cflLegacy)
+	candidates := credstore.ConnCandidates(sharedPath, store.Default, proj, cflLegacy, jtkLegacy)
 	chosen, conflicts := credstore.DetectConnDivergence(candidates)
 	if len(conflicts) > 0 {
-		return nil, connConflictError(conflicts)
+		return nil, credstore.ConnConflictError(conflicts, candidates, "jtk")
 	}
 
 	// affectsSibling judged on the ORIGINAL loaded store, BEFORE folding
@@ -102,89 +100,6 @@ func detectAndReconcile(
 	}, nil
 }
 
-// connCandidates assembles the origin-labeled connection sources for the
-// detector: shared default, the pre-MON-5328 shared per-tool sections as
-// effective overrides (default ⊕ section), and the legacy jtk/cfl files.
-func connCandidates(
-	sharedPath string,
-	store *credstore.Store,
-	proj *credstore.SharedLegacyProjection,
-	jtkLegacy, cflLegacy *credstore.LegacyCreds,
-) []credstore.NamedConn {
-	var out []credstore.NamedConn
-	add := func(label, section, path string, c credstore.ConnProfile) {
-		if c.URL == "" && c.Email == "" && c.AuthMethod == "" && c.CloudID == "" {
-			return
-		}
-		out = append(out, credstore.NamedConn{Label: label, Section: section, Path: path, Conn: c})
-	}
-	def := credstore.ConnProfile{
-		URL: store.Default.URL, Email: store.Default.Email,
-		AuthMethod: store.Default.AuthMethod, CloudID: store.Default.CloudID,
-	}
-	add("shared config", "default", sharedPath, def)
-	add("shared config", "cfl", sharedPath, effectiveConn(proj.Default, proj.CFL))
-	add("shared config", "jtk", sharedPath, effectiveConn(proj.Default, proj.JTK))
-	if jtkLegacy != nil {
-		add("legacy jtk config", "", jtkLegacy.Path, legacyConn(jtkLegacy))
-	}
-	if cflLegacy != nil {
-		add("legacy cfl config", "", cflLegacy.Path, legacyConn(cflLegacy))
-	}
-	return out
-}
-
-func effectiveConn(def, sec credstore.SharedLegacyConn) credstore.ConnProfile {
-	pick := func(o, d string) string {
-		if o != "" {
-			return o
-		}
-		return d
-	}
-	return credstore.ConnProfile{
-		URL:        pick(sec.URL, def.URL),
-		Email:      pick(sec.Email, def.Email),
-		AuthMethod: pick(sec.AuthMethod, def.AuthMethod),
-		CloudID:    pick(sec.CloudID, def.CloudID),
-	}
-}
-
-func legacyConn(l *credstore.LegacyCreds) credstore.ConnProfile {
-	return credstore.ConnProfile{
-		URL: l.URL, Email: l.Email, AuthMethod: l.AuthMethod, CloudID: l.CloudID,
-	}
-}
-
-// connConflictError renders the fail-loud message: every conflicting
-// field with every contributing source descriptor, NEVER a value
-// (§1.12), plus an actionable remediation pointing at every file.
-func connConflictError(conflicts []credstore.ConnConflict) error {
-	var b strings.Builder
-	b.WriteString("connection config diverges across sources; init will not pick a winner. Conflicts:\n")
-	paths := map[string]struct{}{}
-	for _, c := range conflicts {
-		fmt.Fprintf(&b, "  - %s: %s\n", c.Field, strings.Join(c.Sources, ", "))
-		for _, s := range c.Sources {
-			if i := strings.LastIndex(s, "("); i >= 0 {
-				if j := strings.Index(s[i:], ")"); j > 0 {
-					paths[s[i+1:i+j]] = struct{}{}
-				}
-			}
-		}
-	}
-	b.WriteString("Resolve by editing/removing all but one connection in: ")
-	first := true
-	for p := range paths {
-		if !first {
-			b.WriteString(", ")
-		}
-		b.WriteString(p)
-		first = false
-	}
-	b.WriteString(" — then re-run jtk init. (No values shown; secrets live only in the OS keyring.)")
-	return errors.New(b.String())
-}
-
 func preserveDefaultsAndCollect(
 	store *credstore.Store,
 	jtkLegacy, cflLegacy *credstore.LegacyCreds,
@@ -194,7 +109,7 @@ func preserveDefaultsAndCollect(
 		if jtkLegacy.DefaultProject != "" {
 			store.JTK.DefaultProject = jtkLegacy.DefaultProject
 		}
-		if hasConn(legacyConn(jtkLegacy)) {
+		if legacyHasConn(jtkLegacy) {
 			consumed = append(consumed, jtkLegacy.Path)
 		}
 	}
@@ -205,15 +120,15 @@ func preserveDefaultsAndCollect(
 		if cflLegacy.OutputFormat != "" {
 			store.CFL.OutputFormat = cflLegacy.OutputFormat
 		}
-		if hasConn(legacyConn(cflLegacy)) {
+		if legacyHasConn(cflLegacy) {
 			consumed = append(consumed, cflLegacy.Path)
 		}
 	}
 	return consumed
 }
 
-func hasConn(c credstore.ConnProfile) bool {
-	return c.URL != "" || c.Email != "" || c.AuthMethod != "" || c.CloudID != ""
+func legacyHasConn(l *credstore.LegacyCreds) bool {
+	return l.URL != "" || l.Email != "" || l.AuthMethod != "" || l.CloudID != ""
 }
 
 func configFromConn(c credstore.ConnProfile) *config.Config {

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -74,10 +74,21 @@ func detectAndReconcile(
 
 	// affectsSibling judged on the ORIGINAL loaded store, BEFORE folding
 	// `chosen` (else a first-time legacy migration falsely looks like it
-	// overwrites a usable shared default). Pure: store.HasUsableConfig
-	// only — NO keyring I/O in reconcile (B3 leak-regression rule).
-	affectsSibling := store.HasUsableConfig(credstore.ToolJTK)
+	// overwrites a usable shared default). True only when the store
+	// already held usable creds AND the resolved connection actually
+	// DIFFERS from disk: re-running `jtk init` without changing the
+	// connection is a no-op for cfl and must not nag (one shared default
+	// would otherwise prompt on every re-init). Pure (HasUsableConfig +
+	// value compare only): NO keyring I/O in reconcile (B3 rule).
+	origDefault := store.Default
+	affectsSibling := store.HasUsableConfig(credstore.ToolJTK) &&
+		!credstore.ConnEqualsSection(chosen, origDefault)
 
+	// Fold the unified connection into the shared default. This in-place
+	// write is intentionally redundant with applyResultToStore (called
+	// by finalizeInit after the form, with the final URL-normalized
+	// values); result.store.Default is never read between the two, so
+	// the transient state is not observable.
 	store.Default = credstore.Section{
 		URL:        chosen.URL,
 		Email:      chosen.Email,
@@ -100,13 +111,19 @@ func detectAndReconcile(
 	}, nil
 }
 
+// preserveDefaultsAndCollect fills per-tool non-secret defaults from the
+// legacy files. Legacy values only fill fields the shared store leaves
+// EMPTY: a value the user already set in the shared store (e.g. a prior
+// init that changed default_project) must not be silently reverted to a
+// stale legacy value just because the old file still exists. Shared
+// store wins; legacy backfills absent.
 func preserveDefaultsAndCollect(
 	store *credstore.Store,
 	jtkLegacy, cflLegacy *credstore.LegacyCreds,
 ) []string {
 	var consumed []string
 	if jtkLegacy != nil {
-		if jtkLegacy.DefaultProject != "" {
+		if store.JTK.DefaultProject == "" && jtkLegacy.DefaultProject != "" {
 			store.JTK.DefaultProject = jtkLegacy.DefaultProject
 		}
 		if legacyHasConn(jtkLegacy) {
@@ -114,10 +131,10 @@ func preserveDefaultsAndCollect(
 		}
 	}
 	if cflLegacy != nil {
-		if cflLegacy.DefaultSpace != "" {
+		if store.CFL.DefaultSpace == "" && cflLegacy.DefaultSpace != "" {
 			store.CFL.DefaultSpace = cflLegacy.DefaultSpace
 		}
-		if cflLegacy.OutputFormat != "" {
+		if store.CFL.OutputFormat == "" && cflLegacy.OutputFormat != "" {
 			store.CFL.OutputFormat = cflLegacy.OutputFormat
 		}
 		if legacyHasConn(cflLegacy) {

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -74,6 +74,12 @@ func detectAndReconcile(
 		return nil, connConflictError(conflicts)
 	}
 
+	// affectsSibling judged on the ORIGINAL loaded store, BEFORE folding
+	// `chosen` (else a first-time legacy migration falsely looks like it
+	// overwrites a usable shared default). Pure: store.HasUsableConfig
+	// only — NO keyring I/O in reconcile (B3 leak-regression rule).
+	affectsSibling := store.HasUsableConfig(credstore.ToolJTK)
+
 	store.Default = credstore.Section{
 		URL:        chosen.URL,
 		Email:      chosen.Email,
@@ -81,11 +87,6 @@ func detectAndReconcile(
 		CloudID:    chosen.CloudID,
 	}
 	consumed := preserveDefaultsAndCollect(store, jtkLegacy, cflLegacy)
-
-	// Pure: store.HasUsableConfig only — NO keyring I/O in reconcile
-	// (B3 leak-regression rule). finalizeInit confirms before editing a
-	// shared connection cfl also reads.
-	affectsSibling := store.HasUsableConfig(credstore.ToolJTK)
 
 	cfg := configFromConn(chosen)
 	if store.JTK.DefaultProject != "" {

--- a/tools/jtk/internal/cmd/initcmd/reconcile.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile.go
@@ -3,51 +3,36 @@ package initcmd
 import (
 	"errors"
 	"fmt"
-
-	"github.com/charmbracelet/huh"
+	"strings"
 
 	"github.com/open-cli-collective/atlassian-go/credstore"
-	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
 )
 
-// hasUsableCreds composes the non-secret config completeness check
-// (credstore) with keyring token presence. The token no longer lives in
-// the shared store, so neither half alone means "already configured".
-func hasUsableCreds(store *credstore.Store, tool string) (bool, error) {
-	if !store.HasUsableConfig(tool) {
-		return false, nil
-	}
-	return keyring.HasToken()
-}
-
-// writeTarget tells the post-form save logic which section of the
-// shared store to write credential edits into.
-type writeTarget int
-
-const (
-	writeDefault writeTarget = iota
-	writeJTKOverride
-)
-
+// reconcileResult captures what finalizeInit needs after detection. Per
+// §2.2 (MON-5328) connection config is single-sourced from the shared
+// `default` section — no per-tool override, so no write-target choice;
+// connection always saves to `default`. jtk's mirror of cfl init's
+// reconcileResult (sibling/tool roles swapped).
 type reconcileResult struct {
 	prefill          *config.Config
-	target           writeTarget
 	store            *credstore.Store
 	consumedLegacies []string
-	// affectsSibling is true when finalizeInit should confirm before
-	// writing because the save will mutate credentials the sibling tool
-	// is currently reading from. Set when reuse=yes was chosen on a
-	// shared store that already had usable creds.
+	// affectsSibling: the save mutates the one shared default cfl also
+	// reads AND the store already held usable creds.
 	affectsSibling bool
 }
 
-// detectAndReconcile is jtk's mirror of cfl init's reconciliation
-// flow. See tools/cfl/internal/cmd/init/reconcile.go for the
-// canonical commentary; the logic here is symmetric with sibling and
-// tool roles swapped.
+// detectAndReconcile is jtk's mirror of cfl init's single-source
+// reconciliation. It gathers every connection candidate (shared
+// default, the pre-MON-5328 shared per-tool sections via the migration
+// projection, legacy jtk/cfl files), runs the pure divergence detector,
+// and FAILS LOUD if they disagree (naming every source + field, never a
+// value) instead of precedence-picking. Aligned → the unified
+// connection is folded into the shared default; per-tool non-secret
+// defaults are preserved.
 func detectAndReconcile(
 	v *view.View,
 	jtkLegacyPath, cflLegacyPath, sharedPath string,
@@ -59,13 +44,21 @@ func detectAndReconcile(
 		v.Error("Refusing to overwrite. Fix or remove the file, then re-run jtk init.")
 		return nil, err
 	}
+	proj, err := credstore.LoadSharedLegacyProjection(sharedPath)
+	if err != nil {
+		v.Error("Shared credential store at %s is unreadable: %v", sharedPath, err)
+		v.Error("Refusing to overwrite. Fix or remove the file, then re-run jtk init.")
+		return nil, err
+	}
+	if proj == nil {
+		proj = &credstore.SharedLegacyProjection{Path: sharedPath}
+	}
 
 	jtkLegacy, jtkErr := credstore.LoadLegacyJTK(jtkLegacyPath)
 	if jtkErr != nil {
 		if errors.Is(jtkErr, credstore.ErrCorruptStore) {
 			v.Error("Legacy jtk config at %s is unreadable: %v", jtkLegacyPath, jtkErr)
 			v.Error("Refusing to overwrite. Fix or remove the file, then re-run jtk init.")
-			return nil, jtkErr
 		}
 		return nil, jtkErr
 	}
@@ -75,237 +68,160 @@ func detectAndReconcile(
 		cflLegacy = nil
 	}
 
-	// Case 1: shared store + keyring already hold usable jtk creds.
-	usable, err := hasUsableCreds(store, credstore.ToolJTK)
-	if err != nil {
-		return nil, err
-	}
-	if usable {
-		hasOverride := !sectionEmpty(store.JTK.Section)
-		if hasOverride {
-			return resultFromSharedWithOverride(store, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID), nil
-		}
-		var reuse bool
-		err := huh.NewConfirm().
-			Title("Shared Atlassian credentials found").
-			Description(fmt.Sprintf(
-				"%s\n\nReuse these for jtk? (no = set up jtk-specific credentials)",
-				credstore.FormatSection("default", store.Default),
-			)).
-			Affirmative("Reuse").
-			Negative("Set jtk-specific").
-			Value(&reuse).
-			Run()
-		if err != nil {
-			return nil, err
-		}
-		if reuse {
-			v.Info("Note: editing these credentials will also affect cfl (writes go to shared default).")
-		}
-		return resultFromSharedNoOverride(store, reuse, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID), nil
+	candidates := connCandidates(sharedPath, store, proj, jtkLegacy, cflLegacy)
+	chosen, conflicts := credstore.DetectConnDivergence(candidates)
+	if len(conflicts) > 0 {
+		return nil, connConflictError(conflicts)
 	}
 
-	// Case 2: only this tool's legacy.
-	if jtkLegacy != nil && cflLegacy == nil {
-		v.Info("Migrating existing jtk config at %s to shared store.", jtkLegacy.Path)
-		return resultFromJTKLegacy(jtkLegacy, store, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID), nil
+	store.Default = credstore.Section{
+		URL:        chosen.URL,
+		Email:      chosen.Email,
+		AuthMethod: chosen.AuthMethod,
+		CloudID:    chosen.CloudID,
 	}
+	consumed := preserveDefaultsAndCollect(store, jtkLegacy, cflLegacy)
 
-	// Case 3: only sibling cfl legacy.
-	if jtkLegacy == nil && cflLegacy != nil {
-		var reuse bool
-		err := huh.NewConfirm().
-			Title("Found cfl credentials").
-			Description(fmt.Sprintf(
-				"%s\n\nReuse these for jtk? (Atlassian API tokens are account-wide and usually work across products.)",
-				credstore.FormatSection("cfl", cflLegacy.Section()),
-			)).
-			Affirmative("Reuse").
-			Negative("Fresh setup").
-			Value(&reuse).
-			Run()
-		if err != nil {
-			return nil, err
-		}
-		return resultFromSiblingLegacy(cflLegacy, store, reuse, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID), nil
-	}
+	// Pure: store.HasUsableConfig only — NO keyring I/O in reconcile
+	// (B3 leak-regression rule). finalizeInit confirms before editing a
+	// shared connection cfl also reads.
+	affectsSibling := store.HasUsableConfig(credstore.ToolJTK)
 
-	// Case 4: both legacies exist. Preserve cfl's per-tool defaults on
-	// the store either way so default_space/output_format aren't lost.
-	if jtkLegacy != nil && cflLegacy != nil {
-		store.CFL.DefaultSpace = cflLegacy.DefaultSpace
-		store.CFL.OutputFormat = cflLegacy.OutputFormat
-		store.JTK.DefaultProject = jtkLegacy.DefaultProject
-		if credstore.SectionsEqual(jtkLegacy.Section(), cflLegacy.Section()) {
-			v.Info("Found matching jtk and cfl credentials; migrating to shared store.")
-			cfg := configFromLegacy(jtkLegacy)
-			applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-			return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path, cflLegacy.Path}}, nil
-		}
-		choice, err := promptReconcileMismatch(jtkLegacy, cflLegacy)
-		if err != nil {
-			return nil, err
-		}
-		return resultFromMismatch(jtkLegacy, cflLegacy, choice, store, v, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID), nil
-	}
-
-	cfg := &config.Config{}
-	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-	return &reconcileResult{prefill: cfg, target: writeDefault, store: store}, nil
-}
-
-// mismatchDescription is the prompt description for the both-legacies-
-// mismatch reconciliation. Extracted so tests can assert the
-// educational language without driving huh.
-func mismatchDescription(jtkLegacy, cflLegacy *credstore.LegacyCreds) string {
-	return fmt.Sprintf(
-		"%s\n\n%s\n\nNote: Atlassian API tokens are account-wide. One token usually works for both Jira and Confluence.\nManage tokens: https://id.atlassian.com/manage-profile/security/api-tokens",
-		credstore.FormatSection("jtk ("+jtkLegacy.Path+")", jtkLegacy.Section()),
-		credstore.FormatSection("cfl ("+cflLegacy.Path+")", cflLegacy.Section()),
-	)
-}
-
-func promptReconcileMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds) (string, error) {
-	desc := mismatchDescription(jtkLegacy, cflLegacy)
-	var choice string
-	err := huh.NewSelect[string]().
-		Title("Different Atlassian credentials found").
-		Description(desc).
-		Options(
-			huh.NewOption("Use jtk's credentials for both tools", "use_jtk"),
-			huh.NewOption("Use cfl's credentials for both tools", "use_cfl"),
-			huh.NewOption("Keep them different (advanced)", "keep_different"),
-		).
-		Value(&choice).
-		Run()
-	return choice, err
-}
-
-// resultFromJTKLegacy / resultFromSiblingLegacy / resultFromMismatch
-// are the post-prompt branches lifted out so tests can drive them
-// without huh. See the cfl mirror in tools/cfl/internal/cmd/init/reconcile.go.
-
-func resultFromJTKLegacy(jtkLegacy *credstore.LegacyCreds, store *credstore.Store, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
-	cfg := configFromLegacy(jtkLegacy)
-	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-	return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: []string{jtkLegacy.Path}}
-}
-
-func resultFromSiblingLegacy(cflLegacy *credstore.LegacyCreds, store *credstore.Store, reuse bool, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
-	store.CFL.DefaultSpace = cflLegacy.DefaultSpace
-	store.CFL.OutputFormat = cflLegacy.OutputFormat
-	var cfg *config.Config
-	if reuse {
-		cfg = configFromLegacy(cflLegacy)
-	} else {
-		cfg = &config.Config{}
+	cfg := configFromConn(chosen)
+	if store.JTK.DefaultProject != "" {
+		cfg.DefaultProject = store.JTK.DefaultProject
 	}
 	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-	consumed := []string{}
-	if reuse {
-		consumed = []string{cflLegacy.Path}
-	}
-	return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
-}
 
-func resultFromSharedNoOverride(store *credstore.Store, reuse bool, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
-	var cfg *config.Config
-	target := writeJTKOverride
-	if reuse {
-		cfg = configFromSection(store.Resolve(credstore.ToolJTK))
-		copyJTKDefaults(cfg, store.JTK)
-		target = writeDefault
-	} else {
-		cfg = &config.Config{}
-		copyJTKDefaults(cfg, store.JTK)
-	}
-	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
 	return &reconcileResult{
-		prefill:        cfg,
-		target:         target,
-		store:          store,
-		affectsSibling: reuse,
-	}
+		prefill:          cfg,
+		store:            store,
+		consumedLegacies: consumed,
+		affectsSibling:   affectsSibling,
+	}, nil
 }
 
-func resultFromSharedWithOverride(store *credstore.Store, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
-	cfg := configFromSection(store.Resolve(credstore.ToolJTK))
-	copyJTKDefaults(cfg, store.JTK)
-	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-	return &reconcileResult{prefill: cfg, target: writeJTKOverride, store: store}
-}
-
-func resultFromMismatch(jtkLegacy, cflLegacy *credstore.LegacyCreds, choice string, store *credstore.Store, v *view.View, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string) *reconcileResult {
-	consumed := []string{jtkLegacy.Path, cflLegacy.Path}
-	switch choice {
-	case "use_jtk", "use_cfl":
-		// User chose to unify on one tool's creds. Clear both
-		// override Sections so each tool resolves to the new default
-		// rather than a leftover override from a prior keep_different
-		// run. Per-tool defaults (default_space, default_project,
-		// output_format) are preserved.
-		store.JTK.Section = credstore.Section{}
-		store.CFL.Section = credstore.Section{}
-		var cfg *config.Config
-		if choice == "use_jtk" {
-			cfg = configFromLegacy(jtkLegacy)
-		} else {
-			cfg = configFromLegacy(cflLegacy)
-			cfg.DefaultProject = jtkLegacy.DefaultProject
+// connCandidates assembles the origin-labeled connection sources for the
+// detector: shared default, the pre-MON-5328 shared per-tool sections as
+// effective overrides (default ⊕ section), and the legacy jtk/cfl files.
+func connCandidates(
+	sharedPath string,
+	store *credstore.Store,
+	proj *credstore.SharedLegacyProjection,
+	jtkLegacy, cflLegacy *credstore.LegacyCreds,
+) []credstore.NamedConn {
+	var out []credstore.NamedConn
+	add := func(label, section, path string, c credstore.ConnProfile) {
+		if c.URL == "" && c.Email == "" && c.AuthMethod == "" && c.CloudID == "" {
+			return
 		}
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-		// Non-secret connection reconcile only. The token is now a single
-		// shared key: divergent legacy tokens are caught by the keyring
-		// migration (fail-loud §1.8), not chosen here.
-		return &reconcileResult{prefill: cfg, target: writeDefault, store: store, consumedLegacies: consumed}
-	case "keep_different":
-		// Both tools land in their override sections so the split is
-		// stable: store.Default stays empty, jtk reads its override,
-		// cfl reads its override. Save target is writeJTKOverride so
-		// post-form edits stay in the jtk section. Per-tool defaults
-		// are set here so the function is self-contained — callers
-		// don't have to pre-populate the store.
-		store.JTK.Section = jtkLegacy.Section()
-		store.JTK.DefaultProject = jtkLegacy.DefaultProject
-		store.CFL.Section = cflLegacy.Section()
-		store.CFL.DefaultSpace = cflLegacy.DefaultSpace
-		store.CFL.OutputFormat = cflLegacy.OutputFormat
-		cfg := configFromLegacy(jtkLegacy)
-		applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-		v.Info("Keeping per-tool credentials. jtk will use jtk's token; cfl will use cfl's token.")
-		return &reconcileResult{prefill: cfg, target: writeJTKOverride, store: store, consumedLegacies: consumed}
+		out = append(out, credstore.NamedConn{Label: label, Section: section, Path: path, Conn: c})
 	}
-	cfg := &config.Config{}
-	applyFlagOverrides(cfg, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID)
-	return &reconcileResult{prefill: cfg, target: writeDefault, store: store}
-}
-
-func sectionEmpty(s credstore.Section) bool {
-	return s.URL == "" && s.Email == "" && s.APIToken == "" && s.AuthMethod == "" && s.CloudID == ""
-}
-
-func configFromSection(s credstore.Section) *config.Config {
-	cfg := &config.Config{
-		URL:        s.URL,
-		Email:      s.Email,
-		APIToken:   s.APIToken,
-		AuthMethod: s.AuthMethod,
-		CloudID:    s.CloudID,
+	def := credstore.ConnProfile{
+		URL: store.Default.URL, Email: store.Default.Email,
+		AuthMethod: store.Default.AuthMethod, CloudID: store.Default.CloudID,
 	}
-	return cfg
-}
-
-func configFromLegacy(l *credstore.LegacyCreds) *config.Config {
-	cfg := configFromSection(l.Section())
-	if l.DefaultProject != "" {
-		cfg.DefaultProject = l.DefaultProject
+	add("shared config", "default", sharedPath, def)
+	add("shared config", "cfl", sharedPath, effectiveConn(proj.Default, proj.CFL))
+	add("shared config", "jtk", sharedPath, effectiveConn(proj.Default, proj.JTK))
+	if jtkLegacy != nil {
+		add("legacy jtk config", "", jtkLegacy.Path, legacyConn(jtkLegacy))
 	}
-	return cfg
+	if cflLegacy != nil {
+		add("legacy cfl config", "", cflLegacy.Path, legacyConn(cflLegacy))
+	}
+	return out
 }
 
-func copyJTKDefaults(cfg *config.Config, t credstore.ToolSection) {
-	if t.DefaultProject != "" {
-		cfg.DefaultProject = t.DefaultProject
+func effectiveConn(def, sec credstore.SharedLegacyConn) credstore.ConnProfile {
+	pick := func(o, d string) string {
+		if o != "" {
+			return o
+		}
+		return d
+	}
+	return credstore.ConnProfile{
+		URL:        pick(sec.URL, def.URL),
+		Email:      pick(sec.Email, def.Email),
+		AuthMethod: pick(sec.AuthMethod, def.AuthMethod),
+		CloudID:    pick(sec.CloudID, def.CloudID),
+	}
+}
+
+func legacyConn(l *credstore.LegacyCreds) credstore.ConnProfile {
+	return credstore.ConnProfile{
+		URL: l.URL, Email: l.Email, AuthMethod: l.AuthMethod, CloudID: l.CloudID,
+	}
+}
+
+// connConflictError renders the fail-loud message: every conflicting
+// field with every contributing source descriptor, NEVER a value
+// (§1.12), plus an actionable remediation pointing at every file.
+func connConflictError(conflicts []credstore.ConnConflict) error {
+	var b strings.Builder
+	b.WriteString("connection config diverges across sources; init will not pick a winner. Conflicts:\n")
+	paths := map[string]struct{}{}
+	for _, c := range conflicts {
+		fmt.Fprintf(&b, "  - %s: %s\n", c.Field, strings.Join(c.Sources, ", "))
+		for _, s := range c.Sources {
+			if i := strings.LastIndex(s, "("); i >= 0 {
+				if j := strings.Index(s[i:], ")"); j > 0 {
+					paths[s[i+1:i+j]] = struct{}{}
+				}
+			}
+		}
+	}
+	b.WriteString("Resolve by editing/removing all but one connection in: ")
+	first := true
+	for p := range paths {
+		if !first {
+			b.WriteString(", ")
+		}
+		b.WriteString(p)
+		first = false
+	}
+	b.WriteString(" — then re-run jtk init. (No values shown; secrets live only in the OS keyring.)")
+	return errors.New(b.String())
+}
+
+func preserveDefaultsAndCollect(
+	store *credstore.Store,
+	jtkLegacy, cflLegacy *credstore.LegacyCreds,
+) []string {
+	var consumed []string
+	if jtkLegacy != nil {
+		if jtkLegacy.DefaultProject != "" {
+			store.JTK.DefaultProject = jtkLegacy.DefaultProject
+		}
+		if hasConn(legacyConn(jtkLegacy)) {
+			consumed = append(consumed, jtkLegacy.Path)
+		}
+	}
+	if cflLegacy != nil {
+		if cflLegacy.DefaultSpace != "" {
+			store.CFL.DefaultSpace = cflLegacy.DefaultSpace
+		}
+		if cflLegacy.OutputFormat != "" {
+			store.CFL.OutputFormat = cflLegacy.OutputFormat
+		}
+		if hasConn(legacyConn(cflLegacy)) {
+			consumed = append(consumed, cflLegacy.Path)
+		}
+	}
+	return consumed
+}
+
+func hasConn(c credstore.ConnProfile) bool {
+	return c.URL != "" || c.Email != "" || c.AuthMethod != "" || c.CloudID != ""
+}
+
+func configFromConn(c credstore.ConnProfile) *config.Config {
+	// jtk uses the bare instance URL (no /wiki suffix).
+	return &config.Config{
+		URL:        c.URL,
+		Email:      c.Email,
+		AuthMethod: c.AuthMethod,
+		CloudID:    c.CloudID,
 	}
 }
 
@@ -327,19 +243,15 @@ func applyFlagOverrides(cfg *config.Config, url, email, token, authMethod, cloud
 	}
 }
 
-func applyResultToStore(store *credstore.Store, cfg *config.Config, target writeTarget) {
-	cred := credstore.Section{
+// applyResultToStore writes the form's final cfg into the shared default
+// (connection is single-sourced — §2.2) and sets the jtk per-tool
+// non-secret default. The cfl section and cfl defaults are untouched.
+func applyResultToStore(store *credstore.Store, cfg *config.Config) {
+	store.Default = credstore.Section{
 		URL:        credstore.NormalizeBaseURL(cfg.URL),
 		Email:      cfg.Email,
-		APIToken:   cfg.APIToken,
 		AuthMethod: cfg.AuthMethod,
 		CloudID:    cfg.CloudID,
-	}
-	switch target {
-	case writeDefault:
-		store.Default = cred
-	case writeJTKOverride:
-		store.JTK.Section = cred
 	}
 	if cfg.DefaultProject != "" {
 		store.JTK.DefaultProject = cfg.DefaultProject

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -179,6 +179,34 @@ func TestReconcile_SharedPerToolConnDivergence_FailLoud(t *testing.T) {
 	}
 }
 
+// Pins the prior Codex blocker: detectAndReconcile (init runs it BEFORE
+// keyring.EnsureMigrated) must fail loud AND mutate nothing on a
+// divergent pre-MON-5328 per-tool connection + plaintext api_token.
+func TestReconcile_DivergentWithToken_NoMutation(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	pre := "default:\n  url: https://default.atlassian.net\n  email: u@e\n  api_token: PLAINTEXT_TOK\njtk:\n  url: https://jtk-only.atlassian.net\n"
+	testutil.RequireNoError(t, os.WriteFile(sharedPath, []byte(pre), 0o600))
+	before, _ := os.ReadFile(sharedPath) //nolint:gosec // test reads its own temp file
+
+	v, _, _ := newReconcileView()
+	_, err := detectAndReconcile(v,
+		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "cfl.yml"),
+		sharedPath, "", "", "", "", "")
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "jtk.url") {
+		t.Fatalf("expected connection divergence; got: %v", err)
+	}
+	after, _ := os.ReadFile(sharedPath) //nolint:gosec // test reads its own temp file
+	if string(before) != string(after) {
+		t.Fatalf("divergent detect must mutate NOTHING; file changed:\n%s", after)
+	}
+	if !strings.Contains(string(after), "PLAINTEXT_TOK") {
+		t.Fatalf("token must NOT be scrubbed on divergence:\n%s", after)
+	}
+}
+
 func TestReconcile_AffectsSibling_WhenSharedUsable(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
 )
 
+// These tests are pure: detectAndReconcile does NO keyring I/O (the B3
+// leak-regression rule — keyring access lives only in the command
+// layer), so no hermetic credtest harness is required.
+
 func newReconcileView() (*view.View, *bytes.Buffer, *bytes.Buffer) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -27,49 +31,42 @@ func TestReconcile_NoFilesAnywhere(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	v, _, _ := newReconcileView()
-
 	r, err := detectAndReconcile(v,
-		filepath.Join(tmp, "jtk.json"),
-		filepath.Join(tmp, "cfl.yml"),
-		filepath.Join(tmp, "shared.yml"),
-		"", "", "", "", "")
+		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "cfl.yml"),
+		filepath.Join(tmp, "shared.yml"), "", "", "", "", "")
 	testutil.RequireNoError(t, err)
 	testutil.NotNil(t, r)
-	testutil.Equal(t, writeDefault, r.target)
 	testutil.Equal(t, "", r.prefill.URL)
+	testutil.Equal(t, false, r.affectsSibling)
 }
 
-func TestReconcile_OnlyJTKLegacy_AutoMigrates(t *testing.T) {
+func TestReconcile_OnlyJTKLegacy_FoldsIntoDefault(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	jtkPath := filepath.Join(tmp, "jtk.json")
 	body := `{"url":"https://acme.atlassian.net","email":"u@e","api_token":"jtk-tok","default_project":"PROJ"}`
 	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte(body), 0o600))
 
-	v, stdout, _ := newReconcileView()
+	v, _, _ := newReconcileView()
 	r, err := detectAndReconcile(v, jtkPath,
-		filepath.Join(tmp, "cfl.yml"),
-		filepath.Join(tmp, "shared.yml"),
+		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "shared.yml"),
 		"", "", "", "", "")
 	testutil.RequireNoError(t, err)
-	testutil.Equal(t, writeDefault, r.target)
 	testutil.Equal(t, "https://acme.atlassian.net", r.prefill.URL)
-	testutil.Equal(t, "jtk-tok", r.prefill.APIToken)
 	testutil.Equal(t, "PROJ", r.prefill.DefaultProject)
+	// Connection folded into the shared default (single-source §2.2).
+	testutil.Equal(t, "https://acme.atlassian.net", r.store.Default.URL)
+	testutil.Equal(t, "u@e", r.store.Default.Email)
+	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
 	testutil.Equal(t, []string{jtkPath}, r.consumedLegacies)
-	if !strings.Contains(stdout.String(), "Migrating existing jtk config") {
-		t.Errorf("expected migration message; got: %s", stdout.String())
-	}
 }
 
 func TestReconcile_FlagOverridesPrefill(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	v, _, _ := newReconcileView()
-
 	r, err := detectAndReconcile(v,
-		filepath.Join(tmp, "jtk.json"),
-		filepath.Join(tmp, "cfl.yml"),
+		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "cfl.yml"),
 		filepath.Join(tmp, "shared.yml"),
 		"https://flag.atlassian.net", "flag@e.com", "flag-tok", "", "")
 	testutil.RequireNoError(t, err)
@@ -81,268 +78,14 @@ func TestReconcile_CorruptSharedAborts(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	sharedPath := filepath.Join(tmp, "shared.yml")
-	testutil.RequireNoError(t, os.MkdirAll(filepath.Dir(sharedPath), 0o700))
 	testutil.RequireNoError(t, os.WriteFile(sharedPath, []byte("default: : :: ["), 0o600))
-
 	v, _, stderr := newReconcileView()
 	_, err := detectAndReconcile(v,
-		filepath.Join(tmp, "jtk.json"),
-		filepath.Join(tmp, "cfl.yml"),
-		sharedPath,
-		"", "", "", "", "")
+		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "cfl.yml"),
+		sharedPath, "", "", "", "", "")
 	testutil.RequireError(t, err)
 	if !strings.Contains(stderr.String(), "unreadable") {
 		t.Errorf("expected unreadable warning; got: %s", stderr.String())
-	}
-}
-
-func TestApplyResultToStore_DefaultTarget_PreservesCFLSection(t *testing.T) {
-	t.Parallel()
-	store := &credstore.Store{
-		CFL: credstore.ToolSection{
-			Section:      credstore.Section{APIToken: "preserved-cfl"},
-			DefaultSpace: "SPACE",
-		},
-	}
-	cfg := &config.Config{
-		URL: "https://acme.atlassian.net", Email: "u@e", APIToken: "jtk-tok",
-		DefaultProject: "PROJ",
-	}
-
-	applyResultToStore(store, cfg, writeDefault)
-
-	testutil.Equal(t, "https://acme.atlassian.net", store.Default.URL)
-	testutil.Equal(t, "jtk-tok", store.Default.APIToken)
-	testutil.Equal(t, "PROJ", store.JTK.DefaultProject)
-	// CFL section preserved.
-	testutil.Equal(t, "preserved-cfl", store.CFL.APIToken)
-	testutil.Equal(t, "SPACE", store.CFL.DefaultSpace)
-}
-
-func TestApplyResultToStore_OverrideTarget(t *testing.T) {
-	t.Parallel()
-	store := &credstore.Store{
-		Default: credstore.Section{URL: "https://default.atlassian.net", APIToken: "default-tok"},
-	}
-	cfg := &config.Config{URL: "https://jtk.atlassian.net", Email: "u@e", APIToken: "jtk-tok"}
-
-	applyResultToStore(store, cfg, writeJTKOverride)
-
-	testutil.Equal(t, "https://jtk.atlassian.net", store.JTK.URL)
-	testutil.Equal(t, "jtk-tok", store.JTK.APIToken)
-	// Default left alone.
-	testutil.Equal(t, "https://default.atlassian.net", store.Default.URL)
-	testutil.Equal(t, "default-tok", store.Default.APIToken)
-}
-
-func TestResultFromSiblingLegacy_ReuseYes(t *testing.T) {
-	t.Parallel()
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://acme.atlassian.net/wiki", Email: "u@e", APIToken: "cfl-tok"}
-	r := resultFromSiblingLegacy(cfl, &credstore.Store{}, true, "", "", "", "", "")
-	testutil.Equal(t, "cfl-tok", r.prefill.APIToken)
-	testutil.Equal(t, []string{"/cfl.yml"}, r.consumedLegacies)
-}
-
-func TestResultFromSiblingLegacy_ReuseNo(t *testing.T) {
-	t.Parallel()
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", APIToken: "cfl-tok"}
-	r := resultFromSiblingLegacy(cfl, &credstore.Store{}, false, "", "", "", "", "")
-	testutil.Equal(t, "", r.prefill.APIToken)
-	testutil.Equal(t, 0, len(r.consumedLegacies))
-}
-
-func TestResultFromMismatch_UseJTK(t *testing.T) {
-	t.Parallel()
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok", DefaultProject: "PROJ"}
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
-	v, _, _ := newReconcileView()
-	r := resultFromMismatch(jtk, cfl, "use_jtk", &credstore.Store{}, v, "", "", "", "", "")
-	testutil.Equal(t, "jtk-tok", r.prefill.APIToken)
-	testutil.Equal(t, "PROJ", r.prefill.DefaultProject)
-}
-
-// TestResultFromMismatch_UseJTK_ClearsStaleCFLOverride pins the
-// daemon-r3 fix: prior keep_different override on cfl must be cleared
-// when the user picks use_jtk, so cfl resolves to the new default
-// rather than the stale cfl override.
-func TestResultFromMismatch_UseJTK_ClearsStaleCFLOverride(t *testing.T) {
-	t.Parallel()
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok"}
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
-	v, _, _ := newReconcileView()
-	store := &credstore.Store{
-		CFL: credstore.ToolSection{
-			Section:      credstore.Section{URL: "https://stale.atlassian.net", APIToken: "stale-tok"},
-			DefaultSpace: "SPACE", // per-tool default must survive
-		},
-	}
-	r := resultFromMismatch(jtk, cfl, "use_jtk", store, v, "", "", "", "", "")
-	testutil.Equal(t, writeDefault, r.target)
-	testutil.Equal(t, "", r.store.CFL.URL)
-	testutil.Equal(t, "", r.store.CFL.APIToken)
-	testutil.Equal(t, "", r.store.JTK.URL)
-	testutil.Equal(t, "", r.store.JTK.APIToken)
-	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
-}
-
-// Symmetric to UseJTK_ClearsStaleCFLOverride: use_cfl also clears
-// both overrides so jtk falls through to the new default.
-func TestResultFromMismatch_UseCFL_ClearsBothOverrides(t *testing.T) {
-	t.Parallel()
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok", DefaultProject: "PROJ"}
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
-	v, _, _ := newReconcileView()
-	store := &credstore.Store{
-		JTK: credstore.ToolSection{
-			Section:        credstore.Section{URL: "https://stale-jtk.atlassian.net", APIToken: "stale-jtk"},
-			DefaultProject: "STALE",
-		},
-		CFL: credstore.ToolSection{
-			Section: credstore.Section{URL: "https://stale-cfl.atlassian.net", APIToken: "stale-cfl"},
-		},
-	}
-	r := resultFromMismatch(jtk, cfl, "use_cfl", store, v, "", "", "", "", "")
-	testutil.Equal(t, writeDefault, r.target)
-	testutil.Equal(t, "", r.store.JTK.URL)
-	testutil.Equal(t, "", r.store.JTK.APIToken)
-	testutil.Equal(t, "", r.store.CFL.URL)
-	testutil.Equal(t, "", r.store.CFL.APIToken)
-	testutil.Equal(t, "STALE", r.store.JTK.DefaultProject) // per-tool default survives
-}
-
-func TestResultFromMismatch_UseCFL_PreservesJTKDefaults(t *testing.T) {
-	t.Parallel()
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", APIToken: "jtk-tok", DefaultProject: "PROJ"}
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", APIToken: "cfl-tok"}
-	v, _, _ := newReconcileView()
-	r := resultFromMismatch(jtk, cfl, "use_cfl", &credstore.Store{}, v, "", "", "", "", "")
-	testutil.Equal(t, "cfl-tok", r.prefill.APIToken)    // cfl creds chosen
-	testutil.Equal(t, "PROJ", r.prefill.DefaultProject) // jtk's default_project preserved
-}
-
-func TestResultFromMismatch_KeepDifferent(t *testing.T) {
-	t.Parallel()
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://jtk.atlassian.net", Email: "u@e", APIToken: "jtk-tok"}
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://cfl.atlassian.net/wiki", Email: "u@e", APIToken: "cfl-tok", DefaultSpace: "SPACE"}
-	v, stdout, _ := newReconcileView()
-	jtk.DefaultProject = "PROJ"
-	r := resultFromMismatch(jtk, cfl, "keep_different", &credstore.Store{}, v, "", "", "", "", "")
-	// jtk creds → JTK override; cfl creds → CFL override; default empty.
-	testutil.Equal(t, writeJTKOverride, r.target)
-	testutil.Equal(t, "", r.store.Default.URL)
-	testutil.Equal(t, "", r.store.Default.APIToken)
-	testutil.Equal(t, "https://jtk.atlassian.net", r.store.JTK.URL)
-	testutil.Equal(t, "jtk-tok", r.store.JTK.APIToken)
-	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
-	testutil.Equal(t, "https://cfl.atlassian.net", r.store.CFL.URL)
-	testutil.Equal(t, "cfl-tok", r.store.CFL.APIToken)
-	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
-	if !strings.Contains(stdout.String(), "Keeping per-tool credentials") {
-		t.Errorf("expected keep-different note; got: %s", stdout.String())
-	}
-}
-
-func TestResultFromSharedNoOverride_ReuseYes(t *testing.T) {
-	t.Parallel()
-	store := &credstore.Store{
-		Default: credstore.Section{
-			URL:      "https://acme.atlassian.net",
-			Email:    "u@e",
-			APIToken: "shared-tok",
-		},
-		JTK: credstore.ToolSection{DefaultProject: "EXISTING"},
-	}
-	r := resultFromSharedNoOverride(store, true, "", "", "", "", "")
-	testutil.Equal(t, writeDefault, r.target)
-	testutil.Equal(t, "shared-tok", r.prefill.APIToken)
-	testutil.Equal(t, "EXISTING", r.prefill.DefaultProject)
-	testutil.Equal(t, true, r.affectsSibling)
-}
-
-func TestResultFromSharedNoOverride_ReuseNo_FreshForm(t *testing.T) {
-	t.Parallel()
-	store := &credstore.Store{
-		Default: credstore.Section{URL: "https://x", APIToken: "shared-tok"},
-		JTK:     credstore.ToolSection{DefaultProject: "EXISTING"},
-	}
-	r := resultFromSharedNoOverride(store, false, "", "", "", "", "")
-	testutil.Equal(t, writeJTKOverride, r.target)
-	testutil.Equal(t, "", r.prefill.APIToken)
-	testutil.Equal(t, "EXISTING", r.prefill.DefaultProject)
-	testutil.Equal(t, false, r.affectsSibling)
-}
-
-func TestResultFromSharedWithOverride(t *testing.T) {
-	t.Parallel()
-	store := &credstore.Store{
-		Default: credstore.Section{URL: "https://default", APIToken: "default-tok"},
-		JTK: credstore.ToolSection{
-			Section:        credstore.Section{URL: "https://jtk-override", APIToken: "jtk-tok"},
-			DefaultProject: "PROJ",
-		},
-	}
-	r := resultFromSharedWithOverride(store, "", "", "", "", "")
-	testutil.Equal(t, writeJTKOverride, r.target)
-	testutil.Equal(t, "jtk-tok", r.prefill.APIToken)
-	testutil.Equal(t, "PROJ", r.prefill.DefaultProject)
-	testutil.Equal(t, false, r.affectsSibling)
-}
-
-func TestResultFromSiblingLegacy_PreservesCFLDefaults(t *testing.T) {
-	t.Parallel()
-	cfl := &credstore.LegacyCreds{
-		Path:         "/cfl.yml",
-		URL:          "https://x",
-		Email:        "u@e",
-		APIToken:     "cfl-tok",
-		DefaultSpace: "SPACE",
-		OutputFormat: "json",
-	}
-	store := &credstore.Store{}
-	r := resultFromSiblingLegacy(cfl, store, true, "", "", "", "", "")
-	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
-	testutil.Equal(t, "json", r.store.CFL.OutputFormat)
-}
-
-func TestMismatchDescription_EducationalText(t *testing.T) {
-	t.Parallel()
-	jtk := &credstore.LegacyCreds{Path: "/jtk.json", URL: "https://x", Email: "u@e", APIToken: "tok"}
-	cfl := &credstore.LegacyCreds{Path: "/cfl.yml", URL: "https://x", Email: "u@e", APIToken: "different"}
-	desc := mismatchDescription(jtk, cfl)
-	for _, want := range []string{
-		"account-wide",
-		"both Jira and Confluence",
-		"id.atlassian.com/manage-profile",
-		"/jtk.json",
-		"/cfl.yml",
-	} {
-		if !strings.Contains(desc, want) {
-			t.Errorf("expected %q in mismatch description; got:\n%s", want, desc)
-		}
-	}
-}
-
-func TestReconcile_BothLegaciesMatch_AutoMigrates(t *testing.T) {
-	t.Parallel()
-	tmp := t.TempDir()
-	jtkPath := filepath.Join(tmp, "jtk.json")
-	cflPath := filepath.Join(tmp, "cfl.yml")
-	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte(
-		`{"url":"https://acme.atlassian.net","email":"u@e","api_token":"tok","default_project":"PROJ"}`), 0o600))
-	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte(
-		"url: https://acme.atlassian.net/wiki\nemail: u@e\napi_token: tok\ndefault_space: SPACE\n"), 0o600))
-
-	v, stdout, _ := newReconcileView()
-	r, err := detectAndReconcile(v, jtkPath, cflPath,
-		filepath.Join(tmp, "shared.yml"),
-		"", "", "", "", "")
-	testutil.RequireNoError(t, err)
-	testutil.Equal(t, writeDefault, r.target)
-	testutil.Equal(t, "tok", r.prefill.APIToken)
-	// cfl's per-tool defaults preserved on the store.
-	testutil.Equal(t, "SPACE", r.store.CFL.DefaultSpace)
-	if !strings.Contains(stdout.String(), "Found matching jtk and cfl credentials") {
-		t.Errorf("expected matched-legacy message; got: %s", stdout.String())
 	}
 }
 
@@ -351,38 +94,114 @@ func TestReconcile_CorruptJTKLegacyAborts(t *testing.T) {
 	tmp := t.TempDir()
 	jtkPath := filepath.Join(tmp, "jtk.json")
 	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte("{not json"), 0o600))
-
-	v, _, stderr := newReconcileView()
+	v, _, _ := newReconcileView()
 	_, err := detectAndReconcile(v, jtkPath,
-		filepath.Join(tmp, "cfl.yml"),
-		filepath.Join(tmp, "shared.yml"),
+		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "shared.yml"),
 		"", "", "", "", "")
 	testutil.RequireError(t, err)
-
-	body, ferr := os.ReadFile(jtkPath) //nolint:gosec // test-controlled tempdir path
-	testutil.RequireNoError(t, ferr)
-	testutil.Equal(t, "{not json", string(body))
-
-	if !strings.Contains(stderr.String(), "unreadable") {
-		t.Errorf("expected unreadable warning; got: %s", stderr.String())
-	}
 }
 
 func TestReconcile_CorruptCFLLegacyDowngradesToWarning(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	testutil.RequireNoError(t, os.WriteFile(jtkPath,
+		[]byte(`{"url":"https://acme.atlassian.net","email":"u@e","api_token":"t"}`), 0o600))
 	cflPath := filepath.Join(tmp, "cfl.yml")
-	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte("url: : :: ["), 0o600))
-
-	v, stdout, _ := newReconcileView()
-	r, err := detectAndReconcile(v,
-		filepath.Join(tmp, "jtk.json"),
-		cflPath,
-		filepath.Join(tmp, "shared.yml"),
-		"", "", "", "", "")
-	testutil.RequireNoError(t, err)
-	testutil.NotNil(t, r)
-	if !strings.Contains(stdout.String(), "ignoring") {
-		t.Errorf("expected ignore note for sibling-corrupt; got: %s", stdout.String())
+	testutil.RequireNoError(t, os.WriteFile(cflPath, []byte(": ::: ["), 0o600))
+	v, stdout, stderr := newReconcileView()
+	r, err := detectAndReconcile(v, jtkPath, cflPath,
+		filepath.Join(tmp, "shared.yml"), "", "", "", "", "")
+	testutil.RequireNoError(t, err) // sibling-corrupt is a warning, not fatal
+	testutil.Equal(t, "https://acme.atlassian.net", r.store.Default.URL)
+	if !strings.Contains(stdout.String()+stderr.String(), "sibling cfl config") {
+		t.Errorf("expected sibling-ignored note; got stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
+}
+
+func TestReconcile_BothLegaciesAligned_FoldsAndPreservesDefaults(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	testutil.RequireNoError(t, os.WriteFile(jtkPath,
+		[]byte(`{"url":"https://acme.atlassian.net","email":"u@e","api_token":"t","default_project":"PR"}`), 0o600))
+	testutil.RequireNoError(t, os.WriteFile(cflPath,
+		[]byte("url: https://acme.atlassian.net\nemail: u@e\napi_token: t\ndefault_space: SP\noutput_format: json\n"), 0o600))
+	v, _, _ := newReconcileView()
+	r, err := detectAndReconcile(v, jtkPath, cflPath,
+		filepath.Join(tmp, "shared.yml"), "", "", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "https://acme.atlassian.net", r.store.Default.URL)
+	testutil.Equal(t, "PR", r.store.JTK.DefaultProject)
+	testutil.Equal(t, "SP", r.store.CFL.DefaultSpace)
+	testutil.Equal(t, "json", r.store.CFL.OutputFormat)
+}
+
+func TestReconcile_DivergentLegacies_FailLoudNoValueLeak(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	cflPath := filepath.Join(tmp, "cfl.yml")
+	testutil.RequireNoError(t, os.WriteFile(jtkPath,
+		[]byte(`{"url":"https://jtk-host.atlassian.net","email":"u@e","api_token":"t"}`), 0o600))
+	testutil.RequireNoError(t, os.WriteFile(cflPath,
+		[]byte("url: https://cfl-host.atlassian.net\nemail: u@e\napi_token: t\n"), 0o600))
+	v, _, _ := newReconcileView()
+	_, err := detectAndReconcile(v, jtkPath, cflPath,
+		filepath.Join(tmp, "shared.yml"), "", "", "", "", "")
+	testutil.RequireError(t, err)
+	msg := err.Error()
+	if strings.Contains(msg, "jtk-host.atlassian.net") || strings.Contains(msg, "cfl-host.atlassian.net") {
+		t.Fatalf("fail-loud must not leak values: %s", msg)
+	}
+	if !strings.Contains(msg, "url:") || !strings.Contains(msg, jtkPath) || !strings.Contains(msg, cflPath) {
+		t.Fatalf("fail-loud must name the conflicting field + every source path: %s", msg)
+	}
+}
+
+func TestReconcile_SharedPerToolConnDivergence_FailLoud(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	// Pre-MON-5328 file: default vs a divergent per-tool jtk url. The
+	// canonical Store drops jtk.url, but the migration projection still
+	// sees it → divergence must fail loud.
+	testutil.RequireNoError(t, os.WriteFile(sharedPath,
+		[]byte("default:\n  url: https://default.atlassian.net\n  email: u@e\njtk:\n  url: https://jtk-only.atlassian.net\n"), 0o600))
+	v, _, _ := newReconcileView()
+	_, err := detectAndReconcile(v,
+		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "cfl.yml"),
+		sharedPath, "", "", "", "", "")
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "jtk.url") {
+		t.Fatalf("must name the shared per-tool section.field: %s", err.Error())
+	}
+}
+
+func TestReconcile_AffectsSibling_WhenSharedUsable(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	testutil.RequireNoError(t, os.WriteFile(sharedPath,
+		[]byte("default:\n  url: https://acme.atlassian.net\n  email: u@e\n"), 0o600))
+	v, _, _ := newReconcileView()
+	r, err := detectAndReconcile(v,
+		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "cfl.yml"),
+		sharedPath, "", "", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, true, r.affectsSibling) // usable shared default → editing affects cfl
+}
+
+func TestApplyResultToStore_WritesDefaultAndJTKDefault(t *testing.T) {
+	t.Parallel()
+	store := &credstore.Store{CFL: credstore.ToolSection{DefaultSpace: "KEEP"}}
+	applyResultToStore(store, &config.Config{
+		URL: "https://acme.atlassian.net/", Email: "u@e",
+		AuthMethod: "basic", DefaultProject: "PR",
+	})
+	testutil.Equal(t, "https://acme.atlassian.net", store.Default.URL) // normalized
+	testutil.Equal(t, "u@e", store.Default.Email)
+	testutil.Equal(t, "PR", store.JTK.DefaultProject)
+	testutil.Equal(t, "KEEP", store.CFL.DefaultSpace) // sibling section untouched
 }

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -59,6 +59,10 @@ func TestReconcile_OnlyJTKLegacy_FoldsIntoDefault(t *testing.T) {
 	testutil.Equal(t, "u@e", r.store.Default.Email)
 	testutil.Equal(t, "PROJ", r.store.JTK.DefaultProject)
 	testutil.Equal(t, []string{jtkPath}, r.consumedLegacies)
+	// First-time legacy migration: no usable shared default existed, so
+	// affectsSibling must be false. Pins the documented pre-fold
+	// judgement (a post-fold check would wrongly report true).
+	testutil.Equal(t, false, r.affectsSibling)
 }
 
 func TestReconcile_FlagOverridesPrefill(t *testing.T) {
@@ -157,6 +161,10 @@ func TestReconcile_DivergentLegacies_FailLoudNoValueLeak(t *testing.T) {
 	}
 	if !strings.Contains(msg, "url:") || !strings.Contains(msg, jtkPath) || !strings.Contains(msg, cflPath) {
 		t.Fatalf("fail-loud must name the conflicting field + every source path: %s", msg)
+	}
+	// email is identical across sources → must NOT spuriously conflict.
+	if strings.Contains(msg, "email:") {
+		t.Fatalf("agreed field must not spuriously conflict: %s", msg)
 	}
 }
 

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -97,7 +97,8 @@ func TestReconcile_CorruptJTKLegacyAborts(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	jtkPath := filepath.Join(tmp, "jtk.json")
-	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte("{not json"), 0o600))
+	corrupt := []byte("{not json")
+	testutil.RequireNoError(t, os.WriteFile(jtkPath, corrupt, 0o600))
 	v, _, stderr := newReconcileView()
 	_, err := detectAndReconcile(v, jtkPath,
 		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "shared.yml"),
@@ -105,6 +106,13 @@ func TestReconcile_CorruptJTKLegacyAborts(t *testing.T) {
 	testutil.RequireError(t, err)
 	if !strings.Contains(stderr.String(), "unreadable") {
 		t.Errorf("corrupt own-legacy must surface an actionable 'unreadable' message; got: %s", stderr.String())
+	}
+	// Fail-loud must mutate NOTHING: the unreadable file is byte-identical
+	// afterwards (a future refactor that truncates/overwrites before the
+	// early return would otherwise pass undetected).
+	after, _ := os.ReadFile(jtkPath) //nolint:gosec // test reads its own temp file
+	if string(after) != string(corrupt) {
+		t.Errorf("corrupt legacy file was mutated by a failed detect; want byte-identical")
 	}
 }
 
@@ -218,7 +226,11 @@ func TestReconcile_DivergentWithToken_NoMutation(t *testing.T) {
 	}
 }
 
-func TestReconcile_AffectsSibling_WhenSharedUsable(t *testing.T) {
+// Re-running init with the connection UNCHANGED must NOT nag about
+// affecting the sibling: the resolved connection is canonically
+// equivalent to the shared default already on disk. Pins the
+// §2.2/MON-5328 fix for the daemon-flagged UX regression.
+func TestReconcile_NoNagWhenConnUnchanged(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
 	sharedPath := filepath.Join(tmp, "shared.yml")
@@ -229,7 +241,46 @@ func TestReconcile_AffectsSibling_WhenSharedUsable(t *testing.T) {
 		filepath.Join(tmp, "jtk.json"), filepath.Join(tmp, "cfl.yml"),
 		sharedPath, "", "", "", "", "")
 	testutil.RequireNoError(t, err)
-	testutil.Equal(t, true, r.affectsSibling) // usable shared default → editing affects cfl
+	testutil.Equal(t, false, r.affectsSibling)
+}
+
+// When a usable shared default exists AND the resolved connection
+// actually DIFFERS from it (a legacy file contributes a cloud_id the
+// default lacked), the save changes what cfl reads, so the sibling
+// confirmation MUST still fire.
+func TestReconcile_NagsWhenResolvedConnDiffers(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	testutil.RequireNoError(t, os.WriteFile(sharedPath,
+		[]byte("default:\n  url: https://acme.atlassian.net\n  email: u@e\n"), 0o600))
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	body := `{"url":"https://acme.atlassian.net","email":"u@e","cloud_id":"CID"}`
+	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte(body), 0o600))
+	v, _, _ := newReconcileView()
+	r, err := detectAndReconcile(v, jtkPath,
+		filepath.Join(tmp, "cfl.yml"), sharedPath, "", "", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, true, r.affectsSibling)
+}
+
+// A per-tool default the user already set in the SHARED store must win
+// over a stale value in a still-present legacy file. Pins the
+// daemon-flagged silent-revert regression in preserveDefaultsAndCollect.
+func TestReconcile_SharedPerToolDefaultWinsOverLegacy(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sharedPath := filepath.Join(tmp, "shared.yml")
+	testutil.RequireNoError(t, os.WriteFile(sharedPath,
+		[]byte("default:\n  url: https://acme.atlassian.net\n  email: u@e\njtk:\n  default_project: NEW\n"), 0o600))
+	jtkPath := filepath.Join(tmp, "jtk.json")
+	body := `{"url":"https://acme.atlassian.net","email":"u@e","default_project":"OLD"}`
+	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte(body), 0o600))
+	v, _, _ := newReconcileView()
+	r, err := detectAndReconcile(v, jtkPath,
+		filepath.Join(tmp, "cfl.yml"), sharedPath, "", "", "", "", "")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "NEW", r.store.JTK.DefaultProject) // shared store wins
 }
 
 func TestApplyResultToStore_WritesDefaultAndJTKDefault(t *testing.T) {

--- a/tools/jtk/internal/cmd/initcmd/reconcile_test.go
+++ b/tools/jtk/internal/cmd/initcmd/reconcile_test.go
@@ -98,11 +98,14 @@ func TestReconcile_CorruptJTKLegacyAborts(t *testing.T) {
 	tmp := t.TempDir()
 	jtkPath := filepath.Join(tmp, "jtk.json")
 	testutil.RequireNoError(t, os.WriteFile(jtkPath, []byte("{not json"), 0o600))
-	v, _, _ := newReconcileView()
+	v, _, stderr := newReconcileView()
 	_, err := detectAndReconcile(v, jtkPath,
 		filepath.Join(tmp, "cfl.yml"), filepath.Join(tmp, "shared.yml"),
 		"", "", "", "", "")
 	testutil.RequireError(t, err)
+	if !strings.Contains(stderr.String(), "unreadable") {
+		t.Errorf("corrupt own-legacy must surface an actionable 'unreadable' message; got: %s", stderr.String())
+	}
 }
 
 func TestReconcile_CorruptCFLLegacyDowngradesToWarning(t *testing.T) {

--- a/tools/jtk/internal/config/config.go
+++ b/tools/jtk/internal/config/config.go
@@ -37,8 +37,8 @@ func warnCorruptSharedOnce(err error) {
 	})
 }
 
-// jtkSection returns the resolved Section for jtk merged from default
-// and the jtk override.
+// jtkSection returns the resolved connection Section from the shared
+// `default` (§2.2: single-sourced — no per-tool override).
 func jtkSection() credstore.Section {
 	return loadShared().Resolve(credstore.ToolJTK)
 }
@@ -144,7 +144,7 @@ func Clear() error {
 }
 
 // GetURL returns the Jira URL from config or environment.
-// Precedence: JIRA_URL → ATLASSIAN_URL → shared jtk override → shared default → legacy config url → JIRA_DOMAIN → legacy config domain.
+// Precedence: JIRA_URL → ATLASSIAN_URL → shared default → legacy config url → JIRA_DOMAIN → legacy config domain.
 func GetURL() string {
 	if v := os.Getenv("JIRA_URL"); v != "" {
 		return url.NormalizeURL(v)
@@ -186,7 +186,7 @@ func GetDomain() string {
 }
 
 // GetEmail returns the email from config or environment.
-// Precedence: JIRA_EMAIL → ATLASSIAN_EMAIL → shared jtk override → shared default → legacy config email.
+// Precedence: JIRA_EMAIL → ATLASSIAN_EMAIL → shared default → legacy config email.
 func GetEmail() string {
 	if v := os.Getenv("JIRA_EMAIL"); v != "" {
 		return v
@@ -249,7 +249,7 @@ func GetAuthMethod() string {
 }
 
 // GetAuthMethodWithSource returns the auth method and its source.
-// Precedence: JIRA_AUTH_METHOD → ATLASSIAN_AUTH_METHOD → shared jtk override → shared default → legacy config auth_method → "basic"
+// Precedence: JIRA_AUTH_METHOD → ATLASSIAN_AUTH_METHOD → shared default → legacy config auth_method → "basic"
 // Invalid values are skipped and fall through to the next source.
 // Validation happens at entry points (api.New, init --auth-method) not here.
 func GetAuthMethodWithSource() (value, source string) {
@@ -286,7 +286,7 @@ func GetCloudID() string {
 }
 
 // GetCloudIDWithSource returns the Cloud ID and its source.
-// Precedence: JIRA_CLOUD_ID → ATLASSIAN_CLOUD_ID → shared jtk override → shared default → legacy config cloud_id.
+// Precedence: JIRA_CLOUD_ID → ATLASSIAN_CLOUD_ID → shared default → legacy config cloud_id.
 func GetCloudIDWithSource() (value, source string) {
 	if v := os.Getenv("JIRA_CLOUD_ID"); v != "" {
 		return v, "env (JIRA_CLOUD_ID)"


### PR DESCRIPTION
## Summary

Sibling of MON-5326 (token collapse, merged). Completes **Secret-Handling Standard §2.2**: per-tool `cfl:`/`jtk:` sections may carry **only** non-secret defaults (`default_space`/`default_project`/`output_format`). Connection fields (`url`/`email`/`auth_method`/`cloud_id`) and `api_token` leave the per-tool schema — connection is **single-sourced from the shared `default`** section (env override unchanged).

**Stakeholder decision (locked):** fail-loud on divergence, **no** `detectConnProfiles`, **no** N-profile init picker (the #368 body proposed those; explicitly descoped here).

## What changed

- **credstore**: `ToolSection` no longer embeds `Section`; `Resolve` returns the shared default (signature unchanged → ripple contained to credstore + the two reconcile files + the migration). `SourceOverrideCFL/JTK` removed.
- **Migration-only projection** (`LoadSharedLegacyProjection`) retains pre-change per-tool connection/token so the keyring token migration still finds them — evidence is never destroyed before it's read. `scrubSharedStore` is now a **token-only `yaml.Node` rewrite** that *deletes* `api_token` nodes and preserves every other key; a runtime command can never silently strip a user's legacy per-tool connection (stripping happens only at `init`, after detection).
- **Pure detector** `DetectConnDivergence`: secret-free by type (`ConnProfile`, no token), IO/keyring-free, **field-wise union** over the full named candidate set; a field with ≥2 distinct non-empty canonical values fails loud naming every `label section.field (path)` (never a value); a usable-basic source materializes implicit basic so it can't be silently unioned to bearer.
- **init (cfl + jtk)**: per-tool-divergence reconcile machinery removed (`writeCFLOverride`/`writeJTKOverride`, `use_cfl`/`use_jtk`/`keep_different` picker, `resultFromMismatch`, shared-with-override branch). Aligned → fold into `default`; divergent → fail loud with a multi-path remediation. Per-tool non-secret defaults preserved. Reconcile stays **keyring-free** (B3 leak-regression rule).

## Tests
- Detector unit table (all-equal / canonically-equal / partial-default-compatible / divergent / implicit-basic-vs-bearer conflict / fragmentary / all-empty; asserts no value leak).
- Projection load (absent/corrupt), token-only-scrub preservation, **end-to-end runtime regression** (real migrating path preserves legacy per-tool connection + deletes only the token node).
- cfl + jtk reconcile rewritten to the single-source model; obsolete per-tool-override tests removed (no surviving analogue), not mis-re-pointed.
- All 3 modules green: gofmt · build · vet · `test -race` (shared 419 / jtk 1794 / cfl 987) · `mod tidy` no-drift · golangci-lint 0. Net 21 files, +1251 / −1362.

## Codex
Architect plan review converged **0/0/0/0** over 4 rounds (caught the scrub-before-detect ordering, secret-free detector type, implicit-basic-vs-bearer trap, multi-path remediation labels).

## Breaking change
Per-tool sections can no longer override connection fields or carry `api_token`. A pre-existing file whose per-tool connection diverges from `default` makes the next `init` fail loud (names every source + field, no value) until resolved to one connection; aligned configs migrate silently. Runtime read paths never mutate/drop connection fields.

Closes #368
[MON-5328]
