### PR TITLE
feat(set-credential): §1.5.2 surface conformance for jtk + cfl (#389)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,9 +190,15 @@ who *permanently* exports the token via env therefore keeps the plaintext
 file until they run `init`/`set-credential` — env is an explicit runtime
 override, so a read path is never forced to mutate disk behind it.
 
-**Non-interactive ingress:** `cfl set-credential` / `jtk set-credential`
-read a token from stdin or `--from-env VAR` and store it in the keyring
-(never echoed). `config show` reports token presence + source + keyring
+**Non-interactive ingress (§1.5.2):** `cfl set-credential` / `jtk set-credential`
+read a token from `--stdin` or `--from-env VAR` (exactly one; mutually
+exclusive) and store it in the keyring (never echoed). `--key` is always
+required (`--key api_token`); `--ref` is required when no shared config
+exists (`--ref atlassian-cli/default`) and defaults to the canonical ref
+otherwise. Replacing an existing entry requires `--overwrite`. `--json`
+emits a control-plane envelope `{"ref","key","backend","written",
+"error?"}` per cli-common §1.5.2 with stderr empty (envelope is the only
+stdout artifact). `config show` reports token presence + source + keyring
 backend only (never the value). `config clear` removes the single shared
 `api_token` (warning that the sibling tool loses access too, since both
 resolve the same key); `config clear --all` removes the whole bundle

--- a/shared/credstore/credstore.go
+++ b/shared/credstore/credstore.go
@@ -217,6 +217,54 @@ func (s *Store) HasUsableConfig(tool string) bool {
 	}
 }
 
