### PR TITLE
cfl: remove resource-read -o json (BREAKING) [#392]

### DIFF
--- a/docs/ARTIFACT_CONTRACT.md
+++ b/docs/ARTIFACT_CONTRACT.md
@@ -60,7 +60,7 @@ Some commands expose a `--raw` mode for source-faithful content where transforma
 
 ## Output Format
 
-JTK uses text-first output. The `-o json/plain/table` flag has been removed from JTK (CFL retains it). JTK commands render through presenters; `automation export` is the only command that emits JSON directly.
+JTK and CFL both use text-first output. The `-o json` resource surface has been removed from both tools (JTK earlier, then CFL via #392); CFL retains `-o table` and `-o plain` only. Both tools render through presenters; JSON is reserved for control-plane envelopes (`cfl set-credential --json`, `jtk set-credential --json`) and round-trip payloads (`jtk automation export`).
 
 **Text output modes:**
 - Default = focused output for human and agent consumption (defined per-command)

--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -231,10 +231,6 @@ cfl me
 # Show only the account ID (for scripting)
 cfl me --id
 # → 60e09bae7fcd820073089249
-
-# -o json falls through to the one-liner — there is no JSON representation of `cfl me`.
-cfl me -o json
-# → 60e09bae7fcd820073089249 | Rian Stockbower | rian@example.com
 ```
 
 | Flag | Short | Default | Description |
@@ -253,7 +249,7 @@ List Confluence spaces.
 cfl space list
 cfl space list --type global
 cfl space list --type personal
-cfl space list -l 50 -o json
+cfl space list -l 50
 ```
 
 | Flag | Short | Default | Description |
@@ -273,7 +269,6 @@ List pages in a space.
 cfl page list --space DEV
 cfl page list -s DEV -l 50
 cfl page list -s DEV --status archived
-cfl page list -s DEV -o json
 ```
 
 | Flag | Short | Default | Description |
@@ -292,7 +287,6 @@ View a Confluence page. **Content is displayed as markdown by default.**
 cfl page view 12345
 cfl page view 12345 --raw
 cfl page view 12345 --web
-cfl page view 12345 -o json
 cfl page view 12345 --content-only             # Output only content (no headers)
 cfl page view 12345 --show-macros --content-only | cfl page edit 12345 --legacy  # Roundtrip with macros
 ```
@@ -402,7 +396,7 @@ cfl page edit 12345 --file content.md --legacy
 echo "<p>Updated</p>" | cfl page edit 12345 --storage
 
 # Extract, transform, and re-upload storage-format content
-cfl page view 12345 --output json | jq -r '.body.storage.value' | \
+cfl page view 12345 --raw --content-only | \
   sed 's/old/new/g' | cfl page edit 12345 --storage
 ```
 
@@ -497,9 +491,6 @@ cfl search "kubernetes" --space DEV --type page --label infrastructure
 
 # Raw CQL for power users (find pages modified in last 7 days)
 cfl search --cql "type=page AND space=DEV AND lastModified > now('-7d')"
-
-# Output as JSON for scripting
-cfl search "config" -o json
 ```
 
 | Flag | Short | Default | Description |
@@ -581,7 +572,6 @@ List attachments on a page.
 ```bash
 cfl attachment list --page 12345
 cfl attachment list -p 12345 -l 50
-cfl attachment list -p 12345 -o json
 
 # List unused (orphaned) attachments not referenced in page content
 cfl attachment list --page 12345 --unused
@@ -881,9 +871,14 @@ Use `--output` or `-o` to change output format:
 
 ```bash
 cfl space list -o table  # Default: human-readable table
-cfl space list -o json   # JSON for scripting/automation
 cfl space list -o plain  # Tab-separated for piping to other tools
 ```
+
+**Breaking change (#392):** resource `-o json` has been removed. JSON is
+reserved for control-plane envelopes per cli-common
+`docs/output-and-rendering.md` §2. The surviving JSON surface is
+[`cfl set-credential --json`](#cfl-set-credential), which emits a §1.5.2
+write-confirmation envelope for scripted credential rotation.
 
 ---
 

--- a/tools/cfl/chaos-testing.md
+++ b/tools/cfl/chaos-testing.md
@@ -3,6 +3,12 @@
 **Started:** 2026-01-03
 **Focus:** Read-only operations (list, view, download)
 
+> **Historical note (#392):** The `-o json` rows below describe behavior from
+> a session that pre-dates the removal of resource-read JSON. As of #392 the
+> closed set is `{table, plain}`; the `-o json` and `-o yaml` rows below are
+> no longer reproducible — both now error at the root with the same
+> "invalid output format" message.
+
 ---
 
 ## Bugs Found

--- a/tools/cfl/integration-tests.md
+++ b/tools/cfl/integration-tests.md
@@ -63,7 +63,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 |-----------|---------|-----------------|
 | List pages in space | `cfl page list --space confluence` | Shows table of pages with ID, title, status, version |
 | List with limit | `cfl page list --space confluence --limit 5` | Shows only 5 pages with "showing first N results" message |
-| JSON output | `cfl page list --space confluence --output json` | Valid JSON array |
+| ~~JSON output~~ (#392 removed) | `cfl page list --space confluence --output json` | Valid JSON array |
 | Plain output | `cfl page list --space confluence --output plain` | Tab-separated values |
 | List trashed pages | `cfl page list --space confluence --status trashed` | Shows deleted pages |
 | List archived pages | `cfl page list --space confluence --status archived` | Shows archived pages |
@@ -75,13 +75,13 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 |-----------|---------|-----------------|
 | View page content | `cfl page view <page-id>` | Shows title, ID, version, and markdown content |
 | View raw HTML | `cfl page view <page-id> --raw` | Shows Confluence storage format (XHTML) |
-| JSON output | `cfl page view <page-id> --output json` | Full page object as JSON |
+| ~~JSON output~~ (#392 removed) | `cfl page view <page-id> --output json` | Full page object as JSON |
 | Non-existent page | `cfl page view 99999999999` | Error: 404 not found |
 | View content only | `cfl page view <id> --content-only` | Markdown only, no Title/ID/Version headers |
 | Content only with raw | `cfl page view <id> --content-only --raw` | XHTML only, no headers |
 | Content only with macros | `cfl page view <id> --content-only --show-macros` | Markdown with [TOC] etc., no headers |
 | Roundtrip macros (content-only) | `cfl page view <id> --show-macros --content-only \| cfl page edit <id> --legacy` | Macros preserved |
-| Content only JSON error | `cfl page view <id> --content-only -o json` | Error: incompatible flags |
+| ~~Content only JSON error~~ (#392 removed; -o json itself errors before --content-only checks) | `cfl page view <id> --content-only -o json` | Errors: invalid output format |
 | Content only web error | `cfl page view <id> --content-only --web` | Error: incompatible flags |
 
 ### page create
@@ -154,7 +154,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 |-----------|---------|-----------------|
 | List attachments | `cfl attachment list --page <id>` | Table of attachments with ID, title, type, size |
 | No attachments | List on page with none | "No attachments found" |
-| JSON output | `cfl attachment list --page <id> --output json` | Valid JSON array with full attachment metadata |
+| ~~JSON output~~ (#392 removed) | `cfl attachment list --page <id> --output json` | Valid JSON array with full attachment metadata |
 | List unused attachments | `cfl attachment list --page <id> --unused` | Only attachments not referenced in page content |
 | No unused attachments | `--unused` on page using all attachments | "No unused attachments found" |
 
@@ -198,7 +198,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Test Case | Command | Expected Result |
 |-----------|---------|-----------------|
 | List all spaces | `cfl space list` | Table of spaces with key, name, type |
-| JSON output | `cfl space list --output json` | Valid JSON array |
+| ~~JSON output~~ (#392 removed) | `cfl space list --output json` | Valid JSON array |
 | Limit results | `cfl space list --limit 5` | Shows first 5 spaces |
 
 ### space view
@@ -206,7 +206,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Test Case | Command | Expected Result |
 |-----------|---------|-----------------|
 | View space by key | `cfl space view confluence` | Key-value pairs: KEY, NAME, ID, TYPE, STATUS, DESCRIPTION |
-| JSON output | `cfl space view confluence -o json` | Valid JSON object with id, key, name, type, status, description |
+| ~~JSON output~~ (#392 removed) | `cfl space view confluence -o json` | Valid JSON object with id, key, name, type, status, description |
 | Non-existent space | `cfl space view NONEXISTENT` | Error: Space with key 'NONEXISTENT' not found |
 | View personal space | `cfl space view ~accountid` | Shows personal space details (if accessible) |
 | Alias: get | `cfl space get confluence` | Same output as `space view` |
@@ -216,7 +216,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Test Case | Command | Expected Result |
 |-----------|---------|-----------------|
 | Create global space | `cfl space create --key INTTEST --name "[Test] Integration" --description "Test space"` | Space created, shows KEY, NAME, URL |
-| Create with JSON output | `cfl space create --key INTTEST2 --name "[Test] Int2" -o json` | Valid JSON with id, key, name, type |
+| ~~Create with JSON output~~ (#392 removed) | `cfl space create --key INTTEST2 --name "[Test] Int2" -o json` | Valid JSON with id, key, name, type |
 | Missing key flag | `cfl space create --name "Test"` | Error: required flag(s) "key" not set |
 | Missing name flag | `cfl space create --key TST` | Error: required flag(s) "name" not set |
 | Duplicate key | `cfl space create --key INTTEST --name "Duplicate"` (after creating INTTEST) | Error: API rejects duplicate key |
@@ -228,7 +228,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Update name | `cfl space update INTTEST --name "[Test] Updated Name"` | Shows updated key and name |
 | Update description | `cfl space update INTTEST --description "Updated description"` | Shows updated key and name |
 | Update both | `cfl space update INTTEST --name "[Test] Both" --description "Both updated"` | Both name and description changed |
-| JSON output | `cfl space update INTTEST --name "[Test] JSON" -o json` | Valid JSON with updated fields |
+| ~~JSON output~~ (#392 removed) | `cfl space update INTTEST --name "[Test] JSON" -o json` | Valid JSON with updated fields |
 | No flags provided | `cfl space update INTTEST` | Error: at least one of --name or --description required |
 | Non-existent space | `cfl space update NONEXISTENT --name "X"` | Error: not found |
 | Verify update | `cfl space view INTTEST` | Shows new name and description |
@@ -240,7 +240,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Delete with confirmation | `cfl space delete INTTEST` (type "y") | Space deleted after confirmation prompt |
 | Delete cancelled | `cfl space delete INTTEST` (type "n") | "Deletion cancelled" message |
 | Delete with --force | `cfl space delete INTTEST --force` | Space deleted without confirmation |
-| JSON output | `cfl space delete INTTEST --force -o json` | `{"status": "deleted", "space_key": "INTTEST", "name": "..."}` |
+| ~~JSON output~~ (#392 removed) | `cfl space delete INTTEST --force -o json` | `{"status": "deleted", "space_key": "INTTEST", "name": "..."}` |
 | Non-existent space | `cfl space delete NONEXISTENT --force` | Error: not found |
 
 ### Space CRUD End-to-End (sequential)
@@ -252,7 +252,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | 3. Update name | `cfl space update INTTEST --name "[Test] Updated"` | Name updated |
 | 4. Verify update | `cfl space view INTTEST` | Shows new name |
 | 5. Update desc | `cfl space update INTTEST --description "New description"` | Description updated |
-| 6. List includes it | `cfl space list -o json \| jq '.[] \| select(.key == "INTTEST")'` | Space appears in list |
+| 6. List includes it | `cfl space list \| grep INTTEST` | Space appears in list (was `-o json \| jq` pre-#392) |
 | 7. Delete | `cfl space delete INTTEST --force` | "Deleted space INTTEST" |
 | 8. Verify gone | `cfl space view INTTEST` | Error: not found |
 
@@ -271,7 +271,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Search by label | `cfl search --label test-label` | Content with specified label |
 | Combined filters | `cfl search "deploy" --space DEV --type page` | Filtered results |
 | Raw CQL | `cfl search --cql "type=page AND space=DEV"` | CQL executed directly |
-| JSON output | `cfl search "test" -o json` | Valid JSON with results and _meta |
+| ~~JSON output~~ (#392 removed) | `cfl search "test" -o json` | Valid JSON with results and _meta |
 | Plain output | `cfl search "test" -o plain` | Tab-separated values |
 | Limit results | `cfl search "test" --limit 5` | Max 5 results |
 | No results | `cfl search "xyznonexistent123"` | "No results found" message |
@@ -533,7 +533,7 @@ Copies in the TEST space (originals from INT, CUS, PROD, PLAYBOOK):
 |-----------|---------|-----------------|
 | View ADF page (default) | `cfl page view <adf-id>` | Shows markdown content (not "(No content)") |
 | View ADF page (raw) | `cfl page view <adf-id> --raw` | Shows raw XHTML (or ADF JSON if storage was empty) |
-| View ADF page (JSON) | `cfl page view <adf-id> -o json` | `body.storage` populated (or `body.atlas_doc_format` if storage was empty) |
+| ~~View ADF page (JSON)~~ (#392 removed) | `cfl page view <adf-id> -o json` | Errors: invalid output format |
 | View ADF page (content-only) | `cfl page view <adf-id> --content-only` | Shows content without headers |
 | View legacy page (no regression) | `cfl page view <legacy-id>` | Shows markdown content via storage path |
 
@@ -580,7 +580,7 @@ Copies in the TEST space (originals from INT, CUS, PROD, PLAYBOOK):
 | Format | Flag | Verified With |
 |--------|------|---------------|
 | Table (default) | (none) | Visual inspection |
-| JSON | `--output json` | `jq .` parsing |
+| ~~JSON~~ (#392 removed) | `--output json` | errors at root |
 | Plain | `--output plain` | Tab-separated, scriptable |
 
 ---
@@ -622,7 +622,7 @@ All cfl commands work with both auth methods (no scope restrictions for Confluen
 #### ADF Body Fallback (#150)
 - [ ] View ADF page with empty storage → content displayed via ADF fallback
 - [ ] View ADF page (raw) → shows ADF JSON
-- [ ] View ADF page (JSON output) → body.atlas_doc_format populated
+- [ ] ~~View ADF page (JSON output)~~ (#392 removed)
 - [ ] Edit ADF page (title only) → ADF body preserved
 - [ ] Edit ADF page (new content) → submitted as ADF
 - [ ] View/edit legacy page → no regression (storage path used)
@@ -648,15 +648,15 @@ All cfl commands work with both auth methods (no scope restrictions for Confluen
 - [ ] Full-text search returns results
 - [ ] Space filter works
 - [ ] Type filter works
-- [ ] JSON output is valid
+- [ ] ~~JSON output is valid~~ (#392 removed; -o json errors at root)
 - [ ] Raw CQL works
 
 #### Space CRUD
 - [ ] View space (table output)
-- [ ] View space (JSON output)
+- [ ] ~~View space (JSON output)~~ (#392 removed)
 - [ ] View non-existent space (expect error)
 - [ ] Create space with key, name, description
-- [ ] Create space (JSON output)
+- [ ] ~~Create space (JSON output)~~ (#392 removed)
 - [ ] Create duplicate key (expect error)
 - [ ] Update space name
 - [ ] Update space description
@@ -715,7 +715,7 @@ All cfl commands work with both auth methods (no scope restrictions for Confluen
 #### ADF Body Fallback (#150)
 - [ ] View ADF page with empty storage → content displayed via ADF fallback
 - [ ] View ADF page (raw) → shows ADF JSON
-- [ ] View ADF page (JSON output) → body.atlas_doc_format populated
+- [ ] ~~View ADF page (JSON output)~~ (#392 removed)
 - [ ] Edit ADF page (title only) → ADF body preserved
 - [ ] Edit ADF page (new content) → submitted as ADF
 - [ ] View/edit legacy page → no regression (storage path used)
@@ -741,15 +741,15 @@ All cfl commands work with both auth methods (no scope restrictions for Confluen
 - [ ] Full-text search returns results
 - [ ] Space filter works
 - [ ] Type filter works
-- [ ] JSON output is valid
+- [ ] ~~JSON output is valid~~ (#392 removed; -o json errors at root)
 - [ ] Raw CQL works
 
 #### Space CRUD
 - [ ] View space (table output)
-- [ ] View space (JSON output)
+- [ ] ~~View space (JSON output)~~ (#392 removed)
 - [ ] View non-existent space (expect error)
 - [ ] Create space with key, name, description
-- [ ] Create space (JSON output)
+- [ ] ~~Create space (JSON output)~~ (#392 removed)
 - [ ] Create duplicate key (expect error)
 - [ ] Update space name
 - [ ] Update space description

--- a/tools/cfl/integration-tests.md
+++ b/tools/cfl/integration-tests.md
@@ -63,7 +63,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 |-----------|---------|-----------------|
 | List pages in space | `cfl page list --space confluence` | Shows table of pages with ID, title, status, version |
 | List with limit | `cfl page list --space confluence --limit 5` | Shows only 5 pages with "showing first N results" message |
-| ~~JSON output~~ (#392 removed) | `cfl page list --space confluence --output json` | Valid JSON array |
+| ~~JSON output~~ (#392 removed) | `cfl page list --space confluence --output json` | Errors: invalid output format |
 | Plain output | `cfl page list --space confluence --output plain` | Tab-separated values |
 | List trashed pages | `cfl page list --space confluence --status trashed` | Shows deleted pages |
 | List archived pages | `cfl page list --space confluence --status archived` | Shows archived pages |
@@ -75,7 +75,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 |-----------|---------|-----------------|
 | View page content | `cfl page view <page-id>` | Shows title, ID, version, and markdown content |
 | View raw HTML | `cfl page view <page-id> --raw` | Shows Confluence storage format (XHTML) |
-| ~~JSON output~~ (#392 removed) | `cfl page view <page-id> --output json` | Full page object as JSON |
+| ~~JSON output~~ (#392 removed) | `cfl page view <page-id> --output json` | Errors: invalid output format |
 | Non-existent page | `cfl page view 99999999999` | Error: 404 not found |
 | View content only | `cfl page view <id> --content-only` | Markdown only, no Title/ID/Version headers |
 | Content only with raw | `cfl page view <id> --content-only --raw` | XHTML only, no headers |
@@ -154,7 +154,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 |-----------|---------|-----------------|
 | List attachments | `cfl attachment list --page <id>` | Table of attachments with ID, title, type, size |
 | No attachments | List on page with none | "No attachments found" |
-| ~~JSON output~~ (#392 removed) | `cfl attachment list --page <id> --output json` | Valid JSON array with full attachment metadata |
+| ~~JSON output~~ (#392 removed) | `cfl attachment list --page <id> --output json` | Errors: invalid output format |
 | List unused attachments | `cfl attachment list --page <id> --unused` | Only attachments not referenced in page content |
 | No unused attachments | `--unused` on page using all attachments | "No unused attachments found" |
 
@@ -198,7 +198,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Test Case | Command | Expected Result |
 |-----------|---------|-----------------|
 | List all spaces | `cfl space list` | Table of spaces with key, name, type |
-| ~~JSON output~~ (#392 removed) | `cfl space list --output json` | Valid JSON array |
+| ~~JSON output~~ (#392 removed) | `cfl space list --output json` | Errors: invalid output format |
 | Limit results | `cfl space list --limit 5` | Shows first 5 spaces |
 
 ### space view
@@ -206,7 +206,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Test Case | Command | Expected Result |
 |-----------|---------|-----------------|
 | View space by key | `cfl space view confluence` | Key-value pairs: KEY, NAME, ID, TYPE, STATUS, DESCRIPTION |
-| ~~JSON output~~ (#392 removed) | `cfl space view confluence -o json` | Valid JSON object with id, key, name, type, status, description |
+| ~~JSON output~~ (#392 removed) | `cfl space view confluence -o json` | Errors: invalid output format |
 | Non-existent space | `cfl space view NONEXISTENT` | Error: Space with key 'NONEXISTENT' not found |
 | View personal space | `cfl space view ~accountid` | Shows personal space details (if accessible) |
 | Alias: get | `cfl space get confluence` | Same output as `space view` |
@@ -216,7 +216,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Test Case | Command | Expected Result |
 |-----------|---------|-----------------|
 | Create global space | `cfl space create --key INTTEST --name "[Test] Integration" --description "Test space"` | Space created, shows KEY, NAME, URL |
-| ~~Create with JSON output~~ (#392 removed) | `cfl space create --key INTTEST2 --name "[Test] Int2" -o json` | Valid JSON with id, key, name, type |
+| ~~Create with JSON output~~ (#392 removed) | `cfl space create --key INTTEST2 --name "[Test] Int2" -o json` | Errors: invalid output format |
 | Missing key flag | `cfl space create --name "Test"` | Error: required flag(s) "key" not set |
 | Missing name flag | `cfl space create --key TST` | Error: required flag(s) "name" not set |
 | Duplicate key | `cfl space create --key INTTEST --name "Duplicate"` (after creating INTTEST) | Error: API rejects duplicate key |
@@ -228,7 +228,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Update name | `cfl space update INTTEST --name "[Test] Updated Name"` | Shows updated key and name |
 | Update description | `cfl space update INTTEST --description "Updated description"` | Shows updated key and name |
 | Update both | `cfl space update INTTEST --name "[Test] Both" --description "Both updated"` | Both name and description changed |
-| ~~JSON output~~ (#392 removed) | `cfl space update INTTEST --name "[Test] JSON" -o json` | Valid JSON with updated fields |
+| ~~JSON output~~ (#392 removed) | `cfl space update INTTEST --name "[Test] JSON" -o json` | Errors: invalid output format |
 | No flags provided | `cfl space update INTTEST` | Error: at least one of --name or --description required |
 | Non-existent space | `cfl space update NONEXISTENT --name "X"` | Error: not found |
 | Verify update | `cfl space view INTTEST` | Shows new name and description |
@@ -240,7 +240,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Delete with confirmation | `cfl space delete INTTEST` (type "y") | Space deleted after confirmation prompt |
 | Delete cancelled | `cfl space delete INTTEST` (type "n") | "Deletion cancelled" message |
 | Delete with --force | `cfl space delete INTTEST --force` | Space deleted without confirmation |
-| ~~JSON output~~ (#392 removed) | `cfl space delete INTTEST --force -o json` | `{"status": "deleted", "space_key": "INTTEST", "name": "..."}` |
+| ~~JSON output~~ (#392 removed) | `cfl space delete INTTEST --force -o json` | Errors: invalid output format |
 | Non-existent space | `cfl space delete NONEXISTENT --force` | Error: not found |
 
 ### Space CRUD End-to-End (sequential)
@@ -271,7 +271,7 @@ All cfl commands should work with both auth methods (no scope limitations for Co
 | Search by label | `cfl search --label test-label` | Content with specified label |
 | Combined filters | `cfl search "deploy" --space DEV --type page` | Filtered results |
 | Raw CQL | `cfl search --cql "type=page AND space=DEV"` | CQL executed directly |
-| ~~JSON output~~ (#392 removed) | `cfl search "test" -o json` | Valid JSON with results and _meta |
+| ~~JSON output~~ (#392 removed) | `cfl search "test" -o json` | Errors: invalid output format |
 | Plain output | `cfl search "test" -o plain` | Tab-separated values |
 | Limit results | `cfl search "test" --limit 5` | Max 5 results |
 | No results | `cfl search "xyznonexistent123"` | "No results found" message |

--- a/tools/cfl/integration-tests.md
+++ b/tools/cfl/integration-tests.md
@@ -2,6 +2,8 @@
 
 This document catalogs the manual integration test suite for `cfl`. These tests verify real-world behavior against a live Confluence instance and catch edge cases that are difficult to cover with unit tests.
 
+> **#392 update:** Rows that exercise `-o json` / `--output json` on resource commands are obsolete — the resource JSON surface has been removed. They now error at the root with `invalid output format: "json" (valid formats: table, plain)`. Skip those rows. The surviving JSON surface is `cfl set-credential --json` (control-plane envelope per cli-common §1.5.2); test that one normally.
+
 ## Auth Methods
 
 cfl supports two authentication methods. The full integration test suite should be run with both:

--- a/tools/cfl/internal/cmd/attachment/delete.go
+++ b/tools/cfl/internal/cmd/attachment/delete.go
@@ -76,14 +76,6 @@ func runDeleteAttachment(ctx context.Context, attachmentID string, opts *deleteO
 		return fmt.Errorf("deleting attachment: %w", err)
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(map[string]string{
-			"status":        "deleted",
-			"attachment_id": attachmentID,
-			"title":         attachment.Title,
-		})
-	}
-
 	v.Success("Deleted attachment: %s (ID: %s)", attachment.Title, attachmentID)
 
 	return nil

--- a/tools/cfl/internal/cmd/attachment/list.go
+++ b/tools/cfl/internal/cmd/attachment/list.go
@@ -97,7 +97,7 @@ func runList(ctx context.Context, opts *listOptions) error {
 		rows = append(rows, []string{att.ID, att.Title, att.MediaType, size})
 	}
 
-	if len(attachments) == 0 && opts.Output != "json" {
+	if len(attachments) == 0 {
 		if opts.unused {
 			_, _ = fmt.Fprintln(opts.Stderr, "No unused attachments found.")
 		} else {
@@ -108,7 +108,7 @@ func runList(ctx context.Context, opts *listOptions) error {
 
 	_ = v.RenderList(headers, rows, result.HasMore())
 
-	if result.HasMore() && opts.Output != "json" {
+	if result.HasMore() {
 		fmt.Fprintf(os.Stderr, "\n(showing first %d results, use --limit to see more)\n", len(attachments))
 	}
 

--- a/tools/cfl/internal/cmd/attachment/list_test.go
+++ b/tools/cfl/internal/cmd/attachment/list_test.go
@@ -94,33 +94,6 @@ func TestRunList_APIError(t *testing.T) {
 	testutil.Contains(t, err.Error(), "listing attachments")
 }
 
-func TestRunList_JSONOutput(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{
-			"results": [
-				{"id": "att1", "title": "doc.pdf", "mediaType": "application/pdf", "fileSize": 1024}
-			]
-		}`))
-	}))
-	defer server.Close()
-
-	rootOpts := newListTestRootOptions()
-	rootOpts.Output = "json"
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &listOptions{
-		Options: rootOpts,
-		pageID:  "12345",
-		limit:   25,
-	}
-
-	err := runList(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-}
-
 func TestRunList_InvalidOutputFormat(t *testing.T) {
 	t.Parallel()
 	// Don't need a server - should fail before API call

--- a/tools/cfl/internal/cmd/attachment/list_test.go
+++ b/tools/cfl/internal/cmd/attachment/list_test.go
@@ -69,6 +69,9 @@ func TestRunList_Empty(t *testing.T) {
 
 	err := runList(context.Background(), opts)
 	testutil.RequireNoError(t, err)
+	// The empty-results banner used to be suppressed under -o json; #392
+	// removed that skip, so the banner now always prints to stderr.
+	testutil.Contains(t, rootOpts.Stderr.(*bytes.Buffer).String(), "No attachments found.")
 }
 
 func TestRunList_APIError(t *testing.T) {
@@ -325,4 +328,5 @@ func TestRunList_UnusedFlag_NoUnused(t *testing.T) {
 
 	err := runList(context.Background(), opts)
 	testutil.RequireNoError(t, err)
+	testutil.Contains(t, rootOpts.Stderr.(*bytes.Buffer).String(), "No unused attachments found.")
 }

--- a/tools/cfl/internal/cmd/attachment/upload.go
+++ b/tools/cfl/internal/cmd/attachment/upload.go
@@ -66,10 +66,6 @@ func runUpload(ctx context.Context, opts *uploadOptions) error {
 
 	v := opts.View()
 
-	if opts.Output == "json" {
-		return v.JSON(attachment)
-	}
-
 	v.Success("Uploaded: %s", filename)
 	v.RenderKeyValue("ID", attachment.ID)
 	v.RenderKeyValue("Title", attachment.Title)

--- a/tools/cfl/internal/cmd/attachment/upload_test.go
+++ b/tools/cfl/internal/cmd/attachment/upload_test.go
@@ -147,38 +147,3 @@ func TestRunUpload_APIError(t *testing.T) {
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "uploading attachment")
 }
-
-func TestRunUpload_JSONOutput(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
-	testFile := filepath.Join(tmpDir, "upload.txt")
-	err := os.WriteFile(testFile, []byte("test content"), 0600)
-	testutil.RequireNoError(t, err)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{
-			"results": [{
-				"id": "att123",
-				"title": "upload.txt",
-				"mediaType": "text/plain",
-				"fileSize": 12
-			}]
-		}`))
-	}))
-	defer server.Close()
-
-	rootOpts := newUploadTestRootOptions()
-	rootOpts.Output = "json"
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &uploadOptions{
-		Options: rootOpts,
-		pageID:  "12345",
-		file:    testFile,
-	}
-
-	err = runUpload(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-}

--- a/tools/cfl/internal/cmd/me/me_test.go
+++ b/tools/cfl/internal/cmd/me/me_test.go
@@ -92,22 +92,6 @@ func TestRun_MissingEmail(t *testing.T) {
 	testutil.Equal(t, "abc123 | Rian Stockbower | -\n", stdout)
 }
 
-func TestRun_JSONOutputFallsThroughToOneLiner(t *testing.T) {
-	t.Parallel()
-	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
-	defer server.Close()
-
-	opts := newTestRootOptions()
-	opts.Output = "json"
-	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
-
-	err := Run(context.Background(), opts, false)
-	testutil.RequireNoError(t, err)
-
-	stdout := opts.Stdout.(*bytes.Buffer).String()
-	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com\n", stdout)
-}
-
 func TestRun_MissingAccountID(t *testing.T) {
 	t.Parallel()
 	server := userServer(t, `{"displayName":"Joe","email":"joe@example.com"}`)

--- a/tools/cfl/internal/cmd/page/copy.go
+++ b/tools/cfl/internal/cmd/page/copy.go
@@ -95,10 +95,6 @@ func runCopy(ctx context.Context, pageID string, opts *copyOptions) error {
 
 	v := opts.View()
 
-	if opts.Output == "json" {
-		return v.JSON(newPage)
-	}
-
 	v.Success("Copied page to: %s", newPage.Title)
 	v.RenderKeyValue("ID", newPage.ID)
 	v.RenderKeyValue("Title", newPage.Title)

--- a/tools/cfl/internal/cmd/page/copy_test.go
+++ b/tools/cfl/internal/cmd/page/copy_test.go
@@ -165,35 +165,6 @@ func TestRunCopy_PageNotFound(t *testing.T) {
 	testutil.Contains(t, err.Error(), "copying page")
 }
 
-func TestRunCopy_JSONOutput(t *testing.T) {
-	t.Parallel()
-	server := mockCopyServer(t, nil, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{
-			"id": "99999",
-			"title": "Copied Page",
-			"space": {"key": "TEST"},
-			"version": {"number": 1},
-			"_links": {}
-		}`))
-	})
-	defer server.Close()
-
-	rootOpts := newTestRootOptions()
-	rootOpts.Output = "json"
-	client := api.NewClient(server.URL, "user@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &copyOptions{
-		Options: rootOpts,
-		title:   "Copied Page",
-		space:   "TEST",
-	}
-
-	err := runCopy(context.Background(), "12345", opts)
-	testutil.RequireNoError(t, err)
-}
-
 func TestRunCopy_InvalidOutputFormat(t *testing.T) {
 	t.Parallel()
 	rootOpts := newTestRootOptions()

--- a/tools/cfl/internal/cmd/page/create.go
+++ b/tools/cfl/internal/cmd/page/create.go
@@ -200,10 +200,6 @@ func runCreate(ctx context.Context, opts *createOptions) error {
 
 	v := opts.View()
 
-	if opts.Output == "json" {
-		return v.JSON(page)
-	}
-
 	v.Success("Created page: %s", page.Title)
 	v.RenderKeyValue("ID", page.ID)
 	v.RenderKeyValue("URL", cfg.URL+page.Links.WebUI)

--- a/tools/cfl/internal/cmd/page/create_test.go
+++ b/tools/cfl/internal/cmd/page/create_test.go
@@ -303,32 +303,6 @@ func TestRunCreate_WithParent(t *testing.T) {
 	testutil.Equal(t, "12345", receivedBody["parentId"])
 }
 
-func TestRunCreate_JSONOutput(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
-	mdFile := filepath.Join(tmpDir, "content.md")
-	err := os.WriteFile(mdFile, []byte("# Hello"), 0600)
-	testutil.RequireNoError(t, err)
-
-	server := mockCreateServer(t, "DEV", "123456", http.StatusOK)
-	defer server.Close()
-
-	rootOpts := newCreateTestRootOptions()
-	rootOpts.Output = "json"
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &createOptions{
-		Options: rootOpts,
-		space:   "DEV",
-		title:   "Test Page",
-		file:    mdFile,
-	}
-
-	err = runCreate(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-}
-
 func TestRunCreate_MarkdownConversion_Legacy(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/tools/cfl/internal/cmd/page/delete.go
+++ b/tools/cfl/internal/cmd/page/delete.go
@@ -77,14 +77,6 @@ func runDelete(ctx context.Context, pageID string, opts *deleteOptions) error {
 		return fmt.Errorf("deleting page: %w", err)
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(map[string]string{
-			"status":  "deleted",
-			"page_id": pageID,
-			"title":   page.Title,
-		})
-	}
-
 	v.Success("Deleted page: %s (ID: %s)", page.Title, pageID)
 
 	return nil

--- a/tools/cfl/internal/cmd/page/delete_test.go
+++ b/tools/cfl/internal/cmd/page/delete_test.go
@@ -202,25 +202,6 @@ func TestRunDelete_DeleteFailed(t *testing.T) {
 	testutil.Contains(t, err.Error(), "deleting page")
 }
 
-func TestRunDelete_JSONOutput(t *testing.T) {
-	t.Parallel()
-	server := mockPageServer(t, "12345", "Test Page", http.StatusNoContent)
-	defer server.Close()
-
-	rootOpts := newDeleteTestRootOptions()
-	rootOpts.Output = "json"
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &deleteOptions{
-		Options: rootOpts,
-		force:   true,
-	}
-
-	err := runDelete(context.Background(), "12345", opts)
-	testutil.RequireNoError(t, err)
-}
-
 func TestRunDelete_ConfirmationInputs(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -79,7 +79,7 @@ Content format:
   echo "<p>Updated</p>" | cfl page edit 12345 --storage
 
   # Extract, transform, and re-upload storage-format content
-  cfl page view 12345 --output json | jq -r '.body.storage.value' | \
+  cfl page view 12345 --raw --content-only | \
     sed 's/old/new/g' | cfl page edit 12345 --storage`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -231,10 +231,6 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	}
 
 	v := opts.View()
-
-	if opts.Output == "json" {
-		return v.JSON(page)
-	}
 
 	v.Success("Updated page: %s", page.Title)
 	v.RenderKeyValue("ID", page.ID)

--- a/tools/cfl/internal/cmd/page/list.go
+++ b/tools/cfl/internal/cmd/page/list.go
@@ -7,11 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/artifact"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/confluence-cli/api"
-	cflartifact "github.com/open-cli-collective/confluence-cli/internal/artifact"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
@@ -38,10 +36,7 @@ page content.`,
   cfl page list --space DEV
 
   # List with limit
-  cfl page list -s DEV -l 50
-
-  # Output as JSON
-  cfl page list -s DEV -o json`,
+  cfl page list -s DEV -l 50`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runList(cmd.Context(), opts)
 		},
@@ -78,10 +73,6 @@ func runList(ctx context.Context, opts *listOptions) error {
 	v := opts.View()
 
 	if opts.limit == 0 {
-		if opts.Output == "json" {
-			arts := cflartifact.ProjectPageListItems(nil, opts.ArtifactMode())
-			return v.RenderArtifactList(artifact.NewListResult(arts, false))
-		}
 		v.RenderText("No pages found.")
 		return nil
 	}
@@ -121,21 +112,10 @@ func runList(ctx context.Context, opts *listOptions) error {
 	}
 
 	if len(result.Results) == 0 {
-		if opts.Output == "json" {
-			arts := cflartifact.ProjectPageListItems(nil, opts.ArtifactMode())
-			return v.RenderArtifactList(artifact.NewListResult(arts, false))
-		}
 		v.RenderText(fmt.Sprintf("No pages found in space %s.", spaceKey))
 		return nil
 	}
 
-	// JSON output uses artifact projection
-	if opts.Output == "json" {
-		arts := cflartifact.ProjectPageListItems(result.Results, opts.ArtifactMode())
-		return v.RenderArtifactList(artifact.NewListResult(arts, result.HasMore()))
-	}
-
-	// Table output
 	headers := []string{"ID", "TITLE", "STATUS", "VERSION"}
 	rows := make([][]string, 0, len(result.Results))
 

--- a/tools/cfl/internal/cmd/page/list_test.go
+++ b/tools/cfl/internal/cmd/page/list_test.go
@@ -91,31 +91,6 @@ func TestRunList_PageList_EmptyResults(t *testing.T) {
 	testutil.RequireNoError(t, err)
 }
 
-func TestRunList_PageList_JSONOutput(t *testing.T) {
-	t.Parallel()
-	server := mockListServer(t, "DEV", "123456", `{
-		"results": [
-			{"id": "11111", "title": "Page One", "status": "current", "version": {"number": 1}}
-		]
-	}`)
-	defer server.Close()
-
-	rootOpts := newListPageTestRootOptions()
-	rootOpts.Output = "json"
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &listOptions{
-		Options: rootOpts,
-		space:   "DEV",
-		limit:   25,
-		status:  "current",
-	}
-
-	err := runList(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-}
-
 func TestRunList_PageList_InvalidOutputFormat(t *testing.T) {
 	t.Parallel()
 	rootOpts := newListPageTestRootOptions()

--- a/tools/cfl/internal/cmd/page/view.go
+++ b/tools/cfl/internal/cmd/page/view.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/view"
 
-	cflartifact "github.com/open-cli-collective/confluence-cli/internal/artifact"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	"github.com/open-cli-collective/confluence-cli/pkg/md"
 )
@@ -42,8 +41,7 @@ markdown for display. Use --raw to see the original storage format.
 
 By default, output is truncated to 5000 characters for concise display.
 Use --no-truncate to show the complete page content without truncation.
-The --content-only flag implies --no-truncate since it is intended for piping.
-JSON output (--output json) always includes the full body.`,
+The --content-only flag implies --no-truncate since it is intended for piping.`,
 		Example: `  # View a page (markdown, truncated if large)
   cfl page view 12345
 
@@ -82,9 +80,6 @@ func runView(ctx context.Context, pageID string, opts *viewOptions) error {
 	}
 
 	if opts.contentOnly {
-		if opts.Output == "json" {
-			return fmt.Errorf("--content-only is incompatible with --output json")
-		}
 		if opts.web {
 			return fmt.Errorf("--content-only is incompatible with --web")
 		}
@@ -125,19 +120,6 @@ func runView(ctx context.Context, pageID string, opts *viewOptions) error {
 			spaceKey = space.Key
 		}
 		// Graceful fallback: if GetSpace fails, we just won't show the key
-	}
-
-	if opts.Output == "json" {
-		// Extract content (XHTML storage format by default, until #196 validates markdown)
-		content := ""
-		if hasStorageContent(page) {
-			content = page.Body.Storage.Value
-		} else if hasADFContent(page) {
-			content = page.Body.AtlasDocFormat.Value
-		}
-
-		art := cflartifact.ProjectPage(page, spaceKey, content, opts.ArtifactMode())
-		return v.RenderArtifact(art)
 	}
 
 	if !opts.contentOnly {

--- a/tools/cfl/internal/cmd/page/view_test.go
+++ b/tools/cfl/internal/cmd/page/view_test.go
@@ -88,33 +88,6 @@ func TestRunView_RawFormat(t *testing.T) {
 	testutil.Contains(t, stdout.String(), "<p>Raw HTML Content</p>")
 }
 
-func TestRunView_JSONOutput(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{
-			"id": "12345",
-			"title": "Test Page",
-			"version": {"number": 1},
-			"body": {"storage": {"value": "<p>Content</p>"}},
-			"_links": {"webui": "/pages/12345"}
-		}`))
-	}))
-	defer server.Close()
-
-	rootOpts := newViewTestRootOptions()
-	rootOpts.Output = "json"
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &viewOptions{
-		Options: rootOpts,
-	}
-
-	err := runView(context.Background(), "12345", opts)
-	testutil.RequireNoError(t, err)
-}
-
 func TestRunView_PageNotFound(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -286,21 +259,6 @@ func TestRunView_ContentOnly_ShowMacros(t *testing.T) {
 	err := runView(context.Background(), "12345", opts)
 	testutil.RequireNoError(t, err)
 	// Output should contain markdown with [TOC] macro placeholder
-}
-
-func TestRunView_ContentOnly_JSON_Error(t *testing.T) {
-	t.Parallel()
-	rootOpts := newViewTestRootOptions()
-	rootOpts.Output = "json"
-
-	opts := &viewOptions{
-		Options:     rootOpts,
-		contentOnly: true,
-	}
-
-	err := runView(context.Background(), "12345", opts)
-	testutil.RequireError(t, err)
-	testutil.Contains(t, err.Error(), "--content-only is incompatible with --output json")
 }
 
 func TestRunView_ContentOnly_Web_Error(t *testing.T) {

--- a/tools/cfl/internal/cmd/root/root.go
+++ b/tools/cfl/internal/cmd/root/root.go
@@ -118,17 +118,23 @@ Get started by running: cfl init`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Version:       version.Version,
-		// PersistentPreRunE wires --backend and keyring.backend (config)
-		// into shared/keyring before any subcommand runs. Must NOT read
-		// ATLASSIAN_CLI_KEYRING_BACKEND directly — credstore reads it.
+		// PersistentPreRunE validates the closed-set output format (§2:
+		// JSON is reserved for round-trip + control-plane envelopes; cfl
+		// resource output is text-only), then wires --backend and
+		// keyring.backend (config) into shared/keyring. Output validation
+		// runs first so a flag/policy error fails fast without touching
+		// config or keyring.
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := validateOutputFormat(opts.Output); err != nil {
+				return err
+			}
 			return wireBackendSelection(cmd)
 		},
 	}
 
 	// Global flags - bound to opts struct
 	cmd.PersistentFlags().StringP("config", "c", "", "config file (default: ~/.config/cfl/config.yml)")
-	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "table", "output format: table, json, plain")
+	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "table", "output format: table, plain")
 	cmd.PersistentFlags().BoolVar(&opts.NoColor, "no-color", false, "disable colored output")
 	cmd.PersistentFlags().BoolVar(&opts.Full, "full", false, "show full inspection-oriented output (default: agent)")
 	cmd.PersistentFlags().BoolVar(&opts.NonInteractive, "non-interactive", false, "Never prompt; fail loud naming any required value missing from flags/env/stdin (§3.4)")
@@ -138,6 +144,20 @@ Get started by running: cfl init`,
 	cmd.SetVersionTemplate("cfl version {{.Version}} (commit: " + version.Commit + ", built: " + version.BuildDate + ")\n")
 
 	return cmd, opts
+}
+
+// validateOutputFormat enforces the §2 closed set for cfl's resource
+// surface. JSON is reserved for round-trip payloads + control-plane
+// envelopes (e.g. set-credential's local --json flag) and is rejected
+// here. Anything outside {table, plain} fails fast with the same error
+// shape so users get one unambiguous "valid formats" line.
+func validateOutputFormat(format string) error {
+	switch format {
+	case "table", "plain":
+		return nil
+	default:
+		return fmt.Errorf("invalid output format: %q (valid formats: table, plain)", format)
+	}
 }
 
 // wireBackendSelection reads --backend (via cmd.Flag so the lookup

--- a/tools/cfl/internal/cmd/root/root_test.go
+++ b/tools/cfl/internal/cmd/root/root_test.go
@@ -71,7 +71,7 @@ func TestOptions_View(t *testing.T) {
 	t.Parallel()
 	var stdout, stderr bytes.Buffer
 	opts := &Options{
-		Output:  "json",
+		Output:  "plain",
 		NoColor: true,
 		Stdout:  &stdout,
 		Stderr:  &stderr,
@@ -112,6 +112,67 @@ func TestRegisterCommands(t *testing.T) {
 
 	RegisterCommands(cmd, opts, registrar)
 	testutil.True(t, called)
+}
+
+func TestValidateOutputFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"table accepted", "table", false},
+		{"plain accepted", "plain", false},
+		{"json rejected — §2 control-plane carve-out", "json", true},
+		{"yaml rejected — outside closed set", "yaml", true},
+		{"empty rejected", "", true},
+		{"random rejected", "csv", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateOutputFormat(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("validateOutputFormat(%q) returned nil, want error", tt.input)
+				}
+				testutil.Contains(t, err.Error(), "valid formats: table, plain")
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateOutputFormat(%q) returned error: %v", tt.input, err)
+			}
+		})
+	}
+}
+
+func TestRoot_RejectsInvalidOutput_AtPreRun(t *testing.T) {
+	t.Parallel()
+
+	for _, format := range []string{"json", "yaml", ""} {
+		format := format
+		t.Run("rejects "+format, func(t *testing.T) {
+			t.Parallel()
+			cmd, _ := NewCmd()
+			// Stub child so cobra reaches PersistentPreRunE.
+			cmd.AddCommand(&cobra.Command{
+				Use:  "probe",
+				RunE: func(*cobra.Command, []string) error { return nil },
+			})
+			cmd.SetArgs([]string{"-o", format, "probe"})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("-o %q should be rejected, got nil error", format)
+			}
+			testutil.Contains(t, err.Error(), "invalid output format")
+			testutil.Contains(t, err.Error(), "valid formats: table, plain")
+		})
+	}
 }
 
 func TestOptions_View_UsesDefaultPolicy(t *testing.T) {

--- a/tools/cfl/internal/cmd/root/root_test.go
+++ b/tools/cfl/internal/cmd/root/root_test.go
@@ -175,6 +175,36 @@ func TestRoot_RejectsInvalidOutput_AtPreRun(t *testing.T) {
 	}
 }
 
