### PR TITLE
jtk cache → cli-common (re-migrate ~/.jtk/cache → os.UserCacheDir()/jtk)

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -10,7 +10,6 @@ github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 golang.org/x/crypto v0.44.0/go.mod h1:013i+Nw79BMiQiMsOPcVCB5ZIJbYkerPrGnOa00tvmc=
 golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8/go.mod h1:Pi4ztBfryZoJEkyFTI5/Ocsu2jXyDr6iSdgJiYE/uwE=
-golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
-golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
 golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=

--- a/tools/jtk/go.mod
+++ b/tools/jtk/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/charmbracelet/huh v0.8.0
 	github.com/open-cli-collective/atlassian-go v0.0.0-00010101000000-000000000000
+	github.com/open-cli-collective/cli-common v0.0.0-20260519134256-e67b2fc81f9d
 	github.com/spf13/cobra v1.10.2
 )
 
@@ -45,7 +46,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/open-cli-collective/cli-common v0.0.0-20260516182733-b753d5c62d14 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/tools/jtk/go.sum
+++ b/tools/jtk/go.sum
@@ -94,8 +94,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/open-cli-collective/cli-common v0.0.0-20260516182733-b753d5c62d14 h1:78EW5uCbAzbAO32+oY4HDaFOqS2sPYnc4AT+G5UjdL0=
-github.com/open-cli-collective/cli-common v0.0.0-20260516182733-b753d5c62d14/go.mod h1:5i4MkFToMVPLBW29O01lsHS9d1m9pC0BxSOYjFDz7ds=
+github.com/open-cli-collective/cli-common v0.0.0-20260519134256-e67b2fc81f9d h1:fiyfxc/Wvpuen/u6Mk3bCUG0DLyOylF0K+eol4y9C64=
+github.com/open-cli-collective/cli-common v0.0.0-20260519134256-e67b2fc81f9d/go.mod h1:5i4MkFToMVPLBW29O01lsHS9d1m9pC0BxSOYjFDz7ds=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/tools/jtk/internal/cache/envelope.go
+++ b/tools/jtk/internal/cache/envelope.go
@@ -1,132 +1,75 @@
 // Package cache provides caching functionality for jtk resources.
+//
+// Tier-1 (the on-disk envelope, atomic writes, freshness classification) is a
+// thin facade over github.com/open-cli-collective/cli-common/cache — the
+// shared state component (working-with-state.md §5b). The public API here is
+// kept byte-stable so jtk's tier-2 (registry/fetchers/lookups/invalidate) and
+// the ~25 downstream test files do not churn; only the internals delegate.
 package cache
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-	"time"
+
+	cccache "github.com/open-cli-collective/cli-common/cache"
 )
 
-const Version = 1
+// Version is the on-disk envelope schema version (delegated to cli-common so
+// a schema bump self-heals identically everywhere).
+const Version = cccache.Version
 
-var ErrCacheMiss = errors.New("cache miss")
+// ErrCacheMiss is re-exported so existing errors.Is(err, cache.ErrCacheMiss)
+// call sites keep matching.
+var ErrCacheMiss = cccache.ErrCacheMiss
 
-// Envelope is the on-disk JSON shape for a single cached resource.
-type Envelope[T any] struct {
-	Resource  string    `json:"resource"`
-	Instance  string    `json:"instance"`
-	FetchedAt time.Time `json:"fetched_at"`
-	TTL       string    `json:"ttl"`
-	Version   int       `json:"version"`
-	Data      T         `json:"data"`
-}
+// Envelope is an alias for the shared envelope, so callers that reference
+// cache.Envelope / .FetchedAt / .TTL / .Data are unchanged.
+type Envelope[T any] = cccache.Envelope[T]
 
-// ReadResource reads the envelope for `name` from disk.
-//   - Returns (envelope, nil) on success.
-//   - Returns (zero, ErrCacheMiss) if the file does not exist.
-//   - Returns (zero, error) on I/O or JSON decode failure.
+// ReadResource reads the envelope for name.
+//   - (envelope, nil) on success.
+//   - (zero, ErrCacheMiss) if absent / version- or identity-mismatched and no
+//     valid legacy ~/.jtk/cache envelope can be promoted.
+//   - (zero, error) on path/instance resolution, I/O, or decode failure.
 //