+// HasSharedConfig reports whether a shared atlassian-cli config.yml
+// exists at any recognized location. Composes with §3.2 relocation:
+// an old-only hand-rolled file (pre-statedir layout) registers as
+// present, mirroring LoadSharedRuntime's transparent read-fallback.
+//
+// Corrupt/unparseable files surface as ErrCorruptStore — callers that
+// gate behavior on "config present" (set-credential's --ref defaulting)
+// must NOT silently fall back to the no-config branch when the user's
+// actual file is unreadable.
+func HasSharedConfig() (bool, error) {
+	canonical, err := DefaultPath()
+	if err != nil {
+		return false, err
+	}
+	return hasSharedConfigAt(canonical)
+}
+
+// hasSharedConfigAt is the testable seam — accepts the canonical path
+// as an argument so Linux CI (where oldSharedPath ≡ DefaultPath) can
+// exercise old≠new branches under a synthesized distinct canonical,
+// matching the loadSharedRuntime(newPath) split used by relocate.go.
+func hasSharedConfigAt(canonical string) (bool, error) {
+	if present, err := checkConfigAt(canonical); err != nil || present {
+		return present, err
+	}
+	old := oldSharedPath()
+	if old == "" || old == canonical {
+		return false, nil
+	}
+	return checkConfigAt(old)
+}
+
+func checkConfigAt(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("checking shared config %s: %w", path, err)
+	}
+	// File present — validate parse so corruption surfaces as
+	// ErrCorruptStore rather than silently registering as absent.
+	if _, lerr := Load(path); lerr != nil {
+		return false, lerr
+	}
+	return true, nil
+}
+
 // NormalizeBaseURL strips the "/wiki" suffix and any trailing "/" so
 // the shared store always carries the bare instance URL. Idempotent.
 func NormalizeBaseURL(raw string) string {

--- a/shared/credstore/has_shared_config_test.go
+++ b/shared/credstore/has_shared_config_test.go
@@ -1,0 +1,150 @@
+package credstore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-cli-collective/cli-common/statedirtest"
+)
+
+// TestHasSharedConfig_Neither_False — empty hermetic state dir, no canonical
+// and no old shared file, expect (false, nil) so the §1.5.2 caller routes to
+// "no config → require --ref".
+func TestHasSharedConfig_Neither_False(t *testing.T) {
+	_ = oldBase(t)
+	newPath := filepath.Join(t.TempDir(), "new", "config.yml")
+
+	has, err := hasSharedConfigAt(newPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if has {
+		t.Fatal("empty state must report absent")
+	}
+}
+
+// TestHasSharedConfig_CanonicalOnly_True — canonical present registers as
+// present, no fallback needed.
+func TestHasSharedConfig_CanonicalOnly_True(t *testing.T) {
+	_ = oldBase(t)
+	newPath := filepath.Join(t.TempDir(), "new", "config.yml")
+	writeFile(t, newPath, "default:\n  url: https://acme.atlassian.net\n  email: u@x.io\n")
+
+	has, err := hasSharedConfigAt(newPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !has {
+		t.Fatal("canonical present must register as true")
+	}
+}
+
+// TestHasSharedConfig_OldOnly_True — pre-relocation user with config only at
+// the old hand-rolled path must register as present (matches
+// LoadSharedRuntime's transparent read-fallback).
+func TestHasSharedConfig_OldOnly_True(t *testing.T) {
+	oldPath := oldBase(t)
+	newPath := filepath.Join(t.TempDir(), "new", "config.yml")
+	writeFile(t, oldPath, "default:\n  url: https://acme.atlassian.net\n  email: u@x.io\n")
+
+	has, err := hasSharedConfigAt(newPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !has {
+		t.Fatal("old-only config must register as true (relocation fallback)")
+	}
+}
+
+// TestHasSharedConfig_BothPresent_True — divergence is irrelevant for the
+// presence question; canonical short-circuits the old-path check. Conflict is
+// surfaced at config-read time via LoadSharedRuntime, not here.
+func TestHasSharedConfig_BothPresent_True(t *testing.T) {
+	oldPath := oldBase(t)
+	newPath := filepath.Join(t.TempDir(), "new", "config.yml")
+	writeFile(t, oldPath, "default:\n  url: https://acme.atlassian.net\n")
+	writeFile(t, newPath, "default:\n  url: https://other.atlassian.net\n")
+
+	has, err := hasSharedConfigAt(newPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !has {
+		t.Fatal("both-present must register as true (canonical short-circuits)")
+	}
+}
+
+// TestHasSharedConfig_CanonicalCorrupt_SurfacesError — a corrupt canonical
+// file MUST NOT silently route the caller to the no-config branch.
+// set-credential expects the error to propagate so the §1.5.2 envelope
+// reports the real failure, not a misleading "missing --ref" hint.
+func TestHasSharedConfig_CanonicalCorrupt_SurfacesError(t *testing.T) {
+	_ = oldBase(t)
+	newPath := filepath.Join(t.TempDir(), "new", "config.yml")
+	writeFile(t, newPath, "[unclosed_array: yes\n")
+
+	has, err := hasSharedConfigAt(newPath)
+	if err == nil {
+		t.Fatal("corrupt canonical must surface error")
+	}
+	if !errors.Is(err, ErrCorruptStore) {
+		t.Fatalf("error must wrap ErrCorruptStore, got %v", err)
+	}
+	if has {
+		t.Fatal("corrupt canonical must report has=false")
+	}
+}
+
+// TestHasSharedConfig_OldCorrupt_SurfacesError — canonical absent, old
+// corrupt. Same loud-fail contract as the canonical-corrupt case.
+func TestHasSharedConfig_OldCorrupt_SurfacesError(t *testing.T) {
+	oldPath := oldBase(t)
+	newPath := filepath.Join(t.TempDir(), "new", "config.yml")
+	writeFile(t, oldPath, "[unclosed_array: yes\n")
+
+	has, err := hasSharedConfigAt(newPath)
+	if err == nil {
+		t.Fatal("corrupt old must surface error")
+	}
+	if !errors.Is(err, ErrCorruptStore) {
+		t.Fatalf("error must wrap ErrCorruptStore, got %v", err)
+	}
+	if has {
+		t.Fatal("corrupt old must report has=false")
+	}
+}
+
+// TestHasSharedConfig_StatedirResolution — exercises the exported wrapper
+// HasSharedConfig() through the production statedir resolver. On any OS it
+// must report false in an empty hermetic root and true after writing to the
+// resolved canonical path.
+func TestHasSharedConfig_StatedirResolution(t *testing.T) {
+	statedirtest.Hermetic(t)
+
+	has, err := HasSharedConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if has {
+		t.Fatal("empty hermetic root must report absent")
+	}
+
+	p, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, p, "default:\n  url: https://acme.atlassian.net\n")
+
+	has, err = HasSharedConfig()
+	if err != nil {
+		t.Fatalf("unexpected error after write: %v", err)
+	}
+	if !has {
+		t.Fatal("present canonical must register as true via exported wrapper")
+	}
+}

--- a/shared/keyring/keyring.go
+++ b/shared/keyring/keyring.go
@@ -190,6 +190,14 @@ func (s *Store) SetToken(key, val string) error {
 	return s.setToken(key, val, true)
 }
 
+// SetTokenStrict writes only if no entry already exists at <ref>/<key>.
+// Surfaces cccredstore.ErrExists when the entry is present. This is the
+// §1.5.2 --overwrite gate: callers that did NOT pass --overwrite must
+// fail loud rather than silently replacing a token.
+func (s *Store) SetTokenStrict(key, val string) error {
+	return s.setToken(key, val, false)
+}
+
 // setToken is the single guarded write chokepoint. With overwrite=false a
 // value created between a caller's read and this write surfaces as
 // cccredstore.ErrExists instead of being silently clobbered — the §1.8

--- a/shared/keyring/setcredential.go
+++ b/shared/keyring/setcredential.go
@@ -105,8 +105,6 @@ func SetCredentialV2(opts SetCredentialOpts) (SetCredentialResult, error) {
 	post := func(err error) (SetCredentialResult, error) {
 		if cerr := s.Close(); cerr != nil && err == nil {
 			err = fmt.Errorf("close keyring %s: %w", s.ref, cerr)
-		} else {
-			_ = s.Close()
 		}
 		return SetCredentialResult{
 			Ref:     opts.Ref,

--- a/shared/keyring/setcredential.go
+++ b/shared/keyring/setcredential.go
@@ -220,8 +220,7 @@ var ErrSetCredentialEnvelopeEmitted = errors.New("set-credential envelope alread
 // now, --json runs that perform a migration silently consume the human
 // notice; the migration itself still occurred and is reflected in the
 // envelope's `written=true`.
-func RunSetCredential(opts SetCredentialOpts, stdout, stderr io.Writer, emitJSON bool, toolName string) error {
-	_ = toolName
+func RunSetCredential(opts SetCredentialOpts, stdout, stderr io.Writer, emitJSON bool) error {
 	res, err := SetCredentialV2(opts)
 	if emitJSON {
 		// Drain any pending §1.8 migration notice so main.go's

--- a/shared/keyring/setcredential.go
+++ b/shared/keyring/setcredential.go
@@ -117,18 +117,21 @@ func SetCredentialV2(opts SetCredentialOpts) (SetCredentialResult, error) {
 		}, err
 	}
 
-	if !opts.Overwrite {
-		exists, herr := s.HasToken(opts.Key)
-		if herr != nil {
-			return post(herr)
-		}
-		if exists {
+	// §1.5.2 default-fail-on-existing: use the atomic strict path so a
+	// concurrent writer between an exists-check and a set cannot slip a
+	// silent overwrite through. SetTokenStrict surfaces ErrExists from the
+	// underlying credstore; translate to the actionable hint.
+	var writeErr error
+	if opts.Overwrite {
+		writeErr = s.SetToken(opts.Key, token)
+	} else {
+		writeErr = s.SetTokenStrict(opts.Key, token)
+		if writeErr != nil && errors.Is(writeErr, cccredstore.ErrExists) {
 			return post(fmt.Errorf("entry exists at %s/%s; pass --overwrite to replace", opts.Ref, opts.Key))
 		}
 	}
-
-	if err := s.SetToken(opts.Key, token); err != nil {
-		return post(err)
+	if writeErr != nil {
+		return post(writeErr)
 	}
 	if cerr := s.Close(); cerr != nil {
 		return SetCredentialResult{
@@ -206,12 +209,25 @@ var ErrSetCredentialEnvelopeEmitted = errors.New("set-credential envelope alread
 // inspects it and suppresses its usual fmt.Fprintln(stderr, err)
 // fallback so the envelope is the sole stdout artifact.
 //
-// toolName feeds the human-facing stderr line so jtk and cfl produce
-// distinguishable output ("wrote api_token to atlassian-cli/default via
-// file (cfl)") without each tool re-implementing the formatting.
+// Migration-notice handling under --json: SetCredentialV2 calls the
+// migrating Open() path, which may record the §1.8 one-time notice in
+// the package sink. Each tool's main.go later calls FlushMigrationNotice
+// on stderr, which would contaminate the envelope-only stdout contract.
+// To keep stderr clean we drain the sink here under --json. The trade-off
+// is that the §1.8 structured `_migration` JSON signal is NOT YET added
+// to the §1.5.2 envelope schema — that schema expansion is tracked as a
+// family-wide follow-up (matches the current nrq #107 behavior). For
+// now, --json runs that perform a migration silently consume the human
+// notice; the migration itself still occurred and is reflected in the
+// envelope's `written=true`.
 func RunSetCredential(opts SetCredentialOpts, stdout, stderr io.Writer, emitJSON bool, toolName string) error {
+	_ = toolName
 	res, err := SetCredentialV2(opts)
 	if emitJSON {
+		// Drain any pending §1.8 migration notice so main.go's
+		// FlushMigrationNotice has nothing left to write to stderr.
+		FlushMigrationNotice(io.Discard)
+
 		enc, mErr := json.Marshal(res)
 		if mErr != nil {
 			return fmt.Errorf("marshal set-credential envelope: %w", mErr)
@@ -227,7 +243,9 @@ func RunSetCredential(opts SetCredentialOpts, stdout, stderr io.Writer, emitJSON
 	if err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(stderr, "wrote %s to %s via %s (%s)\n", res.Key, res.Ref, res.Backend, toolName)
+	// §1.5.2 verbatim — no tool-name suffix; the binary name already
+	// distinguishes jtk from cfl in the user's shell history.
+	_, _ = fmt.Fprintf(stderr, "wrote %s to %s via %s\n", res.Key, res.Ref, res.Backend)
 	return nil
 }
 
@@ -251,8 +269,3 @@ func SetCredential(in io.Reader, envVar string) error {
 	})
 	return err
 }
-
-// Ensure cccredstore is referenced (imported above) — the SetCredentialV2
-// path uses cccredstore indirectly via Store.HasToken / Store.SetToken,
-// but the explicit import keeps the relationship visible.
-var _ = cccredstore.ErrNotFound

--- a/shared/keyring/setcredential.go
+++ b/shared/keyring/setcredential.go
@@ -1,65 +1,258 @@
 package keyring
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+
+	cccredstore "github.com/open-cli-collective/cli-common/credstore"
+
+	"github.com/open-cli-collective/atlassian-go/credstore"
 )
 
-// SetCredential is the §Ingress write logic, kept here (a pure library)
-// so each tool only needs a thin cobra wrapper — shared/ never imports
-// cobra. It reads the token from envVar (when non-empty) else from in,
-// trims surrounding whitespace, refuses an empty value, and stores it as
-// the single shared api_token in the one canonical bundle (the ref is a
-// compile-time constant and there is one key per logical credential —
-// §1.11.10 — so there is no key or ref to choose: runtime resolution,
-// migration, show, and clear all target the same bundle).
+// SetCredentialOpts collects the §1.5.2 ingress inputs surfaced by the
+// `set-credential` cobra wrappers. The shared/keyring layer is the only
+// place these are validated and dispatched, so both jtk and cfl get the
+// same enforcement automatically.
+type SetCredentialOpts struct {
+	Stdin     io.Reader // bound from cobra opts; required when UseStdin is true
+	Ref       string    // explicit value from --ref; empty triggers config-presence defaulting
+	Key       string    // explicit value from --key; required (no defaulting)
+	FromEnv   string    // env-var name from --from-env (xor with UseStdin)
+	UseStdin  bool      // true when --stdin was passed
+	Overwrite bool      // true when --overwrite was passed
+}
+
+// SetCredentialResult is the §1.5.2 control-plane envelope shape (also the
+// pure-library return value). Backend is empty for pre-keyring failures
+// (flag validation, config-presence probe) and populated once the keyring
+// has been opened and the backend selected.
+type SetCredentialResult struct {
+	Ref     string `json:"ref"`
+	Key     string `json:"key"`
+	Backend string `json:"backend"`
+	Written bool   `json:"written"`
+	Error   string `json:"error,omitempty"`
+}
+
+// SetCredentialV2 is the §1.5.2 ingress chokepoint shared by jtk and cfl.
+// It validates the flags, resolves --ref defaulting against the shared
+// config, opens the keyring (running the §1.8 migration up front via the
+// same Open() path used everywhere else), and writes the token. The
+// returned result is the JSON envelope (caller decides whether to emit
+// it); the error is non-nil whenever Written is false.
 //
-// The token is never echoed: it is read, trimmed, and written; no caller
-// branch logs or returns it. The one-time §1.8 migration runs first so a
-// pre-existing legacy token cannot later collide.
-func SetCredential(in io.Reader, envVar string) (err error) {
+// The token is never echoed; the value never appears in the Result, the
+// returned error, or any log output. Empty / whitespace-only sources are
+// rejected with a generic "refusing to store an empty API token" message.
+func SetCredentialV2(opts SetCredentialOpts) (SetCredentialResult, error) {
+	pre := func(err error) (SetCredentialResult, error) {
+		return SetCredentialResult{
+			Ref:     opts.Ref,
+			Key:     opts.Key,
+			Backend: "",
+			Written: false,
+			Error:   err.Error(),
+		}, err
+	}
+
+	if opts.Key == "" {
+		return pre(fmt.Errorf("--key is required; pass --key %s", KeyAPIToken))
+	}
+	if !isAllowedKey(opts.Key) {
+		return pre(fmt.Errorf("--key %q not supported; today only %s is valid", opts.Key, KeyAPIToken))
+	}
+	if opts.Ref == "" {
+		has, herr := credstore.HasSharedConfig()
+		if herr != nil {
+			return pre(fmt.Errorf("probe shared config presence: %w", herr))
+		}
+		if !has {
+			return pre(fmt.Errorf("--ref is required when no shared config exists; pass --ref %s", Ref))
+		}
+		opts.Ref = Ref
+	}
+	if opts.Ref != Ref {
+		return pre(fmt.Errorf("--ref %q not supported; today only %s is valid", opts.Ref, Ref))
+	}
+
+	switch {
+	case opts.UseStdin && opts.FromEnv != "":
+		return pre(errors.New("--stdin and --from-env are mutually exclusive; pick one"))
+	case !opts.UseStdin && opts.FromEnv == "":
+		return pre(errors.New("no token source: pass --stdin to read from stdin or --from-env VAR"))
+	}
+
+	token, err := readToken(opts)
+	if err != nil {
+		return pre(err)
+	}
+
+	s, err := Open()
+	if err != nil {
+		return SetCredentialResult{
+			Ref:     opts.Ref,
+			Key:     opts.Key,
+			Backend: "",
+			Written: false,
+			Error:   err.Error(),
+		}, err
+	}
+	backend := storeBackendName(s)
+	post := func(err error) (SetCredentialResult, error) {
+		if cerr := s.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close keyring %s: %w", s.ref, cerr)
+		} else {
+			_ = s.Close()
+		}
+		return SetCredentialResult{
+			Ref:     opts.Ref,
+			Key:     opts.Key,
+			Backend: backend,
+			Written: false,
+			Error:   err.Error(),
+		}, err
+	}
+
+	if !opts.Overwrite {
+		exists, herr := s.HasToken(opts.Key)
+		if herr != nil {
+			return post(herr)
+		}
+		if exists {
+			return post(fmt.Errorf("entry exists at %s/%s; pass --overwrite to replace", opts.Ref, opts.Key))
+		}
+	}
+
+	if err := s.SetToken(opts.Key, token); err != nil {
+		return post(err)
+	}
+	if cerr := s.Close(); cerr != nil {
+		return SetCredentialResult{
+			Ref: opts.Ref, Key: opts.Key, Backend: backend, Written: false,
+			Error: fmt.Errorf("close keyring %s: %w", s.ref, cerr).Error(),
+		}, fmt.Errorf("close keyring %s: %w", s.ref, cerr)
+	}
+	return SetCredentialResult{
+		Ref:     opts.Ref,
+		Key:     opts.Key,
+		Backend: backend,
+		Written: true,
+	}, nil
+}
+
+// readToken pulls the token from the configured source. The value is
+// trimmed and validated non-empty; the value itself never appears in any
+// returned error message (§1.12).
+func readToken(opts SetCredentialOpts) (string, error) {
 	var raw string
-	if strings.TrimSpace(envVar) != "" {
-		v, ok := os.LookupEnv(envVar)
+	if opts.FromEnv != "" {
+		v, ok := os.LookupEnv(opts.FromEnv)
 		if !ok || strings.TrimSpace(v) == "" {
-			return fmt.Errorf("environment variable %s is unset or empty", envVar)
+			return "", fmt.Errorf("environment variable %s is unset or empty", opts.FromEnv)
 		}
 		raw = v
 	} else {
-		if in == nil {
-			return errors.New("no token source: provide it on stdin or use --from-env")
+		if opts.Stdin == nil {
+			return "", errors.New("--stdin set but stdin reader is nil")
 		}
-		b, err := io.ReadAll(in)
+		b, err := io.ReadAll(opts.Stdin)
 		if err != nil {
-			return fmt.Errorf("read API token: %w", err)
+			return "", fmt.Errorf("read API token: %w", err)
 		}
 		raw = string(b)
 	}
-
 	token := strings.TrimSpace(raw)
 	if token == "" {
-		return errors.New("refusing to store an empty API token")
+		return "", errors.New("refusing to store an empty API token")
 	}
+	return token, nil
+}
 
-	// A single migrating open: Open() runs the one-time §1.8 migration
-	// (so a pre-existing legacy token cannot later collide) and returns
-	// the open canonical bundle. Doing this in one open avoids a second
-	// keyring unlock — important for the file backend, which would
-	// otherwise prompt for the passphrase twice per invocation.
-	s, err := Open()
+func isAllowedKey(key string) bool {
+	for _, k := range allowedKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+func storeBackendName(s *Store) string {
+	if s == nil {
+		return ""
+	}
+	b, _ := s.Backend()
+	return string(b)
+}
+
+// ErrSetCredentialEnvelopeEmitted is the sentinel returned by
+// RunSetCredential when --json was in effect AND the operation failed:
+// the JSON envelope has already been written to stdout, so the caller
+// (each tool's main.go) MUST NOT double-print the underlying error to
+// stderr. Use errors.Is(err, ErrSetCredentialEnvelopeEmitted) to detect.
+var ErrSetCredentialEnvelopeEmitted = errors.New("set-credential envelope already written to stdout")
+
+// RunSetCredential is the cobra-layer orchestrator: validates+writes via
+// SetCredentialV2, then either emits the §1.5.2 JSON envelope to stdout
+// (when emitJSON is true) or prints the one-line stderr success/no-op.
+//
+// Under emitJSON, on failure the returned error wraps both the
+// underlying failure AND ErrSetCredentialEnvelopeEmitted — that sentinel
+// is the "stderr stays empty under --json" contract: each tool's main.go
+// inspects it and suppresses its usual fmt.Fprintln(stderr, err)
+// fallback so the envelope is the sole stdout artifact.
+//
+// toolName feeds the human-facing stderr line so jtk and cfl produce
+// distinguishable output ("wrote api_token to atlassian-cli/default via
+// file (cfl)") without each tool re-implementing the formatting.
+func RunSetCredential(opts SetCredentialOpts, stdout, stderr io.Writer, emitJSON bool, toolName string) error {
+	res, err := SetCredentialV2(opts)
+	if emitJSON {
+		enc, mErr := json.Marshal(res)
+		if mErr != nil {
+			return fmt.Errorf("marshal set-credential envelope: %w", mErr)
+		}
+		if _, werr := fmt.Fprintln(stdout, string(enc)); werr != nil {
+			return fmt.Errorf("write set-credential envelope: %w", werr)
+		}
+		if err != nil {
+			return fmt.Errorf("%w (%w)", err, ErrSetCredentialEnvelopeEmitted)
+		}
+		return nil
+	}
 	if err != nil {
 		return err
 	}
-	// WRITE path: surface the Close error (the file backend may flush on
-	// Close) so a swallowed Close after a "successful" SetToken cannot
-	// hide a non-durable write.
-	defer func() {
-		if cerr := s.Close(); cerr != nil && err == nil {
-			err = fmt.Errorf("set-credential: close keyring %s: %w", s.ref, cerr)
-		}
-	}()
-	return s.SetToken(KeyAPIToken, token)
+	_, _ = fmt.Fprintf(stderr, "wrote %s to %s via %s (%s)\n", res.Key, res.Ref, res.Backend, toolName)
+	return nil
 }
+
+// SetCredential is the pre-§1.5.2 implicit-stdin / silent-overwrite
+// ingress shim retained ONLY so the shared/keyring e2e test suite
+// (keyring_e2e_test.go) keeps exercising the migrating-Open path through
+// the production write chokepoint. Production code (jtk + cfl cobra
+// wrappers) calls SetCredentialV2 / RunSetCredential directly. A
+// follow-up tracking issue will migrate the e2e tests and delete this
+// shim.
+//
+// Deprecated: use SetCredentialV2 (or RunSetCredential at the cobra layer).
+func SetCredential(in io.Reader, envVar string) error {
+	_, err := SetCredentialV2(SetCredentialOpts{
+		Stdin:     in,
+		Ref:       Ref,
+		Key:       KeyAPIToken,
+		FromEnv:   envVar,
+		UseStdin:  envVar == "",
+		Overwrite: true,
+	})
+	return err
+}
+
+// Ensure cccredstore is referenced (imported above) — the SetCredentialV2
+// path uses cccredstore indirectly via Store.HasToken / Store.SetToken,
+// but the explicit import keeps the relationship visible.
+var _ = cccredstore.ErrNotFound

--- a/shared/keyring/setcredential_v2_test.go
+++ b/shared/keyring/setcredential_v2_test.go
@@ -371,14 +371,46 @@ func TestRunSetCredential_HumanLineOnSuccess(t *testing.T) {
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout must be empty without --json, got %q", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "wrote "+keyring.KeyAPIToken) {
-		t.Fatalf("stderr line missing wrote-line: %q", stderr.String())
+	// §1.5.2 verbatim — "wrote <key> to <ref> via <backend>"; no tool suffix.
+	want := "wrote " + keyring.KeyAPIToken + " to " + keyring.Ref + " via "
+	if !strings.HasPrefix(stderr.String(), want) {
+		t.Fatalf("stderr line shape mismatch: got %q, want prefix %q", stderr.String(), want)
 	}
-	if !strings.Contains(stderr.String(), "(cfl)") {
-		t.Fatalf("stderr line missing toolName: %q", stderr.String())
+	if strings.Contains(stderr.String(), "(") {
+		t.Fatalf("stderr line must not have tool suffix per §1.5.2: %q", stderr.String())
 	}
 	if strings.Contains(stderr.String(), v2Sentinel) {
 		t.Fatal("stderr leaked sentinel")
+	}
+}
+
+// TestRunSetCredential_JSONDrainsMigrationNotice — under --json, the
+// §1.8 one-time migration notice that SetCredentialV2's migrating Open()
+// may record MUST be drained so the caller's later FlushMigrationNotice
+// has nothing to write. Stderr stays empty even after a migration.
+func TestRunSetCredential_JSONDrainsMigrationNotice(t *testing.T) {
+	keyring.ResetMigrationNotice()
+	t.Cleanup(keyring.ResetMigrationNotice)
+	credtest.Hermetic(t)
+	// Seed a deprecated per-tool key so §1.8 migration runs during Open().
+	credtest.SeedDeprecatedKey(t, "cfl_api_token", "legacy-token-value")
+
+	var stdout, stderr bytes.Buffer
+	err := keyring.RunSetCredential(keyring.SetCredentialOpts{
+		Stdin:     strings.NewReader(v2Sentinel),
+		Ref:       keyring.Ref,
+		Key:       keyring.KeyAPIToken,
+		UseStdin:  true,
+		Overwrite: true, // migration consolidates to api_token; --overwrite required
+	}, &stdout, &stderr, true, "jtk")
+	testutil.RequireNoError(t, err)
+
+	// Caller's downstream FlushMigrationNotice into a buffer to assert it
+	// got drained by RunSetCredential.
+	var sink bytes.Buffer
+	keyring.FlushMigrationNotice(&sink)
+	if sink.Len() != 0 {
+		t.Fatalf("--json must drain the migration notice; caller would have written %q", sink.String())
 	}
 }
 

--- a/shared/keyring/setcredential_v2_test.go
+++ b/shared/keyring/setcredential_v2_test.go
@@ -311,7 +311,7 @@ func TestRunSetCredential_JSONEmitsEnvelope_OnSuccess(t *testing.T) {
 		Ref:      keyring.Ref,
 		Key:      keyring.KeyAPIToken,
 		UseStdin: true,
-	}, &stdout, &stderr, true, "jtk")
+	}, &stdout, &stderr, true)
 	testutil.RequireNoError(t, err)
 
 	if stderr.Len() != 0 {
@@ -337,7 +337,7 @@ func TestRunSetCredential_JSONEmitsEnvelope_OnPreKeyringFailure(t *testing.T) {
 		Stdin:    strings.NewReader(v2Sentinel),
 		Key:      keyring.KeyAPIToken,
 		UseStdin: true,
-	}, &stdout, &stderr, true, "jtk")
+	}, &stdout, &stderr, true)
 	if err == nil {
 		t.Fatal("expected pre-keyring error")
 	}
@@ -366,7 +366,7 @@ func TestRunSetCredential_HumanLineOnSuccess(t *testing.T) {
 		Ref:      keyring.Ref,
 		Key:      keyring.KeyAPIToken,
 		UseStdin: true,
-	}, &stdout, &stderr, false, "cfl")
+	}, &stdout, &stderr, false)
 	testutil.RequireNoError(t, err)
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout must be empty without --json, got %q", stdout.String())
@@ -402,7 +402,7 @@ func TestRunSetCredential_JSONDrainsMigrationNotice(t *testing.T) {
 		Key:       keyring.KeyAPIToken,
 		UseStdin:  true,
 		Overwrite: true, // migration consolidates to api_token; --overwrite required
-	}, &stdout, &stderr, true, "jtk")
+	}, &stdout, &stderr, true)
 	testutil.RequireNoError(t, err)
 
 	// Caller's downstream FlushMigrationNotice into a buffer to assert it

--- a/shared/keyring/setcredential_v2_test.go
+++ b/shared/keyring/setcredential_v2_test.go
@@ -1,0 +1,408 @@
+package keyring_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/credstore"
+	"github.com/open-cli-collective/atlassian-go/credtest"
+	"github.com/open-cli-collective/atlassian-go/keyring"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+const v2Sentinel = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0123456789sentinel"
+
+func TestSetCredentialV2_StdinSuccess(t *testing.T) {
+	credtest.Hermetic(t)
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel + "\n"),
+		Ref:      keyring.Ref,
+		Key:      keyring.KeyAPIToken,
+		UseStdin: true,
+	})
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, true, res.Written)
+	testutil.Equal(t, keyring.Ref, res.Ref)
+	testutil.Equal(t, keyring.KeyAPIToken, res.Key)
+	if res.Backend == "" {
+		t.Fatal("Backend must be populated on success")
+	}
+	if res.Error != "" {
+		t.Fatalf("Error must be empty on success, got %q", res.Error)
+	}
+
+	got, ok, err := readbackToken(t)
+	testutil.RequireNoError(t, err)
+	testutil.True(t, ok)
+	testutil.Equal(t, v2Sentinel, got)
+}
+
+func TestSetCredentialV2_FromEnvSuccess(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("V2_TEST_TOKEN_ENV", v2Sentinel)
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Ref:     keyring.Ref,
+		Key:     keyring.KeyAPIToken,
+		FromEnv: "V2_TEST_TOKEN_ENV",
+	})
+	testutil.RequireNoError(t, err)
+	testutil.True(t, res.Written)
+
+	got, ok, err := readbackToken(t)
+	testutil.RequireNoError(t, err)
+	testutil.True(t, ok)
+	testutil.Equal(t, v2Sentinel, got)
+}
+
+func TestSetCredentialV2_BothSourcesRejected_PreKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Ref:      keyring.Ref,
+		Key:      keyring.KeyAPIToken,
+		FromEnv:  "ANYTHING",
+		UseStdin: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	testutil.Equal(t, "", res.Backend)
+	testutil.Equal(t, false, res.Written)
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error should mention mutual exclusion, got %q", err)
+	}
+}
+
+func TestSetCredentialV2_NeitherSourceRejected_PreKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Ref: keyring.Ref,
+		Key: keyring.KeyAPIToken,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	testutil.Equal(t, "", res.Backend)
+	testutil.Equal(t, false, res.Written)
+	if !strings.Contains(err.Error(), "--stdin") || !strings.Contains(err.Error(), "--from-env") {
+		t.Fatalf("error should mention both flag options, got %q", err)
+	}
+}
+
+func TestSetCredentialV2_KeyOmittedRejected_PreKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Ref:      keyring.Ref,
+		UseStdin: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	testutil.Equal(t, "", res.Backend)
+	if !strings.Contains(err.Error(), "--key") || !strings.Contains(err.Error(), keyring.KeyAPIToken) {
+		t.Fatalf("error should mention --key and %s, got %q", keyring.KeyAPIToken, err)
+	}
+}
+
+func TestSetCredentialV2_NonCanonicalKeyRejected_PreKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Ref:      keyring.Ref,
+		Key:      "bogus_key",
+		UseStdin: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	testutil.Equal(t, "", res.Backend)
+	if !strings.Contains(err.Error(), "bogus_key") || !strings.Contains(err.Error(), keyring.KeyAPIToken) {
+		t.Fatalf("error should name the bad key and the only valid key, got %q", err)
+	}
+}
+
+func TestSetCredentialV2_NonCanonicalRefRejected_PreKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+	seedShared(t)
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Ref:      "bogus/ref",
+		Key:      keyring.KeyAPIToken,
+		UseStdin: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	testutil.Equal(t, "", res.Backend)
+	if !strings.Contains(err.Error(), "bogus/ref") || !strings.Contains(err.Error(), keyring.Ref) {
+		t.Fatalf("error should name the bad ref and the only valid ref, got %q", err)
+	}
+}
+
+func TestSetCredentialV2_RefOmittedNoConfig_PreKeyring(t *testing.T) {
+	credtest.Hermetic(t) // empty state — no config.yml
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Key:      keyring.KeyAPIToken,
+		UseStdin: true,
+	})
+	if err == nil {
+		t.Fatal("expected error on fresh install with no --ref")
+	}
+	testutil.Equal(t, "", res.Backend)
+	if !strings.Contains(err.Error(), "--ref") || !strings.Contains(err.Error(), keyring.Ref) {
+		t.Fatalf("error should hint at --ref %s, got %q", keyring.Ref, err)
+	}
+}
+
+func TestSetCredentialV2_RefOmittedConfigExists_DefaultsToCanonical(t *testing.T) {
+	credtest.Hermetic(t)
+	seedShared(t)
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Key:      keyring.KeyAPIToken,
+		UseStdin: true,
+	})
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, keyring.Ref, res.Ref)
+	testutil.True(t, res.Written)
+}
+
+func TestSetCredentialV2_RefOmittedCorruptConfig_PreKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+	p := credtest.SharedConfigPath(t)
+	if err := writeFileSimple(p, "[unclosed_array: yes\n"); err != nil {
+		t.Fatalf("seed corrupt config: %v", err)
+	}
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Key:      keyring.KeyAPIToken,
+		UseStdin: true,
+	})
+	if err == nil {
+		t.Fatal("expected error from corrupt config probe")
+	}
+	if !errors.Is(err, credstore.ErrCorruptStore) {
+		t.Fatalf("error should wrap ErrCorruptStore, got %v", err)
+	}
+	testutil.Equal(t, "", res.Backend)
+	if res.Written {
+		t.Fatal("Written must be false on pre-keyring failure")
+	}
+}
+
+func TestSetCredentialV2_ExistingNoOverwriteFails_PostKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "pre-existing-token-value")
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Ref:      keyring.Ref,
+		Key:      keyring.KeyAPIToken,
+		UseStdin: true,
+	})
+	if err == nil {
+		t.Fatal("expected error on existing entry without --overwrite")
+	}
+	if res.Backend == "" {
+		t.Fatal("Backend must be populated on post-keyring failure")
+	}
+	testutil.False(t, res.Written)
+	if !strings.Contains(err.Error(), "--overwrite") {
+		t.Fatalf("error should mention --overwrite, got %q", err)
+	}
+
+	got, ok, rerr := readbackToken(t)
+	testutil.RequireNoError(t, rerr)
+	testutil.True(t, ok)
+	testutil.Equal(t, "pre-existing-token-value", got)
+}
+
+func TestSetCredentialV2_ExistingWithOverwriteReplaces_PostKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "old-token")
+
+	res, err := keyring.SetCredentialV2(keyring.SetCredentialOpts{
+		Stdin:     strings.NewReader(v2Sentinel),
+		Ref:       keyring.Ref,
+		Key:       keyring.KeyAPIToken,
+		UseStdin:  true,
+		Overwrite: true,
+	})
+	testutil.RequireNoError(t, err)
+	testutil.True(t, res.Written)
+
+	got, ok, rerr := readbackToken(t)
+	testutil.RequireNoError(t, rerr)
+	testutil.True(t, ok)
+	testutil.Equal(t, v2Sentinel, got)
+}
+
+func TestSetCredentialV2_NeverEmitsSecret_AllPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		seed func(t *testing.T)
+		opts keyring.SetCredentialOpts
+	}{
+		{
+			name: "happy-stdin",
+			opts: keyring.SetCredentialOpts{Stdin: strings.NewReader(v2Sentinel), Ref: keyring.Ref, Key: keyring.KeyAPIToken, UseStdin: true},
+		},
+		{
+			name: "happy-env",
+			seed: func(t *testing.T) { t.Setenv("V2_LEAK_ENV", v2Sentinel) },
+			opts: keyring.SetCredentialOpts{Ref: keyring.Ref, Key: keyring.KeyAPIToken, FromEnv: "V2_LEAK_ENV"},
+		},
+		{
+			name: "fail-both-sources",
+			opts: keyring.SetCredentialOpts{Stdin: strings.NewReader(v2Sentinel), Ref: keyring.Ref, Key: keyring.KeyAPIToken, FromEnv: "V2_LEAK_ENV", UseStdin: true},
+		},
+		{
+			name: "fail-empty-source",
+			opts: keyring.SetCredentialOpts{Stdin: strings.NewReader("   "), Ref: keyring.Ref, Key: keyring.KeyAPIToken, UseStdin: true},
+		},
+		{
+			name: "fail-existing-no-overwrite",
+			seed: func(t *testing.T) { credtest.SeedToken(t, v2Sentinel) },
+			opts: keyring.SetCredentialOpts{Stdin: strings.NewReader(v2Sentinel), Ref: keyring.Ref, Key: keyring.KeyAPIToken, UseStdin: true},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			credtest.Hermetic(t)
+			if tc.seed != nil {
+				tc.seed(t)
+			}
+			res, err := keyring.SetCredentialV2(tc.opts)
+			if strings.Contains(res.Ref, v2Sentinel) ||
+				strings.Contains(res.Key, v2Sentinel) ||
+				strings.Contains(res.Backend, v2Sentinel) ||
+				strings.Contains(res.Error, v2Sentinel) {
+				t.Fatalf("envelope leaked sentinel: %+v", res)
+			}
+			if err != nil && strings.Contains(err.Error(), v2Sentinel) {
+				t.Fatalf("returned error leaked sentinel: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunSetCredential_JSONEmitsEnvelope_OnSuccess(t *testing.T) {
+	credtest.Hermetic(t)
+	var stdout, stderr bytes.Buffer
+
+	err := keyring.RunSetCredential(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Ref:      keyring.Ref,
+		Key:      keyring.KeyAPIToken,
+		UseStdin: true,
+	}, &stdout, &stderr, true, "jtk")
+	testutil.RequireNoError(t, err)
+
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr must be empty under --json on success, got %q", stderr.String())
+	}
+	line := strings.TrimSpace(stdout.String())
+	if !strings.HasPrefix(line, `{"ref":"`+keyring.Ref+`"`) {
+		t.Fatalf("envelope shape mismatch: %q", line)
+	}
+	if !strings.Contains(line, `"written":true`) {
+		t.Fatalf("written must be true: %q", line)
+	}
+	if strings.Contains(line, v2Sentinel) {
+		t.Fatal("envelope leaked sentinel")
+	}
+}
+
+func TestRunSetCredential_JSONEmitsEnvelope_OnPreKeyringFailure(t *testing.T) {
+	credtest.Hermetic(t)
+	var stdout, stderr bytes.Buffer
+
+	err := keyring.RunSetCredential(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Key:      keyring.KeyAPIToken,
+		UseStdin: true,
+	}, &stdout, &stderr, true, "jtk")
+	if err == nil {
+		t.Fatal("expected pre-keyring error")
+	}
+	if !errors.Is(err, keyring.ErrSetCredentialEnvelopeEmitted) {
+		t.Fatalf("error must wrap ErrSetCredentialEnvelopeEmitted (so main() suppresses double-print), got %v", err)
+	}
+
+	line := strings.TrimSpace(stdout.String())
+	if !strings.Contains(line, `"backend":""`) {
+		t.Fatalf("pre-keyring envelope must have empty backend: %q", line)
+	}
+	if !strings.Contains(line, `"written":false`) {
+		t.Fatalf("written must be false: %q", line)
+	}
+	if !strings.Contains(line, `"error":"`) {
+		t.Fatalf("envelope must carry error field: %q", line)
+	}
+}
+
+func TestRunSetCredential_HumanLineOnSuccess(t *testing.T) {
+	credtest.Hermetic(t)
+	var stdout, stderr bytes.Buffer
+
+	err := keyring.RunSetCredential(keyring.SetCredentialOpts{
+		Stdin:    strings.NewReader(v2Sentinel),
+		Ref:      keyring.Ref,
+		Key:      keyring.KeyAPIToken,
+		UseStdin: true,
+	}, &stdout, &stderr, false, "cfl")
+	testutil.RequireNoError(t, err)
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout must be empty without --json, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "wrote "+keyring.KeyAPIToken) {
+		t.Fatalf("stderr line missing wrote-line: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "(cfl)") {
+		t.Fatalf("stderr line missing toolName: %q", stderr.String())
+	}
+	if strings.Contains(stderr.String(), v2Sentinel) {
+		t.Fatal("stderr leaked sentinel")
+	}
+}
+
+func readbackToken(t *testing.T) (string, bool, error) {
+	t.Helper()
+	s, err := keyring.OpenNoMigrate()
+	if err != nil {
+		return "", false, err
+	}
+	defer func() { _ = s.Close() }()
+	return s.Token()
+}
+
+func seedShared(t *testing.T) {
+	t.Helper()
+	p := credtest.SharedConfigPath(t)
+	if err := writeFileSimple(p, "default:\n  url: https://acme.atlassian.net\n  email: u@x.io\n"); err != nil {
+		t.Fatalf("seed shared: %v", err)
+	}
+}
+
+func writeFileSimple(path, body string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(body), 0o600)
+}

