### PR TITLE
feat(root): --non-interactive persistent flag for jtk + cfl (#391)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,21 @@ backend only (never the value). `config clear` removes the single shared
 resolve the same key); `config clear --all` removes the whole bundle
 (including any deprecated per-tool keys) plus the non-secret config file.
 
+**`--non-interactive` persistent root flag (§3.4):** both jtk and cfl
+accept `--non-interactive` on every command. Under it: no interactive
+prompts run (init wizards, destructive-confirm questions, file-backend
+passphrase TTY prompt). Init wizards fail loud naming the first missing
+required field (URL, email/cloud-id, token). Destructive commands
+(`issues/projects/automation/fields/config clear` on jtk;
+`page/space/attachment/config clear` on cfl) require `--force` to
+proceed; without it they return a clear "confirmation required;
+re-run with --force" error. Init's sibling-impact confirm and
+legacy-cleanup confirms default to safe behavior under
+`--non-interactive` (proceed-with-save, leave-legacy-files-in-place).
+The flag is forwarded into the keyring package via `WireBackendSelection`
+so the file-backend passphrase callback fails loud asking for
+`ATLASSIAN_CLI_KEYRING_PASSPHRASE` rather than prompting on a real TTY.
+
 ## Git History
 
 This monorepo was created using `git subtree` to preserve the full commit history of both tools. Use `git log --oneline` to see the complete history from both source repositories.

--- a/shared/keyring/non_interactive.go
+++ b/shared/keyring/non_interactive.go
@@ -1,0 +1,31 @@
+package keyring
+
+import "sync"
+
+// SetNonInteractive wires the root-command --non-interactive policy into
+// the package state consulted by the file-backend passphrase callback.
+//
+// Mirrors the SetBackendSelection pattern at keyring.go:28. Callers
+// (each tool's root PersistentPreRunE) invoke this once before any
+// Open* runs; the mutex guards against surprise concurrent callers
+// (test code rebuilding the command tree, future goroutine-launching
+// subcommands).
+func SetNonInteractive(nonInteractive bool) {
+	nonInteractiveMu.Lock()
+	defer nonInteractiveMu.Unlock()
+	selectedNonInteractive = nonInteractive
+}
+
+// GetNonInteractive returns the current package-level non-interactive
+// state. Consumed by passphraseFunc to fail loud on --non-interactive
+// even when stdin is a real TTY.
+func GetNonInteractive() bool {
+	nonInteractiveMu.RLock()
+	defer nonInteractiveMu.RUnlock()
+	return selectedNonInteractive
+}
+
+var (
+	nonInteractiveMu       sync.RWMutex
+	selectedNonInteractive bool
+)