+// Local --json flags (e.g. set-credential's control-plane envelope) must
+// not be confused with the global -o json guard. The guard inspects
+// opts.Output (the global -o/--output value); a child command's local
+// boolean --json flag has no bearing on it. This pins the invariant so a
+// future "uniform JSON rejection" sweep doesn't accidentally reach into
+// child command flags.
+func TestRoot_LocalJSONFlag_NotRejectedByOutputGuard(t *testing.T) {
+	t.Parallel()
+	cmd, _ := NewCmd()
+	probeJSON := false
+	probe := &cobra.Command{
+		Use: "probe",
+		RunE: func(*cobra.Command, []string) error {
+			return nil
+		},
+	}
+	probe.Flags().BoolVar(&probeJSON, "json", false, "local boolean flag (e.g. set-credential's control-plane envelope)")
+	cmd.AddCommand(probe)
+	cmd.SetArgs([]string{"probe", "--json"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("local --json should not be rejected by the global -o guard, got: %v", err)
+	}
+	if !probeJSON {
+		t.Fatalf("local --json flag did not flip; cobra registration regression?")
+	}
+}
+
 func TestOptions_View_UsesDefaultPolicy(t *testing.T) {
 	t.Parallel()
 	opts := &Options{

--- a/tools/cfl/internal/cmd/search/search.go
+++ b/tools/cfl/internal/cmd/search/search.go
@@ -9,11 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/artifact"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/confluence-cli/api"
-	cflartifact "github.com/open-cli-collective/confluence-cli/internal/artifact"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
@@ -75,10 +73,7 @@ convenient flags for common filters, or provide raw CQL for advanced queries.`,
   cfl search "kubernetes" --space DEV --type page --label infrastructure
 
   # Power user: raw CQL query
-  cfl search --cql "type=page AND space=DEV AND lastModified > now('-7d')"
-
-  # Output as JSON for scripting
-  cfl search "config" -o json`,
+  cfl search --cql "type=page AND space=DEV AND lastModified > now('-7d')"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
@@ -125,12 +120,7 @@ func runSearch(ctx context.Context, opts *searchOptions) error {
 
 	v := opts.View()
 
-	// Handle limit 0 - return empty
 	if opts.limit == 0 {
-		if opts.Output == "json" {
-			arts := cflartifact.ProjectSearchResults(nil, opts.ArtifactMode())
-			return v.RenderArtifactList(artifact.NewListResult(arts, false))
-		}
 		v.RenderText("No results.")
 		return nil
 	}
@@ -169,21 +159,10 @@ func runSearch(ctx context.Context, opts *searchOptions) error {
 	}
 
 	if len(result.Results) == 0 {
-		if opts.Output == "json" {
-			arts := cflartifact.ProjectSearchResults(nil, opts.ArtifactMode())
-			return v.RenderArtifactList(artifact.NewListResult(arts, false))
-		}
 		v.RenderText("No results found.")
 		return nil
 	}
 
-	// JSON output uses artifact projection
-	if opts.Output == "json" {
-		arts := cflartifact.ProjectSearchResults(result.Results, opts.ArtifactMode())
-		return v.RenderArtifactList(artifact.NewListResult(arts, result.HasMore()))
-	}
-
-	// Table output
 	headers := []string{"ID", "TYPE", "SPACE KEY", "TITLE"}
 	rows := make([][]string, 0, len(result.Results))
 

--- a/tools/cfl/internal/cmd/search/search_test.go
+++ b/tools/cfl/internal/cmd/search/search_test.go
@@ -94,36 +94,6 @@ func TestRunSearch_EmptyResults(t *testing.T) {
 	testutil.RequireNoError(t, err)
 }
 
-func TestRunSearch_JSONOutput(t *testing.T) {
-	t.Parallel()
-	server := mockSearchServer(t, `{
-		"results": [
-			{
-				"content": {"id": "12345", "type": "page", "status": "current", "title": "Test Page"},
-				"resultGlobalContainer": {"title": "DEV"}
-			}
-		],
-		"start": 0,
-		"size": 1,
-		"totalSize": 1
-	}`)
-	defer server.Close()
-
-	rootOpts := newTestRootOptions()
-	rootOpts.Output = "json"
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &searchOptions{
-		Options: rootOpts,
-		query:   "test",
-		limit:   25,
-	}
-
-	err := runSearch(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-}
-
 func TestRunSearch_PlainOutput(t *testing.T) {
 	t.Parallel()
 	server := mockSearchServer(t, `{

--- a/tools/cfl/internal/cmd/setcredential/setcredential_test.go
+++ b/tools/cfl/internal/cmd/setcredential/setcredential_test.go
@@ -207,6 +207,44 @@ func TestSetCredential_JSONSuccess(t *testing.T) {
 	}
 }
 
+// TestSetCredential_ThroughRealRoot_LocalJSONFlagPreserved dispatches
+// set-credential --json through the real root.NewCmd() with its
+// PersistentPreRunE wired (closed-set output guard + wireBackendSelection).
+// runCmd() above uses a bare cobra.Command root so it bypasses the guard;
+// this test exercises the production path. The guarantee being pinned: the
+// global -o/--output closed-set guard does not interfere with the local
+// --json envelope flag (§1.5.2 control-plane carve-out).
+func TestSetCredential_ThroughRealRoot_LocalJSONFlagPreserved(t *testing.T) {
+	credtest.Hermetic(t)
+
+	rootCmd, opts := root.NewCmd()
+	opts.Stdin = strings.NewReader(sentinel)
+	opts.Stdout = &bytes.Buffer{}
+	opts.Stderr = &bytes.Buffer{}
+	Register(rootCmd, opts)
+
+	rootCmd.SetArgs([]string{
+		"set-credential",
+		"--ref", keyring.Ref,
+		"--key", keyring.KeyAPIToken,
+		"--stdin",
+		"--json",
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("set-credential --json failed through real root: %v", err)
+	}
+
+	stderr := opts.Stderr.(*bytes.Buffer).String()
+	if stderr != "" {
+		t.Fatalf("stderr must be empty under --json: %q", stderr)
+	}
+	env := parseEnvelope(t, opts.Stdout.(*bytes.Buffer).String())
+	testutil.True(t, env.Written)
+	if env.Backend == "" {
+		t.Fatal("Backend must be populated on success")
+	}
+}
+
 // TestSetCredential_JSONFailure_PreKeyring_EmptyToken — empty-stdin
 // rejection is technically a "pre-keyring" failure (we never Open() with
 // no source). Asserts the envelope contract: backend:"", written:false,

--- a/tools/cfl/internal/cmd/space/create.go
+++ b/tools/cfl/internal/cmd/space/create.go
@@ -82,10 +82,6 @@ func runCreate(ctx context.Context, opts *createOptions) error {
 
 	v := opts.View()
 
-	if opts.Output == "json" {
-		return v.JSON(space)
-	}
-
 	v.Success("Created space: %s", space.Name)
 	v.RenderKeyValue("Key", space.Key)
 	if space.Links.WebUI != "" {

--- a/tools/cfl/internal/cmd/space/delete.go
+++ b/tools/cfl/internal/cmd/space/delete.go
@@ -82,14 +82,6 @@ func runDelete(ctx context.Context, spaceKey string, opts *deleteOptions) error 
 		return fmt.Errorf("deleting space: %w", err)
 	}
 
-	if opts.Output == "json" {
-		return v.JSON(map[string]string{
-			"status":    "deleted",
-			"space_key": spaceKey,
-			"name":      space.Name,
-		})
-	}
-
 	v.Success("Deleted space: %s (%s)", space.Name, spaceKey)
 
 	return nil

--- a/tools/cfl/internal/cmd/space/list.go
+++ b/tools/cfl/internal/cmd/space/list.go
@@ -7,11 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/artifact"
 	"github.com/open-cli-collective/atlassian-go/view"
 
 	"github.com/open-cli-collective/confluence-cli/api"
-	cflartifact "github.com/open-cli-collective/confluence-cli/internal/artifact"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
@@ -35,9 +33,6 @@ func newListCmd(rootOpts *root.Options) *cobra.Command {
 
   # List only global spaces
   cfl space list --type global
-
-  # Output as JSON
-  cfl space list -o json
 
   # Paginate through results
   cfl space list --cursor "eyJpZCI6MTIzfQ=="`,
@@ -65,10 +60,6 @@ func runList(ctx context.Context, opts *listOptions) error {
 	v := opts.View()
 
 	if opts.limit == 0 {
-		if opts.Output == "json" {
-			arts := cflartifact.ProjectSpaces(nil, opts.ArtifactMode())
-			return v.RenderArtifactList(artifact.NewListResult(arts, false))
-		}
 		v.RenderText("No spaces found.")
 		return nil
 	}
@@ -90,21 +81,10 @@ func runList(ctx context.Context, opts *listOptions) error {
 	}
 
 	if len(result.Results) == 0 {
-		if opts.Output == "json" {
-			arts := cflartifact.ProjectSpaces(nil, opts.ArtifactMode())
-			return v.RenderArtifactList(artifact.NewListResult(arts, false))
-		}
 		v.RenderText("No spaces found.")
 		return nil
 	}
 
-	// JSON output uses artifact projection
-	if opts.Output == "json" {
-		arts := cflartifact.ProjectSpaces(result.Results, opts.ArtifactMode())
-		return v.RenderArtifactList(artifact.NewListResult(arts, result.HasMore()))
-	}
-
-	// Table output
 	headers := []string{"KEY", "NAME", "TYPE", "DESCRIPTION"}
 	rows := make([][]string, 0, len(result.Results))
 

--- a/tools/cfl/internal/cmd/space/list_test.go
+++ b/tools/cfl/internal/cmd/space/list_test.go
@@ -84,32 +84,6 @@ func TestRunList_EmptyResults(t *testing.T) {
 	testutil.RequireNoError(t, err)
 }
 
-func TestRunList_JSONOutput(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{
-			"results": [
-				{"id": "123456", "key": "DEV", "name": "Development", "type": "global"}
-			]
-		}`))
-	}))
-	defer server.Close()
-
-	rootOpts := newTestRootOptions()
-	rootOpts.Output = "json"
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &listOptions{
-		Options: rootOpts,
-		limit:   25,
-	}
-
-	err := runList(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-}
-
 func TestRunList_InvalidOutputFormat(t *testing.T) {
 	t.Parallel()
 	rootOpts := newTestRootOptions()
@@ -149,21 +123,6 @@ func TestRunList_ZeroLimit(t *testing.T) {
 	}
 
 	// Zero limit should return empty without making API call
-	err := runList(context.Background(), opts)
-	testutil.RequireNoError(t, err)
-}
-
-func TestRunList_ZeroLimitJSON(t *testing.T) {
-	t.Parallel()
-	rootOpts := newTestRootOptions()
-	rootOpts.Output = "json"
-
-	opts := &listOptions{
-		Options: rootOpts,
-		limit:   0,
-	}
-
-	// Zero limit should return empty JSON array without making API call
 	err := runList(context.Background(), opts)
 	testutil.RequireNoError(t, err)
 }

--- a/tools/cfl/internal/cmd/space/space_test.go
+++ b/tools/cfl/internal/cmd/space/space_test.go
@@ -73,34 +73,6 @@ func TestRunView_Table(t *testing.T) {
 	testutil.Contains(t, output, "A test space")
 }
 
-func TestRunView_JSON(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(spaceListResponse))
-	}))
-	defer server.Close()
-
-	stdout := &bytes.Buffer{}
-	rootOpts := &root.Options{
-		Output:  "json",
-		NoColor: true,
-		Stdout:  stdout,
-		Stderr:  &bytes.Buffer{},
-	}
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &viewOptions{Options: rootOpts}
-	err := runView(context.Background(), "TEST", opts)
-
-	testutil.RequireNoError(t, err)
-	var result map[string]any
-	err = json.Unmarshal(stdout.Bytes(), &result)
-	testutil.RequireNoError(t, err)
-	testutil.Equal(t, "TEST", result["key"])
-}
-
 func TestRunView_NotFound(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -171,46 +143,6 @@ func TestRunCreate(t *testing.T) {
 	testutil.Contains(t, output, "Created space")
 	testutil.Contains(t, output, "Test Space")
 	testutil.Contains(t, output, "TEST")
-}
-
-func TestRunCreate_JSON(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{
-			"id": "123456",
-			"key": "TEST",
-			"name": "Test Space",
-			"type": "global"
-		}`))
-	}))
-	defer server.Close()
-
-	stdout := &bytes.Buffer{}
-	rootOpts := &root.Options{
-		Output:  "json",
-		NoColor: true,
-		Stdout:  stdout,
-		Stderr:  &bytes.Buffer{},
-	}
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-	rootOpts.SetConfig(&config.Config{URL: "https://example.atlassian.net/wiki"})
-
-	opts := &createOptions{
-		Options:   rootOpts,
-		key:       "TEST",
-		name:      "Test Space",
-		spaceType: "global",
-	}
-
-	err := runCreate(context.Background(), opts)
-
-	testutil.RequireNoError(t, err)
-	var result map[string]any
-	err = json.Unmarshal(stdout.Bytes(), &result)
-	testutil.RequireNoError(t, err)
-	testutil.Equal(t, "TEST", result["key"])
 }
 
 func TestRunCreate_WithDescription(t *testing.T) {
@@ -289,38 +221,6 @@ func TestRunUpdate(t *testing.T) {
 	output := stdout.String()
 	testutil.Contains(t, output, "Updated space")
 	testutil.Contains(t, output, "Updated Name")
-}
-
-func TestRunUpdate_JSON(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(v1SpaceUpdateResponse))
-	}))
-	defer server.Close()
-
-	stdout := &bytes.Buffer{}
-	rootOpts := &root.Options{
-		Output:  "json",
-		NoColor: true,
-		Stdout:  stdout,
-		Stderr:  &bytes.Buffer{},
-	}
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &updateOptions{
-		Options: rootOpts,
-		name:    "Updated Name",
-	}
-
-	err := runUpdate(context.Background(), "TEST", opts)
-
-	testutil.RequireNoError(t, err)
-	var result map[string]any
-	err = json.Unmarshal(stdout.Bytes(), &result)
-	testutil.RequireNoError(t, err)
-	testutil.Equal(t, "TEST", result["key"])
 }
 
 func TestRunUpdate_NoFlags(t *testing.T) {
@@ -407,46 +307,6 @@ func TestRunDelete_Force(t *testing.T) {
 	output := stdout.String()
 	testutil.Contains(t, output, "Deleted space")
 	testutil.Contains(t, output, "Test Space")
-}
-
-func TestRunDelete_Force_JSON(t *testing.T) {
-	t.Parallel()
-	callCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		callCount++
-		if callCount == 1 {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(spaceListResponse))
-			return
-		}
-		w.WriteHeader(http.StatusAccepted)
-	}))
-	defer server.Close()
-
-	stdout := &bytes.Buffer{}
-	rootOpts := &root.Options{
-		Output:  "json",
-		NoColor: true,
-		Stdout:  stdout,
-		Stderr:  &bytes.Buffer{},
-	}
-	client := api.NewClient(server.URL, "test@example.com", "token")
-	rootOpts.SetAPIClient(client)
-
-	opts := &deleteOptions{
-		Options: rootOpts,
-		force:   true,
-	}
-
-	err := runDelete(context.Background(), "TEST", opts)
-
-	testutil.RequireNoError(t, err)
-	var result map[string]string
-	err = json.Unmarshal(stdout.Bytes(), &result)
-	testutil.RequireNoError(t, err)
-	testutil.Equal(t, "deleted", result["status"])
-	testutil.Equal(t, "TEST", result["space_key"])
-	testutil.Equal(t, "Test Space", result["name"])
 }
 
 func TestRunDelete_NoForce_Declined(t *testing.T) {

--- a/tools/cfl/internal/cmd/space/update.go
+++ b/tools/cfl/internal/cmd/space/update.go
@@ -83,10 +83,6 @@ func runUpdate(ctx context.Context, spaceKey string, opts *updateOptions) error 
 
 	v := opts.View()
 
-	if opts.Output == "json" {
-		return v.JSON(space)
-	}
-
 	v.Success("Updated space: %s (%s)", space.Name, space.Key)
 
 	return nil

--- a/tools/cfl/internal/cmd/space/view.go
+++ b/tools/cfl/internal/cmd/space/view.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/open-cli-collective/atlassian-go/view"
 
-	cflartifact "github.com/open-cli-collective/confluence-cli/internal/artifact"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 )
 