-// ReadResource does NOT check freshness; callers use freshness.go.
+// On a miss against the new (os.UserCacheDir()/jtk) root, exactly one valid
+// legacy envelope is promoted in place if present (the one-time, per-resource,
+// non-destructive re-migration — see migrate.go). Reads never check freshness.
 func ReadResource[T any](name string) (Envelope[T], error) {
-	path, err := ResourceFile(name)
+	loc, err := locator()
 	if err != nil {
 		return Envelope[T]{}, err
 	}
-
-	data, err := os.ReadFile(path) //nolint:gosec // path derives from config, not user input
-	if err != nil {
-		if os.IsNotExist(err) {
-			return Envelope[T]{}, ErrCacheMiss
+	env, err := cccache.ReadResource[T](loc, name)
+	if errors.Is(err, ErrCacheMiss) {
+		if penv, ok := promoteLegacyOnMiss[T](loc, name); ok {
+			return penv, nil
 		}
-		return Envelope[T]{}, fmt.Errorf("reading resource file: %w", err)
-	}
-
-	var env Envelope[T]
-	if err := json.Unmarshal(data, &env); err != nil {
-		return Envelope[T]{}, fmt.Errorf("parsing resource file: %w", err)
-	}
-
-	// A version mismatch is treated as a miss — the next write will overwrite
-	// the envelope with the current schema. This makes schema bumps self-healing.
-	if env.Version != Version {
 		return Envelope[T]{}, ErrCacheMiss
 	}
-
-	return env, nil
+	return env, err
 }
 
-// WriteResource atomically writes an envelope for `name`.
-//   - TTL comes from the caller (registry entry). Resource, Instance, Version,
-//     and FetchedAt are set by WriteResource itself.
-//   - Atomic: write to a temp file in the same directory, then rename.
-//   - Ensures the instance directory exists with mode 0700.
-//   - Writes the file with mode 0600.
-func WriteResource[T any](name string, ttl string, data T) error {
-	instance, err := InstanceKey()
+// WriteResource atomically writes an envelope for name. Resource, Instance,
+// Version, and a fresh FetchedAt are set by the shared writer; ttl is the
+// caller's hard-coded per-resource value.
+func WriteResource[T any](name, ttl string, data T) error {
+	loc, err := locator()
 	if err != nil {
 		return err
 	}
-
-	env := Envelope[T]{
-		Resource:  name,
-		Instance:  instance,
-		FetchedAt: time.Now().UTC(),
-		TTL:       ttl,
-		Version:   Version,
-		Data:      data,
-	}
-	return atomicWriteEnvelope(name, env)
+	return cccache.WriteResource(loc, name, ttl, data)
 }
 
-// atomicWriteEnvelope marshals an envelope and writes it to the cache path for
-// `name` using a temp-file-rename pattern. Shared by WriteResource (which
-// constructs a fresh envelope) and writeRaw (which preserves existing metadata
-// for Touch-style invalidation).
-func atomicWriteEnvelope[T any](name string, env Envelope[T]) error {
-	path, err := ResourceFile(name)
+// atomicWriteEnvelope writes a caller-supplied envelope verbatim (preserving
+// its FetchedAt — used by writeRaw/Touch to persist the zeroed "stale"
+// marker). The legacy first parameter is retained for call-site stability
+// (writeRaw and the *_lookup_test.go helpers pass it positionally); the
+// shared verbatim writer derives the file from env.Resource, which by
+// construction equals it.
+func atomicWriteEnvelope[T any](_ string, env Envelope[T]) error {
+	loc, err := locator()
 	if err != nil {
 		return err
 	}
-
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("creating cache directory: %w", err)
-	}
-
-	jsonData, err := json.MarshalIndent(env, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshaling envelope: %w", err)
-	}
-
-	tmp, err := os.CreateTemp(dir, name+"-*.json.tmp")
-	if err != nil {
-		return fmt.Errorf("creating temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-
-	if _, err := tmp.Write(jsonData); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("writing temp file: %w", err)
-	}
-
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("closing temp file: %w", err)
-	}
-
-	if err := os.Chmod(tmpPath, 0o600); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("setting file mode: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("moving temp file to final path: %w", err)
-	}
-
-	return nil
+	return cccache.WriteEnvelope(loc, env)
 }

--- a/tools/jtk/internal/cache/envelope.go
+++ b/tools/jtk/internal/cache/envelope.go
@@ -9,6 +9,7 @@ package cache
 
 import (
 	"errors"
+	"fmt"
 
 	cccache "github.com/open-cli-collective/cli-common/cache"
 )
@@ -62,11 +63,16 @@ func WriteResource[T any](name, ttl string, data T) error {
 
 // atomicWriteEnvelope writes a caller-supplied envelope verbatim (preserving
 // its FetchedAt — used by writeRaw/Touch to persist the zeroed "stale"
-// marker). The legacy first parameter is retained for call-site stability
-// (writeRaw and the *_lookup_test.go helpers pass it positionally); the
-// shared verbatim writer derives the file from env.Resource, which by
-// construction equals it.
-func atomicWriteEnvelope[T any](_ string, env Envelope[T]) error {
+// marker). The shared verbatim writer derives the file from env.Resource;
+// the legacy first parameter is retained for call-site stability (writeRaw
+// and the *_lookup_test.go helpers pass it positionally). The name ==
+// env.Resource invariant is enforced (not just assumed) so a future caller
+// passing a mismatched name fails loudly instead of silently writing to the
+// wrong cache file.
+func atomicWriteEnvelope[T any](name string, env Envelope[T]) error {
+	if name != "" && name != env.Resource {
+		return fmt.Errorf("cache: atomicWriteEnvelope name %q does not match envelope resource %q", name, env.Resource)
+	}
 	loc, err := locator()
 	if err != nil {
 		return err

--- a/tools/jtk/internal/cache/envelope_test.go
+++ b/tools/jtk/internal/cache/envelope_test.go
@@ -129,6 +129,10 @@ func TestReadResource_VersionMismatchTreatedAsMiss(t *testing.T) {
 	tmpDir := t.TempDir()
 	cleanup := SetRootForTest(tmpDir)
 	defer cleanup()
+	// Stays hermetic post-facade: SetRootForTest is set but
+	// SetLegacyRootForTest is NOT, so legacyRoot()=="" and the version-miss
+	// never triggers a real ~/.jtk/cache promotion probe. Do not remove the
+	// root override expecting the same behavior.
 	t.Setenv("JIRA_URL", "https://test.atlassian.net")
 
 	// Write a current-version envelope, then overwrite the on-disk file with a

--- a/tools/jtk/internal/cache/freshness.go
+++ b/tools/jtk/internal/cache/freshness.go
@@ -1,88 +1,36 @@
 package cache
 
 import (
-	"fmt"
 	"time"
+
+	cccache "github.com/open-cli-collective/cli-common/cache"
 )
 
-// Status is the coarse freshness classification used by `jtk refresh --status`.
-type Status int
+// Status is the coarse freshness classification, re-exported from cli-common
+// so downstream references (cache.StatusFresh, present.StatusRow, etc.) are
+// unchanged. Classify returns only Fresh|Stale|Manual; Uninitialized is
+// caller-derived from a miss and Unavailable is registry-derived (set by
+// refresh via Entry.IsAvailable, not by Classify).
+type Status = cccache.Status
 
 const (
-	StatusUninitialized Status = iota // no envelope on disk
-	StatusFresh                       // on disk, FetchedAt + TTL still in the future
-	StatusStale                       // on disk, FetchedAt + TTL elapsed
-	StatusManual                      // TTL == "manual"; never reported stale
-	StatusUnavailable                 // Registry Entry.Available(client) reported false
+	StatusUninitialized = cccache.StatusUninitialized
+	StatusFresh         = cccache.StatusFresh
+	StatusStale         = cccache.StatusStale
+	StatusManual        = cccache.StatusManual
+	StatusUnavailable   = cccache.StatusUnavailable
 )
 
-// String returns the status label used in `--status` output.
-func (s Status) String() string {
-	switch s {
-	case StatusUninitialized:
-		return "uninitialized"
-	case StatusFresh:
-		return "fresh"
-	case StatusStale:
-		return "stale"
-	case StatusManual:
-		return "manual"
-	case StatusUnavailable:
-		return "unavailable"
-	default:
-		return "unknown"
-	}
-}
-
-const ttlManual = "manual"
-
-// parseTTL returns the TTL as a time.Duration. The sentinel "manual" returns (0, true).
-func parseTTL(ttl string) (time.Duration, bool, error) {
-	if ttl == ttlManual {
-		return 0, true, nil
-	}
-	d, err := time.ParseDuration(ttl)
-	if err != nil {
-		return 0, false, fmt.Errorf("parsing TTL %q: %w", ttl, err)
-	}
-	return d, false, nil
-}
-
-// Classify inspects the envelope's FetchedAt + TTL at `now` and returns a Status.
-// The FetchedAt.IsZero() case is the "uninitialized" / "touched" state and returns StatusStale
-// (callers that want to distinguish "never fetched" from "touched" check IsZero themselves).
+// Classify inspects an envelope's FetchedAt + TTL at now. Semantics are
+// identical to the previous local implementation (the shared version was
+// lifted from it): "manual" or an unparseable TTL is handled, a zero or
+// elapsed FetchedAt is stale, otherwise fresh.
 func Classify(fetchedAt time.Time, ttl string, now time.Time) Status {
-	d, manual, err := parseTTL(ttl)
-	if err != nil {
-		return StatusStale
-	}
-	if manual {
-		return StatusManual
-	}
-	if fetchedAt.IsZero() || now.Sub(fetchedAt) >= d {
-		return StatusStale
-	}
-	return StatusFresh
+	return cccache.Classify(fetchedAt, ttl, now)
 }
 
-// Age returns a short human-readable age ("8h", "3d", "2m") for `--status` output.
-// Returns "-" when fetchedAt is zero.
-func Age(fetchedAt time.Time, now time.Time) string {
-	if fetchedAt.IsZero() {
-		return "-"
-	}
-	delta := now.Sub(fetchedAt)
-	if delta < 0 {
-		delta = 0
-	}
-	switch {
-	case delta >= 24*time.Hour:
-		return fmt.Sprintf("%dd", int(delta/(24*time.Hour)))
-	case delta >= time.Hour:
-		return fmt.Sprintf("%dh", int(delta/time.Hour))
-	case delta >= time.Minute:
-		return fmt.Sprintf("%dm", int(delta/time.Minute))
-	default:
-		return fmt.Sprintf("%ds", int(delta/time.Second))
-	}
+// Age returns a short human-readable age ("8h", "3d", "2m", "45s") for
+// `jtk refresh --status`; "-" when fetchedAt is zero.
+func Age(fetchedAt, now time.Time) string {
+	return cccache.Age(fetchedAt, now)
 }

--- a/tools/jtk/internal/cache/migrate.go
+++ b/tools/jtk/internal/cache/migrate.go
@@ -1,0 +1,61 @@
+package cache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	cccache "github.com/open-cli-collective/cli-common/cache"
+)
+
+// promoteLegacyOnMiss implements the one-time, per-resource, non-destructive
+// re-migration from the legacy ~/.jtk/cache root to the new
+// os.UserCacheDir()/jtk root (working-with-state.md §6.4, cache variant).
+//
+// It runs ONLY when cli-common ReadResource already returned ErrCacheMiss. It
+// never moves or deletes legacy, never overwrites an existing new envelope,
+// and never fails a command: any problem (absent / unreadable / malformed /
+// version- or identity-mismatched legacy, or a copy error) yields ok=false,
+// which the caller surfaces as a normal miss → refetch. Cache is disposable.
+//
+// Promotion copies exactly one valid envelope via the shared verbatim writer,
+// so the promoted file is byte-faithful and immediately readable (the same
+// identity contract the next ReadResource enforces).
+func promoteLegacyOnMiss[T any](loc cccache.Locator, name string) (Envelope[T], bool) {
+	var zero Envelope[T]
+
+	legRoot := legacyRoot()
+	if legRoot == "" {
+		return zero, false // hermetic test mode or no home → never probe a real dir
+	}
+
+	// Never overwrite an existing new envelope. We reach here on ErrCacheMiss,
+	// which also covers "present but version/identity-mismatched"; in that case
+	// the new file exists and must be left for a clean refetch to replace.
+	newPath, err := ResourceFile(name)
+	if err != nil {
+		return zero, false
+	}
+	if _, statErr := os.Stat(newPath); statErr == nil {
+		return zero, false
+	}
+
+	legPath := filepath.Join(legRoot, loc.InstanceKey, name+".json")
+	data, err := os.ReadFile(legPath) //nolint:gosec // legRoot is the fixed ~/.jtk/cache (or a test override); InstanceKey/name are regex-validated by the shared Locator on write
+	if err != nil {
+		return zero, false // absent / unreadable → plain miss
+	}
+
+	var env cccache.Envelope[T]
+	if json.Unmarshal(data, &env) != nil {
+		return zero, false // malformed legacy → miss, not an error
+	}
+	if env.Version != cccache.Version || env.Resource != name || env.Instance != loc.InstanceKey {
+		return zero, false // stale schema / misplaced file → miss
+	}
+
+	if cccache.WriteEnvelope(loc, env) != nil {
+		return zero, false // copy failure is non-fatal → behave as a miss
+	}
+	return env, true
+}

--- a/tools/jtk/internal/cache/migrate.go
+++ b/tools/jtk/internal/cache/migrate.go
@@ -29,19 +29,20 @@ func promoteLegacyOnMiss[T any](loc cccache.Locator, name string) (Envelope[T], 
 		return zero, false // hermetic test mode or no home → never probe a real dir
 	}
 
-	// Never overwrite an existing new envelope. We reach here on ErrCacheMiss,
-	// which also covers "present but version/identity-mismatched"; in that case
-	// the new file exists and must be left for a clean refetch to replace.
-	newPath, err := ResourceFile(name)
-	if err != nil {
-		return zero, false
-	}
+	// Best-effort "do not overwrite an existing new envelope": derived from
+	// the SAME already-resolved locator as the write path (not a second
+	// independent Root()/InstanceKey() resolution) so the guard and the
+	// write can never anchor to different paths. This is not locked against
+	// a concurrent WriteResource landing between this stat and the promote
+	// write — jtk is a short-lived single process so that race is accepted;
+	// worst case is one stale entry until TTL, never corruption.
+	newPath := filepath.Join(loc.Root, loc.InstanceKey, name+".json")
 	if _, statErr := os.Stat(newPath); statErr == nil {
 		return zero, false
 	}
 
 	legPath := filepath.Join(legRoot, loc.InstanceKey, name+".json")
-	data, err := os.ReadFile(legPath) //nolint:gosec // legRoot is the fixed ~/.jtk/cache (or a test override); InstanceKey/name are regex-validated by the shared Locator on write
+	data, err := os.ReadFile(legPath) //nolint:gosec // name is always a hardcoded registry key (never user input); legRoot is the fixed ~/.jtk/cache or a test override
 	if err != nil {
 		return zero, false // absent / unreadable → plain miss
 	}

--- a/tools/jtk/internal/cache/migrate_test.go
+++ b/tools/jtk/internal/cache/migrate_test.go
@@ -1,0 +1,168 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cccache "github.com/open-cli-collective/cli-common/cache"
+)
+
+const migInstance = "test.atlassian.net"
+
+// writeLegacy plants a raw envelope JSON at <legacyRoot>/<instance>/<name>.json.
+func writeLegacy(t *testing.T, legacyDir, name string, env cccache.Envelope[[]int]) {
+	t.Helper()
+	dir := filepath.Join(legacyDir, migInstance)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".json"), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeLegacyRaw(t *testing.T, legacyDir, name, body string) {
+	t.Helper()
+	dir := filepath.Join(legacyDir, migInstance)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validLegacyEnv(name string) cccache.Envelope[[]int] {
+	return cccache.Envelope[[]int]{
+		Resource:  name,
+		Instance:  migInstance,
+		FetchedAt: time.Now().UTC(),
+		TTL:       "24h",
+		Version:   cccache.Version,
+		Data:      []int{1, 2, 3},
+	}
+}
+
+// migEnv isolates root + legacy root + instance key for one migration test.
+func migEnv(t *testing.T) (newRoot, legacyDir string) {
+	t.Helper()
+	newRoot = t.TempDir()
+	legacyDir = t.TempDir()
+	t.Cleanup(SetRootForTest(newRoot))
+	t.Cleanup(SetInstanceKeyForTest(migInstance))
+	t.Cleanup(SetLegacyRootForTest(legacyDir))
+	return newRoot, legacyDir
+}
+
+func TestPromote_LegacyOnly_Promoted(t *testing.T) {
+	newRoot, legacyDir := migEnv(t)
+	writeLegacy(t, legacyDir, "boards", validLegacyEnv("boards"))
+
+	env, err := ReadResource[[]int]("boards")
+	if err != nil {
+		t.Fatalf("expected promotion, got err %v", err)
+	}
+	if len(env.Data) != 3 {
+		t.Fatalf("promoted data wrong: %+v", env.Data)
+	}
+	// The promoted envelope is now in the new root.
+	if _, statErr := os.Stat(filepath.Join(newRoot, migInstance, "boards.json")); statErr != nil {
+		t.Fatalf("promotion did not copy into the new root: %v", statErr)
+	}
+}
+
+func TestPromote_NewPresent_LegacyIgnored(t *testing.T) {
+	_, legacyDir := migEnv(t)
+	// New has [9]; legacy has [1,2,3]. New must win and legacy not consulted.
+	if err := WriteResource("boards", "24h", []int{9}); err != nil {
+		t.Fatal(err)
+	}
+	writeLegacy(t, legacyDir, "boards", validLegacyEnv("boards"))
+
+	env, err := ReadResource[[]int]("boards")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data) != 1 || env.Data[0] != 9 {
+		t.Fatalf("new root must win; got %+v", env.Data)
+	}
+}
+
+func TestPromote_MalformedLegacy_IsMiss(t *testing.T) {
+	_, legacyDir := migEnv(t)
+	writeLegacyRaw(t, legacyDir, "boards", "{ not json")
+
+	if _, err := ReadResource[[]int]("boards"); !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("malformed legacy must be a miss, got %v", err)
+	}
+}
+
+func TestPromote_IdentityMismatchLegacy_IsMiss(t *testing.T) {
+	_, legacyDir := migEnv(t)
+	bad := validLegacyEnv("boards")
+	bad.Instance = "someone-else.atlassian.net" // wrong instance
+	writeLegacy(t, legacyDir, "boards", bad)
+
+	if _, err := ReadResource[[]int]("boards"); !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("identity-mismatched legacy must be a miss, got %v", err)
+	}
+}
+
+func TestPromote_VersionMismatchLegacy_IsMiss(t *testing.T) {
+	_, legacyDir := migEnv(t)
+	bad := validLegacyEnv("boards")
+	bad.Version = cccache.Version + 99
+	writeLegacy(t, legacyDir, "boards", bad)
+
+	if _, err := ReadResource[[]int]("boards"); !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("version-mismatched legacy must be a miss, got %v", err)
+	}
+}
+
+func TestPromote_NeitherPresent_IsMiss(t *testing.T) {
+	migEnv(t)
+	if _, err := ReadResource[[]int]("boards"); !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("no legacy + no new must be a miss, got %v", err)
+	}
+}
+
+func TestPromote_Idempotent_NoRepromoteOverEditedNew(t *testing.T) {
+	_, legacyDir := migEnv(t)
+	writeLegacy(t, legacyDir, "boards", validLegacyEnv("boards")) // Data [1,2,3]
+
+	if _, err := ReadResource[[]int]("boards"); err != nil { // promote
+		t.Fatal(err)
+	}
+	// User refreshes the new cache to [7]; legacy still [1,2,3].
+	if err := WriteResource("boards", "24h", []int{7}); err != nil {
+		t.Fatal(err)
+	}
+	env, err := ReadResource[[]int]("boards")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data) != 1 || env.Data[0] != 7 {
+		t.Fatalf("second read must not re-promote over the edited new cache; got %+v", env.Data)
+	}
+}
+
+func TestPromote_HermeticWhenNoLegacyOverride(t *testing.T) {
+	// rootOverride set but NO SetLegacyRootForTest: legacyRoot()=="" so the
+	// real ~/.jtk/cache is never probed (the B3-class leak guard).
+	t.Cleanup(SetRootForTest(t.TempDir()))
+	t.Cleanup(SetInstanceKeyForTest(migInstance))
+	if got := legacyRoot(); got != "" {
+		t.Fatalf("legacyRoot() must be \"\" in isolated tests, got %q", got)
+	}
+	if _, err := ReadResource[[]int]("boards"); !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("must be a clean miss with no real-dir probe, got %v", err)
+	}
+}

--- a/tools/jtk/internal/cache/migrate_test.go
+++ b/tools/jtk/internal/cache/migrate_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -73,9 +74,49 @@ func TestPromote_LegacyOnly_Promoted(t *testing.T) {
 	if len(env.Data) != 3 {
 		t.Fatalf("promoted data wrong: %+v", env.Data)
 	}
+	// Identity contract: a promoted envelope must carry correct metadata,
+	// not just correct Data (a metadata-corrupt promote would self-miss).
+	if env.Resource != "boards" || env.Instance != migInstance || env.Version != cccache.Version {
+		t.Fatalf("promoted metadata wrong: resource=%q instance=%q version=%d",
+			env.Resource, env.Instance, env.Version)
+	}
 	// The promoted envelope is now in the new root.
 	if _, statErr := os.Stat(filepath.Join(newRoot, migInstance, "boards.json")); statErr != nil {
 		t.Fatalf("promotion did not copy into the new root: %v", statErr)
+	}
+}
+
+func TestPromote_ResourceMismatchLegacy_IsMiss(t *testing.T) {
+	_, legacyDir := migEnv(t)
+	bad := validLegacyEnv("boards")
+	bad.Resource = "other" // legacy file at boards.json but envelope names "other"
+	writeLegacy(t, legacyDir, "boards", bad)
+
+	if _, err := ReadResource[[]int]("boards"); !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("resource-mismatched legacy must be a miss, got %v", err)
+	}
+}
+
+func TestPromote_CopyErrorIsNonFatalMiss(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("perm-based copy-failure injection is unreliable on windows / as root")
+	}
+	legacyDir := t.TempDir()
+	// New root is a real dir but read-only, so the promotion's WriteEnvelope
+	// (MkdirAll of the instance subdir) fails. ReadResource of the (absent)
+	// new file still cleanly misses, so promotion runs and its copy errors.
+	newRoot := t.TempDir()
+	if err := os.Chmod(newRoot, 0o500); err != nil { //nolint:gosec // directory perms: 0500 intentionally removes write to force the copy failure
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(newRoot, 0o700) }) //nolint:gosec // restore dir perms so t.TempDir cleanup can remove it
+	t.Cleanup(SetRootForTest(newRoot))
+	t.Cleanup(SetInstanceKeyForTest(migInstance))
+	t.Cleanup(SetLegacyRootForTest(legacyDir))
+	writeLegacy(t, legacyDir, "boards", validLegacyEnv("boards"))
+
+	if _, err := ReadResource[[]int]("boards"); !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("a copy failure must be non-fatal (ErrCacheMiss), got %v", err)
 	}
 }
 
