### PR TITLE
fix: restore static release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,19 @@ jobs:
           filters: |
             cfl:
               - 'tools/cfl/**'
+              - '.goreleaser-cfl.yml'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release-cfl.yml'
             jtk:
               - 'tools/jtk/**'
+              - '.goreleaser-jtk.yml'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release-jtk.yml'
             shared:
               - 'shared/**'
+              - 'go.work'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
 
   build-test-cfl:
     needs: detect-changes
@@ -38,6 +47,24 @@ jobs:
         run: cd tools/cfl && go mod tidy && git diff --exit-code go.mod go.sum
       - name: Build cfl
         run: go build -v ./tools/cfl/...
+      - name: Static release build guard cfl
+        run: |
+          set -euo pipefail
+          cd tools/cfl
+          for target in linux/amd64 linux/arm64 windows/amd64 windows/arm64; do
+            goos="${target%/*}"
+            goarch="${target#*/}"
+            CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+              go build -o "$RUNNER_TEMP/cfl-$goos-$goarch" ./cmd/cfl
+          done
+
+          for goarch in amd64 arm64; do
+            deps=$(CGO_ENABLED=0 GOOS=linux GOARCH="$goarch" go list -deps ./cmd/cfl)
+            if printf '%s\n' "$deps" | grep -E '^(github.com/byteness/keyring|github.com/1password/onepassword-sdk-go)(/|$)'; then
+              echo "static Linux cfl $goarch build graph must not include byteness/keyring or onepassword-sdk-go"
+              exit 1
+            fi
+          done
       - name: Test cfl
         run: go test -v -race -coverprofile=coverage-cfl.out ./tools/cfl/...
 
@@ -54,6 +81,24 @@ jobs:
         run: cd tools/jtk && go mod tidy && git diff --exit-code go.mod go.sum
       - name: Build jtk
         run: go build -v ./tools/jtk/...
+      - name: Static release build guard jtk
+        run: |
+          set -euo pipefail
+          cd tools/jtk
+          for target in linux/amd64 linux/arm64 windows/amd64 windows/arm64; do
+            goos="${target%/*}"
+            goarch="${target#*/}"
+            CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+              go build -o "$RUNNER_TEMP/jtk-$goos-$goarch" ./cmd/jtk
+          done
+
+          for goarch in amd64 arm64; do
+            deps=$(CGO_ENABLED=0 GOOS=linux GOARCH="$goarch" go list -deps ./cmd/jtk)
+            if printf '%s\n' "$deps" | grep -E '^(github.com/byteness/keyring|github.com/1password/onepassword-sdk-go)(/|$)'; then
+              echo "static Linux jtk $goarch build graph must not include byteness/keyring or onepassword-sdk-go"
+              exit 1
+            fi
+          done
       - name: Test jtk
         run: go test -v -race -coverprofile=coverage-jtk.out ./tools/jtk/...
 
@@ -98,6 +143,18 @@ jobs:
         run: cd shared && go mod tidy && git diff --exit-code go.mod go.sum
       - name: Build shared
         run: go build -v ./shared/...
+      - name: Static Linux build guard shared
+        run: |
+          set -euo pipefail
+          cd shared
+          for goarch in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="$goarch" go build ./...
+            deps=$(CGO_ENABLED=0 GOOS=linux GOARCH="$goarch" go list -deps ./...)
+            if printf '%s\n' "$deps" | grep -E '^(github.com/byteness/keyring|github.com/1password/onepassword-sdk-go)(/|$)'; then
+              echo "static Linux shared $goarch build graph must not include byteness/keyring or onepassword-sdk-go"
+              exit 1
+            fi
+          done
       - name: Test shared
         run: go test -v -race -coverprofile=coverage-shared.out ./shared/...
 

--- a/shared/go.mod
+++ b/shared/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/fatih/color v1.18.0
 	github.com/gohugoio/hugo-goldmark-extensions/extras v0.6.0
-	github.com/open-cli-collective/cli-common v0.2.1
+	github.com/open-cli-collective/cli-common v0.2.2
 	github.com/yuin/goldmark v1.7.16
 	golang.org/x/term v0.43.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/shared/go.sum
+++ b/shared/go.sum
@@ -49,8 +49,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.2.1 h1:awnwmDD9ubGUmYLg+SGkPGzbiraJsJb/eMWWTV4fwPI=
-github.com/open-cli-collective/cli-common v0.2.1/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
+github.com/open-cli-collective/cli-common v0.2.2 h1:m5Uzvw5ya/Xljgn54wuCiVP4zXE9BZKikpQBqrXLCKg=
+github.com/open-cli-collective/cli-common v0.2.2/go.mod h1:nXAwJcuAo5+bMUD2soABKDwy2o27snBggS6/OTKQgvQ=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tools/cfl/go.mod
+++ b/tools/cfl/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0
 	github.com/charmbracelet/huh v0.8.0
 	github.com/open-cli-collective/atlassian-go v0.0.0-00010101000000-000000000000
-	github.com/open-cli-collective/cli-common v0.2.1
+	github.com/open-cli-collective/cli-common v0.2.2
 	github.com/spf13/cobra v1.8.1
 	github.com/yuin/goldmark v1.7.16
 	golang.org/x/text v0.37.0

--- a/tools/cfl/go.sum
+++ b/tools/cfl/go.sum
@@ -118,8 +118,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.2.1 h1:awnwmDD9ubGUmYLg+SGkPGzbiraJsJb/eMWWTV4fwPI=
-github.com/open-cli-collective/cli-common v0.2.1/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
+github.com/open-cli-collective/cli-common v0.2.2 h1:m5Uzvw5ya/Xljgn54wuCiVP4zXE9BZKikpQBqrXLCKg=
+github.com/open-cli-collective/cli-common v0.2.2/go.mod h1:nXAwJcuAo5+bMUD2soABKDwy2o27snBggS6/OTKQgvQ=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tools/jtk/go.mod
+++ b/tools/jtk/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/charmbracelet/huh v0.8.0
 	github.com/open-cli-collective/atlassian-go v0.0.0-00010101000000-000000000000
-	github.com/open-cli-collective/cli-common v0.2.1
+	github.com/open-cli-collective/cli-common v0.2.2
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/tools/jtk/go.sum
+++ b/tools/jtk/go.sum
@@ -114,8 +114,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.2.1 h1:awnwmDD9ubGUmYLg+SGkPGzbiraJsJb/eMWWTV4fwPI=
-github.com/open-cli-collective/cli-common v0.2.1/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
+github.com/open-cli-collective/cli-common v0.2.2 h1:m5Uzvw5ya/Xljgn54wuCiVP4zXE9BZKikpQBqrXLCKg=
+github.com/open-cli-collective/cli-common v0.2.2/go.mod h1:nXAwJcuAo5+bMUD2soABKDwy2o27snBggS6/OTKQgvQ=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
## Summary
- bump all atlassian-cli modules to cli-common v0.2.2
- add static release build guards for cfl and jtk across Linux and Windows targets
- add shared-module static Linux build/dependency guards so cli-common regressions are caught before release

## Verification
- make test
- make tidy
- static guard equivalents for cfl, jtk, and shared
- git diff --check

Closes #398