### PR TITLE
Add cfl space type regression coverage

### DIFF
--- a/tools/cfl/internal/cmd/space/list_test.go
+++ b/tools/cfl/internal/cmd/space/list_test.go
@@ -3,6 +3,7 @@ package space
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -161,27 +162,25 @@ func TestRunList_PreservesRawSpaceTypes(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		if key := r.URL.Query().Get("keys"); key != "" {
-			spaceTypeByKey := map[string]string{
-				"GLOBAL":     "global",
-				"~123":       "personal",
-				"CONFLUENCE": "collaboration",
-				"Education":  "knowledge_base",
+			spaces := map[string]api.Space{
+				"GLOBAL":     {ID: "1", Key: "GLOBAL", Name: "Space With Words", Type: "global", Status: "current"},
+				"~123":       {ID: "2", Key: "~123", Name: "Space With Words", Type: "personal", Status: "current"},
+				"CONFLUENCE": {ID: "3", Key: "CONFLUENCE", Name: "Space With Words", Type: "collaboration", Status: "current"},
+				"Education":  {ID: "4", Key: "Education", Name: "Space With Words", Type: "knowledge_base", Status: "current"},
 			}
-			_, _ = w.Write([]byte(`{
-				"results": [
-					{"id": "3", "key": "` + key + `", "name": "Space With Words", "type": "` + spaceTypeByKey[key] + `", "status": "current"}
-				]
-			}`))
+			_ = json.NewEncoder(w).Encode(api.PaginatedResponse[api.Space]{
+				Results: []api.Space{spaces[key]},
+			})
 			return
 		}
-		_, _ = w.Write([]byte(`{
-			"results": [
-				{"id": "1", "key": "GLOBAL", "name": "Global Space", "type": "global", "status": "current"},
-				{"id": "2", "key": "~123", "name": "Personal Space", "type": "personal", "status": "current"},
-				{"id": "3", "key": "CONFLUENCE", "name": "Confluence CLI", "type": "collaboration", "status": "current"},
-				{"id": "4", "key": "Education", "name": "Education Space", "type": "knowledge_base", "status": "current"}
-			]
-		}`))
+		_ = json.NewEncoder(w).Encode(api.PaginatedResponse[api.Space]{
+			Results: []api.Space{
+				{ID: "1", Key: "GLOBAL", Name: "Global Space", Type: "global", Status: "current"},
+				{ID: "2", Key: "~123", Name: "Personal Space", Type: "personal", Status: "current"},
+				{ID: "3", Key: "CONFLUENCE", Name: "Confluence CLI", Type: "collaboration", Status: "current"},
+				{ID: "4", Key: "Education", Name: "Education Space", Type: "knowledge_base", Status: "current"},
+			},
+		})
 	}))
 	defer server.Close()
 

