### PR TITLE
test: serialize jtk links tests that share the global cache override

### DIFF
--- a/tools/jtk/internal/cmd/links/links_test.go
+++ b/tools/jtk/internal/cmd/links/links_test.go
@@ -17,10 +17,13 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
-// isolateCache points cache I/O at a temp directory and overrides the
-// derived instance key directly (bypassing env-var parsing) so tests can
-// run under t.Parallel() without the t.Setenv race. Matches the pattern
-// used by the rest of the package.
+// isolateCache points cache I/O at a temp directory and overrides the derived
+// instance key directly (bypassing env-var parsing), avoiding the t.Setenv
+// panic. The overrides are process-global (cache.rootOverride/instanceOverride),
+// so a test that seeds or reads the cache MUST NOT call t.Parallel(): concurrent
+// tests would clobber the shared root and one could read another's (or an empty)
+// cache dir. Tests in this package that don't touch the cache may still run in
+// parallel.
 func isolateCache(t *testing.T) {
 	t.Helper()
 	t.Cleanup(cache.SetRootForTest(t.TempDir()))
@@ -393,7 +396,7 @@ func seedLinkTypesForTest(t *testing.T) {
 }
 
 func TestRunCreate_CanonicalRow(t *testing.T) {
-	t.Parallel()
+	// no t.Parallel(): seeds the process-global cache override (see isolateCache).
 	server := createServerWithRefetch(t)
 	defer server.Close()
 
@@ -422,7 +425,7 @@ func TestRunCreate_CanonicalRow(t *testing.T) {
 }
 
 func TestRunCreate_IDOnly(t *testing.T) {
-	t.Parallel()
+	// no t.Parallel(): seeds the process-global cache override (see isolateCache).
 	server := createServerWithRefetch(t)
 	defer server.Close()
 


### PR DESCRIPTION
## Problem

`TestRunCreate_IDOnly` (and `TestRunCreate_CanonicalRow`) flaked the jtk release build once with:

```
links_test.go: cannot resolve link type "Blocker" from cache — run `jtk refresh linktypes`
```

Root cause: `cache.SetRootForTest`/`SetInstanceKeyForTest` set **process-global** overrides (the mutex guards the variable, not the logical interleaving). Both tests call `t.Parallel()` while seeding that global via `isolateCache`/`seedLinkTypesForTest`. A parallel sibling can reset the root between a test's seed-write and its read → cache miss. It passes under favorable scheduling (PR CI) and fails under others (the release runner). The `isolateCache` comment claimed a `t.Parallel()`-safety it never had.

## Fix (Codex-reviewed, Plan A)

Drop `t.Parallel()` from the **only two** tests that are both parallel *and* cache-touching. The other nine parallel tests in the package don't touch the cache and stay parallel. Corrected the misleading `isolateCache` comment. No production code touched.

## Verification

- `go test ./...` (full jtk module) green.
- `go test ./internal/cmd/links -count=30 -shuffle=on` → clean (205s). (`-count=100` only "failed" earlier by exceeding the default 600s test timeout — a single run is ~7.3s.)
- `go vet` / `gofmt` clean.