--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -802,9 +802,39 @@ cfl:
 There is **no `api_token:` field** — the secret never touches a
 plaintext file. The same config file and keyring bundle are shared with
 `jtk` — one Atlassian token, both tools. Run `cfl init` after `jtk init`
-(or vice versa) and you'll be offered to reuse the credentials. To set a
-token non-interactively: `cfl set-credential` (reads stdin or
-`--from-env VAR`).
+(or vice versa) and you'll be offered to reuse the credentials.
+
+**Non-interactive token ingress (§1.5.2):** use `cfl set-credential` for
+installer scripts, CI, and credential-manager driven setup. Required
+flags:
+
+- `--ref atlassian-cli/default` (required on fresh installs; defaults to
+  the canonical ref when a shared config already exists)
+- `--key api_token` (always required)
+- exactly one of `--stdin` or `--from-env VAR` (mutually exclusive; no
+  `--value` — flag-passed secrets leak into process listings)
+- `--overwrite` to replace an existing entry (default: fail loud)
+- `--json` to emit the §1.5.2 control-plane envelope
+  `{"ref","key","backend","written","error?"}` on stdout (stderr stays
+  empty under `--json`)
+
+```bash
+# From a secrets manager
+op read 'op://Vault/Atlassian/token' | cfl set-credential \
+  --ref atlassian-cli/default --key api_token --stdin
+
+# From an environment variable
+cfl set-credential --ref atlassian-cli/default --key api_token \
+  --from-env CFL_API_TOKEN
+
+# Replace an existing entry
+op read 'op://Vault/Atlassian/token' | cfl set-credential \
+  --ref atlassian-cli/default --key api_token --stdin --overwrite
+
+# Installer-script control-plane envelope
+cfl set-credential --ref atlassian-cli/default --key api_token \
+  --from-env CFL_API_TOKEN --json
+```
 
 Legacy `~/.config/cfl/config.yml` keeps working indefinitely. The first
 command auto-migrates any pre-existing plaintext token into the keyring