@@ -149,6 +190,9 @@ func TestPromote_Idempotent_NoRepromoteOverEditedNew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Exactly [7] (the edited new value) mechanically proves the
+	// never-overwrite stat-guard held: had promotion run it would have
+	// returned/retained the legacy [1,2,3], which can never appear here.
 	if len(env.Data) != 1 || env.Data[0] != 7 {
 		t.Fatalf("second read must not re-promote over the edited new cache; got %+v", env.Data)
 	}

--- a/tools/jtk/internal/cache/paths.go
+++ b/tools/jtk/internal/cache/paths.go
@@ -1,4 +1,3 @@
-// Package cache manages the jtk resource cache on disk.
 package cache
 
 import (
@@ -9,6 +8,9 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+
+	cccache "github.com/open-cli-collective/cli-common/cache"
+	"github.com/open-cli-collective/cli-common/statedir"
 
 	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
 )
@@ -23,71 +25,81 @@ var ErrNoInstance = errors.New("no Jira instance configured — run 'jtk init' f
 var instanceKeySafe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9.\-]*$`)
 
 // isSafeInstanceKey validates that the key is safe to use as a filesystem
-// path component: only allowed characters, and no parent-dir traversal.
+// path component: only allowed characters, no parent-dir traversal, and no
+// trailing dot (Windows strips it, which would collide two instances). This
+// mirrors cli-common/cache's component guard so the facade and the shared
+// library agree on what a valid instance key is.
 func isSafeInstanceKey(k string) bool {
 	if k == "" || !instanceKeySafe.MatchString(k) {
 		return false
 	}
-	// Reject `..` anywhere in the key (subdomains don't have consecutive dots).
-	if strings.Contains(k, "..") {
+	if strings.Contains(k, "..") || strings.HasSuffix(k, ".") {
 		return false
 	}
 	return true
 }
 
-// rootOverride / instanceOverride are package-level overrides for tests,
-// guarded by overrideMu. Tests running in parallel still race for the
-// *values* (the last writer wins), but the reads/writes themselves are
-// synchronized so the race detector is satisfied.
+// rootOverride / instanceOverride / legacyRootOverride are package-level
+// overrides for tests, guarded by overrideMu. Parallel tests still race for
+// the values (last writer wins) but the reads/writes are synchronized so the
+// race detector is satisfied.
 var (
-	overrideMu       sync.RWMutex
-	rootOverride     string
-	instanceOverride string
+	overrideMu         sync.RWMutex
+	rootOverride       string
+	instanceOverride   string
+	legacyRootOverride string
 )
 
-func getRootOverride() string {
-	overrideMu.RLock()
-	defer overrideMu.RUnlock()
-	return rootOverride
-}
-
+func getRootOverride() string { overrideMu.RLock(); defer overrideMu.RUnlock(); return rootOverride }
 func getInstanceOverride() string {
 	overrideMu.RLock()
 	defer overrideMu.RUnlock()
 	return instanceOverride
 }
-
-func setRootOverride(v string) {
-	overrideMu.Lock()
-	rootOverride = v
-	overrideMu.Unlock()
+func getLegacyRootOverride() string {
+	overrideMu.RLock()
+	defer overrideMu.RUnlock()
+	return legacyRootOverride
 }
 
-func setInstanceOverride(v string) {
-	overrideMu.Lock()
-	instanceOverride = v
-	overrideMu.Unlock()
-}
+func setRootOverride(v string)       { overrideMu.Lock(); rootOverride = v; overrideMu.Unlock() }
+func setInstanceOverride(v string)   { overrideMu.Lock(); instanceOverride = v; overrideMu.Unlock() }
+func setLegacyRootOverride(v string) { overrideMu.Lock(); legacyRootOverride = v; overrideMu.Unlock() }
 
-// Root returns the cache root directory, expanded from "~/.jtk/cache".
-// If SetRootForTest has overridden it, returns the override.
+// Root returns the cache root directory. It is now os.UserCacheDir()/jtk via
+// the shared cli-common resolver (was ~/.jtk/cache; see legacyRoot for the
+// one-time promotion source). A test override short-circuits it.
 func Root() (string, error) {
 	if o := getRootOverride(); o != "" {
 		return o, nil
 	}
+	return statedir.Cache{Tool: "jtk"}.CacheDir()
+}
 
+// legacyRoot returns the pre-migration cache root (~/.jtk/cache), used ONLY
+// as a read-only promotion source by promoteLegacyOnMiss.
+//
+// Hermeticity rule: if a root override is set (test mode) but no explicit
+// legacy override is, return "" so tests never probe the developer's real
+// ~/.jtk/cache (the B3-class leak). Migration tests call
+// SetLegacyRootForTest to point the probe at a temp dir.
+func legacyRoot() string {
+	if o := getLegacyRootOverride(); o != "" {
+		return o
+	}
+	if getRootOverride() != "" {
+		return ""
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", err
+		return ""
 	}
-
-	return filepath.Join(home, ".jtk", "cache"), nil
+	return filepath.Join(home, ".jtk", "cache")
 }
 
 // InstanceKey derives a per-Jira-instance directory name.
-// For basic auth: the hostname of config.GetURL() (e.g., "monit.atlassian.net").
-// For bearer auth: config.GetCloudID() when the URL is api.atlassian.com.
-// Returns ErrNoInstance if no valid instance configuration is found.
+// Basic auth: the hostname of config.GetURL(). Bearer auth: config.GetCloudID()
+// when the URL is the api.atlassian.com gateway. ErrNoInstance if none valid.
 func InstanceKey() (string, error) {
 	if o := getInstanceOverride(); o != "" {
 		return o, nil
@@ -98,15 +110,10 @@ func InstanceKey() (string, error) {
 	}
 
 	parsed, err := url.Parse(urlStr)
-	if err != nil {
+	if err != nil || parsed.Host == "" {
 		return "", ErrNoInstance
 	}
 
-	if parsed.Host == "" {
-		return "", ErrNoInstance
-	}
-
-	// Bearer auth path: use CloudID when gateway is detected
 	if parsed.Host == "api.atlassian.com" {
 		cloudID := config.GetCloudID()
 		if !isSafeInstanceKey(cloudID) {
@@ -115,55 +122,72 @@ func InstanceKey() (string, error) {
 		return cloudID, nil
 	}
 
-	// Basic auth path: return the hostname
 	if !isSafeInstanceKey(parsed.Host) {
 		return "", ErrNoInstance
 	}
 	return parsed.Host, nil
 }
 
-// ResourceFile returns the absolute path for a resource's envelope file.
-// For example: ~/.jtk/cache/monit.atlassian.net/fields.json
+// locator builds the cli-common cache Locator from the resolved root +
+// instance key. The shared library validates Root (absolute) and the
+// instance key / resource name before composing any path.
+func locator() (cccache.Locator, error) {
+	root, err := Root()
+	if err != nil {
+		return cccache.Locator{}, err
+	}
+	key, err := InstanceKey()
+	if err != nil {
+		return cccache.Locator{}, err
+	}
+	return cccache.Locator{Root: root, InstanceKey: key}, nil
+}
+
+// ResourceFile returns the absolute path for a resource's envelope file under
+// the (new) cache root, e.g. <os.UserCacheDir>/jtk/monit.atlassian.net/fields.json.
 func ResourceFile(name string) (string, error) {
 	root, err := Root()
 	if err != nil {
 		return "", err
 	}
-
 	key, err := InstanceKey()
 	if err != nil {
 		return "", err
 	}
-
 	return filepath.Join(root, key, name+".json"), nil
 }
 
-// SetRootForTest overrides the cache root directory for testing.
-// Returns a cleanup function that restores the prior value.
-// Must only be called from tests in the cache package.
+// SetRootForTest overrides the cache root directory for testing. Returns a
+// cleanup that restores the prior value. Must only be called from tests.
 func SetRootForTest(dir string) func() {
 	overrideMu.Lock()
-	oldRoot := rootOverride
+	old := rootOverride
 	rootOverride = dir
 	overrideMu.Unlock()
-	return func() { setRootOverride(oldRoot) }
+	return func() { setRootOverride(old) }
 }
 
-// SetInstanceKeyForTest overrides the derived instance-key name used for
-// per-instance cache directories. Pairs with SetRootForTest to give tests a
-// fully isolated cache directory without touching JIRA_URL/config state
-// (which would conflict with t.Parallel).
+// SetInstanceKeyForTest overrides the derived instance-key name. Pairs with
+// SetRootForTest to give tests a fully isolated cache dir without touching
+// JIRA_URL/config state.
 func SetInstanceKeyForTest(key string) func() {
-	// Defense-in-depth: validate the override with the same character set
-	// the production InstanceKey() path enforces. Prevents a test author
-	// from accidentally escaping the temp-root isolation set up by
-	// SetRootForTest (e.g. "../outside-tmp" would otherwise traverse).
 	if !isSafeInstanceKey(key) {
 		panic("cache.SetInstanceKeyForTest: unsafe instance key: " + key)
 	}
 	overrideMu.Lock()
-	oldInstance := instanceOverride
+	old := instanceOverride
 	instanceOverride = key
 	overrideMu.Unlock()
-	return func() { setInstanceOverride(oldInstance) }
+	return func() { setInstanceOverride(old) }
+}
+
+// SetLegacyRootForTest points the one-time legacy-promotion probe at a temp
+// dir so migration tests are hermetic. Returns a cleanup. Must only be called
+// from tests.
+func SetLegacyRootForTest(dir string) func() {
+	overrideMu.Lock()
+	old := legacyRootOverride
+	legacyRootOverride = dir
+	overrideMu.Unlock()
+	return func() { setLegacyRootOverride(old) }
 }

--- a/tools/jtk/internal/cache/paths_test.go
+++ b/tools/jtk/internal/cache/paths_test.go
@@ -108,6 +108,10 @@ func TestInstanceKey_RejectsPathInjection(t *testing.T) {
 		{"cloudID with forward slash", "https://api.atlassian.com", "foo/bar"},
 		{"cloudID with backslash", "https://api.atlassian.com", `foo\bar`},
 		{"cloudID with space", "https://api.atlassian.com", "foo bar"},
+		// Trailing dot: the regex would accept it, so the HasSuffix guard is
+		// the sole protection (Windows strips trailing dots → collision).
+		{"cloudID with trailing dot", "https://api.atlassian.com", "foo."},
+		{"hostname with trailing dot", "https://foo./", ""},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -136,6 +140,7 @@ func TestSetInstanceKeyForTest_RejectsUnsafeKeys(t *testing.T) {
 		`foo\bar`,
 		"",
 		"foo bar",
+		"foo.", // trailing dot — sole-protected by the HasSuffix guard
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/tools/jtk/internal/cache/paths_test.go
+++ b/tools/jtk/internal/cache/paths_test.go
@@ -2,27 +2,31 @@ package cache
 
 import (
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
+	"github.com/open-cli-collective/cli-common/statedir"
+	"github.com/open-cli-collective/cli-common/statedirtest"
 )
 
 func TestRoot_DefaultExpansion(t *testing.T) {
-	// Clear any override
+	// MON-5369: the default cache root is now os.UserCacheDir()/jtk via the
+	// shared cli-common resolver (was ~/.jtk/cache). Hermetic so it never
+	// touches the developer's real cache dir.
+	statedirtest.Hermetic(t)
 	cleanup := SetRootForTest("")
 	defer cleanup()
 
 	root, err := Root()
 	testutil.NoError(t, err)
 
-	// Verify it ends with /.jtk/cache
-	if !strings.HasSuffix(root, "/.jtk/cache") {
-		t.Errorf("Root() should end with /.jtk/cache, got %q", root)
-	}
+	want, err := statedir.Cache{Tool: "jtk"}.CacheDir()
+	testutil.NoError(t, err)
+	testutil.Equal(t, root, want)
 }
 
 func TestRoot_RespectSetRootForTest(t *testing.T) {
+	statedirtest.Hermetic(t)
 	tempDir := t.TempDir()
 
 	// Override the root
@@ -36,12 +40,12 @@ func TestRoot_RespectSetRootForTest(t *testing.T) {
 	// Clean up should restore prior value
 	cleanup()
 
-	// After cleanup, Root should return default again
+	// After cleanup, Root should return the default (shared resolver) again.
 	root, err = Root()
 	testutil.NoError(t, err)
-	if !strings.HasSuffix(root, "/.jtk/cache") {
-		t.Errorf("After cleanup, Root() should end with /.jtk/cache, got %q", root)
-	}
+	want, err := statedir.Cache{Tool: "jtk"}.CacheDir()
+	testutil.NoError(t, err)
+	testutil.Equal(t, root, want)
 }
 
 func TestInstanceKey_BasicAuth(t *testing.T) {

--- a/tools/jtk/internal/cmd/boards/boards_test.go
+++ b/tools/jtk/internal/cmd/boards/boards_test.go
@@ -41,7 +41,11 @@ func TestNewListCmd(t *testing.T) {
 }
 
 func TestRunList_Table(t *testing.T) {
-	t.Parallel()
+	// NOT t.Parallel(): isolates the package-global cache so the boards
+	// lookup is a guaranteed miss and the mock server is exercised (was
+	// latently non-hermetic — read the dev's real ~/.jtk cache).
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(api.BoardsResponse{
 			Values: []api.Board{
@@ -126,7 +130,9 @@ func TestRunList_Extended(t *testing.T) {
 }
 
 func TestRunList_IDOnly(t *testing.T) {
-	t.Parallel()
+	// NOT t.Parallel(): cache isolation (see TestRunList_Table).
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(api.BoardsResponse{
 			Values: []api.Board{
@@ -154,7 +160,9 @@ func TestRunList_IDOnly(t *testing.T) {
 }
 
 func TestRunList_Empty(t *testing.T) {
-	t.Parallel()
+	// NOT t.Parallel(): cache isolation (see TestRunList_Table).
+	t.Cleanup(cache.SetRootForTest(t.TempDir()))
+	t.Cleanup(cache.SetInstanceKeyForTest("test.atlassian.net"))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(api.BoardsResponse{
 			Values: []api.Board{},


### PR DESCRIPTION
**working-with-state.md §6.4 unit 1** — jtk cache re-migration (MON-5369, KTLO). The first per-CLI port adopting the §6 commons buildout (PR-B; cli-common PR-A #20 + PR-A2 #21 are merged prerequisites).

## Strategy — tier-1 *facade* (surgical)
jtk `internal/cache` (~200 refs, ~25 test files, tier-1+tier-2 mixed) keeps its **public API byte-stable** and delegates tier-1 internals to `cli-common/cache` + `cli-common/statedir`:
- `Envelope[T]` = type alias to the shared envelope; `ErrCacheMiss`/`Status*` re-exported; `Classify`/`Age` pass through ⇒ the ~25 cache-using test files and tier-2 (registry/fetchers/lookups/invalidate) **do not churn**.
- `Root()` → `statedir.Cache{Tool:"jtk"}.CacheDir()` (os.UserCacheDir()/jtk; was ~/.jtk/cache).
- `Touch`/`writeRaw` → the shared `WriteEnvelope` verbatim writer (preserves the zeroed-FetchedAt stale marker).

## Re-migration (cache variant — declared)
Per-resource, copy-of-valid-only, on read-miss (`promoteLegacyOnMiss`). Legacy `~/.jtk/cache` is a **read-only** promotion source: never moved/deleted, never overwrites a new envelope; malformed / identity- / version-mismatched legacy ⇒ miss (not error); any probe/copy failure is non-fatal (cache is disposable). Hermetic in tests (legacy probe is "" under root isolation unless `SetLegacyRootForTest`).

## §5 first-port generalizations (additive cli-common, merged + repinned)
- **#20** `WriteEnvelope` — verbatim atomic writer with an identity-safe contract (jtk's `Touch` needs FetchedAt-preserving writes; `WriteResource` re-stamps).
- **#21** allow `_` in instance keys / resource names — jtk imposed no charset limit on resource names; purely permissive widening.
Both additive; jtk repinned to the merged SHA. `go work sync` deliberately not run.

## Verification
- jtk: **1798 tests pass**; new `migrate_test.go` covers every §4 row (legacy-only→promoted; new wins; malformed/identity/version→miss; neither→miss; idempotent; hermetic-without-override).
- Workspace (go.work — `./...` invalid): module-qualified build OK across shared/cfl/jtk; **cfl 991 / shared 422 pass** (jtk-only repin is workspace-consistent — the additive-MVS nuance holds).
- Facade proof: the ~25 isolated cache test files pass **unmodified**. The only non-cache test edits are `boards_test.go` (3 tests that were *latently non-hermetic* — no cache isolation → promotion surfaced the dev's real cache; isolated them per the file's own convention) and the 2 `paths_test.go` root assertions (this ticket changes `Root()`).
- Lint clean except a **pre-existing** `internal/config/config.go:120` G117 (untouched by this PR; `git diff main` empty — not traceable to MON-5369).

## Review provenance
Architect session 019e4019 (whole INT-310 state workstream) reviewed the plan: round 1 found blockers=1 majors=3 — all fixed verbatim (per-resource copy-of-valid migration; identity-safe `WriteEnvelope`; `Touch`-only scope; workspace-qualified commands). Codex quota was exhausted at round-2 (policy: never blocks); the same session will review this diff once quota resets.

Closes #371
[MON-5369]