--- a/tools/cfl/internal/cmd/space/list_test.go
+++ b/tools/cfl/internal/cmd/space/list_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -157,13 +158,21 @@ func TestRunList_WithTypeFilter(t *testing.T) {
 
 func TestRunList_PreservesRawSpaceTypes(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
+		if r.URL.Query().Get("keys") == "CONFLUENCE" {
+			_, _ = w.Write([]byte(`{
+				"results": [
+					{"id": "3", "key": "CONFLUENCE", "name": "ConfluenceCLI", "type": "collaboration", "status": "current"}
+				]
+			}`))
+			return
+		}
 		_, _ = w.Write([]byte(`{
 			"results": [
 				{"id": "1", "key": "GLOBAL", "name": "Global", "type": "global"},
 				{"id": "2", "key": "~123", "name": "Personal", "type": "personal"},
-				{"id": "3", "key": "CONFLUENCE", "name": "Confluence CLI", "type": "collaboration"},
+				{"id": "3", "key": "CONFLUENCE", "name": "ConfluenceCLI", "type": "collaboration"},
 				{"id": "4", "key": "Education", "name": "Education", "type": "knowledge_base"}
 			]
 		}`))
@@ -183,11 +192,32 @@ func TestRunList_PreservesRawSpaceTypes(t *testing.T) {
 
 	err := runList(context.Background(), opts)
 	testutil.RequireNoError(t, err)
-	output := stdout.String()
-	testutil.Contains(t, output, "global")
-	testutil.Contains(t, output, "personal")
-	testutil.Contains(t, output, "collaboration")
-	testutil.Contains(t, output, "knowledge_base")
+	gotTypes := spaceTypesByKey(stdout.String())
+	testutil.Equal(t, "global", gotTypes["GLOBAL"])
+	testutil.Equal(t, "personal", gotTypes["~123"])
+	testutil.Equal(t, "collaboration", gotTypes["CONFLUENCE"])
+	testutil.Equal(t, "knowledge_base", gotTypes["Education"])
+
+	viewStdout := &bytes.Buffer{}
+	viewRootOpts := newTestRootOptions()
+	viewRootOpts.Stdout = viewStdout
+	viewRootOpts.SetAPIClient(client)
+
+	viewOpts := &viewOptions{Options: viewRootOpts}
+	err = runView(context.Background(), "CONFLUENCE", viewOpts)
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, viewStdout.String(), "Type: "+gotTypes["CONFLUENCE"])
+}
+
+func spaceTypesByKey(output string) map[string]string {
+	types := make(map[string]string)
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[0] != "KEY" {
+			types[fields[0]] = fields[2]
+		}
+	}
+	return types
 }
 
 func TestRunList_WithLimitParameter(t *testing.T) {

--- a/tools/cfl/internal/cmd/space/list_test.go
+++ b/tools/cfl/internal/cmd/space/list_test.go
@@ -155,6 +155,41 @@ func TestRunList_WithTypeFilter(t *testing.T) {
 	testutil.RequireNoError(t, err)
 }
 
+func TestRunList_PreservesRawSpaceTypes(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{"id": "1", "key": "GLOBAL", "name": "Global", "type": "global"},
+				{"id": "2", "key": "~123", "name": "Personal", "type": "personal"},
+				{"id": "3", "key": "CONFLUENCE", "name": "Confluence CLI", "type": "collaboration"},
+				{"id": "4", "key": "Education", "name": "Education", "type": "knowledge_base"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	rootOpts := newTestRootOptions()
+	rootOpts.Stdout = stdout
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &listOptions{
+		Options: rootOpts,
+		limit:   25,
+	}
+
+	err := runList(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+	output := stdout.String()
+	testutil.Contains(t, output, "global")
+	testutil.Contains(t, output, "personal")
+	testutil.Contains(t, output, "collaboration")
+	testutil.Contains(t, output, "knowledge_base")
+}
+
 func TestRunList_WithLimitParameter(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tools/cfl/internal/cmd/space/list_test.go
+++ b/tools/cfl/internal/cmd/space/list_test.go
@@ -160,20 +160,26 @@ func TestRunList_PreservesRawSpaceTypes(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		if r.URL.Query().Get("keys") == "CONFLUENCE" {
+		if key := r.URL.Query().Get("keys"); key != "" {
+			spaceTypeByKey := map[string]string{
+				"GLOBAL":     "global",
+				"~123":       "personal",
+				"CONFLUENCE": "collaboration",
+				"Education":  "knowledge_base",
+			}
 			_, _ = w.Write([]byte(`{
 				"results": [
-					{"id": "3", "key": "CONFLUENCE", "name": "ConfluenceCLI", "type": "collaboration", "status": "current"}
+					{"id": "3", "key": "` + key + `", "name": "Space With Words", "type": "` + spaceTypeByKey[key] + `", "status": "current"}
 				]
 			}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{
 			"results": [
-				{"id": "1", "key": "GLOBAL", "name": "Global", "type": "global"},
-				{"id": "2", "key": "~123", "name": "Personal", "type": "personal"},
-				{"id": "3", "key": "CONFLUENCE", "name": "ConfluenceCLI", "type": "collaboration"},
-				{"id": "4", "key": "Education", "name": "Education", "type": "knowledge_base"}
+				{"id": "1", "key": "GLOBAL", "name": "Global Space", "type": "global", "status": "current"},
+				{"id": "2", "key": "~123", "name": "Personal Space", "type": "personal", "status": "current"},
+				{"id": "3", "key": "CONFLUENCE", "name": "Confluence CLI", "type": "collaboration", "status": "current"},
+				{"id": "4", "key": "Education", "name": "Education Space", "type": "knowledge_base", "status": "current"}
 			]
 		}`))
 	}))
@@ -198,24 +204,44 @@ func TestRunList_PreservesRawSpaceTypes(t *testing.T) {
 	testutil.Equal(t, "collaboration", gotTypes["CONFLUENCE"])
 	testutil.Equal(t, "knowledge_base", gotTypes["Education"])
 
-	viewStdout := &bytes.Buffer{}
-	viewRootOpts := newTestRootOptions()
-	viewRootOpts.Stdout = viewStdout
-	viewRootOpts.SetAPIClient(client)
+	for key, listType := range gotTypes {
+		viewStdout := &bytes.Buffer{}
+		viewRootOpts := newTestRootOptions()
+		viewRootOpts.Stdout = viewStdout
+		viewRootOpts.SetAPIClient(client)
 
-	viewOpts := &viewOptions{Options: viewRootOpts}
-	err = runView(context.Background(), "CONFLUENCE", viewOpts)
-	testutil.RequireNoError(t, err)
-	testutil.Contains(t, viewStdout.String(), "Type: "+gotTypes["CONFLUENCE"])
+		viewOpts := &viewOptions{Options: viewRootOpts}
+		err = runView(context.Background(), key, viewOpts)
+		testutil.RequireNoError(t, err)
+		testutil.Contains(t, viewStdout.String(), "Type: "+listType)
+	}
 }
 
 func spaceTypesByKey(output string) map[string]string {
 	types := make(map[string]string)
-	for _, line := range strings.Split(output, "\n") {
-		fields := strings.Fields(line)
-		if len(fields) >= 3 && fields[0] != "KEY" {
-			types[fields[0]] = fields[2]
+	lines := strings.Split(output, "\n")
+	if len(lines) == 0 {
+		return types
+	}
+	header := lines[0]
+	typeStart := strings.Index(header, "TYPE")
+	descStart := strings.Index(header, "DESCRIPTION")
+	if typeStart < 0 || descStart < 0 || descStart <= typeStart {
+		return types
+	}
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) == "" || len(line) <= typeStart {
+			continue
 		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		end := descStart
+		if len(line) < end {
+			end = len(line)
+		}
+		types[fields[0]] = strings.TrimSpace(line[typeStart:end])
 	}
 	return types
 }

--- a/tools/cfl/internal/cmd/space/space_test.go
+++ b/tools/cfl/internal/cmd/space/space_test.go
@@ -73,6 +73,58 @@ func TestRunView_Table(t *testing.T) {
 	testutil.Contains(t, output, "A test space")
 }
 
+func TestRunView_PreservesRawSpaceType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		spaceKey  string
+		spaceType string
+	}{
+		{name: "collaboration", spaceKey: "CONFLUENCE", spaceType: "collaboration"},
+		{name: "knowledge base", spaceKey: "Education", spaceType: "knowledge_base"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				testutil.Equal(t, "GET", r.Method)
+				testutil.Equal(t, "/api/v2/spaces", r.URL.Path)
+				testutil.Equal(t, tt.spaceKey, r.URL.Query().Get("keys"))
+				testutil.Equal(t, "1", r.URL.Query().Get("limit"))
+
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{
+					"results": [{
+						"id": "123456",
+						"key": "` + tt.spaceKey + `",
+						"name": "Test Space",
+						"type": "` + tt.spaceType + `",
+						"status": "current"
+					}]
+				}`))
+			}))
+			defer server.Close()
+
+			stdout := &bytes.Buffer{}
+			rootOpts := &root.Options{
+				Output:  "table",
+				NoColor: true,
+				Stdout:  stdout,
+				Stderr:  &bytes.Buffer{},
+			}
+			client := api.NewClient(server.URL, "test@example.com", "token")
+			rootOpts.SetAPIClient(client)
+
+			opts := &viewOptions{Options: rootOpts}
+			err := runView(context.Background(), tt.spaceKey, opts)
+
+			testutil.RequireNoError(t, err)
+			testutil.Contains(t, stdout.String(), "Type: "+tt.spaceType)
+		})
+	}
+}
+
 func TestRunView_NotFound(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary
- add regression coverage that cfl space view preserves raw Confluence type values
- add list coverage for global, personal, collaboration, and knowledge_base types
- no production behavior changes; current dev already shows list/view agreement

Closes #382

## Tests
- rtk go test ./tools/cfl/api ./tools/cfl/internal/cmd/space
- rtk make test
- rtk go run ./tools/cfl/cmd/cfl --no-color --non-interactive space list --limit 100
- rtk go run ./tools/cfl/cmd/cfl --no-color --non-interactive space view confluence

Manual smoke note: the preceding space list output included key `confluence` with type `collaboration`; the follow-up space view for the same key also reported `Type: collaboration`.