--- a/tools/cfl/cmd/cfl/main.go
+++ b/tools/cfl/cmd/cfl/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -51,7 +52,11 @@ func main() {
 	// still prints when a later command error triggers os.Exit.
 	keyring.FlushMigrationNotice(os.Stderr)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		// set-credential --json may have already emitted its envelope on
+		// stdout; in that case stderr stays empty per §1.5.2.
+		if !errors.Is(err, keyring.ErrSetCredentialEnvelopeEmitted) {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		}
 		os.Exit(exitcode.GeneralError)
 	}
 }

--- a/tools/cfl/cmd/cfl/main_test.go
+++ b/tools/cfl/cmd/cfl/main_test.go
@@ -126,7 +126,14 @@ func TestEntrypoint_PlaintextMigration_Exit0(t *testing.T) {
 	dir := credtest.Hermetic(t)
 	shared := writeLegacyShared(t, dir, "https://acme.atlassian.net", legacyTok)
 
-	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n", "set-credential")
+	// §1.5.2: set-credential needs --ref / --key / --stdin explicitly;
+	// --overwrite is required because the §1.8 migration writes legacyTok
+	// to the keyring during Open() before the new value lands.
+	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n",
+		"set-credential",
+		"--ref", "atlassian-cli/default",
+		"--key", "api_token",
+		"--stdin", "--overwrite")
 	if code != 0 {
 		t.Fatalf("set-credential should exit 0; got %d\nstderr:\n%s", code, stderr)
 	}
@@ -174,7 +181,14 @@ func TestEntrypoint_B3UpgradeFixture_DeprecatedKeysOnly(t *testing.T) {
 	credtest.SeedDeprecatedKey(t, "cfl_api_token", legacyTok)
 	credtest.SeedDeprecatedKey(t, "jtk_api_token", legacyTok)
 
-	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n", "set-credential")
+	// B3 upgrade: migration consolidates deprecated per-tool keys onto
+	// api_token, so by the time set-credential's write fires the entry
+	// already exists — --overwrite is required for the new value to land.
+	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n",
+		"set-credential",
+		"--ref", "atlassian-cli/default",
+		"--key", "api_token",
+		"--stdin", "--overwrite")
 	if code != 0 {
 		t.Fatalf("set-credential should exit 0; got %d\nstderr:\n%s", code, stderr)
 	}

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -313,7 +313,7 @@ func finalizeInit(
 	// only NON-secret placement, untouched here).
 	if err := keyring.PersistToken(cfg.APIToken); err != nil {
 		v.Error("Saved the non-secret config to %s, but could not store the API token in the keyring: %v", sharedPath, err)
-		v.Error("Recover by storing just the token (no need to re-run init): `cfl set-credential` (reads stdin or --from-env VAR).")
+		v.Error("Recover by storing just the token (no need to re-run init): `cfl set-credential --ref atlassian-cli/default --key api_token --stdin --overwrite` (reads stdin; use --from-env VAR for env-driven setup).")
 		return err
 	}
 	v.Success("Configuration saved to %s (token stored in the OS keyring)", sharedPath)

--- a/tools/cfl/internal/cmd/setcredential/setcredential.go
+++ b/tools/cfl/internal/cmd/setcredential/setcredential.go
@@ -65,7 +65,7 @@ installer-script parsing per cli-common §1.5.2.`,
 				FromEnv:   fromEnv,
 				UseStdin:  useStdin,
 				Overwrite: overwrite,
-			}, opts.Stdout, opts.Stderr, j, "cfl")
+			}, opts.Stdout, opts.Stderr, j)
 		},
 	}
 

--- a/tools/cfl/internal/cmd/setcredential/setcredential.go
+++ b/tools/cfl/internal/cmd/setcredential/setcredential.go
@@ -1,11 +1,10 @@
 // Package setcredential provides the `cfl set-credential` command — a
-// thin cobra wrapper over shared keyring.SetCredential. All read/
-// validate/write logic lives in shared/ (which never imports cobra).
+// thin cobra wrapper over shared keyring.RunSetCredential. All read /
+// validate / write logic lives in shared/keyring (which never imports
+// cobra) so cfl and jtk get identical §1.5.2 behavior.
 package setcredential
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/keyring"
@@ -15,31 +14,67 @@ import (
 
 // Register adds the set-credential command to the root command.
 func Register(rootCmd *cobra.Command, opts *root.Options) {
-	var fromEnv string
+	var (
+		ref, key, fromEnv      string
+		useStdin, overwrite, j bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "set-credential",
-		Short: "Store the Atlassian API token in the OS keyring",
-		Long: `Store the Atlassian API token in the OS keyring (non-interactive).
+		Short: "Store the Atlassian API token in the OS keyring (§1.5.2 control-plane ingress)",
+		Long: `Store the shared Atlassian API token in the OS keyring (non-interactive).
 
-The token is read from stdin, or from an environment variable with
---from-env. It is never echoed. There is one shared token (api_token)
-used by both cfl and jtk.`,
-		Example: `  # From a secrets manager, into the shared bundle
-  op read op://vault/atlassian/token | cfl set-credential
+Exactly one of --stdin or --from-env VAR supplies the token value. The
+value is never echoed.
+
+--key is always required. --ref is required when no shared config exists;
+when a shared config file is present, --ref defaults to the active
+canonical ref. Today there is one shared token (atlassian-cli/default/
+api_token) used by both jtk and cfl, so the only currently valid
+explicit values are --ref atlassian-cli/default --key api_token; both
+flags are forward-compat reservations for future multi-ref support.
+
+Re-running set-credential against an existing entry requires --overwrite.
+
+With --json, emits a control-plane envelope on stdout suitable for
+installer-script parsing per cli-common §1.5.2.`,
+		Example: `  # From a secrets manager
+  op read 'op://Vault/Atlassian/token' | cfl set-credential \
+    --ref atlassian-cli/default --key api_token --stdin
 
   # From an environment variable
-  cfl set-credential --from-env CFL_API_TOKEN`,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			if err := keyring.SetCredential(opts.Stdin, fromEnv); err != nil {
-				return err
+  cfl set-credential --ref atlassian-cli/default --key api_token \
+    --from-env CFL_API_TOKEN
+
+  # Replace an existing entry
+  op read 'op://Vault/Atlassian/token' | cfl set-credential \
+    --ref atlassian-cli/default --key api_token --stdin --overwrite
+
+  # Control-plane envelope for installer scripts
+  cfl set-credential --ref atlassian-cli/default --key api_token \
+    --from-env CFL_API_TOKEN --json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if j {
+				cmd.SilenceErrors = true
+				cmd.SilenceUsage = true
 			}
-			_, _ = fmt.Fprintln(opts.Stderr, "API token stored in the OS keyring.")
-			return nil
+			return keyring.RunSetCredential(keyring.SetCredentialOpts{
+				Stdin:     opts.Stdin,
+				Ref:       ref,
+				Key:       key,
+				FromEnv:   fromEnv,
+				UseStdin:  useStdin,
+				Overwrite: overwrite,
+			}, opts.Stdout, opts.Stderr, j, "cfl")
 		},
 	}
 