@@ -25,10 +24,7 @@ func newViewCmd(rootOpts *root.Options) *cobra.Command {
 		Short:   "View space details",
 		Long:    `View details of a Confluence space by its key.`,
 		Example: `  # View a space
-  cfl space view DEV
-
-  # View as JSON
-  cfl space view DEV -o json`,
+  cfl space view DEV`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runView(cmd.Context(), args[0], opts)
@@ -54,11 +50,6 @@ func runView(ctx context.Context, spaceKey string, opts *viewOptions) error {
 	}
 
 	v := opts.View()
-
-	if opts.Output == "json" {
-		art := cflartifact.ProjectSpace(space, opts.ArtifactMode())
-		return v.RenderArtifact(art)
-	}
 
 	v.RenderKeyValue("Key", space.Key)
 	v.RenderKeyValue("Name", space.Name)

--- a/tools/cfl/scripts/roundtrip-test.sh
+++ b/tools/cfl/scripts/roundtrip-test.sh
@@ -175,11 +175,19 @@ process_page() {
     # Step 4: Create test page from markdown.
     # JSON output was removed in #392; parse the ID line from the default
     # text output instead. --no-color keeps the parser robust against any
-    # future ANSI styling around the key:value pairs.
+    # future ANSI styling around the key:value pairs. The gsub() in awk
+    # trims leading/trailing whitespace so RenderKeyValue emitting "ID:  12345"
+    # (two spaces) still yields "12345" rather than " 12345".
+    local create_output
+    if ! create_output=$(printf '%s' "$md_content" | cfl --no-color page create -s "$SPACE" -t "[Test] Roundtrip $id" --legacy 2>&1); then
+        echo "[$id] FAIL: cfl page create exited non-zero: $create_output"
+        FAIL=$((FAIL + 1))
+        return 1
+    fi
     local new_id
-    new_id=$(printf '%s' "$md_content" | cfl --no-color page create -s "$SPACE" -t "[Test] Roundtrip $id" --legacy 2>/dev/null | awk -F': ' '/^ID:[[:space:]]/ {print $2; exit}') || true
+    new_id=$(printf '%s' "$create_output" | awk -F: '/^ID:/ {sub(/^[ \t]+/, "", $2); sub(/[ \t]+$/, "", $2); print $2; exit}')
     if [[ -z "$new_id" ]]; then
-        echo "[$id] FAIL: Could not create test page"
+        echo "[$id] FAIL: Could not parse page ID from cfl page create output: $create_output"
         FAIL=$((FAIL + 1))
         return 1
     fi

--- a/tools/cfl/scripts/roundtrip-test.sh
+++ b/tools/cfl/scripts/roundtrip-test.sh
@@ -172,10 +172,13 @@ process_page() {
     fi
     printf '%s' "$md_content" > "$staging_md"
 
-    # Step 4: Create test page from markdown
+    # Step 4: Create test page from markdown.
+    # JSON output was removed in #392; parse the ID line from the default
+    # text output instead. --no-color keeps the parser robust against any
+    # future ANSI styling around the key:value pairs.
     local new_id
-    new_id=$(printf '%s' "$md_content" | cfl page create -s "$SPACE" -t "[Test] Roundtrip $id" --legacy -o json 2>/dev/null | jq -r '.id') || true
-    if [[ -z "$new_id" || "$new_id" == "null" ]]; then
+    new_id=$(printf '%s' "$md_content" | cfl --no-color page create -s "$SPACE" -t "[Test] Roundtrip $id" --legacy 2>/dev/null | awk -F': ' '/^ID:[[:space:]]/ {print $2; exit}') || true
+    if [[ -z "$new_id" ]]; then
         echo "[$id] FAIL: Could not create test page"
         FAIL=$((FAIL + 1))
         return 1

--- a/tools/cfl/test-plan-writes.md
+++ b/tools/cfl/test-plan-writes.md
@@ -6,6 +6,8 @@ The documentation (readme.md, cfl-intro.md) makes numerous claims about write op
 
 This document inventories all untested assertions and provides comprehensive test cases.
 
+> **#392 update:** Rows that exercise `-o json` / `--output json` on resource commands are obsolete — the resource JSON surface has been removed. They now error at the root. Skip those rows; the `cfl page create` ID-capture pattern (test 4.2.2) should be re-run by parsing the `ID:` key-value line from the default text output instead.
+
 ---
 
 ## Untested Claims Inventory

--- a/tools/cfl/test-plan-writes.md
+++ b/tools/cfl/test-plan-writes.md
@@ -177,7 +177,7 @@ This document inventories all untested assertions and provides comprehensive tes
 | # | Test Case | Command | Expected | Priority |
 |---|-----------|---------|----------|----------|
 | 1.8.1 | Default output | `cfl page create -s SPACE -t "Test" -f test.md` | Success message with ID, URL | HIGH |
-| 1.8.2 | JSON output | `cfl page create -s SPACE -t "Test" -f test.md -o json` | Valid JSON with page data | MEDIUM |
+| 1.8.2 | ~~JSON output~~ (#392 removed) | `cfl page create -s SPACE -t "Test" -f test.md -o json` | Errors: invalid output format | OBSOLETE |
 | 1.8.3 | Plain output | `cfl page create -s SPACE -t "Test" -f test.md -o plain` | Tab-separated | LOW |
 
 ---
@@ -216,7 +216,7 @@ This document inventories all untested assertions and provides comprehensive tes
 |---|-----------|---------|----------|----------|
 | 2.3.1 | List page with attachments | `cfl attachment list -p PAGE_ID` | Table with ID, name, type, size | HIGH |
 | 2.3.2 | List page without attachments | `cfl attachment list -p PAGE_NO_ATT` | "No attachments" message | MEDIUM |
-| 2.3.3 | JSON output | `cfl attachment list -p PAGE_ID -o json` | Valid JSON array | MEDIUM |
+| 2.3.3 | ~~JSON output~~ (#392 removed) | `cfl attachment list -p PAGE_ID -o json` | Errors: invalid output format | OBSOLETE |
 
 ---
 
@@ -269,7 +269,7 @@ This document inventories all untested assertions and provides comprehensive tes
 | # | Test Case | Command | Expected | Priority |
 |---|-----------|---------|----------|----------|
 | 4.2.1 | Pipe file content | `cat notes.md \| cfl page create -s SPACE -t "Test"` | Page created | HIGH |
-| 4.2.2 | Capture created ID | `cfl page create -s SPACE -t "Test" -f x.md -o json \| jq -r .id` | Extracts page ID | HIGH |
+| 4.2.2 | Capture created ID | `cfl page create -s SPACE -t "Test" -f x.md \| awk -F': ' '/^ID:/ {print $2; exit}'` | Extracts page ID (was `-o json \| jq -r .id` pre-#392) | HIGH |
 | 4.2.3 | Script: create many pages | Loop creating 10 pages | All succeed | MEDIUM |
 
 ---


### PR DESCRIPTION
## Summary

Remove `-o json` from cfl's global resource surface per cli-common `docs/output-and-rendering.md` §2 (JSON reserved for round-trip payloads + control-plane envelopes only). The global `-o/--output` flag now enforces a closed set `{table, plain}` at the cfl root prerun and rejects anything else uniformly with `invalid output format: "json" (valid formats: table, plain)`. 23 JSON branches across `page/`, `space/`, `attachment/`, `search/` (including mutation-success renderers on create/edit/delete/upload) are deleted along with their tests and the corresponding docs/examples.

`cfl set-credential --json` (local boolean flag, §1.5.2 control-plane envelope) is **preserved unchanged** — different flag, different surface. `shared/view.FormatJSON` is untouched (avoids cross-tool API churn; cfl's root guard makes it unreachable from cfl regardless).

## What's in scope

- Root prerun closed-set validator + flag usage update (runs before `wireBackendSelection`, so flag/policy errors fail fast).
- Delete every `if opts.Output == "json"` branch + the two inverse skips in `attachment/list.go`.
- Drop the `--content-only is incompatible with --output json` cross-check (unreachable).
- Strip `-o json` from `cmd.Example` strings.
- `tools/cfl/scripts/roundtrip-test.sh`: replace `-o json | jq -r '.id'` with `awk -F': ' '/^ID:/ {print $2}'` against the default text output; verified locally with a fixture string.
- Tracked-doc sweep: `tools/cfl/README.md`, `docs/ARTIFACT_CONTRACT.md`, `tools/cfl/integration-tests.md`, `tools/cfl/test-plan-writes.md`, `tools/cfl/chaos-testing.md`.

## Out of scope

- `shared/view/view.go` (jtk's `automation export` round-trip still uses `FormatJSON`).
- The `cfl.output_format` config field — currently captured in YAML but never propagated to runtime `opts.Output`. Cleanup deferred to a separate ticket.
- Sibling JSON-removal tickets (slck#173, nrq#108, gro#144, sfdc#44).

## Breaking change

Scripts that piped `cfl <resource> -o json | jq ...` will break. The `cfl page create` ID-capture path now uses `awk -F': ' '/^ID:/ {print $2}'`; round-trips through `page view` / `page edit` can use `cfl page view <id> --raw --content-only | ...`. The surviving JSON surface for scripted automation is `cfl set-credential --json`.

## Test plan

- [x] make build clean
- [x] make test clean (1041 tests pass across cfl + jtk + shared)
- [x] make lint clean
- [x] TestRoot_RejectsInvalidOutput_AtPreRun covers -o json, -o yaml, and -o ""
- [x] TestValidateOutputFormat table test covers the closed set
- [x] roundtrip-test.sh ID-extraction parser verified against fixture output
- [ ] Optional: end-to-end roundtrip-test.sh run against a real Confluence instance (skipped here; no live credentials)

Closes #392