### PR TITLE
chore(deps): bump cli-common to v0.2.1 (pass backend recognized)

### DIFF
--- a/shared/go.mod
+++ b/shared/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/fatih/color v1.18.0
 	github.com/gohugoio/hugo-goldmark-extensions/extras v0.6.0
-	github.com/open-cli-collective/cli-common v0.2.0
+	github.com/open-cli-collective/cli-common v0.2.1
 	github.com/yuin/goldmark v1.7.16
 	golang.org/x/term v0.43.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/shared/go.sum
+++ b/shared/go.sum
@@ -49,8 +49,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.2.0 h1:EOqf75BIA2tfFrGNmYB1jCjFH0jogIgsYqj6JPXoOQA=
-github.com/open-cli-collective/cli-common v0.2.0/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
+github.com/open-cli-collective/cli-common v0.2.1 h1:awnwmDD9ubGUmYLg+SGkPGzbiraJsJb/eMWWTV4fwPI=
+github.com/open-cli-collective/cli-common v0.2.1/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tools/cfl/go.mod
+++ b/tools/cfl/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0
 	github.com/charmbracelet/huh v0.8.0
 	github.com/open-cli-collective/atlassian-go v0.0.0-00010101000000-000000000000
-	github.com/open-cli-collective/cli-common v0.2.0
+	github.com/open-cli-collective/cli-common v0.2.1
 	github.com/spf13/cobra v1.8.1
 	github.com/yuin/goldmark v1.7.16
 	golang.org/x/text v0.37.0

--- a/tools/cfl/go.sum
+++ b/tools/cfl/go.sum
@@ -118,8 +118,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.2.0 h1:EOqf75BIA2tfFrGNmYB1jCjFH0jogIgsYqj6JPXoOQA=
-github.com/open-cli-collective/cli-common v0.2.0/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
+github.com/open-cli-collective/cli-common v0.2.1 h1:awnwmDD9ubGUmYLg+SGkPGzbiraJsJb/eMWWTV4fwPI=
+github.com/open-cli-collective/cli-common v0.2.1/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tools/jtk/go.mod
+++ b/tools/jtk/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/charmbracelet/huh v0.8.0
 	github.com/open-cli-collective/atlassian-go v0.0.0-00010101000000-000000000000
-	github.com/open-cli-collective/cli-common v0.2.0
+	github.com/open-cli-collective/cli-common v0.2.1
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/tools/jtk/go.sum
+++ b/tools/jtk/go.sum
@@ -114,8 +114,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.2.0 h1:EOqf75BIA2tfFrGNmYB1jCjFH0jogIgsYqj6JPXoOQA=
-github.com/open-cli-collective/cli-common v0.2.0/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
+github.com/open-cli-collective/cli-common v0.2.1 h1:awnwmDD9ubGUmYLg+SGkPGzbiraJsJb/eMWWTV4fwPI=
+github.com/open-cli-collective/cli-common v0.2.1/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Picks up open-cli-collective/cli-common#26: the pass(1) backend is now in the recognized backend set. No code changes — the existing --backend flag wiring passes `pass` through to credstore as an opaque string.

Affects all three modules (`shared`, `tools/jtk`, `tools/cfl`). After merge, users can run e.g. `jtk issues list --backend pass` (requires `pass` CLI on `$PATH` + initialized password-store).