### PR TITLE
feat(init): §1.5.1 secret-ingress hardening for jtk + cfl init (#390)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,16 @@ who *permanently* exports the token via env therefore keeps the plaintext
 file until they run `init`/`set-credential` — env is an explicit runtime
 override, so a read path is never forced to mutate disk behind it.
 
+**Init token-ingress (§1.5.1):** both `jtk init` and `cfl init` accept
+`--token-stdin` (drain stdin) and `--token-from-env VAR` (read env) as
+the canonical scripted ingress paths. Explicit ingress wins over the
+keyring backfill (token-rotation contract). `jtk init --token <value>`
+is deprecated — flag-passed plaintext leaks into shell history and
+process listings — and prints a §1.5.1 deprecation warning to stderr
+when used; it will be removed in a future release. `cfl init` never had
+`--token`. The canonical scripted shape: `op read 'op://Vault/token' |
+<tool> init --non-interactive --url ... --email ... --token-stdin`.
+
 **Non-interactive ingress (§1.5.2):** `cfl set-credential` / `jtk set-credential`
 read a token from `--stdin` or `--from-env VAR` (exactly one; mutually
 exclusive) and store it in the keyring (never echoed). `--key` is always

--- a/shared/prompt/secretingress.go
+++ b/shared/prompt/secretingress.go
@@ -1,0 +1,46 @@
+package prompt
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// ReadSecretFromIngress returns the token from exactly one of stdin
+// (when useStdin is true) or the named env var (when fromEnv is
+// non-empty), trimmed and validated non-empty. Returns ("", nil) when
+// neither ingress is configured so the caller can fall through to the
+// next resolution step (keyring backfill, interactive form, or §3.4
+// non-interactive fail).
+//
+// The token is never echoed; the value never appears in any returned
+// error message. Symmetric to keyring.readToken (which lives in
+// shared/keyring with the write-context and stays unexported there).
+func ReadSecretFromIngress(stdin io.Reader, useStdin bool, fromEnv string) (string, error) {
+	switch {
+	case useStdin && fromEnv != "":
+		return "", errors.New("--token-stdin and --token-from-env are mutually exclusive; pick one")
+	case useStdin:
+		if stdin == nil {
+			return "", errors.New("--token-stdin set but stdin reader is nil")
+		}
+		b, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", fmt.Errorf("read API token from stdin: %w", err)
+		}
+		token := strings.TrimSpace(string(b))
+		if token == "" {
+			return "", errors.New("refusing to store an empty API token (stdin)")
+		}
+		return token, nil
+	case fromEnv != "":
+		v, ok := os.LookupEnv(fromEnv)
+		if !ok || strings.TrimSpace(v) == "" {
+			return "", fmt.Errorf("environment variable %s is unset or empty", fromEnv)
+		}
+		return strings.TrimSpace(v), nil
+	}
+	return "", nil
+}

--- a/shared/prompt/secretingress_test.go
+++ b/shared/prompt/secretingress_test.go
@@ -1,0 +1,163 @@
+package prompt
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+const ingressSentinel = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAingressSentinel"
+
+func TestReadSecretFromIngress_StdinHappy(t *testing.T) {
+	t.Parallel()
+	got, err := ReadSecretFromIngress(strings.NewReader("  "+ingressSentinel+"\n  "), true, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ingressSentinel {
+		t.Fatalf("got %q, want %q", got, ingressSentinel)
+	}
+}
+
+func TestReadSecretFromIngress_EnvHappy(t *testing.T) {
+	t.Setenv("INGRESS_TEST_VAR", "  "+ingressSentinel+"  ")
+	got, err := ReadSecretFromIngress(nil, false, "INGRESS_TEST_VAR")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ingressSentinel {
+		t.Fatalf("got %q, want %q", got, ingressSentinel)
+	}
+}
+
+func TestReadSecretFromIngress_BothRejected(t *testing.T) {
+	t.Setenv("INGRESS_TEST_VAR", "x")
+	_, err := ReadSecretFromIngress(strings.NewReader("y"), true, "INGRESS_TEST_VAR")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error must mention mutual exclusion, got %v", err)
+	}
+}
+
+func TestReadSecretFromIngress_NeitherReturnsEmptyNilErr(t *testing.T) {
+	t.Parallel()
+	got, err := ReadSecretFromIngress(nil, false, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty pass-through, got %q", got)
+	}
+}
+
+func TestReadSecretFromIngress_StdinWhitespaceRejected(t *testing.T) {
+	t.Parallel()
+	_, err := ReadSecretFromIngress(strings.NewReader("   \n  "), true, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("error must mention empty, got %v", err)
+	}
+}
+
+func TestReadSecretFromIngress_EnvUnsetRejected(t *testing.T) {
+	t.Setenv("INGRESS_UNSET_VAR", "")
+	_, err := ReadSecretFromIngress(nil, false, "INGRESS_UNSET_VAR")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "INGRESS_UNSET_VAR") {
+		t.Fatalf("error must name the var, got %v", err)
+	}
+}
+
+func TestReadSecretFromIngress_StdinNilRejected(t *testing.T) {
+	t.Parallel()
+	_, err := ReadSecretFromIngress(nil, true, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestReadSecretFromIngress_StdinReadErrSurfaces — io.ReadAll errors
+// (non-EOF) must propagate without leaking the partial value.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("boom") }
+
+func TestReadSecretFromIngress_StdinReadErrSurfaces(t *testing.T) {
+	t.Parallel()
+	_, err := ReadSecretFromIngress(errReader{}, true, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "read API token") {
+		t.Fatalf("error must wrap the read context, got %v", err)
+	}
+}
+
+func TestReadSecretFromIngress_NeverEmitsSecret_AllPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		seed func(t *testing.T)
+		opts struct {
+			stdin    io.Reader
+			useStdin bool
+			fromEnv  string
+		}
+	}{
+		{
+			name: "happy-stdin",
+			opts: struct {
+				stdin    io.Reader
+				useStdin bool
+				fromEnv  string
+			}{stdin: strings.NewReader(ingressSentinel), useStdin: true},
+		},
+		{
+			name: "happy-env",
+			seed: func(t *testing.T) { t.Setenv("INGRESS_LEAK_VAR", ingressSentinel) },
+			opts: struct {
+				stdin    io.Reader
+				useStdin bool
+				fromEnv  string
+			}{fromEnv: "INGRESS_LEAK_VAR"},
+		},
+		{
+			name: "fail-both-sources",
+			seed: func(t *testing.T) { t.Setenv("INGRESS_LEAK_VAR", ingressSentinel) },
+			opts: struct {
+				stdin    io.Reader
+				useStdin bool
+				fromEnv  string
+			}{stdin: strings.NewReader(ingressSentinel), useStdin: true, fromEnv: "INGRESS_LEAK_VAR"},
+		},
+		{
+			name: "fail-empty-stdin",
+			opts: struct {
+				stdin    io.Reader
+				useStdin bool
+				fromEnv  string
+			}{stdin: strings.NewReader("    "), useStdin: true},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.seed != nil {
+				tc.seed(t)
+			}
+			got, err := ReadSecretFromIngress(tc.opts.stdin, tc.opts.useStdin, tc.opts.fromEnv)
+			// On failure paths, returned err must not leak the secret.
+			if err != nil && strings.Contains(err.Error(), ingressSentinel) {
+				t.Fatalf("error leaked sentinel: %v", err)
+			}
+			// On the happy path got holds the secret intentionally; no leak
+			// assertion against got is meaningful there.
+			_ = got
+		})
+	}
+}

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -148,12 +148,15 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail s
 	// so a returning user isn't forced to re-enter a just-migrated
 	// token. NoMigrate: migration already ran. Value stays
 	// password-masked in the form; never displayed.