-	cmd.Flags().StringVar(&fromEnv, "from-env", "", "Read the token from this environment variable instead of stdin")
+	cmd.Flags().StringVar(&ref, "ref", "", "Credential ref (defaults to atlassian-cli/default when a shared config exists; required otherwise)")
+	cmd.Flags().StringVar(&key, "key", "", "Credential key (required; today only api_token is supported)")
+	cmd.Flags().StringVar(&fromEnv, "from-env", "", "Read the token from this env var (xor with --stdin)")
+	cmd.Flags().BoolVar(&useStdin, "stdin", false, "Read the token from stdin (xor with --from-env)")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Replace an existing entry (default: fail if present)")
+	cmd.Flags().BoolVar(&j, "json", false, "Emit a §1.5.2 control-plane envelope to stdout")
 
 	rootCmd.AddCommand(cmd)
 }

--- a/tools/cfl/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/cfl/internal/cmd/setcredential/setcredential_test.go
@@ -2,11 +2,16 @@ package setcredential
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -14,24 +19,299 @@ import (
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
-func TestSetCredential_StdinStoresToKeyring(t *testing.T) {
-	credtest.Hermetic(t)
+const sentinel = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcflSent"
 
+func runCmd(t *testing.T, stdin string, args ...string) (string, string, *root.Options, error) {
+	t.Helper()
 	opts := &root.Options{
-		Stdin:  strings.NewReader("  cfl-wrapper-token\n"),
+		Stdin:  strings.NewReader(stdin),
 		Stdout: &bytes.Buffer{},
 		Stderr: &bytes.Buffer{},
 	}
-	rootCmd := &cobra.Command{Use: "cfl"}
+	rootCmd := &cobra.Command{Use: "cfl", SilenceErrors: true, SilenceUsage: true}
 	Register(rootCmd, opts)
-	rootCmd.SetArgs([]string{"set-credential"})
-	testutil.RequireNoError(t, rootCmd.Execute())
+	rootCmd.SetArgs(append([]string{"set-credential"}, args...))
+	err := rootCmd.Execute()
+	return opts.Stdout.(*bytes.Buffer).String(), opts.Stderr.(*bytes.Buffer).String(), opts, err
+}
 
-	s, err := keyring.OpenNoMigrate()
+func parseEnvelope(t *testing.T, line string) keyring.SetCredentialResult {
+	t.Helper()
+	var env keyring.SetCredentialResult
+	line = strings.TrimSpace(line)
+	if line == "" {
+		t.Fatal("envelope: empty stdout")
+	}
+	if err := json.Unmarshal([]byte(line), &env); err != nil {
+		t.Fatalf("envelope: unmarshal %q: %v", line, err)
+	}
+	return env
+}
+
+func TestSetCredential_StdinExplicit_Success(t *testing.T) {
+	credtest.Hermetic(t)
+	_, stderr, _, err := runCmd(t, sentinel+"\n",
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin")
 	testutil.RequireNoError(t, err)
+	if !strings.Contains(stderr, "wrote api_token") || !strings.Contains(stderr, "(cfl)") {
+		t.Fatalf("stderr line missing or malformed: %q", stderr)
+	}
+
+	s, oerr := keyring.OpenNoMigrate()
+	testutil.RequireNoError(t, oerr)
 	defer func() { _ = s.Close() }()
-	got, ok, err := s.Token()
-	testutil.RequireNoError(t, err)
+	got, ok, terr := s.Token()
+	testutil.RequireNoError(t, terr)
 	testutil.True(t, ok)
-	testutil.Equal(t, "cfl-wrapper-token", got)
+	testutil.Equal(t, sentinel, got)
+}
+
+func TestSetCredential_FromEnvSuccess(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("CFL_TEST_TOKEN_VAR", sentinel)
+
+	_, _, _, err := runCmd(t, "",
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--from-env", "CFL_TEST_TOKEN_VAR")
+	testutil.RequireNoError(t, err)
+
+	s, oerr := keyring.OpenNoMigrate()
+	testutil.RequireNoError(t, oerr)
+	defer func() { _ = s.Close() }()
+	got, ok, _ := s.Token()
+	testutil.True(t, ok)
+	testutil.Equal(t, sentinel, got)
+}
+
+func TestSetCredential_KeyOmitted_PreKeyringFails(t *testing.T) {
+	credtest.Hermetic(t)
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--stdin")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--key") || !strings.Contains(err.Error(), "api_token") {
+		t.Fatalf("error must hint at --key api_token, got %q", err)
+	}
+}
+
+func TestSetCredential_RefOmittedNoConfig_PreKeyringFails(t *testing.T) {
+	credtest.Hermetic(t)
+	_, _, _, err := runCmd(t, sentinel,
+		"--key", keyring.KeyAPIToken, "--stdin")
+	if err == nil {
+		t.Fatal("expected error on fresh install with no --ref")
+	}
+	if !strings.Contains(err.Error(), "--ref") || !strings.Contains(err.Error(), keyring.Ref) {
+		t.Fatalf("error must hint at --ref %s, got %q", keyring.Ref, err)
+	}
+}
+
+func TestSetCredential_RefOmittedConfigExists_DefaultsToCanonical(t *testing.T) {
+	credtest.Hermetic(t)
+	seedConfig(t, "default:\n  url: https://acme.atlassian.net\n  email: u@x.io\n")
+
+	_, _, _, err := runCmd(t, sentinel,
+		"--key", keyring.KeyAPIToken, "--stdin")
+	testutil.RequireNoError(t, err)
+}
+
+func TestSetCredential_RefOmittedCorruptConfig_PreKeyringFails(t *testing.T) {
+	credtest.Hermetic(t)
+	seedConfig(t, "[unclosed_array: yes\n")
+
+	_, _, _, err := runCmd(t, sentinel,
+		"--key", keyring.KeyAPIToken, "--stdin")
+	if err == nil {
+		t.Fatal("expected error from corrupt config probe")
+	}
+	if !errors.Is(err, credstore.ErrCorruptStore) {
+		t.Fatalf("error must wrap ErrCorruptStore, got %v", err)
+	}
+}
+
+func TestSetCredential_NoSource_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	_, _, _, err := runCmd(t, "",
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--stdin") || !strings.Contains(err.Error(), "--from-env") {
+		t.Fatalf("error must mention both source flags, got %q", err)
+	}
+}
+
+func TestSetCredential_BothSources_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("BOTHSRC_VAR", "x")
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken,
+		"--stdin", "--from-env", "BOTHSRC_VAR")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error must mention mutual exclusion, got %q", err)
+	}
+}
+
+func TestSetCredential_ExistingNoOverwrite_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "previous-token")
+
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin")
+	if err == nil {
+		t.Fatal("expected error on existing entry without --overwrite")
+	}
+	if !strings.Contains(err.Error(), "--overwrite") {
+		t.Fatalf("error must mention --overwrite, got %q", err)
+	}
+
+	s, oerr := keyring.OpenNoMigrate()
+	testutil.RequireNoError(t, oerr)
+	defer func() { _ = s.Close() }()
+	got, _, _ := s.Token()
+	testutil.Equal(t, "previous-token", got)
+}
+
+func TestSetCredential_ExistingWithOverwrite_Succeeds(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "previous-token")
+
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--overwrite")
+	testutil.RequireNoError(t, err)
+
+	s, oerr := keyring.OpenNoMigrate()
+	testutil.RequireNoError(t, oerr)
+	defer func() { _ = s.Close() }()
+	got, _, _ := s.Token()
+	testutil.Equal(t, sentinel, got)
+}
+
+func TestSetCredential_JSONSuccess(t *testing.T) {
+	credtest.Hermetic(t)
+	stdout, stderr, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	testutil.RequireNoError(t, err)
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json: %q", stderr)
+	}
+	env := parseEnvelope(t, stdout)
+	testutil.Equal(t, keyring.Ref, env.Ref)
+	testutil.Equal(t, keyring.KeyAPIToken, env.Key)
+	testutil.True(t, env.Written)
+	if env.Backend == "" {
+		t.Fatal("Backend must be populated on success")
+	}
+}
+
+func TestSetCredential_JSONFailure_PreKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+	stdout, _, _, err := runCmd(t, "", "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	if err == nil {
+		t.Fatal("expected pre-keyring error")
+	}
+	env := parseEnvelope(t, stdout)
+	testutil.Equal(t, "", env.Backend)
+	testutil.False(t, env.Written)
+	if env.Error == "" {
+		t.Fatal("envelope error field must be populated on failure")
+	}
+}
+
+func TestSetCredential_JSONFailure_PostKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "earlier-token")
+
+	stdout, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	if err == nil {
+		t.Fatal("expected post-keyring error")
+	}
+	env := parseEnvelope(t, stdout)
+	if env.Backend == "" {
+		t.Fatal("Backend must be populated on post-keyring failure")
+	}
+	testutil.False(t, env.Written)
+	if !strings.Contains(env.Error, "--overwrite") {
+		t.Fatalf("envelope error must mention --overwrite, got %q", env.Error)
+	}
+}
+
+func TestSetCredential_NonCanonicalRef_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", "bogus/ref", "--key", keyring.KeyAPIToken, "--stdin")
+	if err == nil {
+		t.Fatal("expected error on non-canonical ref")
+	}
+	if !strings.Contains(err.Error(), "bogus/ref") || !strings.Contains(err.Error(), keyring.Ref) {
+		t.Fatalf("error must name bad ref and only valid ref, got %q", err)
+	}
+}
+
+func TestSetCredential_NonCanonicalKey_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", "bogus_key", "--stdin")
+	if err == nil {
+		t.Fatal("expected error on non-canonical key")
+	}
+	if !strings.Contains(err.Error(), "bogus_key") || !strings.Contains(err.Error(), keyring.KeyAPIToken) {
+		t.Fatalf("error must name bad key and only valid key, got %q", err)
+	}
+}
+
+func TestSetCredential_NeverEmitsSecret_AcrossAllPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		seed func(t *testing.T)
+		args []string
+	}{
+		{name: "happy", args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin"}},
+		{name: "happy-json", args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json"}},
+		{name: "fail-no-source", args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken}},
+		{name: "fail-no-source-json", args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--json"}},
+		{
+			name: "fail-existing-no-overwrite",
+			seed: func(t *testing.T) { credtest.SeedToken(t, sentinel) },
+			args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin"},
+		},
+		{
+			name: "fail-existing-no-overwrite-json",
+			seed: func(t *testing.T) { credtest.SeedToken(t, sentinel) },
+			args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			credtest.Hermetic(t)
+			if tc.seed != nil {
+				tc.seed(t)
+			}
+			stdout, stderr, _, err := runCmd(t, sentinel, tc.args...)
+			if strings.Contains(stdout, sentinel) {
+				t.Fatalf("stdout leaked sentinel: %q", stdout)
+			}
+			if strings.Contains(stderr, sentinel) {
+				t.Fatalf("stderr leaked sentinel: %q", stderr)
+			}
+			if err != nil && strings.Contains(err.Error(), sentinel) {
+				t.Fatalf("err leaked sentinel: %v", err)
+			}
+		})
+	}
+}
+
+func seedConfig(t *testing.T, body string) {
+	t.Helper()
+	p := credtest.SharedConfigPath(t)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
 }

