### PR TITLE
fix: remove low-value CLI comments

### DIFF
--- a/tools/cfl/api/attachments.go
+++ b/tools/cfl/api/attachments.go
@@ -107,11 +107,9 @@ func (c *Client) DownloadAttachment(ctx context.Context, attachmentID string) (i
 // UploadAttachment uploads a file as an attachment to a page.
 // Note: This uses the v1 API as v2 doesn't support uploads yet.
 func (c *Client) UploadAttachment(ctx context.Context, pageID, filename string, content io.Reader, comment string) (*Attachment, error) {
-	// Create multipart form
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 
-	// Add file part
 	part, err := writer.CreateFormFile("file", filename)
 	if err != nil {
 		return nil, fmt.Errorf("creating form file: %w", err)
@@ -120,7 +118,6 @@ func (c *Client) UploadAttachment(ctx context.Context, pageID, filename string, 
 		return nil, fmt.Errorf("copying file content: %w", err)
 	}
 
-	// Add comment if provided
 	if comment != "" {
 		if err := writer.WriteField("comment", comment); err != nil {
 			return nil, fmt.Errorf("writing comment field: %w", err)

--- a/tools/jtk/api/client.go
+++ b/tools/jtk/api/client.go
@@ -54,7 +54,6 @@ func New(cfg ClientConfig) (*Client, error) {
 		return nil, ErrAPITokenRequired
 	}
 
-	// Validate auth method if explicitly set
 	if cfg.AuthMethod != "" {
 		if err := auth.ValidateAuthMethod(cfg.AuthMethod); err != nil {
 			return nil, err
@@ -74,7 +73,6 @@ func New(cfg ClientConfig) (*Client, error) {
 	baseURL := url.NormalizeURL(cfg.URL)
 	restURL := baseURL + "/rest/api/3"
 
-	// Create shared client with verbose option
 	var opts *client.Options
 	if cfg.Verbose {
 		opts = &client.Options{Verbose: true}


### PR DESCRIPTION
Closes #402

## Summary
- remove comments that restate obvious standard library calls/control flow
- keep comments that explain non-obvious API constraints or compatibility reasons
- touch both cfl and jtk Go paths so both path-filtered release workflows run after merge

## Release workflow note
The PR title intentionally starts with `fix:` so the squash merge commit should satisfy the auto-release `create-tag` job gate for both cfl and jtk.

## Tests
- `go test ./tools/cfl/api ./tools/jtk/api`