-	// --token-stdin without --non-interactive drains stdin before the
-	// interactive form would read from it, causing every subsequent
-	// prompt to EOF. The canonical usage always pairs the two; reject
-	// the partial form loudly.
-	if tokenStdin && !opts.NonInteractive {
-		return errors.New("--token-stdin requires --non-interactive (otherwise the interactive form's prompts EOF on a drained stdin)")
+	// --token-stdin drains stdin before the interactive form would read
+	// from it. This only matters when the form would actually run —
+	// i.e., a real TTY with no --non-interactive. Piped stdin is already
+	// non-TTY (WantPrompt=false), so canonical CI usage
+	// `op read | cfl init --token-stdin ...` passes through here without
+	// requiring --non-interactive. Only reject the TTY + --token-stdin
+	// + interactive combo, where the form's first read would EOF.
+	if tokenStdin && prompt.WantPrompt(opts.NonInteractive, opts.Stdin) {
+		return errors.New("--token-stdin from a TTY conflicts with the interactive form; pipe stdin or pass --non-interactive")
 	}
 
 	// §1.5.1 token-ingress: explicit --token-stdin / --token-from-env

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -147,21 +147,22 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail s
 	// so a returning user isn't forced to re-enter a just-migrated
 	// token. NoMigrate: migration already ran. Value stays
 	// password-masked in the form; never displayed.
-	if cfg.APIToken == "" {
-		if tok, _, terr := keyring.ResolveTokenNoMigrate(credstore.ToolCFL); terr == nil {
-			cfg.APIToken = tok
-		}
-	}
-
 	// §1.5.1 token-ingress: explicit --token-stdin / --token-from-env
-	// override the keyring backfill (token-rotation contract — a user
-	// must be able to re-run init with the new token to replace a stale
+	// win over the keyring backfill (token-rotation contract — a user
+	// must be able to re-run init with a new token to replace a stale
 	// keyring entry). Mutual exclusion + empty-value validation happen
-	// inside ReadSecretFromIngress.
+	// inside ReadSecretFromIngress. Resolve BEFORE the keyring read so
+	// the read is skipped when explicit ingress provides the value.
 	if scripted, terr := prompt.ReadSecretFromIngress(opts.Stdin, tokenStdin, tokenFromEnv); terr != nil {
 		return terr
 	} else if scripted != "" {
 		cfg.APIToken = scripted
+	}
+
+	if cfg.APIToken == "" {
+		if tok, _, terr := keyring.ResolveTokenNoMigrate(credstore.ToolCFL); terr == nil {
+			cfg.APIToken = tok
+		}
 	}
 
 	// Determine auth method for form building

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -148,6 +148,13 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail s
 	// so a returning user isn't forced to re-enter a just-migrated
 	// token. NoMigrate: migration already ran. Value stays
 	// password-masked in the form; never displayed.
+	// Mutual exclusion fires first so the more specific "pick one" error
+	// wins over the more general TTY conflict guard below. cfl has no
+	// --token flag, so only the --token-stdin/--token-from-env pair.
+	if tokenStdin && tokenFromEnv != "" {
+		return errors.New("--token-stdin and --token-from-env are mutually exclusive; pick one")
+	}
+
 	// --token-stdin drains stdin before the interactive form would read
 	// from it. This only matters when the form would actually run —
 	// i.e., a real TTY with no --non-interactive. Piped stdin is already

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -40,11 +40,13 @@ func Register(rootCmd *cobra.Command, opts *root.Options) {
 // newInitCmd creates the init command.
 func newInitCmd(opts *root.Options) *cobra.Command {
 	var (
-		url        string
-		email      string
-		authMethod string
-		cloudID    string
-		noVerify   bool
+		url          string
+		email        string
+		tokenStdin   bool
+		tokenFromEnv string
+		authMethod   string
+		cloudID      string
+		noVerify     bool
 	)
 
 	cmd := &cobra.Command{
@@ -62,22 +64,35 @@ For classic API tokens (basic auth):
 
 For service account scoped tokens (bearer auth):
   Use --auth-method bearer with your scoped API token and Cloud ID.
-  Find your Cloud ID at: https://your-site.atlassian.net/_edge/tenant_info`,
+  Find your Cloud ID at: https://your-site.atlassian.net/_edge/tenant_info
+
+Scripted ingress (§1.5.1): use --token-stdin or --token-from-env VAR for
+the API token. cfl init has never had a --token <value> flag because
+flag-passed plaintext secrets leak into shell history and process
+listings.`,
 		Example: `  # Interactive setup (basic auth)
   cfl init
 
-  # Pre-populate URL
-  cfl init --url https://mycompany.atlassian.net
+  # Non-interactive setup via stdin pipe (§1.10 idiom)
+  op read 'op://Vault/Atlassian/token' | cfl init --non-interactive \
+    --url https://mycompany.atlassian.net --email user@example.com --token-stdin
+
+  # Non-interactive setup via env var
+  cfl init --non-interactive \
+    --url https://mycompany.atlassian.net --email user@example.com --token-from-env CFL_API_TOKEN
 
   # Service account (bearer auth) setup
-  cfl init --auth-method bearer --url https://mycompany.atlassian.net --cloud-id YOUR_CLOUD_ID`,
+  cfl init --auth-method bearer --url https://mycompany.atlassian.net \
+    --token-from-env CFL_API_TOKEN --cloud-id YOUR_CLOUD_ID`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runInit(cmd.Context(), opts, url, email, authMethod, cloudID, noVerify)
+			return runInit(cmd.Context(), opts, url, email, tokenStdin, tokenFromEnv, authMethod, cloudID, noVerify)
 		},
 	}
 
 	cmd.Flags().StringVar(&url, "url", "", "Confluence URL (e.g., https://mycompany.atlassian.net)")
 	cmd.Flags().StringVar(&email, "email", "", "Your Atlassian account email")
+	cmd.Flags().BoolVar(&tokenStdin, "token-stdin", false, "Read the API token from stdin (xor with --token-from-env)")
+	cmd.Flags().StringVar(&tokenFromEnv, "token-from-env", "", "Read the API token from this env var (xor with --token-stdin)")
 	cmd.Flags().StringVar(&authMethod, "auth-method", "", "Authentication method: basic (default) or bearer")
 	cmd.Flags().StringVar(&cloudID, "cloud-id", "", "Atlassian Cloud ID (required for bearer auth)")
 	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "Skip connection verification")
@@ -85,7 +100,7 @@ For service account scoped tokens (bearer auth):
 	return cmd
 }
 
-func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, prefillAuthMethod, prefillCloudID string, noVerify bool) error {
+func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail string, tokenStdin bool, tokenFromEnv, prefillAuthMethod, prefillCloudID string, noVerify bool) error {
 	v := opts.View()
 
 	// Validate --auth-method flag early, before any interactive prompts
@@ -136,6 +151,17 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 		if tok, _, terr := keyring.ResolveTokenNoMigrate(credstore.ToolCFL); terr == nil {
 			cfg.APIToken = tok
 		}
+	}
+
+	// §1.5.1 token-ingress: explicit --token-stdin / --token-from-env
+	// override the keyring backfill (token-rotation contract — a user
+	// must be able to re-run init with the new token to replace a stale
+	// keyring entry). Mutual exclusion + empty-value validation happen
+	// inside ReadSecretFromIngress.
+	if scripted, terr := prompt.ReadSecretFromIngress(opts.Stdin, tokenStdin, tokenFromEnv); terr != nil {
+		return terr
+	} else if scripted != "" {
+		cfg.APIToken = scripted
 	}
 
 	// Determine auth method for form building
@@ -403,7 +429,7 @@ func requireNonInteractiveFields(cfg *config.Config, isBearer bool) error {
 		}
 	}
 	if cfg.APIToken == "" {
-		return fmt.Errorf("--non-interactive: no API token (cfl init has no --token flag; pre-stage with `cfl set-credential --ref atlassian-cli/default --key api_token --stdin`)")
+		return fmt.Errorf("--non-interactive: missing required value for --token-stdin or --token-from-env VAR (or pre-stage with `cfl set-credential --ref atlassian-cli/default --key api_token --stdin`)")
 	}
 	return nil
 }

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -3,6 +3,7 @@ package init
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -147,6 +148,14 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail s
 	// so a returning user isn't forced to re-enter a just-migrated
 	// token. NoMigrate: migration already ran. Value stays
 	// password-masked in the form; never displayed.
+	// --token-stdin without --non-interactive drains stdin before the
+	// interactive form would read from it, causing every subsequent
+	// prompt to EOF. The canonical usage always pairs the two; reject
+	// the partial form loudly.
+	if tokenStdin && !opts.NonInteractive {
+		return errors.New("--token-stdin requires --non-interactive (otherwise the interactive form's prompts EOF on a drained stdin)")
+	}
+
 	// §1.5.1 token-ingress: explicit --token-stdin / --token-from-env
 	// win over the keyring backfill (token-rotation contract — a user
 	// must be able to re-run init with a new token to replace a stale

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -119,7 +119,7 @@ func TestRunInit_InvalidAuthMethod(t *testing.T) {
 		Stdout:  &bytes.Buffer{},
 		Stderr:  &bytes.Buffer{},
 	}
-	err := runInit(context.Background(), opts, "", "", "Bearer", "", true)
+	err := runInit(context.Background(), opts, "", "", false, "", "Bearer", "", true)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "invalid auth method")
 }
@@ -188,7 +188,7 @@ func TestRunInit_NonInteractive_MissingURL_Fails(t *testing.T) {
 		Stdout:         &bytes.Buffer{},
 		Stderr:         &bytes.Buffer{},
 	}
-	err := runInit(context.Background(), opts, "", "", "", "", true)
+	err := runInit(context.Background(), opts, "", "", false, "", "", "", true)
 	testutil.RequireError(t, err)
 	if !strings.Contains(err.Error(), "--non-interactive") || !strings.Contains(err.Error(), "--url") {
 		t.Fatalf("expected --non-interactive missing --url error, got: %v", err)
@@ -208,7 +208,7 @@ func TestRunInit_NonInteractive_MissingToken_DirectsToSetCredential(t *testing.T
 		Stdout:         &bytes.Buffer{},
 		Stderr:         &bytes.Buffer{},
 	}
-	err := runInit(context.Background(), opts, "https://acme.atlassian.net", "u@x.io", "", "", true)
+	err := runInit(context.Background(), opts, "https://acme.atlassian.net", "u@x.io", false, "", "", "", true)
 	testutil.RequireError(t, err)
 	if !strings.Contains(err.Error(), "set-credential") {
 		t.Fatalf("error must direct user to set-credential, got: %v", err)
@@ -508,4 +508,103 @@ func TestFinalizeInit_NoVerify(t *testing.T) {
 
 	_, err = os.Stat(configPath)
 	testutil.RequireNoError(t, err)
+}
+
+const cflInitSentinel = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcflInitTok"
+
+// TestRunInit_TokenStdin_PopulatesAPIToken — under --non-interactive,
+// --token-stdin populates cfg.APIToken so the run proceeds without
+// requiring a pre-staged keyring entry.
+func TestRunInit_TokenStdin_PopulatesAPIToken(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(cflInitSentinel + "\n"),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", true, "", "", "", true)
+	testutil.RequireNoError(t, err)
+}
+
+// TestRunInit_TokenFromEnv_PopulatesAPIToken — same with --token-from-env.
+func TestRunInit_TokenFromEnv_PopulatesAPIToken(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("CFL_INIT_TOKEN_VAR", cflInitSentinel)
+	opts := &root.Options{
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", false, "CFL_INIT_TOKEN_VAR", "", "", true)
+	testutil.RequireNoError(t, err)
+}
+
+// TestRunInit_TokenStdinAndFromEnv_Fails — mutual exclusion.
+func TestRunInit_TokenStdinAndFromEnv_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("CFL_INIT_TOKEN_VAR", cflInitSentinel)
+	opts := &root.Options{
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(cflInitSentinel),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", true, "CFL_INIT_TOKEN_VAR", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error must mention mutual exclusion, got: %v", err)
+	}
+}
+
+// TestRunInit_TokenStdinEmpty_Fails — empty stdin is rejected.
+func TestRunInit_TokenStdinEmpty_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader("   \n  "),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", true, "", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("error must mention empty, got: %v", err)
+	}
+}
+
+// TestRunInit_TokenStdinOverridesKeyring — explicit ingress wins over
+// keyring backfill (token-rotation contract).
+func TestRunInit_TokenStdinOverridesKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "stale-token-from-keyring")
+
+	opts := &root.Options{
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(cflInitSentinel + "\n"),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", true, "", "", "", true)
+	testutil.RequireNoError(t, err)
+
+	got, _, rerr := keyring.ResolveTokenNoMigrate(credstore.ToolCFL)
+	testutil.RequireNoError(t, rerr)
+	testutil.Equal(t, cflInitSentinel, got)
 }

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -614,3 +614,24 @@ func TestRunInit_TokenStdinOverridesKeyring(t *testing.T) {
 	testutil.RequireNoError(t, rerr)
 	testutil.Equal(t, cflInitSentinel, got)
 }
+
+// TestRunInit_TokenStdinWithoutNonInteractive_Fails — mirrors the jtk
+// guard: --token-stdin drains stdin, so without --non-interactive the
+// subsequent form prompts would EOF. Rejected loudly.
+func TestRunInit_TokenStdinWithoutNonInteractive_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: false,
+		Stdin:          strings.NewReader(cflInitSentinel),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", true, "", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "--token-stdin requires --non-interactive") {
+		t.Fatalf("error must explain the --non-interactive requirement, got: %v", err)
+	}
+}

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -615,23 +615,22 @@ func TestRunInit_TokenStdinOverridesKeyring(t *testing.T) {
 	testutil.Equal(t, cflInitSentinel, got)
 }
 
-// TestRunInit_TokenStdinWithoutNonInteractive_Fails — mirrors the jtk
-// guard: --token-stdin drains stdin, so without --non-interactive the
-// subsequent form prompts would EOF. Rejected loudly.
-func TestRunInit_TokenStdinWithoutNonInteractive_Fails(t *testing.T) {
+// TestRunInit_TokenStdinPipedStdin_NoNonInteractiveRequired — mirrors
+// the jtk test: canonical CI usage `op read | cfl init --token-stdin ...`
+// pipes stdin (non-TTY), so WantPrompt is false and the form skips
+// regardless of --non-interactive. The TTY-only guard does NOT fire on
+// a piped stdin.
+func TestRunInit_TokenStdinPipedStdin_NoNonInteractiveRequired(t *testing.T) {
 	credtest.Hermetic(t)
 	opts := &root.Options{
 		Output:         "table",
 		NoColor:        true,
 		NonInteractive: false,
-		Stdin:          strings.NewReader(cflInitSentinel),
+		Stdin:          strings.NewReader(cflInitSentinel + "\n"),
 		Stdout:         &bytes.Buffer{},
 		Stderr:         &bytes.Buffer{},
 	}
 	err := runInit(context.Background(), opts,
 		"https://acme.atlassian.net", "u@x.io", true, "", "", "", true)
-	testutil.RequireError(t, err)
-	if !strings.Contains(err.Error(), "--token-stdin requires --non-interactive") {
-		t.Fatalf("error must explain the --non-interactive requirement, got: %v", err)
-	}
+	testutil.RequireNoError(t, err)
 }

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -125,29 +125,30 @@ func TestRunInit_InvalidAuthMethod(t *testing.T) {
 }
 
 // TestRequireNonInteractiveFields_NamesFirstMissing — cfl variant.
-// Critically, the token error names `cfl set-credential` rather than
-// `--token` because cfl init has no --token flag.
+// The token error must recommend --token-stdin / --token-from-env (added
+// in #390) first AND name `cfl set-credential` as the alternate
+// pre-stage path.
 func TestRequireNonInteractiveFields_NamesFirstMissing(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string
 		cfg      *config.Config
 		isBearer bool
-		want     string
+		wants    []string
 	}{
-		{"basic — missing URL", &config.Config{}, false, "--url"},
-		{"basic — missing email", &config.Config{URL: "https://acme.atlassian.net"}, false, "--email"},
-		{"bearer — missing cloud-id", &config.Config{URL: "https://acme.atlassian.net"}, true, "--cloud-id"},
+		{"basic — missing URL", &config.Config{}, false, []string{"--url"}},
+		{"basic — missing email", &config.Config{URL: "https://acme.atlassian.net"}, false, []string{"--email"}},
+		{"bearer — missing cloud-id", &config.Config{URL: "https://acme.atlassian.net"}, true, []string{"--cloud-id"}},
 		{
-			name: "basic — missing token directs to set-credential",
-			cfg:  &config.Config{URL: "https://acme.atlassian.net", Email: "u@x.io"},
-			want: "set-credential",
+			name:  "basic — missing token recommends --token-stdin + --token-from-env + set-credential",
+			cfg:   &config.Config{URL: "https://acme.atlassian.net", Email: "u@x.io"},
+			wants: []string{"--token-stdin", "--token-from-env", "set-credential"},
 		},
 		{
-			name:     "bearer — missing token directs to set-credential",
+			name:     "bearer — missing token recommends --token-stdin + --token-from-env + set-credential",
 			cfg:      &config.Config{URL: "https://acme.atlassian.net", CloudID: "cid"},
 			isBearer: true,
-			want:     "set-credential",
+			wants:    []string{"--token-stdin", "--token-from-env", "set-credential"},
 		},
 	}
 	for _, tc := range tests {
@@ -158,8 +159,10 @@ func TestRequireNonInteractiveFields_NamesFirstMissing(t *testing.T) {
 			if !strings.Contains(err.Error(), "--non-interactive") {
 				t.Fatalf("error must mention --non-interactive: %v", err)
 			}
-			if !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("error must mention %s, got %v", tc.want, err)
+			for _, want := range tc.wants {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error must mention %s, got %v", want, err)
+				}
 			}
 		})
 	}
@@ -195,10 +198,11 @@ func TestRunInit_NonInteractive_MissingURL_Fails(t *testing.T) {
 	}
 }
 
-// TestRunInit_NonInteractive_MissingToken_DirectsToSetCredential — cfl
-// has no --token flag so the fail-loud hint points to the canonical
-// pre-staging path.
-func TestRunInit_NonInteractive_MissingToken_DirectsToSetCredential(t *testing.T) {
+// TestRunInit_NonInteractive_MissingToken_RecommendsAllPaths — cfl
+// init has no --token flag; the §1.5.1 fail-loud hint must recommend
+// --token-stdin / --token-from-env (added in this PR) AND point to
+// `cfl set-credential` as the alternate pre-stage path.
+func TestRunInit_NonInteractive_MissingToken_RecommendsAllPaths(t *testing.T) {
 	credtest.Hermetic(t)
 	opts := &root.Options{
 		Output:         "table",
@@ -210,8 +214,10 @@ func TestRunInit_NonInteractive_MissingToken_DirectsToSetCredential(t *testing.T
 	}
 	err := runInit(context.Background(), opts, "https://acme.atlassian.net", "u@x.io", false, "", "", "", true)
 	testutil.RequireError(t, err)
-	if !strings.Contains(err.Error(), "set-credential") {
-		t.Fatalf("error must direct user to set-credential, got: %v", err)
+	for _, want := range []string{"--token-stdin", "--token-from-env", "set-credential"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error must mention %s, got: %v", want, err)
+		}
 	}
 }
 

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -9,6 +9,7 @@ package initcmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -28,8 +29,8 @@ import (
 
 // Register registers the init command
 func Register(parent *cobra.Command, opts *root.Options) {
-	var url, email, token, authMethod, cloudID string
-	var noVerify bool
+	var url, email, token, tokenFromEnv, authMethod, cloudID string
+	var tokenStdin, noVerify bool
 
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -44,26 +45,39 @@ For classic API tokens (basic auth):
 
 For service account scoped tokens (bearer auth):
   Use --auth-method bearer with your scoped API token and Cloud ID.
-  Find your Cloud ID at: https://your-site.atlassian.net/_edge/tenant_info`,
+  Find your Cloud ID at: https://your-site.atlassian.net/_edge/tenant_info
+
+Scripted ingress (§1.5.1): use --token-stdin or --token-from-env VAR for
+the API token. The legacy --token <value> flag is deprecated — it leaks
+the secret into shell history and process listings — and will be removed
+in a future release.`,
 		Example: `  # Interactive setup (basic auth)
   jtk init
 
-  # Non-interactive basic auth setup
-  jtk init --url https://mycompany.atlassian.net --email user@example.com --token YOUR_TOKEN
+  # Non-interactive basic auth setup via stdin pipe (§1.10 idiom)
+  op read 'op://Vault/Atlassian/token' | jtk init --non-interactive \
+    --url https://mycompany.atlassian.net --email user@example.com --token-stdin
+
+  # Non-interactive setup via env var
+  jtk init --non-interactive \
+    --url https://mycompany.atlassian.net --email user@example.com --token-from-env JIRA_API_TOKEN
 
   # Service account (bearer auth) setup
-  jtk init --auth-method bearer --url https://mycompany.atlassian.net --token SCOPED_TOKEN --cloud-id YOUR_CLOUD_ID
+  jtk init --auth-method bearer --url https://mycompany.atlassian.net \
+    --token-from-env JIRA_API_TOKEN --cloud-id YOUR_CLOUD_ID
 
   # Skip connection verification
   jtk init --no-verify`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runInit(cmd.Context(), opts, url, email, token, authMethod, cloudID, noVerify)
+			return runInit(cmd.Context(), opts, url, email, token, tokenStdin, tokenFromEnv, authMethod, cloudID, noVerify)
 		},
 	}
 
 	cmd.Flags().StringVar(&url, "url", "", "Jira URL (e.g., https://mycompany.atlassian.net)")
 	cmd.Flags().StringVar(&email, "email", "", "Email address for authentication")
-	cmd.Flags().StringVar(&token, "token", "", "API token")
+	cmd.Flags().StringVar(&token, "token", "", "DEPRECATED: API token literal (use --token-stdin or --token-from-env; §1.5.1)")
+	cmd.Flags().BoolVar(&tokenStdin, "token-stdin", false, "Read the API token from stdin (xor with --token-from-env)")
+	cmd.Flags().StringVar(&tokenFromEnv, "token-from-env", "", "Read the API token from this env var (xor with --token-stdin)")
 	cmd.Flags().StringVar(&authMethod, "auth-method", "", "Authentication method: basic (default) or bearer")
 	cmd.Flags().StringVar(&cloudID, "cloud-id", "", "Atlassian Cloud ID (required for bearer auth)")
 	cmd.Flags().BoolVar(&noVerify, "no-verify", false, "Skip connection verification")
@@ -71,7 +85,7 @@ For service account scoped tokens (bearer auth):
 	parent.AddCommand(cmd)
 }
 
-func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, prefillToken, prefillAuthMethod, prefillCloudID string, noVerify bool) error {
+func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, prefillToken string, tokenStdin bool, tokenFromEnv, prefillAuthMethod, prefillCloudID string, noVerify bool) error {
 	// Validate --auth-method flag early, before any interactive prompts
 	if prefillAuthMethod != "" {
 		if err := auth.ValidateAuthMethod(prefillAuthMethod); err != nil {
@@ -80,6 +94,31 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	}
 
 	v := opts.View()
+
+	// §1.5.1 token-ingress resolution. Explicit ingress flags win over
+	// the keyring backfill below (token-rotation contract: a user must
+	// be able to re-run init --token-stdin to replace a stale value).
+	// Mutual exclusion + empty-value validation happen here.
+	switch {
+	case tokenStdin && prefillToken != "":
+		return errors.New("--token and --token-stdin are mutually exclusive; pick one (and prefer --token-stdin — §1.5.1)")
+	case tokenFromEnv != "" && prefillToken != "":
+		return errors.New("--token and --token-from-env are mutually exclusive; pick one (and prefer --token-from-env — §1.5.1)")
+	}
+	if scripted, err := prompt.ReadSecretFromIngress(opts.Stdin, tokenStdin, tokenFromEnv); err != nil {
+		return err
+	} else if scripted != "" {
+		prefillToken = scripted
+	} else if prefillToken != "" {
+		// User passed the deprecated --token <value> flag. Print the
+		// §1.5.1 deprecation warning to stderr before proceeding so the
+		// signal lands even when the run later errors for an unrelated
+		// reason.
+		fmt.Fprintln(opts.Stderr,
+			"warning: --token is deprecated and will be removed in a future release; "+
+				"use --token-stdin or --token-from-env VAR to avoid leaking the secret "+
+				"via shell history / process listings (cli-common §1.5.1).")
+	}
 
 	sharedPath, err := credstore.DefaultPath()
 	if err != nil {
@@ -365,7 +404,7 @@ func requireNonInteractiveFields(cfg *config.Config, isBearer bool) error {
 		}
 	}
 	if cfg.APIToken == "" {
-		return fmt.Errorf("--non-interactive: missing required value for --token (or pre-stage with `jtk set-credential --ref atlassian-cli/default --key api_token --stdin`)")
+		return fmt.Errorf("--non-interactive: missing required value for --token-stdin or --token-from-env VAR (or pre-stage with `jtk set-credential --ref atlassian-cli/default --key api_token --stdin`)")
 	}
 	return nil
 }

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -105,6 +105,13 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	case tokenFromEnv != "" && prefillToken != "":
 		return errors.New("--token and --token-from-env are mutually exclusive; pick one (and prefer --token-from-env — §1.5.1)")
 	}
+	// --token-stdin without --non-interactive drains stdin before the
+	// interactive form would read from it, causing every subsequent
+	// prompt to EOF. The canonical usage always pairs the two; reject
+	// the partial form loudly.
+	if tokenStdin && !opts.NonInteractive {
+		return errors.New("--token-stdin requires --non-interactive (otherwise the interactive form's prompts EOF on a drained stdin)")
+	}
 	if scripted, err := prompt.ReadSecretFromIngress(opts.Stdin, tokenStdin, tokenFromEnv); err != nil {
 		return err
 	} else if scripted != "" {

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -98,8 +98,12 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	// §1.5.1 token-ingress resolution. Explicit ingress flags win over
 	// the keyring backfill below (token-rotation contract: a user must
 	// be able to re-run init --token-stdin to replace a stale value).
-	// Mutual exclusion + empty-value validation happen here.
+	// Mutual exclusion + empty-value validation happen here. Mutual-
+	// exclusion checks MUST precede the TTY guard so the more specific
+	// "pick one" error wins over the more general TTY conflict.
 	switch {
+	case tokenStdin && tokenFromEnv != "":
+		return errors.New("--token-stdin and --token-from-env are mutually exclusive; pick one")
 	case tokenStdin && prefillToken != "":
 		return errors.New("--token and --token-stdin are mutually exclusive; pick one (and prefer --token-stdin — §1.5.1)")
 	case tokenFromEnv != "" && prefillToken != "":

--- a/tools/jtk/internal/cmd/initcmd/initcmd.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd.go
@@ -105,12 +105,15 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail, 
 	case tokenFromEnv != "" && prefillToken != "":
 		return errors.New("--token and --token-from-env are mutually exclusive; pick one (and prefer --token-from-env — §1.5.1)")
 	}
-	// --token-stdin without --non-interactive drains stdin before the
-	// interactive form would read from it, causing every subsequent
-	// prompt to EOF. The canonical usage always pairs the two; reject
-	// the partial form loudly.
-	if tokenStdin && !opts.NonInteractive {
-		return errors.New("--token-stdin requires --non-interactive (otherwise the interactive form's prompts EOF on a drained stdin)")
+	// --token-stdin drains stdin before the interactive form would read
+	// from it. This only matters when the form would actually run —
+	// i.e., a real TTY with no --non-interactive. Piped stdin is already
+	// non-TTY (WantPrompt=false), so canonical CI usage
+	// `op read | jtk init --token-stdin ...` passes through here without
+	// requiring --non-interactive. Only reject the TTY + --token-stdin
+	// + interactive combo, where the form's first read would EOF.
+	if tokenStdin && prompt.WantPrompt(opts.NonInteractive, opts.Stdin) {
+		return errors.New("--token-stdin from a TTY conflicts with the interactive form; pipe stdin or pass --non-interactive")
 	}
 	if scripted, err := prompt.ReadSecretFromIngress(opts.Stdin, tokenStdin, tokenFromEnv); err != nil {
 		return err

--- a/tools/jtk/internal/cmd/initcmd/initcmd_test.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd_test.go
@@ -76,37 +76,34 @@ func TestRequireNonInteractiveFields_NamesFirstMissing(t *testing.T) {
 		name     string
 		cfg      *config.Config
 		isBearer bool
-		want     string
+		wants    []string
 	}{
 		{
-			name:     "basic auth — missing URL",
-			cfg:      &config.Config{},
-			isBearer: false,
-			want:     "--url",
+			name:  "basic auth — missing URL",
+			cfg:   &config.Config{},
+			wants: []string{"--url"},
 		},
 		{
-			name:     "basic auth — missing email",
-			cfg:      &config.Config{URL: "https://acme.atlassian.net"},
-			isBearer: false,
-			want:     "--email",
+			name:  "basic auth — missing email",
+			cfg:   &config.Config{URL: "https://acme.atlassian.net"},
+			wants: []string{"--email"},
 		},
 		{
 			name:     "bearer — missing cloud-id",
 			cfg:      &config.Config{URL: "https://acme.atlassian.net"},
 			isBearer: true,
-			want:     "--cloud-id",
+			wants:    []string{"--cloud-id"},
 		},
 		{
-			name:     "basic auth — missing token recommends --token-stdin",
-			cfg:      &config.Config{URL: "https://acme.atlassian.net", Email: "u@x.io"},
-			isBearer: false,
-			want:     "--token-stdin",
+			name:  "basic auth — missing token recommends --token-stdin + --token-from-env + set-credential",
+			cfg:   &config.Config{URL: "https://acme.atlassian.net", Email: "u@x.io"},
+			wants: []string{"--token-stdin", "--token-from-env", "set-credential"},
 		},
 		{
-			name:     "bearer — missing token recommends --token-stdin",
+			name:     "bearer — missing token recommends --token-stdin + --token-from-env + set-credential",
 			cfg:      &config.Config{URL: "https://acme.atlassian.net", CloudID: "cid"},
 			isBearer: true,
-			want:     "--token-stdin",
+			wants:    []string{"--token-stdin", "--token-from-env", "set-credential"},
 		},
 	}
 	for _, tc := range tests {
@@ -117,8 +114,10 @@ func TestRequireNonInteractiveFields_NamesFirstMissing(t *testing.T) {
 			if !strings.Contains(err.Error(), "--non-interactive: missing") {
 				t.Fatalf("error must mention --non-interactive prefix: %v", err)
 			}
-			if !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("error must name %s, got %v", tc.want, err)
+			for _, want := range tc.wants {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error must name %s, got %v", want, err)
+				}
 			}
 		})
 	}
@@ -409,5 +408,48 @@ func TestRunInit_TokenFromEnv_NoDeprecationWarning(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	if strings.Contains(stderr.String(), "deprecated") {
 		t.Fatalf("--token-from-env must NOT trigger the --token deprecation warning: %q", stderr.String())
+	}
+}
+
+// TestRunInit_TokenStdinAndTokenFromEnv_Fails — both new flags set
+// (without --token) must hit the helper's mutual-exclusion guard.
+// Pinned at the jtk integration layer so a jtk-specific short-circuit
+// regression that bypassed ReadSecretFromIngress would be loud.
+func TestRunInit_TokenStdinAndTokenFromEnv_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("JTK_BOTH_VAR", initSentinel)
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(initSentinel),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "", true, "JTK_BOTH_VAR", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error must mention mutual exclusion, got: %v", err)
+	}
+}
+
+// TestRunInit_TokenStdinWithoutNonInteractive_Fails — --token-stdin
+// drains stdin before the interactive form would read from it, so the
+// combination is loudly rejected rather than silently failing later
+// with EOF on the first prompt.
+func TestRunInit_TokenStdinWithoutNonInteractive_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: false, // intentionally not the canonical pair
+		Stdin:          strings.NewReader(initSentinel),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "", true, "", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "--token-stdin requires --non-interactive") {
+		t.Fatalf("error must explain the --non-interactive requirement, got: %v", err)
 	}
 }

--- a/tools/jtk/internal/cmd/initcmd/initcmd_test.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd_test.go
@@ -433,23 +433,23 @@ func TestRunInit_TokenStdinAndTokenFromEnv_Fails(t *testing.T) {
 	}
 }
 
-// TestRunInit_TokenStdinWithoutNonInteractive_Fails — --token-stdin
-// drains stdin before the interactive form would read from it, so the
-// combination is loudly rejected rather than silently failing later
-// with EOF on the first prompt.
-func TestRunInit_TokenStdinWithoutNonInteractive_Fails(t *testing.T) {
+// TestRunInit_TokenStdinPipedStdin_NoNonInteractiveRequired — the
+// canonical CI usage `op read | jtk init --token-stdin --url ... --email ...`
+// pipes stdin (non-TTY), which makes WantPrompt false and skips the
+// huh form. --non-interactive is therefore NOT required for piped
+// usage; the guard only fires when stdin IS a real TTY (would-be
+// interactive form). Pinned so a future regression that re-tightens
+// the guard to require --non-interactive unconditionally is loud.
+func TestRunInit_TokenStdinPipedStdin_NoNonInteractiveRequired(t *testing.T) {
 	credtest.Hermetic(t)
 	opts := &root.Options{
 		NoColor:        true,
-		NonInteractive: false, // intentionally not the canonical pair
-		Stdin:          strings.NewReader(initSentinel),
+		NonInteractive: false, // intentionally — pipe is non-TTY, WantPrompt is false
+		Stdin:          strings.NewReader(initSentinel + "\n"),
 		Stdout:         &bytes.Buffer{},
 		Stderr:         &bytes.Buffer{},
 	}
 	err := runInit(context.Background(), opts,
 		"https://acme.atlassian.net", "u@x.io", "", true, "", "", "", true)
-	testutil.RequireError(t, err)
-	if !strings.Contains(err.Error(), "--token-stdin requires --non-interactive") {
-		t.Fatalf("error must explain the --non-interactive requirement, got: %v", err)
-	}
+	testutil.RequireNoError(t, err)
 }

--- a/tools/jtk/internal/cmd/initcmd/initcmd_test.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd_test.go
@@ -97,16 +97,16 @@ func TestRequireNonInteractiveFields_NamesFirstMissing(t *testing.T) {
 			want:     "--cloud-id",
 		},
 		{
-			name:     "basic auth — missing token",
+			name:     "basic auth — missing token recommends --token-stdin",
 			cfg:      &config.Config{URL: "https://acme.atlassian.net", Email: "u@x.io"},
 			isBearer: false,
-			want:     "--token",
+			want:     "--token-stdin",
 		},
 		{
-			name:     "bearer — missing token",
+			name:     "bearer — missing token recommends --token-stdin",
 			cfg:      &config.Config{URL: "https://acme.atlassian.net", CloudID: "cid"},
 			isBearer: true,
-			want:     "--token",
+			want:     "--token-stdin",
 		},
 	}
 	for _, tc := range tests {
@@ -157,8 +157,9 @@ func TestRunInit_NonInteractive_MissingURL_Fails(t *testing.T) {
 }
 
 // TestRunInit_NonInteractive_MissingToken_FlagAndKeyringEmpty — the
-// fail-loud hint must point to `jtk set-credential` when the user has
-// neither --token nor a pre-staged keyring entry.
+// fail-loud hint must point to --token-stdin / --token-from-env first
+// (the §1.5.1 canonical scripted shape) with `jtk set-credential` as
+// the alternate pre-stage path.
 func TestRunInit_NonInteractive_MissingToken_FlagAndKeyringEmpty(t *testing.T) {
 	credtest.Hermetic(t)
 	opts := &root.Options{
@@ -170,8 +171,11 @@ func TestRunInit_NonInteractive_MissingToken_FlagAndKeyringEmpty(t *testing.T) {
 	}
 	err := runInit(context.Background(), opts, "https://acme.atlassian.net", "u@x.io", "", false, "", "", "", true)
 	testutil.RequireError(t, err)
-	if !strings.Contains(err.Error(), "--token") {
-		t.Fatalf("error must hint at --token, got: %v", err)
+	if !strings.Contains(err.Error(), "--token-stdin") {
+		t.Fatalf("error must hint at --token-stdin, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--token-from-env") {
+		t.Fatalf("error must hint at --token-from-env, got: %v", err)
 	}
 	if !strings.Contains(err.Error(), "set-credential") {
 		t.Fatalf("error must hint at set-credential pre-staging, got: %v", err)

--- a/tools/jtk/internal/cmd/initcmd/initcmd_test.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/credtest"
+	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/spf13/cobra"
 
@@ -53,7 +55,7 @@ func TestRunInit_InvalidAuthMethod(t *testing.T) {
 		Stderr:  &bytes.Buffer{},
 	}
 	// An invalid auth method should be rejected before the interactive form runs
-	err := runInit(context.Background(), opts, "", "", "", "Bearer", "", true)
+	err := runInit(context.Background(), opts, "", "", "", false, "", "Bearer", "", true)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "invalid auth method")
 }
@@ -147,7 +149,7 @@ func TestRunInit_NonInteractive_MissingURL_Fails(t *testing.T) {
 		Stdout:         &bytes.Buffer{},
 		Stderr:         &bytes.Buffer{},
 	}
-	err := runInit(context.Background(), opts, "", "", "", "", "", true)
+	err := runInit(context.Background(), opts, "", "", "", false, "", "", "", true)
 	testutil.RequireError(t, err)
 	if !strings.Contains(err.Error(), "--non-interactive") || !strings.Contains(err.Error(), "--url") {
 		t.Fatalf("expected --non-interactive missing --url error, got: %v", err)
@@ -166,7 +168,7 @@ func TestRunInit_NonInteractive_MissingToken_FlagAndKeyringEmpty(t *testing.T) {
 		Stdout:         &bytes.Buffer{},
 		Stderr:         &bytes.Buffer{},
 	}
-	err := runInit(context.Background(), opts, "https://acme.atlassian.net", "u@x.io", "", "", "", true)
+	err := runInit(context.Background(), opts, "https://acme.atlassian.net", "u@x.io", "", false, "", "", "", true)
 	testutil.RequireError(t, err)
 	if !strings.Contains(err.Error(), "--token") {
 		t.Fatalf("error must hint at --token, got: %v", err)
@@ -213,4 +215,141 @@ func TestInitCommand_Flags(t *testing.T) {
 	cloudIDFlag := initCmd.Flags().Lookup("cloud-id")
 	testutil.NotNil(t, cloudIDFlag)
 	testutil.Equal(t, "", cloudIDFlag.DefValue)
+}
+
+const initSentinel = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAjtkInitTok"
+
+// TestRunInit_TokenStdin_PopulatesAPIToken — under --non-interactive,
+// --token-stdin populates cfg.APIToken and the run proceeds without
+// touching the form.
+func TestRunInit_TokenStdin_PopulatesAPIToken(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(initSentinel + "\n"),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "", true, "", "", "", true)
+	testutil.RequireNoError(t, err)
+}
+
+// TestRunInit_TokenFromEnv_PopulatesAPIToken — same with --token-from-env.
+func TestRunInit_TokenFromEnv_PopulatesAPIToken(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("JTK_INIT_TOKEN_VAR", initSentinel)
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "", false, "JTK_INIT_TOKEN_VAR", "", "", true)
+	testutil.RequireNoError(t, err)
+}
+
+// TestRunInit_TokenAndTokenStdin_Fails — mutual exclusion.
+func TestRunInit_TokenAndTokenStdin_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		NoColor: true,
+		Stdin:   strings.NewReader(initSentinel),
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "tok-value", true, "", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error must mention mutual exclusion, got: %v", err)
+	}
+}
+
+// TestRunInit_TokenAndTokenFromEnv_Fails — mutual exclusion.
+func TestRunInit_TokenAndTokenFromEnv_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("JTK_INIT_TOKEN_VAR", initSentinel)
+	opts := &root.Options{
+		NoColor: true,
+		Stdin:   strings.NewReader(""),
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "tok-value", false, "JTK_INIT_TOKEN_VAR", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error must mention mutual exclusion, got: %v", err)
+	}
+}
+
+// TestRunInit_TokenStdinEmpty_Fails — empty stdin is rejected.
+func TestRunInit_TokenStdinEmpty_Fails(t *testing.T) {
+	credtest.Hermetic(t)
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader("   \n  "),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "", true, "", "", "", true)
+	testutil.RequireError(t, err)
+	if !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("error must mention empty, got: %v", err)
+	}
+}
+
+// TestRunInit_DeprecatedTokenFlag_PrintsWarning — --token <value>
+// triggers the §1.5.1 deprecation warning to stderr before the run
+// proceeds. Asserts the exact prefix so future regressions are loud.
+func TestRunInit_DeprecatedTokenFlag_PrintsWarning(t *testing.T) {
+	credtest.Hermetic(t)
+	var stderr bytes.Buffer
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &stderr,
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "tok-value", false, "", "", "", true)
+	testutil.RequireNoError(t, err)
+	if !strings.Contains(stderr.String(), "warning: --token is deprecated") {
+		t.Fatalf("stderr must contain deprecation warning, got: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "§1.5.1") {
+		t.Fatalf("stderr deprecation must reference §1.5.1, got: %q", stderr.String())
+	}
+}
+
+// TestRunInit_TokenStdinOverridesKeyring — explicit ingress wins over
+// keyring backfill. Pre-stage a different value, run with --token-stdin,
+// assert the keyring ends up with the NEW value (token-rotation
+// contract).
+func TestRunInit_TokenStdinOverridesKeyring(t *testing.T) {
+	credtest.Hermetic(t)
+	credtest.SeedToken(t, "stale-token-from-keyring")
+
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(initSentinel + "\n"),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "", true, "", "", "", true)
+	testutil.RequireNoError(t, err)
+
+	// Assert via the resolver chain that the new value landed.
+	got, _, rerr := keyring.ResolveTokenNoMigrate(credstore.ToolJTK)
+	testutil.RequireNoError(t, rerr)
+	testutil.Equal(t, initSentinel, got)
 }

--- a/tools/jtk/internal/cmd/initcmd/initcmd_test.go
+++ b/tools/jtk/internal/cmd/initcmd/initcmd_test.go
@@ -337,6 +337,16 @@ func TestRunInit_DeprecatedTokenFlag_PrintsWarning(t *testing.T) {
 // keyring backfill. Pre-stage a different value, run with --token-stdin,
 // assert the keyring ends up with the NEW value (token-rotation
 // contract).
+//
+// What this pins: the user-visible rotation outcome.
+// What this does NOT pin: the keyring-read side effect (whether
+// ResolveTokenNoMigrate was called). The production code's guard is
+// `if cfg.APIToken == ""` which only triggers the keyring backfill
+// when ingress didn't fire. A regression that swapped the order
+// (backfill first, then ingress overwrites) would still pass this test
+// because the final value is the same. Pinning the side-effect would
+// require instrumentation on shared/keyring; that's a separate
+// follow-up. The user-facing contract is what matters here.
 func TestRunInit_TokenStdinOverridesKeyring(t *testing.T) {
 	credtest.Hermetic(t)
 	credtest.SeedToken(t, "stale-token-from-keyring")
@@ -356,4 +366,48 @@ func TestRunInit_TokenStdinOverridesKeyring(t *testing.T) {
 	got, _, rerr := keyring.ResolveTokenNoMigrate(credstore.ToolJTK)
 	testutil.RequireNoError(t, rerr)
 	testutil.Equal(t, initSentinel, got)
+}
+
+// TestRunInit_TokenStdin_NoDeprecationWarning — --token-stdin is the
+// canonical §1.5.1 path; it MUST NOT trigger the --token deprecation
+// warning. A regression that emitted the warning for the new flags
+// would confuse users into thinking the recommended flag was also
+// deprecated.
+func TestRunInit_TokenStdin_NoDeprecationWarning(t *testing.T) {
+	credtest.Hermetic(t)
+	var stderr bytes.Buffer
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(initSentinel + "\n"),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &stderr,
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "", true, "", "", "", true)
+	testutil.RequireNoError(t, err)
+	if strings.Contains(stderr.String(), "deprecated") {
+		t.Fatalf("--token-stdin must NOT trigger the --token deprecation warning: %q", stderr.String())
+	}
+}
+
+// TestRunInit_TokenFromEnv_NoDeprecationWarning — same for
+// --token-from-env.
+func TestRunInit_TokenFromEnv_NoDeprecationWarning(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("JTK_DEPRECATION_NEG_VAR", initSentinel)
+	var stderr bytes.Buffer
+	opts := &root.Options{
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(""),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &stderr,
+	}
+	err := runInit(context.Background(), opts,
+		"https://acme.atlassian.net", "u@x.io", "", false, "JTK_DEPRECATION_NEG_VAR", "", "", true)
+	testutil.RequireNoError(t, err)
+	if strings.Contains(stderr.String(), "deprecated") {
+		t.Fatalf("--token-from-env must NOT trigger the --token deprecation warning: %q", stderr.String())
+	}
 }


### PR DESCRIPTION
## Summary

Add `--token-stdin` and `--token-from-env VAR` to both `jtk init` and `cfl init` per cli-common scriptability §1.5.1; deprecate `jtk init --token <value>` with a stderr warning.

Builds on PR #394 (`--non-interactive`): under `--non-interactive`, the new flags are now the canonical token source. Together they make `op read 'op://Vault/token' | <tool> init --non-interactive --url ... --email ... --token-stdin` work end-to-end on both tools.

### Behavior

- `--token-stdin` (bool): drain stdin, trim, reject empty.
- `--token-from-env VAR` (string): read named env var, trim, reject empty/unset.
- `--token <value>` (jtk, deprecated): prints `warning: --token is deprecated...` to stderr referencing §1.5.1; flag stays visible in `--help` for one release.
- **Mutual exclusion**: at most one of the three (jtk) / two (cfl) token-ingress flags. Pre-keyring validation surfaces the error before any side effect.
- **Precedence**: explicit ingress flag → keyring backfill → interactive form → §3.4 fail-loud. Critical: explicit ingress wins over keyring so a user can rotate a stale token by re-running init with the new value.

### #391 message updates

The non-interactive missing-token errors landed in PR #394 now recommend `--token-stdin`/`--token-from-env VAR` first; `set-credential` remains the alternate pre-stage path.

### Helper

`prompt.ReadSecretFromIngress(stdin, useStdin, fromEnv)` lives in `shared/prompt/` next to the existing input-policy helpers (`WantPrompt`, `ConfirmOrFail`). Returns `("", nil)` when neither ingress is configured so the caller can fall through; never echoes the value into errors.

## Test plan

- [x] `shared/prompt/secretingress_test.go` — happy/both-rejected/neither/empty-stdin/env-unset/read-error/sentinel-leak matrix
- [x] `tools/jtk/internal/cmd/initcmd/initcmd_test.go` — TokenStdin/TokenFromEnv happy paths + mutual exclusion + empty-stdin + deprecation-warning shape + **TokenStdinOverridesKeyring** (token-rotation contract pin via `credtest.SeedToken` + `keyring.ResolveTokenNoMigrate`)
- [x] `tools/cfl/internal/cmd/init/init_test.go` — symmetric matrix (no deprecation test since cfl has no `--token`)
- [x] Existing `requireNonInteractiveFields` tests still pass — the updated messages include both `--token` substring and `set-credential` substring (covering both old assertions)
- [x] `make lint` clean across `shared/`, `tools/cfl/`, `tools/jtk/`
- [x] Full test suite passes