--- a/shared/keyring/passphrase.go
+++ b/shared/keyring/passphrase.go
@@ -31,6 +31,15 @@ func passphraseFunc(service string) func() (string, error) {
 		// must supply ATLASSIAN_CLI_KEYRING_PASSPHRASE in that case (the
 		// error message says so). Token delivery and passphrase entry
 		// cannot share stdin.
+		//
+		// Additionally, the --non-interactive root flag (§3.4) forces
+		// fail-loud even on a real TTY: a scripted/CI run must never
+		// block on a prompt, regardless of where it is invoked from.
+		if GetNonInteractive() {
+			return "", fmt.Errorf(
+				"file keyring backend needs a passphrase: set %s (--non-interactive disables the TTY prompt fallback)",
+				passphraseEnvVar(service))
+		}
 		if !term.IsTerminal(int(os.Stdin.Fd())) {
 			return "", fmt.Errorf(
 				"file keyring backend needs a passphrase: set %s, or run interactively",

--- a/shared/keyring/passphrase_test.go
+++ b/shared/keyring/passphrase_test.go
@@ -1,0 +1,59 @@
+package keyring
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPassphraseFunc_NonInteractiveFailsLoud — under --non-interactive
+// the file-backend passphrase callback MUST fail loud asking for the
+// env var, regardless of whether stdin is a real TTY. The error message
+// must NOT include the "or run interactively" hint that the non-TTY
+// path uses, since the user explicitly opted out of interactive mode.
+func TestPassphraseFunc_NonInteractiveFailsLoud(t *testing.T) {
+	SetNonInteractive(true)
+	defer SetNonInteractive(false)
+
+	fn := passphraseFunc("atlassian-cli")
+	got, err := fn()
+	if err == nil {
+		t.Fatalf("expected error, got passphrase %q", got)
+	}
+	if got != "" {
+		t.Fatalf("passphrase must be empty on failure, got %q", got)
+	}
+	if !strings.Contains(err.Error(), "ATLASSIAN_CLI_KEYRING_PASSPHRASE") {
+		t.Fatalf("error must name the env var, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "--non-interactive") {
+		t.Fatalf("error must explain the --non-interactive policy, got %v", err)
+	}
+	if strings.Contains(err.Error(), "or run interactively") {
+		t.Fatalf("under --non-interactive the 'or run interactively' hint is wrong, got %v", err)
+	}
+}
+
+// TestPassphraseFunc_NonInteractiveOff_NonTTYPath — the non-TTY-stdin
+// path (the pre-existing contract) keeps working when --non-interactive
+// is NOT set. The error message format is different (includes "or run
+// interactively") so the two cases stay distinguishable in logs.
+func TestPassphraseFunc_NonInteractiveOff_NonTTYPath(t *testing.T) {
+	SetNonInteractive(false)
+	// In the test process os.Stdin may or may not be a TTY depending on
+	// where the tests run; the assertion below only fires when it isn't.
+	// Both branches (--non-interactive=true above, the non-TTY fallback
+	// below) cover the loud-fail surface; the interactive prompt branch
+	// can't be unit-tested without a real PTY.
+	fn := passphraseFunc("atlassian-cli")
+	got, err := fn()
+	if err == nil {
+		// Real TTY — the prompt would run; nothing to assert here.
+		return
+	}
+	if got != "" {
+		t.Fatalf("passphrase must be empty on failure, got %q", got)
+	}
+	if !strings.Contains(err.Error(), "or run interactively") {
+		t.Fatalf("non-TTY fallback error must mention 'or run interactively', got %v", err)
+	}
+}

--- a/shared/keyring/passphrase_test.go
+++ b/shared/keyring/passphrase_test.go
@@ -1,8 +1,11 @@
 package keyring
 
 import (
+	"os"
 	"strings"
 	"testing"
+
+	"golang.org/x/term"
 )
 
 // TestPassphraseFunc_NonInteractiveFailsLoud — under --non-interactive
@@ -35,20 +38,19 @@ func TestPassphraseFunc_NonInteractiveFailsLoud(t *testing.T) {
 
 // TestPassphraseFunc_NonInteractiveOff_NonTTYPath — the non-TTY-stdin
 // path (the pre-existing contract) keeps working when --non-interactive
-// is NOT set. The error message format is different (includes "or run
-// interactively") so the two cases stay distinguishable in logs.
+// is NOT set. Skip when os.Stdin IS a real TTY (running tests in a
+// terminal) because the callback would enter term.ReadPassword and
+// block. The non-interactive-true branch above covers fail-loud; the
+// interactive prompt branch requires a PTY harness we don't have here.
 func TestPassphraseFunc_NonInteractiveOff_NonTTYPath(t *testing.T) {
 	SetNonInteractive(false)
-	// In the test process os.Stdin may or may not be a TTY depending on
-	// where the tests run; the assertion below only fires when it isn't.
-	// Both branches (--non-interactive=true above, the non-TTY fallback
-	// below) cover the loud-fail surface; the interactive prompt branch
-	// can't be unit-tested without a real PTY.
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		t.Skip("os.Stdin is a real TTY; the prompt path would block — skipping (covered by the --non-interactive=true branch)")
+	}
 	fn := passphraseFunc("atlassian-cli")
 	got, err := fn()
 	if err == nil {
-		// Real TTY — the prompt would run; nothing to assert here.
-		return
+		t.Fatalf("expected non-TTY-fallback error, got passphrase %q", got)
 	}
 	if got != "" {
 		t.Fatalf("passphrase must be empty on failure, got %q", got)

--- a/shared/prompt/confirm.go
+++ b/shared/prompt/confirm.go
@@ -3,8 +3,12 @@ package prompt
 
 import (
 	"bufio"
+	"errors"
 	"io"
+	"os"
 	"strings"
+
+	"golang.org/x/term"
 )
 
 // Confirm prompts the user for confirmation and returns true if they answer yes.
@@ -29,4 +33,39 @@ func ConfirmOrForce(force bool, stdin io.Reader) (bool, error) {
 		return true, nil
 	}
 	return Confirm(stdin)
+}
+
+// ErrConfirmationRequired is the §3.4 sentinel: destructive operations
+// under --non-interactive without --force MUST fail loud rather than
+// block on stdin or silently cancel. The text is the actionable hint.
+var ErrConfirmationRequired = errors.New("--non-interactive: confirmation required; re-run with --force to proceed")
+
+// ConfirmOrFail upgrades ConfirmOrForce with the §3.4 non-interactive
+// gate. Precedence: --force wins (returns true); --non-interactive
+// without --force returns ErrConfirmationRequired; otherwise prompts
+// via Confirm.
+func ConfirmOrFail(force, nonInteractive bool, stdin io.Reader) (bool, error) {
+	if force {
+		return true, nil
+	}
+	if nonInteractive {
+		return false, ErrConfirmationRequired
+	}
+	return Confirm(stdin)
+}
+
+// WantPrompt reports whether interactive prompts should run. Returns
+// false under --non-interactive (regardless of stdin) AND when stdin is
+// not a TTY. Used by init wizards to choose between a huh form (TTY +
+// interactive) and a fail-loud validator (non-interactive or non-TTY).
+func WantPrompt(nonInteractive bool, stdin io.Reader) bool {
+	if nonInteractive {
+		return false
+	}
+	return isTerminal(stdin)
+}
+
+func isTerminal(r io.Reader) bool {
+	f, ok := r.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
 }

--- a/shared/prompt/confirm_test.go
+++ b/shared/prompt/confirm_test.go
@@ -1,6 +1,8 @@
 package prompt
 
 import (
+	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -112,5 +114,80 @@ func TestConfirmOrForce(t *testing.T) {
 			testutil.RequireNoError(t, err)
 			testutil.Equal(t, got, tt.want)
 		})
+	}
+}
+
+func TestConfirmOrFail(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		force          bool
+		nonInteractive bool
+		input          string
+		want           bool
+		wantErr        error
+	}{
+		{
+			name:           "force wins over non-interactive",
+			force:          true,
+			nonInteractive: true,
+			want:           true,
+		},
+		{
+			name:           "non-interactive without force surfaces sentinel",
+			nonInteractive: true,
+			wantErr:        ErrConfirmationRequired,
+		},
+		{
+			name:  "interactive y confirms",
+			input: "y\n",
+			want:  true,
+		},
+		{
+			name:  "interactive n cancels",
+			input: "n\n",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ConfirmOrFail(tt.force, tt.nonInteractive, strings.NewReader(tt.input))
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("want %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			testutil.RequireNoError(t, err)
+			testutil.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestWantPrompt(t *testing.T) {
+	t.Parallel()
+
+	// Non-TTY reader (strings.Reader isn't *os.File so isTerminal returns false).
+	nonTTY := strings.NewReader("")
+
+	if WantPrompt(true, nonTTY) {
+		t.Fatal("nonInteractive=true must force WantPrompt=false")
+	}
+	if WantPrompt(false, nonTTY) {
+		t.Fatal("non-TTY stdin must yield WantPrompt=false")
+	}
+
+	// Build a real TTY-like *os.File via os.Pipe(); the read end isn't a
+	// terminal so isTerminal returns false. We can't easily fabricate a
+	// real TTY in a unit test, so assert the false-case from a real *os.File
+	// to cover that branch of the type assertion.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer func() { _ = r.Close(); _ = w.Close() }()
+	if WantPrompt(false, r) {
+		t.Fatal("pipe read end is not a TTY; WantPrompt must be false")
 	}
 }

--- a/tools/cfl/internal/cmd/attachment/delete.go
+++ b/tools/cfl/internal/cmd/attachment/delete.go
@@ -40,6 +40,13 @@ func newDeleteCmd(rootOpts *root.Options) *cobra.Command {
 }
 
 func runDeleteAttachment(ctx context.Context, attachmentID string, opts *deleteOptions) error {
+	// §3.4: short-circuit BEFORE any API call so --non-interactive without
+	// --force returns ErrConfirmationRequired even if the attachment
+	// lookup would have failed first (auth/not-found/network).
+	if opts.NonInteractive && !opts.force {
+		return prompt.ErrConfirmationRequired
+	}
+
 	client, err := opts.APIClient()
 	if err != nil {
 		return err

--- a/tools/cfl/internal/cmd/attachment/delete.go
+++ b/tools/cfl/internal/cmd/attachment/delete.go
@@ -1,11 +1,12 @@
 package attachment
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/atlassian-go/prompt"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
@@ -51,20 +52,17 @@ func runDeleteAttachment(ctx context.Context, attachmentID string, opts *deleteO
 
 	v := opts.View()
 
-	if !opts.force {
+	if !opts.force && !opts.NonInteractive {
 		_, _ = fmt.Fprintf(opts.Stderr, "About to delete attachment: %s (ID: %s)\n", attachment.Title, attachment.ID)
 		_, _ = fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
-
-		scanner := bufio.NewScanner(opts.Stdin)
-		var confirm string
-		if scanner.Scan() {
-			confirm = scanner.Text()
-		}
-
-		if confirm != "y" && confirm != "Y" {
-			_, _ = fmt.Fprintln(opts.Stderr, "Deletion cancelled.")
-			return nil
-		}
+	}
+	confirmed, err := prompt.ConfirmOrFail(opts.force, opts.NonInteractive, opts.Stdin)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		_, _ = fmt.Fprintln(opts.Stderr, "Deletion cancelled.")
+		return nil
 	}
 
 	if err := client.DeleteAttachment(ctx, attachmentID); err != nil {

--- a/tools/cfl/internal/cmd/attachment/delete_test.go
+++ b/tools/cfl/internal/cmd/attachment/delete_test.go
@@ -3,11 +3,13 @@ package attachment
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/prompt"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/confluence-cli/api"
@@ -239,4 +241,37 @@ func TestRunDeleteAttachment_DeleteFails(t *testing.T) {
 	err := runDeleteAttachment(context.Background(), "att123", opts)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "deleting attachment")
+}
+
+// TestRunDeleteAttachment_NonInteractive_WithoutForce_ShortCircuits
+// pins the §3.4 early-fail contract: the API must NOT be called when
+// --non-interactive is set without --force.
+func TestRunDeleteAttachment_NonInteractive_WithoutForce_ShortCircuits(t *testing.T) {
+	t.Parallel()
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	rootOpts.NonInteractive = true
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &deleteOptions{Options: rootOpts, force: false}
+	err := runDeleteAttachment(context.Background(), "att123", opts)
+	if err == nil {
+		t.Fatal("expected ErrConfirmationRequired")
+	}
+	if !errors.Is(err, prompt.ErrConfirmationRequired) {
+		t.Fatalf("expected prompt.ErrConfirmationRequired, got %v", err)
+	}
+	if hits != 0 {
+		t.Fatalf("API must not be called; got %d hits", hits)
+	}
+	if rootOpts.Stderr.(*bytes.Buffer).Len() != 0 {
+		t.Fatalf("stderr must be empty: %q", rootOpts.Stderr.(*bytes.Buffer).String())
+	}
 }

--- a/tools/cfl/internal/cmd/configcmd/clear.go
+++ b/tools/cfl/internal/cmd/configcmd/clear.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/keyring"
+	promptpkg "github.com/open-cli-collective/atlassian-go/prompt"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
@@ -73,18 +74,11 @@ func runClear(opts *clearOptions) error {
 		return fmt.Errorf("inspecting keyring: %w", err)
 	}
 
-	confirm := func(prompt string) (bool, error) {
-		if opts.force {
-			return true, nil
+	confirm := func(promptText string) (bool, error) {
+		if !opts.force && !opts.NonInteractive {
+			_, _ = fmt.Fprint(opts.Stderr, promptText+" [y/N]: ")
 		}
-		_, _ = fmt.Fprint(opts.Stderr, prompt+" [y/N]: ")
-		var response string
-		_, ferr := fmt.Fscanln(opts.stdin, &response)
-		if ferr != nil && ferr.Error() != "unexpected newline" {
-			return false, ferr
-		}
-		response = strings.TrimSpace(strings.ToLower(response))
-		return response == "y" || response == "yes", nil
+		return promptpkg.ConfirmOrFail(opts.force, opts.NonInteractive, opts.stdin)
 	}
 
 	envNote := func() {

--- a/tools/cfl/internal/cmd/configcmd/clear.go
+++ b/tools/cfl/internal/cmd/configcmd/clear.go
@@ -62,6 +62,14 @@ override at runtime and cannot be cleared by this command.`,
 }
 
 func runClear(opts *clearOptions) error {
+	// §3.4: short-circuit BEFORE any keyring inspection so
+	// --non-interactive without --force returns ErrConfirmationRequired
+	// even if PlanClear would have failed first on a locked/unavailable
+	// keyring or surface warning text that contaminates CI logs.
+	if opts.NonInteractive && !opts.force {
+		return promptpkg.ErrConfirmationRequired
+	}
+
 	// One keyring open for the whole flow: PlanClear hands back the open
 	// store the delete/clear step reuses (no second passphrase prompt).
 	// The env + plaintext-file fields are populated even when the keyring

--- a/tools/cfl/internal/cmd/configcmd/clear_test.go
+++ b/tools/cfl/internal/cmd/configcmd/clear_test.go
@@ -2,12 +2,14 @@ package configcmd
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
+	"github.com/open-cli-collective/atlassian-go/prompt"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
@@ -78,6 +80,48 @@ func TestRunClear_Cancelled(t *testing.T) {
 	testutil.RequireNoError(t, runClear(opts))
 
 	testutil.True(t, tokenPresent(t, keyring.KeyAPIToken))
+}
+
+// TestRunClear_NonInteractive_WithoutForce_ShortCircuits — §3.4 contract
+// for the destructive config-clear path. The short-circuit fires BEFORE
+// keyring.PlanClear so a locked/unavailable keyring can't win first AND
+// the warning text never reaches stderr.
+func TestRunClear_NonInteractive_WithoutForce_ShortCircuits(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "shared-secret")
+
+	opts, out, errBuf := newClearOpts(false, "")
+	opts.NonInteractive = true
+
+	err := runClear(opts)
+	if err == nil {
+		t.Fatal("expected ErrConfirmationRequired")
+	}
+	if !errors.Is(err, prompt.ErrConfirmationRequired) {
+		t.Fatalf("expected prompt.ErrConfirmationRequired, got %v", err)
+	}
+	// Critical: no warning text leaks before the short-circuit fires.
+	if errBuf.Len() != 0 {
+		t.Fatalf("stderr must be empty (no warning text before fail-loud): %q", errBuf.String())
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout must be empty: %q", out.String())
+	}
+	// Token must remain — clear was rejected, not silently completed.
+	testutil.True(t, tokenPresent(t, keyring.KeyAPIToken))
+}
+
+// TestRunClear_NonInteractive_WithForce_Proceeds — --force still
+// bypasses confirmation under --non-interactive (existing contract).
+func TestRunClear_NonInteractive_WithForce_Proceeds(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "shared-secret")
+
+	opts, _, _ := newClearOpts(true, "")
+	opts.NonInteractive = true
+	testutil.RequireNoError(t, runClear(opts))
+
+	testutil.False(t, tokenPresent(t, keyring.KeyAPIToken))
 }
 
 func TestRunClear_All(t *testing.T) {

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/auth"
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/keyring"
+	"github.com/open-cli-collective/atlassian-go/prompt"
 
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/me"
@@ -234,10 +235,21 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 		))
 	}
 
-	form := huh.NewForm(formGroups...)
-
-	if err := form.Run(); err != nil {
-		return err
+	// §3.4: under --non-interactive (or a non-TTY stdin), the huh form
+	// can't run — every required value must already be in cfg from the
+	// flag prefills and the keyring backfill. cfl init has no --token
+	// flag, so the token MUST come from a pre-staged keyring entry
+	// (via `cfl set-credential`). Fail loud naming the first missing
+	// field.
+	if !prompt.WantPrompt(opts.NonInteractive, opts.Stdin) {
+		if err := requireNonInteractiveFields(cfg, isBearer); err != nil {
+			return err
+		}
+	} else {
+		form := huh.NewForm(formGroups...)
+		if err := form.Run(); err != nil {
+			return err
+		}
 	}
 
 	cfg.NormalizeURL()
@@ -286,19 +298,26 @@ func finalizeInit(
 	}
 
 	if result.affectsSibling {
-		var confirm bool
-		if err := huh.NewConfirm().
-			Title("Save will affect jtk").
-			Description("These credentials are stored in shared `default` and used by both cfl and jtk. Continue?").
-			Affirmative("Save").
-			Negative("Cancel").
-			Value(&confirm).
-			Run(); err != nil {
-			return err
-		}
-		if !confirm {
-			v.Info("Initialization cancelled. No changes saved.")
-			return nil
+		if !prompt.WantPrompt(opts.NonInteractive, opts.Stdin) {
+			// §3.4: scripted ingress opted in to shared-store mutation by
+			// passing --non-interactive; surface the sibling impact on
+			// stderr for the audit trail but proceed with the save.
+			v.Info("Saving credentials affects jtk (shared default section); proceeding under --non-interactive.")
+		} else {
+			var confirm bool
+			if err := huh.NewConfirm().
+				Title("Save will affect jtk").
+				Description("These credentials are stored in shared `default` and used by both cfl and jtk. Continue?").
+				Affirmative("Save").
+				Negative("Cancel").
+				Value(&confirm).
+				Run(); err != nil {
+				return err
+			}
+			if !confirm {
+				v.Info("Initialization cancelled. No changes saved.")
+				return nil
+			}
 		}
 	}
 
@@ -320,6 +339,13 @@ func finalizeInit(
 
 	// Optional: clean up legacy files we just migrated.
 	for _, lp := range result.consumedLegacies {
+		if !prompt.WantPrompt(opts.NonInteractive, opts.Stdin) {
+			// §3.4 non-destructive default: under --non-interactive we
+			// neither prompt nor delete. The migration already moved the
+			// data; leaving the legacy file in place is safe and reversible.
+			v.Info("Skipping cleanup of %s under --non-interactive; remove manually if desired.", lp)
+			continue
+		}
 		var deleteIt bool
 		if err := huh.NewConfirm().
 			Title(fmt.Sprintf("Delete legacy config at %s?", lp)).
@@ -356,5 +382,28 @@ func finalizeInit(
 		v.Info("To switch back to basic auth later, run: cfl init --auth-method basic")
 	}
 
+	return nil
+}
+
+// requireNonInteractiveFields enforces the §3.4 fail-loud contract for
+// scripted/CI runs of `cfl init`. cfl init has no --token flag, so the
+// token MUST come from a pre-staged keyring entry via cfl set-credential;
+// the error names that path explicitly.
+func requireNonInteractiveFields(cfg *config.Config, isBearer bool) error {
+	if cfg.URL == "" {
+		return fmt.Errorf("--non-interactive: missing required value for --url")
+	}
+	if isBearer {
+		if cfg.CloudID == "" {
+			return fmt.Errorf("--non-interactive: missing required value for --cloud-id (bearer auth)")
+		}
+	} else {
+		if cfg.Email == "" {
+			return fmt.Errorf("--non-interactive: missing required value for --email (basic auth)")
+		}
+	}
+	if cfg.APIToken == "" {
+		return fmt.Errorf("--non-interactive: no API token (cfl init has no --token flag; pre-stage with `cfl set-credential --ref atlassian-cli/default --key api_token --stdin`)")
+	}
 	return nil
 }

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -124,6 +124,97 @@ func TestRunInit_InvalidAuthMethod(t *testing.T) {
 	testutil.Contains(t, err.Error(), "invalid auth method")
 }
 
+// TestRequireNonInteractiveFields_NamesFirstMissing — cfl variant.
+// Critically, the token error names `cfl set-credential` rather than
+// `--token` because cfl init has no --token flag.
+func TestRequireNonInteractiveFields_NamesFirstMissing(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		isBearer bool
+		want     string
+	}{
+		{"basic — missing URL", &config.Config{}, false, "--url"},
+		{"basic — missing email", &config.Config{URL: "https://acme.atlassian.net"}, false, "--email"},
+		{"bearer — missing cloud-id", &config.Config{URL: "https://acme.atlassian.net"}, true, "--cloud-id"},
+		{
+			name: "basic — missing token directs to set-credential",
+			cfg:  &config.Config{URL: "https://acme.atlassian.net", Email: "u@x.io"},
+			want: "set-credential",
+		},
+		{
+			name:     "bearer — missing token directs to set-credential",
+			cfg:      &config.Config{URL: "https://acme.atlassian.net", CloudID: "cid"},
+			isBearer: true,
+			want:     "set-credential",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := requireNonInteractiveFields(tc.cfg, tc.isBearer)
+			testutil.RequireError(t, err)
+			if !strings.Contains(err.Error(), "--non-interactive") {
+				t.Fatalf("error must mention --non-interactive: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error must mention %s, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestRequireNonInteractiveFields_AllSupplied_NoError(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		URL: "https://acme.atlassian.net", Email: "u@x.io",
+		APIToken: "tok-1234567890",
+	}
+	if err := requireNonInteractiveFields(cfg, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestRunInit_NonInteractive_MissingURL_Fails — drives runInit through
+// the public surface; fail-loud surfaces before any keyring work runs.
+func TestRunInit_NonInteractive_MissingURL_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts, "", "", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "--non-interactive") || !strings.Contains(err.Error(), "--url") {
+		t.Fatalf("expected --non-interactive missing --url error, got: %v", err)
+	}
+}
+
+// TestRunInit_NonInteractive_MissingToken_DirectsToSetCredential — cfl
+// has no --token flag so the fail-loud hint points to the canonical
+// pre-staging path.
+func TestRunInit_NonInteractive_MissingToken_DirectsToSetCredential(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts, "https://acme.atlassian.net", "u@x.io", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "set-credential") {
+		t.Fatalf("error must direct user to set-credential, got: %v", err)
+	}
+}
+
 // finalizeInit tests use t.TempDir() for paths and an httptest-backed
 // clientBuilder so the user's real config is never touched and no real
 // network call is made.

--- a/tools/cfl/internal/cmd/page/delete.go
+++ b/tools/cfl/internal/cmd/page/delete.go
@@ -53,18 +53,17 @@ func runDelete(ctx context.Context, pageID string, opts *deleteOptions) error {
 
 	v := opts.View()
 
-	if !opts.force {
+	if !opts.force && !opts.NonInteractive {
 		_, _ = fmt.Fprintf(opts.Stderr, "About to delete page: %s (ID: %s)\n", page.Title, page.ID)
 		_, _ = fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
-
-		confirmed, err := prompt.Confirm(opts.Stdin)
-		if err != nil {
-			return fmt.Errorf("reading confirmation: %w", err)
-		}
-		if !confirmed {
-			_, _ = fmt.Fprintln(opts.Stderr, "Deletion cancelled.")
-			return nil
-		}
+	}
+	confirmed, err := prompt.ConfirmOrFail(opts.force, opts.NonInteractive, opts.Stdin)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		_, _ = fmt.Fprintln(opts.Stderr, "Deletion cancelled.")
+		return nil
 	}
 
 	if err := client.DeletePage(ctx, pageID); err != nil {

--- a/tools/cfl/internal/cmd/page/delete.go
+++ b/tools/cfl/internal/cmd/page/delete.go
@@ -40,6 +40,13 @@ func newDeleteCmd(rootOpts *root.Options) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, pageID string, opts *deleteOptions) error {
+	// §3.4: short-circuit BEFORE any API call so --non-interactive without
+	// --force returns ErrConfirmationRequired even if the page lookup
+	// would have failed first (auth/not-found/network).
+	if opts.NonInteractive && !opts.force {
+		return prompt.ErrConfirmationRequired
+	}
+
 	client, err := opts.APIClient()
 	if err != nil {
 		return err

--- a/tools/cfl/internal/cmd/page/delete_test.go
+++ b/tools/cfl/internal/cmd/page/delete_test.go
@@ -3,11 +3,13 @@ package page
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/prompt"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/confluence-cli/api"
@@ -267,4 +269,58 @@ func TestRunDelete_ConfirmationInputs(t *testing.T) {
 			testutil.Equal(t, deleteCalled, tt.shouldProceed)
 		})
 	}
+}
+
+// TestRunDelete_NonInteractive_WithoutForce_ShortCircuits — §3.4 contract
+// + the API-lookup-before-confirm short-circuit: --non-interactive
+// without --force MUST surface ErrConfirmationRequired BEFORE the
+// API.GetPage call, so a missing or auth-failing endpoint never wins
+// over the confirmation policy. Asserts the server is never hit.
+func TestRunDelete_NonInteractive_WithoutForce_ShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rootOpts := newDeleteTestRootOptions()
+	rootOpts.NonInteractive = true
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &deleteOptions{Options: rootOpts, force: false}
+	err := runDelete(context.Background(), "12345", opts)
+	if err == nil {
+		t.Fatal("expected ErrConfirmationRequired")
+	}
+	if !errors.Is(err, prompt.ErrConfirmationRequired) {
+		t.Fatalf("expected prompt.ErrConfirmationRequired, got %v", err)
+	}
+	if hits != 0 {
+		t.Fatalf("API must not be called under --non-interactive without --force; got %d hits", hits)
+	}
+	if rootOpts.Stderr.(*bytes.Buffer).Len() != 0 {
+		t.Fatalf("stderr must be empty: %q", rootOpts.Stderr.(*bytes.Buffer).String())
+	}
+}
+
+// TestRunDelete_NonInteractive_WithForce_Proceeds — --force still
+// bypasses confirmation under --non-interactive, so the existing
+// automation contract is preserved.
+func TestRunDelete_NonInteractive_WithForce_Proceeds(t *testing.T) {
+	t.Parallel()
+	server := mockPageServer(t, "12345", "Test Page", http.StatusNoContent)
+	defer server.Close()
+
+	rootOpts := newDeleteTestRootOptions()
+	rootOpts.NonInteractive = true
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &deleteOptions{Options: rootOpts, force: true}
+	err := runDelete(context.Background(), "12345", opts)
+	testutil.RequireNoError(t, err)
 }

--- a/tools/cfl/internal/cmd/root/backend_wire_test.go
+++ b/tools/cfl/internal/cmd/root/backend_wire_test.go
@@ -69,6 +69,46 @@ func TestWireBackendSelection_ConfigPassthrough(t *testing.T) {
 	}
 }
 
+// TestWireBackendSelection_NonInteractiveFlagThreaded — the
+// --non-interactive root flag must be folded into wireBackendSelection
+// so the file-backend passphrase callback fails loud under
+// --non-interactive even on a real TTY. Mirrors the jtk test.
+func TestWireBackendSelection_NonInteractiveFlagThreaded(t *testing.T) {
+	keyring.SetBackendSelection("", "")
+	keyring.SetNonInteractive(false)
+	defer keyring.SetBackendSelection("", "")
+	defer keyring.SetNonInteractive(false)
+
+	rootCmd, _ := NewCmd()
+	rootCmd.AddCommand(newProbeCmd("probe"))
+	rootCmd.SetArgs([]string{"probe", "--non-interactive"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !keyring.GetNonInteractive() {
+		t.Fatal("wireBackendSelection must thread --non-interactive into the keyring package state")
+	}
+}
+
+// TestWireBackendSelection_NonInteractiveDefaultsFalse — absence of the
+// flag must leave keyring state false (no accidental flip).
+func TestWireBackendSelection_NonInteractiveDefaultsFalse(t *testing.T) {
+	keyring.SetBackendSelection("", "")
+	keyring.SetNonInteractive(false)
+	defer keyring.SetBackendSelection("", "")
+	defer keyring.SetNonInteractive(false)
+
+	rootCmd, _ := NewCmd()
+	rootCmd.AddCommand(newProbeCmd("probe"))
+	rootCmd.SetArgs([]string{"probe"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if keyring.GetNonInteractive() {
+		t.Fatal("absence of --non-interactive must leave keyring state false")
+	}
+}
+
 func TestWireBackendSelection_InvalidConfigDeferred(t *testing.T) {
 	t.Setenv(cccredstore.BackendEnvVar(keyring.Service), "")
 	opts := &cccredstore.Options{}

--- a/tools/cfl/internal/cmd/root/root.go
+++ b/tools/cfl/internal/cmd/root/root.go
@@ -22,12 +22,13 @@ import (
 
 // Options contains global options for commands
 type Options struct {
-	Output  string
-	NoColor bool
-	Full    bool
-	Stdin   io.Reader
-	Stdout  io.Writer
-	Stderr  io.Writer
+	Output         string
+	NoColor        bool
+	Full           bool
+	NonInteractive bool // --non-interactive (§3.4): never prompt; fail loud on missing required values.
+	Stdin          io.Reader
+	Stdout         io.Writer
+	Stderr         io.Writer
 
 	// testClient is used for testing; if set, APIClient() returns this instead
 	testClient *api.Client
@@ -130,6 +131,7 @@ Get started by running: cfl init`,
 	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "table", "output format: table, json, plain")
 	cmd.PersistentFlags().BoolVar(&opts.NoColor, "no-color", false, "disable colored output")
 	cmd.PersistentFlags().BoolVar(&opts.Full, "full", false, "show full inspection-oriented output (default: agent)")
+	cmd.PersistentFlags().BoolVar(&opts.NonInteractive, "non-interactive", false, "Never prompt; fail loud naming any required value missing from flags/env/stdin (§3.4)")
 	cmd.PersistentFlags().String(cccredstore.BackendFlagName, "", cccredstore.BackendFlagUsage())
 
 	// Set version template
@@ -168,6 +170,18 @@ func wireBackendSelection(cmd *cobra.Command) error {
 		return fmt.Errorf("--%s: %w", cccredstore.BackendFlagName, err)
 	}
 	keyring.SetBackendSelection(opts.Backend, opts.ConfigBackend)
+
+	// §3.4: thread --non-interactive into the keyring package state so
+	// the file-backend passphrase callback fails loud under
+	// --non-interactive regardless of TTY. Folded into this single
+	// chokepoint so any future shadowing PersistentPreRunE that calls
+	// wireBackendSelection gets both wires.
+	var nonInteractive bool
+	if nif := cmd.Flag("non-interactive"); nif != nil {
+		nonInteractive = nif.Value.String() == "true"
+	}
+	keyring.SetNonInteractive(nonInteractive)
+
 	return nil
 }
 

--- a/tools/cfl/internal/cmd/space/delete.go
+++ b/tools/cfl/internal/cmd/space/delete.go
@@ -45,6 +45,13 @@ func runDelete(ctx context.Context, spaceKey string, opts *deleteOptions) error 
 		return err
 	}
 
+	// §3.4: short-circuit BEFORE any API call so --non-interactive without
+	// --force returns ErrConfirmationRequired even if the space lookup
+	// would have failed first (auth/not-found/network).
+	if opts.NonInteractive && !opts.force {
+		return prompt.ErrConfirmationRequired
+	}
+
 	client, err := opts.APIClient()
 	if err != nil {
 		return err

--- a/tools/cfl/internal/cmd/space/delete.go
+++ b/tools/cfl/internal/cmd/space/delete.go
@@ -41,15 +41,16 @@ func newDeleteCmd(rootOpts *root.Options) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, spaceKey string, opts *deleteOptions) error {
-	if err := view.ValidateFormat(opts.Output); err != nil {
-		return err
-	}
-
-	// §3.4: short-circuit BEFORE any API call so --non-interactive without
-	// --force returns ErrConfirmationRequired even if the space lookup
-	// would have failed first (auth/not-found/network).
+	// §3.4: short-circuit BEFORE any side-effecting check so
+	// --non-interactive without --force returns ErrConfirmationRequired
+	// regardless of output-format validity, API auth/not-found, or
+	// network state. Other validation errors would mask the real cause.
 	if opts.NonInteractive && !opts.force {
 		return prompt.ErrConfirmationRequired
+	}
+
+	if err := view.ValidateFormat(opts.Output); err != nil {
+		return err
 	}
 
 	client, err := opts.APIClient()

--- a/tools/cfl/internal/cmd/space/delete.go
+++ b/tools/cfl/internal/cmd/space/delete.go
@@ -57,18 +57,17 @@ func runDelete(ctx context.Context, spaceKey string, opts *deleteOptions) error 
 
 	v := opts.View()
 
-	if !opts.force {
+	if !opts.force && !opts.NonInteractive {
 		_, _ = fmt.Fprintf(opts.Stderr, "About to delete space: %s (%s)\n", space.Name, space.Key)
 		_, _ = fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
-
-		confirmed, err := prompt.Confirm(opts.Stdin)
-		if err != nil {
-			return fmt.Errorf("reading confirmation: %w", err)
-		}
-		if !confirmed {
-			_, _ = fmt.Fprintln(opts.Stderr, "Deletion cancelled.")
-			return nil
-		}
+	}
+	confirmed, err := prompt.ConfirmOrFail(opts.force, opts.NonInteractive, opts.Stdin)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		_, _ = fmt.Fprintln(opts.Stderr, "Deletion cancelled.")
+		return nil
 	}
 
 	if err := client.DeleteSpace(ctx, spaceKey); err != nil {

--- a/tools/cfl/internal/cmd/space/delete_test.go
+++ b/tools/cfl/internal/cmd/space/delete_test.go
@@ -1,0 +1,115 @@
+package space
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/prompt"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+)
+
+// TestRunDelete_NonInteractive_WithoutForce_ShortCircuits pins the §3.4
+// early-fail contract: cfl space delete must surface
+// ErrConfirmationRequired BEFORE the API GetSpaceByKey call AND before
+// view.ValidateFormat — neither should win precedence over the
+// confirmation gate.
+func TestRunDelete_NonInteractive_WithoutForce_ShortCircuits(t *testing.T) {
+	t.Parallel()
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rootOpts := &root.Options{
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &deleteOptions{Options: rootOpts, force: false}
+	err := runDelete(context.Background(), "SPACE", opts)
+	if err == nil {
+		t.Fatal("expected ErrConfirmationRequired")
+	}
+	if !errors.Is(err, prompt.ErrConfirmationRequired) {
+		t.Fatalf("expected prompt.ErrConfirmationRequired, got %v", err)
+	}
+	if hits != 0 {
+		t.Fatalf("API must not be called; got %d hits", hits)
+	}
+	if rootOpts.Stderr.(*bytes.Buffer).Len() != 0 {
+		t.Fatalf("stderr must be empty: %q", rootOpts.Stderr.(*bytes.Buffer).String())
+	}
+	if rootOpts.Stdout.(*bytes.Buffer).Len() != 0 {
+		t.Fatalf("stdout must be empty: %q", rootOpts.Stdout.(*bytes.Buffer).String())
+	}
+}
+
+// TestRunDelete_NonInteractive_WithoutForce_ShortCircuitsBeforeValidateFormat
+// pins the positioning: even with an invalid --output, the
+// confirmation error wins first under --non-interactive without --force.
+// A regression that re-orders the checks would cause this test to
+// surface a "format not supported" error instead.
+func TestRunDelete_NonInteractive_WithoutForce_ShortCircuitsBeforeValidateFormat(t *testing.T) {
+	t.Parallel()
+	rootOpts := &root.Options{
+		Output:         "bogus-format",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	opts := &deleteOptions{Options: rootOpts, force: false}
+	err := runDelete(context.Background(), "SPACE", opts)
+	if !errors.Is(err, prompt.ErrConfirmationRequired) {
+		t.Fatalf("expected prompt.ErrConfirmationRequired (must win over format-validation), got %v", err)
+	}
+}
+
+// TestRunDelete_NonInteractive_WithForce_Proceeds — --force still
+// bypasses confirmation under --non-interactive.
+func TestRunDelete_NonInteractive_WithForce_Proceeds(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			// GetSpaceByKey internally calls ListSpaces — must return a list.
+			_, _ = w.Write([]byte(`{"results":[{"id":"123","key":"SPACE","name":"Test Space"}]}`))
+			return
+		}
+		// DELETE
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	rootOpts := &root.Options{
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &deleteOptions{Options: rootOpts, force: true}
+	err := runDelete(context.Background(), "SPACE", opts)
+	testutil.RequireNoError(t, err)
+}

--- a/tools/jtk/internal/cmd/automation/delete.go
+++ b/tools/jtk/internal/cmd/automation/delete.go
@@ -57,7 +57,12 @@ func runDelete(ctx context.Context, opts *root.Options, ruleID string, force boo
 		return err
 	}
 
-	if !force {
+	// Defense-in-depth: the early --non-interactive short-circuit above
+	// would have returned by now, but pinning the gate on both `force`
+	// and `NonInteractive` keeps the policy consistent with issues/page/
+	// attachment delete so a future refactor that moves the short-circuit
+	// can't leak warning text to stderr under --non-interactive.
+	if !force && !opts.NonInteractive {
 		fmt.Fprintf(opts.Stderr, "This will permanently delete rule %q (%s). This action cannot be undone.\n", current.Name, ruleID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
 	}

--- a/tools/jtk/internal/cmd/automation/delete.go
+++ b/tools/jtk/internal/cmd/automation/delete.go
@@ -40,6 +40,13 @@ This action cannot be undone.`,
 }
 
 func runDelete(ctx context.Context, opts *root.Options, ruleID string, force bool) error {
+	// §3.4: short-circuit BEFORE any API call so --non-interactive without
+	// --force returns ErrConfirmationRequired even if the API lookup
+	// would have failed first (auth/not-found/network).
+	if opts.NonInteractive && !force {
+		return prompt.ErrConfirmationRequired
+	}
+
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -50,7 +57,7 @@ func runDelete(ctx context.Context, opts *root.Options, ruleID string, force boo
 		return err
 	}
 
-	if !force && !opts.NonInteractive {
+	if !force {
 		fmt.Fprintf(opts.Stderr, "This will permanently delete rule %q (%s). This action cannot be undone.\n", current.Name, ruleID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
 	}

--- a/tools/jtk/internal/cmd/automation/delete.go
+++ b/tools/jtk/internal/cmd/automation/delete.go
@@ -50,20 +50,19 @@ func runDelete(ctx context.Context, opts *root.Options, ruleID string, force boo
 		return err
 	}
 
-	if !force {
+	if !force && !opts.NonInteractive {
 		fmt.Fprintf(opts.Stderr, "This will permanently delete rule %q (%s). This action cannot be undone.\n", current.Name, ruleID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
-
-		confirmed, err := prompt.Confirm(opts.Stdin)
-		if err != nil {
-			return fmt.Errorf("reading confirmation: %w", err)
-		}
-		if !confirmed {
-			model := jtkpresent.AutomationPresenter{}.PresentDeleteCancelled()
-			out := present.Render(model, opts.RenderStyle())
-			fmt.Fprint(opts.Stdout, out.Stdout)
-			return nil
-		}
+	}
+	confirmed, err := prompt.ConfirmOrFail(force, opts.NonInteractive, opts.Stdin)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		model := jtkpresent.AutomationPresenter{}.PresentDeleteCancelled()
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		return nil
 	}
 
 	// API rejects DELETE on ENABLED rules — disable first.

--- a/tools/jtk/internal/cmd/automation/delete_test.go
+++ b/tools/jtk/internal/cmd/automation/delete_test.go
@@ -236,4 +236,46 @@ func TestRunDelete_NonInteractive_WithoutForce_ShortCircuits(t *testing.T) {
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr must be empty: %q", stderr.String())
 	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout must be empty (no PresentDeleteCancelled artifact): %q", stdout.String())
+	}
+}
+
+// TestRunDelete_NonInteractive_WithForce_Proceeds — --force still
+// bypasses confirmation under --non-interactive (matches the family
+// pattern in issues/page/attachment/configcmd tests).
+func TestRunDelete_NonInteractive_WithForce_Proceeds(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_edge/tenant_info" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			rule := api.AutomationRule{
+				ID:    json.Number("42"),
+				Name:  "Test Rule",
+				State: "DISABLED",
+			}
+			_ = json.NewEncoder(w).Encode(rule)
+		}
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.io", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{
+		NonInteractive: true,
+		Stdout:         &stdout,
+		Stderr:         &stderr,
+	}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, "42", true)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted automation 42\n")
 }

--- a/tools/jtk/internal/cmd/automation/delete_test.go
+++ b/tools/jtk/internal/cmd/automation/delete_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/prompt"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -196,4 +198,42 @@ func TestRunDelete_EmitsText(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "Deleted automation 42\n")
 	testutil.Equal(t, stderr.String(), "")
+}
+
+// TestRunDelete_NonInteractive_WithoutForce_ShortCircuits — §3.4
+// early-fail: --non-interactive without --force returns
+// ErrConfirmationRequired BEFORE the API GetAutomationRule call.
+func TestRunDelete_NonInteractive_WithoutForce_ShortCircuits(t *testing.T) {
+	t.Parallel()
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{
+		NonInteractive: true,
+		Stdout:         &stdout,
+		Stderr:         &stderr,
+	}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, "42", false)
+	if err == nil {
+		t.Fatal("expected ErrConfirmationRequired")
+	}
+	if !errors.Is(err, prompt.ErrConfirmationRequired) {
+		t.Fatalf("expected prompt.ErrConfirmationRequired, got %v", err)
+	}
+	if hits != 0 {
+		t.Fatalf("API must not be hit; got %d calls", hits)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr must be empty: %q", stderr.String())
+	}
 }

--- a/tools/jtk/internal/cmd/configcmd/configcmd.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/present"
+	promptpkg "github.com/open-cli-collective/atlassian-go/prompt"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
@@ -129,18 +130,11 @@ func runClear(ctx context.Context, opts *clearOptions) error {
 		return fmt.Errorf("inspecting keyring: %w", err)
 	}
 
-	confirm := func(prompt string) (bool, error) {
-		if opts.force {
-			return true, nil
+	confirm := func(promptText string) (bool, error) {
+		if !opts.force && !opts.NonInteractive {
+			fmt.Fprint(opts.Stderr, promptText+" [y/N]: ")
 		}
-		fmt.Fprint(opts.Stderr, prompt+" [y/N]: ")
-		var response string
-		_, ferr := fmt.Fscanln(opts.stdin, &response)
-		if ferr != nil && ferr.Error() != "unexpected newline" {
-			return false, ferr
-		}
-		response = strings.TrimSpace(strings.ToLower(response))
-		return response == "y" || response == "yes", nil
+		return promptpkg.ConfirmOrFail(opts.force, opts.NonInteractive, opts.stdin)
 	}
 
 	envNote := func() {

--- a/tools/jtk/internal/cmd/configcmd/configcmd.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd.go
@@ -118,6 +118,14 @@ override at runtime and cannot be cleared by this command.`,
 func runClear(ctx context.Context, opts *clearOptions) error {
 	_ = ctx
 
+	// §3.4: short-circuit BEFORE any keyring inspection so
+	// --non-interactive without --force returns ErrConfirmationRequired
+	// even if PlanClear would have failed first on a locked/unavailable
+	// keyring or surface warning text that contaminates CI logs.
+	if opts.NonInteractive && !opts.force {
+		return promptpkg.ErrConfirmationRequired
+	}
+
 	// One keyring open for the whole flow: PlanClear hands back the open
 	// store the delete/clear step reuses (no second passphrase prompt).
 	// The env + plaintext-file fields are populated even when the keyring

--- a/tools/jtk/internal/cmd/configcmd/configcmd_test.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd_test.go
@@ -3,6 +3,7 @@ package configcmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
+	"github.com/open-cli-collective/atlassian-go/prompt"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -225,6 +227,32 @@ func TestRunClear_NothingToClear(t *testing.T) {
 	opts, out, _ := newClearOpts(t, true, "")
 	testutil.RequireNoError(t, runClear(context.Background(), opts))
 	testutil.Contains(t, out.String(), "nothing to clear")
+}
+
+// TestRunClear_NonInteractive_WithoutForce_ShortCircuits — §3.4 contract
+// for the destructive config-clear path on jtk. The short-circuit fires
+// BEFORE keyring.PlanClear so the warning text never reaches stderr.
+func TestRunClear_NonInteractive_WithoutForce_ShortCircuits(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "shared-secret")
+
+	opts, out, errBuf := newClearOpts(t, false, "")
+	opts.NonInteractive = true
+
+	err := runClear(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected ErrConfirmationRequired")
+	}
+	if !errors.Is(err, prompt.ErrConfirmationRequired) {
+		t.Fatalf("expected prompt.ErrConfirmationRequired, got %v", err)
+	}
+	if errBuf.Len() != 0 {
+		t.Fatalf("stderr must be empty (no warning text before fail-loud): %q", errBuf.String())
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout must be empty: %q", out.String())
+	}
+	testutil.True(t, jtkTokenPresent(t, keyring.KeyAPIToken))
 }
 
 func TestGetDefaultProjectWithSource(t *testing.T) {

--- a/tools/jtk/internal/cmd/configcmd/configcmd_test.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd_test.go
@@ -255,6 +255,20 @@ func TestRunClear_NonInteractive_WithoutForce_ShortCircuits(t *testing.T) {
 	testutil.True(t, jtkTokenPresent(t, keyring.KeyAPIToken))
 }
 
+// TestRunClear_NonInteractive_WithForce_Proceeds — --force still
+// bypasses confirmation under --non-interactive (mirrors the cfl
+// counterpart at tools/cfl/internal/cmd/configcmd/clear_test.go).
+func TestRunClear_NonInteractive_WithForce_Proceeds(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "shared-secret")
+
+	opts, _, _ := newClearOpts(t, true, "")
+	opts.NonInteractive = true
+	testutil.RequireNoError(t, runClear(context.Background(), opts))
+
+	testutil.False(t, jtkTokenPresent(t, keyring.KeyAPIToken))
+}
+
 func TestGetDefaultProjectWithSource(t *testing.T) {
 	// Clear env vars
 	t.Setenv("JIRA_DEFAULT_PROJECT", "")

--- a/tools/jtk/internal/cmd/fields/contexts.go
+++ b/tools/jtk/internal/cmd/fields/contexts.go
@@ -142,21 +142,20 @@ func newContextsDeleteCmd(opts *root.Options) *cobra.Command {
 }
 
 func runContextsDelete(ctx context.Context, opts *root.Options, fieldID, contextID string, force bool) error {
-	if !force {
+	if !force && !opts.NonInteractive {
 		fmt.Fprintf(opts.Stderr, "This will delete context %s from field %s.\n", contextID, fieldID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
-
-		confirmed, err := prompt.Confirm(opts.Stdin)
-		if err != nil {
-			return fmt.Errorf("reading confirmation: %w", err)
-		}
-		if !confirmed {
-			model := jtkpresent.FieldPresenter{}.PresentDeleteCancelled()
-			out := present.Render(model, opts.RenderStyle())
-			fmt.Fprint(opts.Stdout, out.Stdout)
-			fmt.Fprint(opts.Stderr, out.Stderr)
-			return nil
-		}
+	}
+	confirmed, err := prompt.ConfirmOrFail(force, opts.NonInteractive, opts.Stdin)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		model := jtkpresent.FieldPresenter{}.PresentDeleteCancelled()
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		fmt.Fprint(opts.Stderr, out.Stderr)
+		return nil
 	}
 
 	client, err := opts.APIClient()

--- a/tools/jtk/internal/cmd/fields/fields.go
+++ b/tools/jtk/internal/cmd/fields/fields.go
@@ -200,21 +200,20 @@ Trashed fields are permanently deleted after 60 days.`,
 }
 
 func runDelete(ctx context.Context, opts *root.Options, fieldID string, force bool) error {
-	if !force {
+	if !force && !opts.NonInteractive {
 		fmt.Fprintf(opts.Stderr, "This will trash field %s. It can be restored later.\n", fieldID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
-
-		confirmed, err := prompt.Confirm(opts.Stdin)
-		if err != nil {
-			return fmt.Errorf("reading confirmation: %w", err)
-		}
-		if !confirmed {
-			model := jtkpresent.FieldPresenter{}.PresentDeleteCancelled()
-			out := present.Render(model, opts.RenderStyle())
-			fmt.Fprint(opts.Stdout, out.Stdout)
-			fmt.Fprint(opts.Stderr, out.Stderr)
-			return nil
-		}
+	}
+	confirmed, err := prompt.ConfirmOrFail(force, opts.NonInteractive, opts.Stdin)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		model := jtkpresent.FieldPresenter{}.PresentDeleteCancelled()
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		fmt.Fprint(opts.Stderr, out.Stderr)
+		return nil
 	}
 
 	client, err := opts.APIClient()

--- a/tools/jtk/internal/cmd/fields/fields_test.go
+++ b/tools/jtk/internal/cmd/fields/fields_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/prompt"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -1455,4 +1457,66 @@ func TestNewShowCmd(t *testing.T) {
 	cmd, _, err := rootCmd.Find([]string{"fields", "show"})
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, cmd.Name(), "show")
+}
+
+// TestFields_NonInteractive_DestructiveSites_FailLoud — single table
+// pinning the §3.4 contract across all three fields destructive call
+// sites (runDelete, runContextsDelete, runOptionsDelete). Each adopts
+// prompt.ConfirmOrFail; without --force they must return
+// ErrConfirmationRequired regardless of prior interactive state.
+func TestFields_NonInteractive_DestructiveSites_FailLoud(t *testing.T) {
+	t.Parallel()
+	mkOpts := func() *root.Options {
+		return &root.Options{
+			NonInteractive: true,
+			Stdout:         &bytes.Buffer{},
+			Stderr:         &bytes.Buffer{},
+			Stdin:          bytes.NewBufferString(""),
+		}
+	}
+
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "t@x.io", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "fields delete",
+			fn: func() error {
+				opts := mkOpts()
+				opts.SetAPIClient(client)
+				return runDelete(context.Background(), opts, "customfield_10100", false)
+			},
+		},
+		{
+			name: "fields contexts delete",
+			fn: func() error {
+				opts := mkOpts()
+				opts.SetAPIClient(client)
+				return runContextsDelete(context.Background(), opts, "customfield_10100", "ctx-1", false)
+			},
+		},
+		{
+			name: "fields options delete",
+			fn: func() error {
+				opts := mkOpts()
+				opts.SetAPIClient(client)
+				return runOptionsDelete(context.Background(), opts, "customfield_10100", "opt-1", "", false)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.fn()
+			if err == nil {
+				t.Fatal("expected ErrConfirmationRequired")
+			}
+			if !errors.Is(err, prompt.ErrConfirmationRequired) {
+				t.Fatalf("expected prompt.ErrConfirmationRequired, got %v", err)
+			}
+		})
+	}
 }

--- a/tools/jtk/internal/cmd/fields/options.go
+++ b/tools/jtk/internal/cmd/fields/options.go
@@ -240,21 +240,20 @@ func newOptionsDeleteCmd(opts *root.Options) *cobra.Command {
 }
 
 func runOptionsDelete(ctx context.Context, opts *root.Options, fieldID, optionID, contextFlag string, force bool) error {
-	if !force {
+	if !force && !opts.NonInteractive {
 		fmt.Fprintf(opts.Stderr, "This will delete option %s from field %s.\n", optionID, fieldID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
-
-		confirmed, err := prompt.Confirm(opts.Stdin)
-		if err != nil {
-			return fmt.Errorf("reading confirmation: %w", err)
-		}
-		if !confirmed {
-			model := jtkpresent.FieldPresenter{}.PresentDeleteCancelled()
-			out := present.Render(model, opts.RenderStyle())
-			fmt.Fprint(opts.Stdout, out.Stdout)
-			fmt.Fprint(opts.Stderr, out.Stderr)
-			return nil
-		}
+	}
+	confirmed, err := prompt.ConfirmOrFail(force, opts.NonInteractive, opts.Stdin)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		model := jtkpresent.FieldPresenter{}.PresentDeleteCancelled()
+		out := present.Render(model, opts.RenderStyle())
+		fmt.Fprint(opts.Stdout, out.Stdout)
+		fmt.Fprint(opts.Stderr, out.Stderr)
+		return nil
 	}
 
 	client, err := opts.APIClient()

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -18,10 +18,12 @@ import (
 	"github.com/open-cli-collective/atlassian-go/auth"
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/keyring"
+	"github.com/open-cli-collective/atlassian-go/prompt"
 	sharedurl "github.com/open-cli-collective/atlassian-go/url"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/config"
 )
 
 // Register registers the init command
@@ -216,10 +218,18 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 		))
 	}
 
-	form := huh.NewForm(formGroups...)
-
-	if err := form.Run(); err != nil {
-		return err
+	// §3.4: under --non-interactive (or a non-TTY stdin), the huh form
+	// can't run — every required value must already be in cfg from the
+	// flag prefills. Fail loud naming the first missing field.
+	if !prompt.WantPrompt(opts.NonInteractive, opts.Stdin) {
+		if err := requireNonInteractiveFields(cfg, isBearer); err != nil {
+			return err
+		}
+	} else {
+		form := huh.NewForm(formGroups...)
+		if err := form.Run(); err != nil {
+			return err
+		}
 	}
 
 	// Normalize URL
@@ -254,19 +264,26 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	}
 
 	if result.affectsSibling {
-		var confirm bool
-		if err := huh.NewConfirm().
-			Title("Save will affect cfl").
-			Description("These credentials are stored in shared `default` and used by both jtk and cfl. Continue?").
-			Affirmative("Save").
-			Negative("Cancel").
-			Value(&confirm).
-			Run(); err != nil {
-			return err
-		}
-		if !confirm {
-			v.Info("Initialization cancelled. No changes saved.")
-			return nil
+		if !prompt.WantPrompt(opts.NonInteractive, opts.Stdin) {
+			// §3.4: scripted ingress opted in to shared-store mutation by
+			// passing --non-interactive; surface the sibling impact on
+			// stderr for the audit trail but proceed with the save.
+			v.Info("Saving credentials affects cfl (shared default section); proceeding under --non-interactive.")
+		} else {
+			var confirm bool
+			if err := huh.NewConfirm().
+				Title("Save will affect cfl").
+				Description("These credentials are stored in shared `default` and used by both jtk and cfl. Continue?").
+				Affirmative("Save").
+				Negative("Cancel").
+				Value(&confirm).
+				Run(); err != nil {
+				return err
+			}
+			if !confirm {
+				v.Info("Initialization cancelled. No changes saved.")
+				return nil
+			}
 		}
 	}
 
@@ -290,6 +307,13 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	v.Success("Configuration saved to %s (token stored in the OS keyring)", sharedPath)
 
 	for _, lp := range result.consumedLegacies {
+		if !prompt.WantPrompt(opts.NonInteractive, opts.Stdin) {
+			// §3.4 non-destructive default: under --non-interactive we
+			// neither prompt nor delete. The migration already moved the
+			// data; leaving the legacy file in place is safe and reversible.
+			v.Info("Skipping cleanup of %s under --non-interactive; remove manually if desired.", lp)
+			continue
+		}
 		var deleteIt bool
 		if err := huh.NewConfirm().
 			Title(fmt.Sprintf("Delete legacy config at %s?", lp)).
@@ -319,5 +343,29 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 		v.Info("To switch back to basic auth later, run: jtk init --auth-method basic")
 	}
 
+	return nil
+}
+
+// requireNonInteractiveFields enforces the §3.4 fail-loud contract for
+// scripted/CI runs of `jtk init`: any required value missing from the
+// flag prefills (which already populated cfg) produces an error naming
+// the first missing field, with the auth-mode shape baked into the
+// message so the operator knows which flag set is required.
+func requireNonInteractiveFields(cfg *config.Config, isBearer bool) error {
+	if cfg.URL == "" {
+		return fmt.Errorf("--non-interactive: missing required value for --url")
+	}
+	if isBearer {
+		if cfg.CloudID == "" {
+			return fmt.Errorf("--non-interactive: missing required value for --cloud-id (bearer auth)")
+		}
+	} else {
+		if cfg.Email == "" {
+			return fmt.Errorf("--non-interactive: missing required value for --email (basic auth)")
+		}
+	}
+	if cfg.APIToken == "" {
+		return fmt.Errorf("--non-interactive: missing required value for --token (or pre-stage with `jtk set-credential --ref atlassian-cli/default --key api_token --stdin`)")
+	}
 	return nil
 }

--- a/tools/jtk/internal/cmd/initcmd/initcmd_test.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd_test.go
@@ -3,8 +3,10 @@ package initcmd
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/spf13/cobra"
 
@@ -59,6 +61,120 @@ func TestRunInit_InvalidAuthMethod(t *testing.T) {
 // Note: Interactive huh form tests are skipped because huh requires a TTY
 // The non-interactive paths (all flags provided) still use huh forms internally,
 // so we test config loading/saving separately
+
+// TestRequireNonInteractiveFields_NamesFirstMissing pins the §3.4
+// fail-loud message shape so the family pattern (jtk + cfl + future
+// nrq-aligned ports) stays consistent. The wizard wrapper isn't tested
+// directly because it depends on huh form state we can't easily fake
+// — the helper IS the contract for what gets named.
+func TestRequireNonInteractiveFields_NamesFirstMissing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		isBearer bool
+		want     string
+	}{
+		{
+			name:     "basic auth — missing URL",
+			cfg:      &config.Config{},
+			isBearer: false,
+			want:     "--url",
+		},
+		{
+			name:     "basic auth — missing email",
+			cfg:      &config.Config{URL: "https://acme.atlassian.net"},
+			isBearer: false,
+			want:     "--email",
+		},
+		{
+			name:     "bearer — missing cloud-id",
+			cfg:      &config.Config{URL: "https://acme.atlassian.net"},
+			isBearer: true,
+			want:     "--cloud-id",
+		},
+		{
+			name:     "basic auth — missing token",
+			cfg:      &config.Config{URL: "https://acme.atlassian.net", Email: "u@x.io"},
+			isBearer: false,
+			want:     "--token",
+		},
+		{
+			name:     "bearer — missing token",
+			cfg:      &config.Config{URL: "https://acme.atlassian.net", CloudID: "cid"},
+			isBearer: true,
+			want:     "--token",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := requireNonInteractiveFields(tc.cfg, tc.isBearer)
+			testutil.RequireError(t, err)
+			if !strings.Contains(err.Error(), "--non-interactive: missing") {
+				t.Fatalf("error must mention --non-interactive prefix: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error must name %s, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// TestRequireNonInteractiveFields_AllSupplied_NoError — happy path; no
+// error returned when every required field is present.
+func TestRequireNonInteractiveFields_AllSupplied_NoError(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		URL: "https://acme.atlassian.net", Email: "u@x.io",
+		APIToken: "tok-1234567890",
+	}
+	if err := requireNonInteractiveFields(cfg, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestRunInit_NonInteractive_MissingURL_Fails — drives runInit through
+// the public surface with --non-interactive but no flags supplied. The
+// fail-loud message must surface BEFORE any keyring/migration work runs.
+func TestRunInit_NonInteractive_MissingURL_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""), // empty stdin so WantPrompt=false
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts, "", "", "", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "--non-interactive") || !strings.Contains(err.Error(), "--url") {
+		t.Fatalf("expected --non-interactive missing --url error, got: %v", err)
+	}
+}
+
+// TestRunInit_NonInteractive_MissingToken_FlagAndKeyringEmpty — the
+// fail-loud hint must point to `jtk set-credential` when the user has
+// neither --token nor a pre-staged keyring entry.
+func TestRunInit_NonInteractive_MissingToken_FlagAndKeyringEmpty(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts, "https://acme.atlassian.net", "u@x.io", "", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "--token") {
+		t.Fatalf("error must hint at --token, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "set-credential") {
+		t.Fatalf("error must hint at set-credential pre-staging, got: %v", err)
+	}
+}
 
 func TestInitCommand_Flags(t *testing.T) {
 	t.Parallel()

--- a/tools/jtk/internal/cmd/issues/delete.go
+++ b/tools/jtk/internal/cmd/issues/delete.go
@@ -41,7 +41,7 @@ func newDeleteCmd(opts *root.Options) *cobra.Command {
 }
 
 func runDelete(ctx context.Context, opts *root.Options, issueKeys []string, force bool) error {
-	if !force {
+	if !force && !opts.NonInteractive {
 		var msg string
 		if len(issueKeys) == 1 {
 			msg = fmt.Sprintf("This will permanently delete issue %s. This action cannot be undone.", issueKeys[0])
@@ -50,17 +50,16 @@ func runDelete(ctx context.Context, opts *root.Options, issueKeys []string, forc
 		}
 		fmt.Fprintln(opts.Stderr, msg)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
-
-		confirmed, err := prompt.Confirm(opts.Stdin)
-		if err != nil {
-			return fmt.Errorf("reading confirmation: %w", err)
-		}
-		if !confirmed {
-			model := jtkpresent.IssuePresenter{}.PresentDeleteCancelled()
-			out := present.Render(model, opts.RenderStyle())
-			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-			return nil
-		}
+	}
+	confirmed, err := prompt.ConfirmOrFail(force, opts.NonInteractive, opts.Stdin)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		model := jtkpresent.IssuePresenter{}.PresentDeleteCancelled()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		return nil
 	}
 
 	client, err := opts.APIClient()

--- a/tools/jtk/internal/cmd/issues/delete_test.go
+++ b/tools/jtk/internal/cmd/issues/delete_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/prompt"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -85,6 +86,68 @@ func TestRunDelete_PartialFailure(t *testing.T) {
 	}
 	testutil.Equal(t, stdout.String(), "Deleted PROJ-1\nDeleted PROJ-3\n")
 	testutil.Contains(t, stderr.String(), "Failed to delete PROJ-2")
+}
+
+// TestRunDelete_NonInteractive_WithoutForce_FailsLoud — §3.4 contract:
+// destructive ops under --non-interactive without --force surface the
+// ErrConfirmationRequired sentinel rather than blocking on stdin or
+// silently cancelling. Also asserts that the prompt-text emission is
+// suppressed (CI logs wouldn't see "Are you sure?" lines either).
+func TestRunDelete_NonInteractive_WithoutForce_FailsLoud(t *testing.T) {
+	t.Parallel()
+
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{
+		NonInteractive: true,
+		Stdout:         &stdout,
+		Stderr:         &stderr,
+		Stdin:          bytes.NewBufferString(""),
+	}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, []string{"PROJ-123"}, false)
+	if err == nil {
+		t.Fatal("expected ErrConfirmationRequired, got nil")
+	}
+	if !errors.Is(err, prompt.ErrConfirmationRequired) {
+		t.Fatalf("expected prompt.ErrConfirmationRequired, got %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr must be empty under --non-interactive (no Are-you-sure line): %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout must be empty (no cancellation marker either): %q", stdout.String())
+	}
+}
+
+// TestRunDelete_NonInteractive_WithForce_Proceeds — --force still
+// bypasses confirmation under --non-interactive (the existing automation
+// contract is preserved).
+func TestRunDelete_NonInteractive_WithForce_Proceeds(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@example.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{
+		NonInteractive: true,
+		Stdout:         &stdout,
+		Stderr:         &stderr,
+	}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, []string{"PROJ-123"}, true)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "Deleted PROJ-123\n")
 }
 
 func TestRunDelete_PromptDeclined(t *testing.T) {

--- a/tools/jtk/internal/cmd/projects/delete.go
+++ b/tools/jtk/internal/cmd/projects/delete.go
@@ -40,20 +40,19 @@ The project can be restored from trash using 'jtk projects restore'.`,
 }
 
 func runDelete(ctx context.Context, opts *root.Options, keyOrID string, force bool) error {
-	if !force {
+	if !force && !opts.NonInteractive {
 		fmt.Fprintf(opts.Stderr, "This will delete project %s (moves to trash). It can be restored later.\n", keyOrID)
 		fmt.Fprint(opts.Stderr, "Are you sure? [y/N]: ")
-
-		confirmed, err := prompt.Confirm(opts.Stdin)
-		if err != nil {
-			return fmt.Errorf("reading confirmation: %w", err)
-		}
-		if !confirmed {
-			model := jtkpresent.ProjectPresenter{}.PresentDeleteCancelled()
-			out := present.Render(model, opts.RenderStyle())
-			_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
-			return nil
-		}
+	}
+	confirmed, err := prompt.ConfirmOrFail(force, opts.NonInteractive, opts.Stdin)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		model := jtkpresent.ProjectPresenter{}.PresentDeleteCancelled()
+		out := present.Render(model, opts.RenderStyle())
+		_, _ = fmt.Fprint(opts.Stdout, out.Stdout)
+		return nil
 	}
 
 	client, err := opts.APIClient()

--- a/tools/jtk/internal/cmd/projects/projects_test.go
+++ b/tools/jtk/internal/cmd/projects/projects_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/prompt"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/jira-ticket-cli/api"
@@ -716,4 +718,60 @@ func TestRunTypes_IDOnly(t *testing.T) {
 
 	testutil.RequireNoError(t, runTypes(context.Background(), opts, ""))
 	testutil.Equal(t, stdout.String(), "software\nbusiness\n")
+}
+
+// TestRunDelete_NonInteractive_WithoutForce_FailsLoud — §3.4 contract:
+// destructive op under --non-interactive without --force surfaces
+// ErrConfirmationRequired with empty stdout/stderr.
+func TestRunDelete_NonInteractive_WithoutForce_FailsLoud(t *testing.T) {
+	t.Parallel()
+	client, err := api.New(api.ClientConfig{URL: "https://test.atlassian.net", Email: "t@x.io", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	opts := &root.Options{
+		NonInteractive: true,
+		Stdout:         &stdout,
+		Stderr:         &stderr,
+		Stdin:          bytes.NewBufferString(""),
+	}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, "TST", false)
+	if err == nil {
+		t.Fatal("expected ErrConfirmationRequired")
+	}
+	if !errors.Is(err, prompt.ErrConfirmationRequired) {
+		t.Fatalf("expected prompt.ErrConfirmationRequired, got %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout must be empty: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr must be empty: %q", stderr.String())
+	}
+}
+
+// TestRunDelete_NonInteractive_WithForce_Proceeds — --force bypasses
+// confirmation under --non-interactive (existing automation contract).
+func TestRunDelete_NonInteractive_WithForce_Proceeds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@x.io", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{
+		NonInteractive: true,
+		Stdout:         &stdout,
+		Stderr:         &bytes.Buffer{},
+	}
+	opts.SetAPIClient(client)
+
+	err = runDelete(context.Background(), opts, "TST", true)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "Deleted project TST")
 }

--- a/tools/jtk/internal/cmd/root/backend_wire_test.go
+++ b/tools/jtk/internal/cmd/root/backend_wire_test.go
@@ -43,6 +43,49 @@ func TestWireBackendSelection_FlagSet(t *testing.T) {
 	}
 }
 
+// TestWireBackendSelection_NonInteractiveFlagThreaded — the
+// --non-interactive root flag is folded into WireBackendSelection so
+// any shadowing subcommand (dashboards/boards/automation/sprints) that
+// calls WireBackendSelection at the top of its PersistentPreRunE also
+// gets the non-interactive wire. Pins that coupling.
+func TestWireBackendSelection_NonInteractiveFlagThreaded(t *testing.T) {
+	keyring.SetBackendSelection("", "")
+	keyring.SetNonInteractive(false)
+	defer keyring.SetBackendSelection("", "")
+	defer keyring.SetNonInteractive(false)
+
+	rootCmd, _ := NewCmd()
+	sub := newProbeCmd("probe")
+	rootCmd.AddCommand(sub)
+	rootCmd.SetArgs([]string{"probe", "--non-interactive"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !keyring.GetNonInteractive() {
+		t.Fatal("WireBackendSelection must thread --non-interactive into the keyring package state")
+	}
+}
+
+// TestWireBackendSelection_NonInteractiveDefaultsFalse — without the
+// flag, the keyring package state must stay false (no accidental flip).
+func TestWireBackendSelection_NonInteractiveDefaultsFalse(t *testing.T) {
+	keyring.SetBackendSelection("", "")
+	keyring.SetNonInteractive(false)
+	defer keyring.SetBackendSelection("", "")
+	defer keyring.SetNonInteractive(false)
+
+	rootCmd, _ := NewCmd()
+	sub := newProbeCmd("probe")
+	rootCmd.AddCommand(sub)
+	rootCmd.SetArgs([]string{"probe"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if keyring.GetNonInteractive() {
+		t.Fatal("absence of --non-interactive must leave keyring state false")
+	}
+}
+
 // TestWireBackendSelection_FlagInvalid asserts a bogus --backend value
 // returns an error wrapping ErrBackendNotImplemented.
 func TestWireBackendSelection_FlagInvalid(t *testing.T) {

--- a/tools/jtk/internal/cmd/root/root.go
+++ b/tools/jtk/internal/cmd/root/root.go
@@ -27,14 +27,15 @@ var ErrAlreadyReported = errors.New("already reported")
 
 // Options contains global options for commands
 type Options struct {
-	NoColor  bool
-	Extended bool // --extended: include admin/schema/audit fields.
-	FullText bool // --fulltext: disable truncation of descriptions/comments.
-	IDOnly   bool // --id: emit only the primary identifier; takes precedence over Extended/FullText.
-	Verbose  bool
-	Stdin    io.Reader
-	Stdout   io.Writer
-	Stderr   io.Writer
+	NoColor        bool
+	Extended       bool // --extended: include admin/schema/audit fields.
+	FullText       bool // --fulltext: disable truncation of descriptions/comments.
+	IDOnly         bool // --id: emit only the primary identifier; takes precedence over Extended/FullText.
+	Verbose        bool
+	NonInteractive bool // --non-interactive (§3.4): never prompt; fail loud on missing required values.
+	Stdin          io.Reader
+	Stdout         io.Writer
+	Stderr         io.Writer
 
 	// testClient is used for testing; if set, APIClient() returns this instead
 	testClient *api.Client
@@ -149,6 +150,7 @@ func NewCmd() (*cobra.Command, *Options) {
 	cmd.PersistentFlags().BoolVar(&opts.FullText, "fulltext", false, "Disable truncation of descriptions and comments")
 	cmd.PersistentFlags().BoolVar(&opts.IDOnly, "id", false, "Emit only the primary identifier (takes precedence over --extended and --fulltext)")
 	cmd.PersistentFlags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Log each request's method/URL, JSON body, and any 4xx/5xx response body (each capped at 4 KB)")
+	cmd.PersistentFlags().BoolVar(&opts.NonInteractive, "non-interactive", false, "Never prompt; fail loud naming any required value missing from flags/env/stdin (§3.4)")
 	cmd.PersistentFlags().String(cccredstore.BackendFlagName, "", cccredstore.BackendFlagUsage())
 
 	return cmd, opts
@@ -159,6 +161,14 @@ func NewCmd() (*cobra.Command, *Options) {
 // persistent flag) and the keyring.backend config key, validates them
 // via credstore.BindBackendFlag, and pushes the result into
 // shared/keyring's package-level state for every subsequent Open*.
+//
+// It ALSO threads the --non-interactive root flag into shared/keyring's
+// package state so the file-backend passphrase callback fails loud
+// under --non-interactive even on a real TTY (§3.4). Folded into a
+// single chokepoint because cobra does NOT chain PersistentPreRunE: a
+// shadowing subcommand (jtk has four — dashboards, boards, automation,
+// sprints) that calls WireBackendSelection gets BOTH wires; splitting
+// them risks one wire missing on those paths.
 //
 // Exported because cobra does NOT chain PersistentPreRunE — a
 // subcommand that defines its own PersistentPreRunE silently shadows
@@ -195,6 +205,16 @@ func WireBackendSelection(cmd *cobra.Command) error {
 		return fmt.Errorf("--%s: %w", cccredstore.BackendFlagName, err)
 	}
 	keyring.SetBackendSelection(opts.Backend, opts.ConfigBackend)
+
+	// §3.4: thread --non-interactive into the keyring package state so
+	// the file-backend passphrase callback fails loud under
+	// --non-interactive regardless of TTY.
+	var nonInteractive bool
+	if nif := cmd.Flag("non-interactive"); nif != nil {
+		nonInteractive = nif.Value.String() == "true"
+	}
+	keyring.SetNonInteractive(nonInteractive)
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Add `--non-interactive` as a **persistent root flag** to both jtk and cfl per `cli-common/docs/scriptability.md` §3.4/§4.1. The flag makes every interactive prompt fail loud with an actionable error rather than blocking on stdin or silently cancelling.

Companion to PR #393 (set-credential surface): `set-credential` was already scriptable; `--non-interactive` makes `init` and every destructive-confirm command scriptable too.

### Gated prompt sites (15 total)

- **Init wizards** (jtk + cfl): skip the huh form, fail loud naming the first missing required field. cfl's token error points to `cfl set-credential` since cfl init has no `--token` flag.
- **Sibling-impact confirm** (init): proceed with an info line on stderr (user opted in by running `--non-interactive` against the shared store).
- **Legacy-cleanup confirm** (init): skip both prompt AND deletion — non-destructive default; legacy files stay in place for manual cleanup.
- **All 11 destructive-confirm sites** (jtk: issues/projects/automation/fields×3/configcmd; cfl: page/space/attachment/configcmd): adopt new `prompt.ConfirmOrFail(force, nonInteractive, stdin)` helper. Without `--force` they return `prompt.ErrConfirmationRequired` ("re-run with --force to proceed"). Prompt-text emission is also gated on `!NonInteractive` so CI logs see neither "Are you sure?" nor the warning text.
- **File-backend passphrase prompt**: a new package-level `keyring.GetNonInteractive()` makes the callback fail loud asking for `ATLASSIAN_CLI_KEYRING_PASSPHRASE` rather than prompting on a real TTY.

### Wiring

`--non-interactive` is folded into the existing `WireBackendSelection` chokepoint (rather than a separate `WireNonInteractive`) because jtk has four shadowing `PersistentPreRunE` subcommands (dashboards, boards, automation, sprints) that already remember to call `WireBackendSelection`. One chokepoint = both wires; a regression test pins this coupling so a future split is loud.

### Helper extension

`shared/prompt/` gains:
- `WantPrompt(nonInteractive, stdin) bool` — true only when interactive AND TTY-stdin
- `ConfirmOrFail(force, nonInteractive, stdin) (bool, error)` — `--force` short-circuits, otherwise `--non-interactive` returns the new `ErrConfirmationRequired` sentinel, otherwise prompts via existing `Confirm`
- `ErrConfirmationRequired` sentinel — text IS the actionable hint

This places the gate next to the existing `Confirm`/`ConfirmOrForce` so a future cli-common extraction (tracked separately as cli-common#32) lands in one place.

## Test plan

- [x] `shared/prompt/confirm_test.go` — `ConfirmOrFail` matrix (force / nonInteractive / interactive) + `WantPrompt` matrix (nonInteractive × TTY/non-TTY)
- [x] `shared/keyring/passphrase_test.go` — `--non-interactive` flips the file-backend prompt to fail-loud even on a real TTY
- [x] `tools/jtk/internal/cmd/initcmd/initcmd_test.go` — `requireNonInteractiveFields` table covering each (basic/bearer × missing field) case + end-to-end `runInit` tests asserting the fail-loud messages for missing `--url` and missing `--token`
- [x] `tools/cfl/internal/cmd/init/init_test.go` — symmetric matrix; cfl's missing-token error directs the user to `set-credential` (no `--token` flag exists)
- [x] `tools/jtk/internal/cmd/issues/delete_test.go` — destructive-confirm regression: `--non-interactive` without `--force` returns `ErrConfirmationRequired` with empty stdout AND stderr; `--non-interactive` with `--force` still proceeds
- [x] `tools/jtk/internal/cmd/root/backend_wire_test.go` — pins the WireBackendSelection coupling: `--non-interactive` on the root flag must populate `keyring.GetNonInteractive()` even on subcommands; absence keeps it false
- [x] `make lint` clean across `shared/`, `tools/cfl/`, `tools/jtk/`
- [x] Full test suite passes