### PR TITLE
docs: post-INT-310 config path correction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,9 +120,11 @@ Tool-specific variables (`CFL_*`, `JIRA_*`) take precedence over shared variable
 
 The **API token is stored in the OS keyring** (macOS Keychain / Linux
 Secret Service / Windows Credential Manager, or an opt-in encrypted-file
-backend) — never in a plaintext file. Only **non-secret** config lives in
-`~/.config/atlassian-cli/config.yml` (mode 0600), written by `cfl init`
-and `jtk init`:
+backend) — never in a plaintext file. Only **non-secret** config lives
+in the shared OS-native config dir (`~/Library/Application
+Support/atlassian-cli/config.yml` on macOS, `%APPDATA%\atlassian-cli\
+config.yml` on Windows, `~/.config/atlassian-cli/config.yml` on Linux;
+mode 0600), written by `cfl init` and `jtk init`:
 
 ```yaml
 default:

--- a/README.md
+++ b/README.md
@@ -166,9 +166,14 @@ The init wizards will prompt for:
 - Email address
 - API token
 
-Configuration is stored in:
-- jtk: `~/.config/jira-ticket-cli/config.json`
-- cfl: `~/.config/cfl/config.yml`
+Configuration is stored under the shared `atlassian-cli` config dir (a
+single credential scope used by both binaries) at the OS-native location:
+- macOS: `~/Library/Application Support/atlassian-cli/config.yml`
+- Linux: `~/.config/atlassian-cli/config.yml` (or under `$XDG_CONFIG_HOME` if set)
+- Windows: `%APPDATA%\atlassian-cli\config.yml`
+
+`config.yml` carries only non-secret fields (URL, email, defaults); the
+API token lives in the OS keyring (see "Shared credential store" below).
 
 ### Authentication
 


### PR DESCRIPTION
The shared atlassian-cli config dir is now OS-native via cli-common/statedir (MON-5370). README still showed the pre-port per-binary hand-rolled paths (`~/.config/jira-ticket-cli/config.json` and `~/.config/cfl/config.yml`); contributor guide still showed Linux-only path.

User-facing fix; no behavior change. Doc-only, no Go files touched (no release triggered).