--- a/tools/cfl/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/cfl/internal/cmd/setcredential/setcredential_test.go
@@ -53,8 +53,8 @@ func TestSetCredential_StdinExplicit_Success(t *testing.T) {
 	_, stderr, _, err := runCmd(t, sentinel+"\n",
 		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin")
 	testutil.RequireNoError(t, err)
-	if !strings.Contains(stderr, "wrote api_token") || !strings.Contains(stderr, "(cfl)") {
-		t.Fatalf("stderr line missing or malformed: %q", stderr)
+	if !strings.HasPrefix(stderr, "wrote api_token to "+keyring.Ref+" via ") {
+		t.Fatalf("stderr line shape mismatch: %q", stderr)
 	}
 
 	s, oerr := keyring.OpenNoMigrate()

--- a/tools/cfl/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/cfl/internal/cmd/setcredential/setcredential_test.go
@@ -209,9 +209,12 @@ func TestSetCredential_JSONSuccess(t *testing.T) {
 
 func TestSetCredential_JSONFailure_PreKeyring(t *testing.T) {
 	credtest.Hermetic(t)
-	stdout, _, _, err := runCmd(t, "", "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	stdout, stderr, _, err := runCmd(t, "", "--key", keyring.KeyAPIToken, "--stdin", "--json")
 	if err == nil {
 		t.Fatal("expected pre-keyring error")
+	}
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json failure: %q", stderr)
 	}
 	env := parseEnvelope(t, stdout)
 	testutil.Equal(t, "", env.Backend)
@@ -225,10 +228,13 @@ func TestSetCredential_JSONFailure_PostKeyring(t *testing.T) {
 	credtest.Hermetic(t)
 	credtest.SeedToken(t, "earlier-token")
 
-	stdout, _, _, err := runCmd(t, sentinel,
+	stdout, stderr, _, err := runCmd(t, sentinel,
 		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json")
 	if err == nil {
 		t.Fatal("expected post-keyring error")
+	}
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json failure: %q", stderr)
 	}
 	env := parseEnvelope(t, stdout)
 	if env.Backend == "" {
@@ -238,6 +244,28 @@ func TestSetCredential_JSONFailure_PostKeyring(t *testing.T) {
 	if !strings.Contains(env.Error, "--overwrite") {
 		t.Fatalf("envelope error must mention --overwrite, got %q", env.Error)
 	}
+}
+
+// TestSetCredential_JSONMigratingInvocation_StderrEmpty — when the §1.8
+// migration runs during set-credential's Open(), the human notice MUST
+// NOT leak to stderr under --json. Mirrors the library-layer drain test
+// but at the cobra wrapper so a regression in the wrapper or its main.go
+// wiring is caught here.
+func TestSetCredential_JSONMigratingInvocation_StderrEmpty(t *testing.T) {
+	keyring.ResetMigrationNotice()
+	t.Cleanup(keyring.ResetMigrationNotice)
+	credtest.Hermetic(t)
+	credtest.SeedDeprecatedKey(t, "cfl_api_token", "legacy-token-value")
+
+	stdout, stderr, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken,
+		"--stdin", "--json", "--overwrite")
+	testutil.RequireNoError(t, err)
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json even during migration: %q", stderr)
+	}
+	env := parseEnvelope(t, stdout)
+	testutil.True(t, env.Written)
 }
 
 func TestSetCredential_NonCanonicalRef_Fails(t *testing.T) {

--- a/tools/cfl/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/cfl/internal/cmd/setcredential/setcredential_test.go
@@ -207,9 +207,13 @@ func TestSetCredential_JSONSuccess(t *testing.T) {
 	}
 }
 
-func TestSetCredential_JSONFailure_PreKeyring(t *testing.T) {
+// TestSetCredential_JSONFailure_PreKeyring_EmptyToken — empty-stdin
+// rejection is technically a "pre-keyring" failure (we never Open() with
+// no source). Asserts the envelope contract: backend:"", written:false,
+// error populated, stderr empty.
+func TestSetCredential_JSONFailure_PreKeyring_EmptyToken(t *testing.T) {
 	credtest.Hermetic(t)
-	stdout, stderr, _, err := runCmd(t, "", "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	stdout, stderr, _, err := runCmd(t, "", "--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json")
 	if err == nil {
 		t.Fatal("expected pre-keyring error")
 	}
@@ -221,6 +225,27 @@ func TestSetCredential_JSONFailure_PreKeyring(t *testing.T) {
 	testutil.False(t, env.Written)
 	if env.Error == "" {
 		t.Fatal("envelope error field must be populated on failure")
+	}
+}
+
+// TestSetCredential_JSONFailure_PreKeyring_MissingRef — ref-validation
+// failure path under --json. The envelope MUST carry backend:"" since
+// the keyring was never opened. Pairs with the EmptyToken case so both
+// pre-keyring routes (validation vs source-read) are covered.
+func TestSetCredential_JSONFailure_PreKeyring_MissingRef(t *testing.T) {
+	credtest.Hermetic(t) // no config — --ref omission is the failure
+	stdout, stderr, _, err := runCmd(t, sentinel, "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	if err == nil {
+		t.Fatal("expected pre-keyring error on missing --ref")
+	}
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json failure: %q", stderr)
+	}
+	env := parseEnvelope(t, stdout)
+	testutil.Equal(t, "", env.Backend)
+	testutil.False(t, env.Written)
+	if !strings.Contains(env.Error, "--ref") {
+		t.Fatalf("envelope error must hint at --ref, got %q", env.Error)
 	}
 }
 

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -1623,9 +1623,39 @@ jtk:
 There is **no `api_token:` field** — the secret never touches a
 plaintext file. The same config file and keyring bundle are shared with
 `cfl` — one Atlassian token, both tools. Run `jtk init` after `cfl init`
-(or vice versa) and you'll be offered to reuse the credentials. To set a
-token non-interactively: `jtk set-credential` (reads stdin or
-`--from-env VAR`).
+(or vice versa) and you'll be offered to reuse the credentials.
+
+**Non-interactive token ingress (§1.5.2):** use `jtk set-credential` for
+installer scripts, CI, and credential-manager driven setup. Required
+flags:
+
+- `--ref atlassian-cli/default` (required on fresh installs; defaults to
+  the canonical ref when a shared config already exists)
+- `--key api_token` (always required)
+- exactly one of `--stdin` or `--from-env VAR` (mutually exclusive; no
+  `--value` — flag-passed secrets leak into process listings)
+- `--overwrite` to replace an existing entry (default: fail loud)
+- `--json` to emit the §1.5.2 control-plane envelope
+  `{"ref","key","backend","written","error?"}` on stdout (stderr stays
+  empty under `--json`)
+
+```bash
+# From a secrets manager
+op read 'op://Vault/Atlassian/token' | jtk set-credential \
+  --ref atlassian-cli/default --key api_token --stdin
+
+# From an environment variable
+jtk set-credential --ref atlassian-cli/default --key api_token \
+  --from-env JIRA_API_TOKEN
+
+# Replace an existing entry
+op read 'op://Vault/Atlassian/token' | jtk set-credential \
+  --ref atlassian-cli/default --key api_token --stdin --overwrite
+
+# Installer-script control-plane envelope
+jtk set-credential --ref atlassian-cli/default --key api_token \
+  --from-env JIRA_API_TOKEN --json
+```
 
 Legacy per-tool config keeps working indefinitely (Linux: `~/.config/jira-ticket-cli/config.json`; macOS: `~/Library/Application Support/jira-ticket-cli/config.json`). The first command auto-migrates any pre-existing plaintext token into the keyring and scrubs the plaintext in place.
 

--- a/tools/jtk/cmd/jtk/main.go
+++ b/tools/jtk/cmd/jtk/main.go
@@ -47,7 +47,9 @@ func main() {
 	// still prints when a command error triggers os.Exit.
 	keyring.FlushMigrationNotice(os.Stderr)
 	if err != nil {
-		if !errors.Is(err, root.ErrAlreadyReported) {
+		// set-credential --json may have already emitted its envelope on
+		// stdout; in that case stderr stays empty per §1.5.2.
+		if !errors.Is(err, root.ErrAlreadyReported) && !errors.Is(err, keyring.ErrSetCredentialEnvelopeEmitted) {
 			fmt.Fprintln(os.Stderr, err)
 		}
 		os.Exit(exitcode.GeneralError)

--- a/tools/jtk/cmd/jtk/main_test.go
+++ b/tools/jtk/cmd/jtk/main_test.go
@@ -113,7 +113,14 @@ func TestEntrypoint_PlaintextMigration_Exit0(t *testing.T) {
 	dir := credtest.Hermetic(t)
 	shared := writeLegacyShared(t, dir, "https://acme.atlassian.net", legacyTok)
 
-	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n", "set-credential")
+	// §1.5.2: set-credential needs --ref / --key / --stdin explicitly;
+	// --overwrite is required because the §1.8 migration writes legacyTok
+	// to the keyring during Open() before the new value lands.
+	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n",
+		"set-credential",
+		"--ref", "atlassian-cli/default",
+		"--key", "api_token",
+		"--stdin", "--overwrite")
 	if code != 0 {
 		t.Fatalf("set-credential should exit 0; got %d\nstderr:\n%s", code, stderr)
 	}
@@ -154,7 +161,14 @@ func TestEntrypoint_B3UpgradeFixture_DeprecatedKeysOnly(t *testing.T) {
 	credtest.SeedDeprecatedKey(t, "cfl_api_token", legacyTok)
 	credtest.SeedDeprecatedKey(t, "jtk_api_token", legacyTok)
 
-	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n", "set-credential")
+	// B3 upgrade: migration consolidates deprecated per-tool keys onto
+	// api_token, so by the time set-credential's write fires the entry
+	// already exists — --overwrite is required for the new value to land.
+	stderr, code := runCLI(t, dir, "NEW-token-from-stdin\n",
+		"set-credential",
+		"--ref", "atlassian-cli/default",
+		"--key", "api_token",
+		"--stdin", "--overwrite")
 	if code != 0 {
 		t.Fatalf("set-credential should exit 0; got %d\nstderr:\n%s", code, stderr)
 	}

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -284,7 +284,7 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	// only NON-secret placement, untouched here).
 	if err := keyring.PersistToken(cfg.APIToken); err != nil {
 		v.Error("Saved the non-secret config to %s, but could not store the API token in the keyring: %v", sharedPath, err)
-		v.Error("Recover by storing just the token (no need to re-run init): `jtk set-credential` (reads stdin or --from-env VAR).")
+		v.Error("Recover by storing just the token (no need to re-run init): `jtk set-credential --ref atlassian-cli/default --key api_token --stdin --overwrite` (reads stdin; use --from-env VAR for env-driven setup).")
 		return err
 	}
 	v.Success("Configuration saved to %s (token stored in the OS keyring)", sharedPath)

--- a/tools/jtk/internal/cmd/setcredential/setcredential.go
+++ b/tools/jtk/internal/cmd/setcredential/setcredential.go
@@ -1,11 +1,10 @@
 // Package setcredential provides the `jtk set-credential` command — a
-// thin cobra wrapper over shared keyring.SetCredential. All read/
-// validate/write logic lives in shared/ (which never imports cobra).
+// thin cobra wrapper over shared keyring.RunSetCredential. All read /
+// validate / write logic lives in shared/keyring (which never imports
+// cobra) so cfl and jtk get identical §1.5.2 behavior.
 package setcredential
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/atlassian-go/keyring"
@@ -15,31 +14,67 @@ import (
 
 // Register adds the set-credential command to the root command.
 func Register(rootCmd *cobra.Command, opts *root.Options) {
-	var fromEnv string
+	var (
+		ref, key, fromEnv      string
+		useStdin, overwrite, j bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "set-credential",
-		Short: "Store the Atlassian API token in the OS keyring",
-		Long: `Store the Atlassian API token in the OS keyring (non-interactive).
+		Short: "Store the Atlassian API token in the OS keyring (§1.5.2 control-plane ingress)",
+		Long: `Store the shared Atlassian API token in the OS keyring (non-interactive).
 
-The token is read from stdin, or from an environment variable with
---from-env. It is never echoed. There is one shared token (api_token)
-used by both jtk and cfl.`,
-		Example: `  # From a secrets manager, into the shared bundle
-  op read op://vault/atlassian/token | jtk set-credential
+Exactly one of --stdin or --from-env VAR supplies the token value. The
+value is never echoed.
+
+--key is always required. --ref is required when no shared config exists;
+when a shared config file is present, --ref defaults to the active
+canonical ref. Today there is one shared token (atlassian-cli/default/
+api_token) used by both jtk and cfl, so the only currently valid
+explicit values are --ref atlassian-cli/default --key api_token; both
+flags are forward-compat reservations for future multi-ref support.
+
+Re-running set-credential against an existing entry requires --overwrite.
+
+With --json, emits a control-plane envelope on stdout suitable for
+installer-script parsing per cli-common §1.5.2.`,
+		Example: `  # From a secrets manager
+  op read 'op://Vault/Atlassian/token' | jtk set-credential \
+    --ref atlassian-cli/default --key api_token --stdin
 
   # From an environment variable
-  jtk set-credential --from-env JIRA_API_TOKEN`,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			if err := keyring.SetCredential(opts.Stdin, fromEnv); err != nil {
-				return err
+  jtk set-credential --ref atlassian-cli/default --key api_token \
+    --from-env JIRA_API_TOKEN
+
+  # Replace an existing entry
+  op read 'op://Vault/Atlassian/token' | jtk set-credential \
+    --ref atlassian-cli/default --key api_token --stdin --overwrite
+
+  # Control-plane envelope for installer scripts
+  jtk set-credential --ref atlassian-cli/default --key api_token \
+    --from-env JIRA_API_TOKEN --json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if j {
+				cmd.SilenceErrors = true
+				cmd.SilenceUsage = true
 			}
-			_, _ = fmt.Fprintln(opts.Stderr, "API token stored in the OS keyring.")
-			return nil
+			return keyring.RunSetCredential(keyring.SetCredentialOpts{
+				Stdin:     opts.Stdin,
+				Ref:       ref,
+				Key:       key,
+				FromEnv:   fromEnv,
+				UseStdin:  useStdin,
+				Overwrite: overwrite,
+			}, opts.Stdout, opts.Stderr, j, "jtk")
 		},
 	}
 
-	cmd.Flags().StringVar(&fromEnv, "from-env", "", "Read the token from this environment variable instead of stdin")
+	cmd.Flags().StringVar(&ref, "ref", "", "Credential ref (defaults to atlassian-cli/default when a shared config exists; required otherwise)")
+	cmd.Flags().StringVar(&key, "key", "", "Credential key (required; today only api_token is supported)")
+	cmd.Flags().StringVar(&fromEnv, "from-env", "", "Read the token from this env var (xor with --stdin)")
+	cmd.Flags().BoolVar(&useStdin, "stdin", false, "Read the token from stdin (xor with --from-env)")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Replace an existing entry (default: fail if present)")
+	cmd.Flags().BoolVar(&j, "json", false, "Emit a §1.5.2 control-plane envelope to stdout")
 
 	rootCmd.AddCommand(cmd)
 }

--- a/tools/jtk/internal/cmd/setcredential/setcredential.go
+++ b/tools/jtk/internal/cmd/setcredential/setcredential.go
@@ -65,7 +65,7 @@ installer-script parsing per cli-common §1.5.2.`,
 				FromEnv:   fromEnv,
 				UseStdin:  useStdin,
 				Overwrite: overwrite,
-			}, opts.Stdout, opts.Stderr, j, "jtk")
+			}, opts.Stdout, opts.Stderr, j)
 		},
 	}
 

--- a/tools/jtk/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/jtk/internal/cmd/setcredential/setcredential_test.go
@@ -226,9 +226,12 @@ func TestSetCredential_JSONSuccess(t *testing.T) {
 
 func TestSetCredential_JSONFailure_PreKeyring(t *testing.T) {
 	credtest.Hermetic(t)
-	stdout, _, _, err := runCmd(t, "", "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	stdout, stderr, _, err := runCmd(t, "", "--key", keyring.KeyAPIToken, "--stdin", "--json")
 	if err == nil {
 		t.Fatal("expected pre-keyring error")
+	}
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json failure: %q", stderr)
 	}
 	env := parseEnvelope(t, stdout)
 	testutil.Equal(t, "", env.Backend)
@@ -242,10 +245,13 @@ func TestSetCredential_JSONFailure_PostKeyring(t *testing.T) {
 	credtest.Hermetic(t)
 	credtest.SeedToken(t, "earlier-token")
 
-	stdout, _, _, err := runCmd(t, sentinel,
+	stdout, stderr, _, err := runCmd(t, sentinel,
 		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json")
 	if err == nil {
 		t.Fatal("expected post-keyring error")
+	}
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json failure: %q", stderr)
 	}
 	env := parseEnvelope(t, stdout)
 	if env.Backend == "" {
@@ -255,6 +261,28 @@ func TestSetCredential_JSONFailure_PostKeyring(t *testing.T) {
 	if !strings.Contains(env.Error, "--overwrite") {
 		t.Fatalf("envelope error must mention --overwrite, got %q", env.Error)
 	}
+}
+
+// TestSetCredential_JSONMigratingInvocation_StderrEmpty — when the §1.8
+// migration runs during set-credential's Open(), the human notice MUST
+// NOT leak to stderr under --json. Mirrors the library-layer drain test
+// but at the cobra wrapper so a regression in the wrapper or its main.go
+// wiring is caught here.
+func TestSetCredential_JSONMigratingInvocation_StderrEmpty(t *testing.T) {
+	keyring.ResetMigrationNotice()
+	t.Cleanup(keyring.ResetMigrationNotice)
+	credtest.Hermetic(t)
+	credtest.SeedDeprecatedKey(t, "jtk_api_token", "legacy-token-value")
+
+	stdout, stderr, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken,
+		"--stdin", "--json", "--overwrite")
+	testutil.RequireNoError(t, err)
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json even during migration: %q", stderr)
+	}
+	env := parseEnvelope(t, stdout)
+	testutil.True(t, env.Written)
 }
 
 func TestSetCredential_NonCanonicalRef_Fails(t *testing.T) {

--- a/tools/jtk/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/jtk/internal/cmd/setcredential/setcredential_test.go
@@ -2,11 +2,16 @@ package setcredential
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -14,24 +19,328 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
-func TestSetCredential_StdinStoresToKeyring(t *testing.T) {
-	credtest.Hermetic(t)
+const sentinel = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAjtkSent"
 
+// runCmd executes `jtk set-credential <args...>` against a fresh root +
+// the setcredential subcommand, returning stdout, stderr, the captured
+// exit error, and the root.Options used. The token never comes through
+// argv; stdin comes from opts.Stdin so the command never sees the value
+// in args.
+func runCmd(t *testing.T, stdin string, args ...string) (string, string, *root.Options, error) {
+	t.Helper()
 	opts := &root.Options{
-		Stdin:  strings.NewReader("jtk-wrapper-token\n"),
+		Stdin:  strings.NewReader(stdin),
 		Stdout: &bytes.Buffer{},
 		Stderr: &bytes.Buffer{},
 	}
-	rootCmd := &cobra.Command{Use: "jtk"}
+	rootCmd := &cobra.Command{Use: "jtk", SilenceErrors: true, SilenceUsage: true}
 	Register(rootCmd, opts)
-	rootCmd.SetArgs([]string{"set-credential"})
-	testutil.RequireNoError(t, rootCmd.Execute())
+	rootCmd.SetArgs(append([]string{"set-credential"}, args...))
+	err := rootCmd.Execute()
+	return opts.Stdout.(*bytes.Buffer).String(), opts.Stderr.(*bytes.Buffer).String(), opts, err
+}
 
-	s, err := keyring.OpenNoMigrate()
+func parseEnvelope(t *testing.T, line string) keyring.SetCredentialResult {
+	t.Helper()
+	var env keyring.SetCredentialResult
+	line = strings.TrimSpace(line)
+	if line == "" {
+		t.Fatal("envelope: empty stdout")
+	}
+	if err := json.Unmarshal([]byte(line), &env); err != nil {
+		t.Fatalf("envelope: unmarshal %q: %v", line, err)
+	}
+	return env
+}
+
+func TestSetCredential_StdinExplicit_Success(t *testing.T) {
+	credtest.Hermetic(t)
+	_, stderr, _, err := runCmd(t, sentinel+"\n",
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin")
 	testutil.RequireNoError(t, err)
+	if !strings.Contains(stderr, "wrote api_token") || !strings.Contains(stderr, "(jtk)") {
+		t.Fatalf("stderr line missing or malformed: %q", stderr)
+	}
+
+	s, oerr := keyring.OpenNoMigrate()
+	testutil.RequireNoError(t, oerr)
 	defer func() { _ = s.Close() }()
-	got, ok, err := s.Token()
-	testutil.RequireNoError(t, err)
+	got, ok, terr := s.Token()
+	testutil.RequireNoError(t, terr)
 	testutil.True(t, ok)
-	testutil.Equal(t, "jtk-wrapper-token", got)
+	testutil.Equal(t, sentinel, got)
+}
+
+func TestSetCredential_FromEnvSuccess(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("JTK_TEST_TOKEN_VAR", sentinel)
+
+	_, _, _, err := runCmd(t, "",
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--from-env", "JTK_TEST_TOKEN_VAR")
+	testutil.RequireNoError(t, err)
+
+	s, oerr := keyring.OpenNoMigrate()
+	testutil.RequireNoError(t, oerr)
+	defer func() { _ = s.Close() }()
+	got, ok, _ := s.Token()
+	testutil.True(t, ok)
+	testutil.Equal(t, sentinel, got)
+}
+
+func TestSetCredential_KeyOmitted_PreKeyringFails(t *testing.T) {
+	credtest.Hermetic(t)
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--stdin")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--key") || !strings.Contains(err.Error(), "api_token") {
+		t.Fatalf("error must hint at --key api_token, got %q", err)
+	}
+}
+
+func TestSetCredential_RefOmittedNoConfig_PreKeyringFails(t *testing.T) {
+	credtest.Hermetic(t) // fresh install — no config.yml
+	_, _, _, err := runCmd(t, sentinel,
+		"--key", keyring.KeyAPIToken, "--stdin")
+	if err == nil {
+		t.Fatal("expected error on fresh install with no --ref")
+	}
+	if !strings.Contains(err.Error(), "--ref") || !strings.Contains(err.Error(), keyring.Ref) {
+		t.Fatalf("error must hint at --ref %s, got %q", keyring.Ref, err)
+	}
+}
+
+func TestSetCredential_RefOmittedConfigExists_DefaultsToCanonical(t *testing.T) {
+	credtest.Hermetic(t)
+	seedConfig(t, "default:\n  url: https://acme.atlassian.net\n  email: u@x.io\n")
+
+	_, _, _, err := runCmd(t, sentinel,
+		"--key", keyring.KeyAPIToken, "--stdin")
+	testutil.RequireNoError(t, err)
+
+	s, oerr := keyring.OpenNoMigrate()
+	testutil.RequireNoError(t, oerr)
+	defer func() { _ = s.Close() }()
+	got, ok, _ := s.Token()
+	testutil.True(t, ok)
+	testutil.Equal(t, sentinel, got)
+}
+
+func TestSetCredential_RefOmittedCorruptConfig_PreKeyringFails(t *testing.T) {
+	credtest.Hermetic(t)
+	seedConfig(t, "[unclosed_array: yes\n")
+
+	_, _, _, err := runCmd(t, sentinel,
+		"--key", keyring.KeyAPIToken, "--stdin")
+	if err == nil {
+		t.Fatal("expected error from corrupt config probe")
+	}
+	if !errors.Is(err, credstore.ErrCorruptStore) {
+		t.Fatalf("error must wrap ErrCorruptStore, got %v", err)
+	}
+}
+
+func TestSetCredential_NoSource_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	_, _, _, err := runCmd(t, "",
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--stdin") || !strings.Contains(err.Error(), "--from-env") {
+		t.Fatalf("error must mention both source flags, got %q", err)
+	}
+}
+
+func TestSetCredential_BothSources_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("BOTHSRC_VAR", "x")
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken,
+		"--stdin", "--from-env", "BOTHSRC_VAR")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error must mention mutual exclusion, got %q", err)
+	}
+}
+
+func TestSetCredential_ExistingNoOverwrite_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "previous-token")
+
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin")
+	if err == nil {
+		t.Fatal("expected error on existing entry without --overwrite")
+	}
+	if !strings.Contains(err.Error(), "--overwrite") {
+		t.Fatalf("error must mention --overwrite, got %q", err)
+	}
+
+	s, oerr := keyring.OpenNoMigrate()
+	testutil.RequireNoError(t, oerr)
+	defer func() { _ = s.Close() }()
+	got, ok, _ := s.Token()
+	testutil.True(t, ok)
+	testutil.Equal(t, "previous-token", got)
+}
+
+func TestSetCredential_ExistingWithOverwrite_Succeeds(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "previous-token")
+
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--overwrite")
+	testutil.RequireNoError(t, err)
+
+	s, oerr := keyring.OpenNoMigrate()
+	testutil.RequireNoError(t, oerr)
+	defer func() { _ = s.Close() }()
+	got, ok, _ := s.Token()
+	testutil.True(t, ok)
+	testutil.Equal(t, sentinel, got)
+}
+
+func TestSetCredential_JSONSuccess(t *testing.T) {
+	credtest.Hermetic(t)
+	stdout, stderr, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	testutil.RequireNoError(t, err)
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json: %q", stderr)
+	}
+	env := parseEnvelope(t, stdout)
+	testutil.Equal(t, keyring.Ref, env.Ref)
+	testutil.Equal(t, keyring.KeyAPIToken, env.Key)
+	testutil.True(t, env.Written)
+	if env.Backend == "" {
+		t.Fatal("Backend must be populated on success")
+	}
+	if env.Error != "" {
+		t.Fatalf("Error must be empty on success, got %q", env.Error)
+	}
+}
+
+func TestSetCredential_JSONFailure_PreKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+	stdout, _, _, err := runCmd(t, "", "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	if err == nil {
+		t.Fatal("expected pre-keyring error")
+	}
+	env := parseEnvelope(t, stdout)
+	testutil.Equal(t, "", env.Backend)
+	testutil.False(t, env.Written)
+	if env.Error == "" {
+		t.Fatal("envelope error field must be populated on failure")
+	}
+}
+
+func TestSetCredential_JSONFailure_PostKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "earlier-token")
+
+	stdout, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	if err == nil {
+		t.Fatal("expected post-keyring error")
+	}
+	env := parseEnvelope(t, stdout)
+	if env.Backend == "" {
+		t.Fatal("Backend must be populated on post-keyring failure")
+	}
+	testutil.False(t, env.Written)
+	if !strings.Contains(env.Error, "--overwrite") {
+		t.Fatalf("envelope error must mention --overwrite, got %q", env.Error)
+	}
+}
+
+func TestSetCredential_NonCanonicalRef_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", "bogus/ref", "--key", keyring.KeyAPIToken, "--stdin")
+	if err == nil {
+		t.Fatal("expected error on non-canonical ref")
+	}
+	if !strings.Contains(err.Error(), "bogus/ref") || !strings.Contains(err.Error(), keyring.Ref) {
+		t.Fatalf("error must name bad ref and only valid ref, got %q", err)
+	}
+}
+
+func TestSetCredential_NonCanonicalKey_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	_, _, _, err := runCmd(t, sentinel,
+		"--ref", keyring.Ref, "--key", "bogus_key", "--stdin")
+	if err == nil {
+		t.Fatal("expected error on non-canonical key")
+	}
+	if !strings.Contains(err.Error(), "bogus_key") || !strings.Contains(err.Error(), keyring.KeyAPIToken) {
+		t.Fatalf("error must name bad key and only valid key, got %q", err)
+	}
+}
+
+func TestSetCredential_NeverEmitsSecret_AcrossAllPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		seed func(t *testing.T)
+		args []string
+	}{
+		{
+			name: "happy",
+			args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin"},
+		},
+		{
+			name: "happy-json",
+			args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json"},
+		},
+		{
+			name: "fail-no-source",
+			args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken},
+		},
+		{
+			name: "fail-no-source-json",
+			args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--json"},
+		},
+		{
+			name: "fail-existing-no-overwrite",
+			seed: func(t *testing.T) { credtest.SeedToken(t, sentinel) },
+			args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin"},
+		},
+		{
+			name: "fail-existing-no-overwrite-json",
+			seed: func(t *testing.T) { credtest.SeedToken(t, sentinel) },
+			args: []string{"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			credtest.Hermetic(t)
+			if tc.seed != nil {
+				tc.seed(t)
+			}
+			stdout, stderr, _, err := runCmd(t, sentinel, tc.args...)
+			if strings.Contains(stdout, sentinel) {
+				t.Fatalf("stdout leaked sentinel: %q", stdout)
+			}
+			if strings.Contains(stderr, sentinel) {
+				t.Fatalf("stderr leaked sentinel: %q", stderr)
+			}
+			if err != nil && strings.Contains(err.Error(), sentinel) {
+				t.Fatalf("err leaked sentinel: %v", err)
+			}
+		})
+	}
+}
+
+func seedConfig(t *testing.T, body string) {
+	t.Helper()
+	p := credtest.SharedConfigPath(t)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
 }

--- a/tools/jtk/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/jtk/internal/cmd/setcredential/setcredential_test.go
@@ -224,9 +224,13 @@ func TestSetCredential_JSONSuccess(t *testing.T) {
 	}
 }
 
-func TestSetCredential_JSONFailure_PreKeyring(t *testing.T) {
+// TestSetCredential_JSONFailure_PreKeyring_EmptyToken — empty-stdin
+// rejection is technically a "pre-keyring" failure (we never Open() with
+// no source). Asserts the envelope contract: backend:"", written:false,
+// error populated, stderr empty.
+func TestSetCredential_JSONFailure_PreKeyring_EmptyToken(t *testing.T) {
 	credtest.Hermetic(t)
-	stdout, stderr, _, err := runCmd(t, "", "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	stdout, stderr, _, err := runCmd(t, "", "--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin", "--json")
 	if err == nil {
 		t.Fatal("expected pre-keyring error")
 	}
@@ -238,6 +242,27 @@ func TestSetCredential_JSONFailure_PreKeyring(t *testing.T) {
 	testutil.False(t, env.Written)
 	if env.Error == "" {
 		t.Fatal("envelope error field must be populated on failure")
+	}
+}
+
+// TestSetCredential_JSONFailure_PreKeyring_MissingRef — ref-validation
+// failure path under --json. The envelope MUST carry backend:"" since
+// the keyring was never opened. Pairs with the EmptyToken case so both
+// pre-keyring routes (validation vs source-read) are covered.
+func TestSetCredential_JSONFailure_PreKeyring_MissingRef(t *testing.T) {
+	credtest.Hermetic(t) // no config — --ref omission is the failure
+	stdout, stderr, _, err := runCmd(t, sentinel, "--key", keyring.KeyAPIToken, "--stdin", "--json")
+	if err == nil {
+		t.Fatal("expected pre-keyring error on missing --ref")
+	}
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json failure: %q", stderr)
+	}
+	env := parseEnvelope(t, stdout)
+	testutil.Equal(t, "", env.Backend)
+	testutil.False(t, env.Written)
+	if !strings.Contains(env.Error, "--ref") {
+		t.Fatalf("envelope error must hint at --ref, got %q", env.Error)
 	}
 }
 

--- a/tools/jtk/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/jtk/internal/cmd/setcredential/setcredential_test.go
@@ -58,8 +58,8 @@ func TestSetCredential_StdinExplicit_Success(t *testing.T) {
 	_, stderr, _, err := runCmd(t, sentinel+"\n",
 		"--ref", keyring.Ref, "--key", keyring.KeyAPIToken, "--stdin")
 	testutil.RequireNoError(t, err)
-	if !strings.Contains(stderr, "wrote api_token") || !strings.Contains(stderr, "(jtk)") {
-		t.Fatalf("stderr line missing or malformed: %q", stderr)
+	if !strings.HasPrefix(stderr, "wrote api_token to "+keyring.Ref+" via ") {
+		t.Fatalf("stderr line shape mismatch: %q", stderr)
 	}
 
 	s, oerr := keyring.OpenNoMigrate()


### PR DESCRIPTION
## Summary

Bring `jtk set-credential` and `cfl set-credential` to the cli-common §1.5.2 control-plane ingress surface. Both tools now accept `--ref`, `--key`, `--stdin`, `--from-env`, `--overwrite`, and `--json` (with envelope output). Validation lives in `shared/keyring` (`SetCredentialV2` + `RunSetCredential`) so both tools get identical enforcement.

This is the **second §1.5.2 conformance ticket** in the batch — nrq #107 (PR open-cli-collective/newrelic-cli#109) is the family reference. The envelope shape (`{"ref","key","backend","written","error?"}`), the phased pre/post-keyring backend population, and the strict-defaulting policy mirror nrq verbatim, setting the precedent that sfdc (#43) will follow next.

### Behavior changes (intentional breaks)

- **`--stdin` becomes explicit.** Previously `cmd | jtk set-credential` (no flag) consumed stdin implicitly; §1.5.2 requires exactly one of `--stdin` xor `--from-env`. Pipes that broke silently now fail loud.
- **`--overwrite` is required to replace an existing entry.** Previously `set-credential` silently replaced `api_token`; now re-runs fail with `entry exists at atlassian-cli/default/api_token; pass --overwrite to replace`.
- **`--key` always required**; `--ref` required when no shared config exists (defaults to `atlassian-cli/default` when a config file is present, composing with §3.2 relocation via the new `credstore.HasSharedConfig()`).

### Notable design choices

- **Pre-keyring vs post-keyring failures.** Flag/config-probe failures return `backend=""`; failures after `Open()` (existing entry, write error) return the resolved backend.
- **stderr stays empty under `--json`.** `RunSetCredential` returns `keyring.ErrSetCredentialEnvelopeEmitted` on JSON-mode failures so each tool's `main.go` suppresses its fallback `fmt.Fprintln(stderr, err)`.
- **Legacy shim.** `SetCredential(io.Reader, string)` is retained as a deprecated thin wrapper over `SetCredentialV2` (legacy implicit-stdin + silent-overwrite) so `shared/keyring/keyring_e2e_test.go` keeps exercising the migrating-`Open()` path through a single orchestrator. The 12 e2e call-sites can migrate in a follow-up.
- **Forward-compat `--ref`/`--key`.** Today only `atlassian-cli/default` / `api_token` is valid; explicit non-canonical values are rejected with a clear message naming the only supported pair. Validators widen when multi-ref lands.

## Test plan

- [x] Unit tests for `SetCredentialV2` (success, every failure class, secret-leak audit, --json envelope shape, `ErrSetCredentialEnvelopeEmitted` sentinel)
- [x] Unit tests for `HasSharedConfig` (canonical-only, old-only relocation, both present, corrupt canonical, corrupt old, statedir resolver round-trip)
- [x] Cobra-layer tests for both jtk and cfl wrappers — parallel matrices covering all 14 §1.5.2 paths so jtk/cfl drift stays loud
- [x] Updated `tools/jtk/cmd/jtk/main_test.go` + `tools/cfl/cmd/cfl/main_test.go` entrypoint migration tests to the new explicit-flag invocation (the §1.8 migration runs inside `Open()` so `--overwrite` is required when set-credential follows a legacy plaintext migration)
- [x] `make lint` clean across `shared/`, `tools/cfl/`, `tools/jtk/`
- [x] Manual file-backend smoke (success / existing-no-overwrite failure / existing-with-overwrite) — envelope on stdout, stderr empty under --json on both success and failure
- [x] CLAUDE.md + both README "Non-interactive ingress" sections updated; `jtk init` and `cfl init` recovery hints show the new canonical form