### PR TITLE
Fix macOS Keychain metadata for shared Atlassian credentials

### DIFF
--- a/shared/go.mod
+++ b/shared/go.mod
@@ -3,9 +3,10 @@ module github.com/open-cli-collective/atlassian-go
 go 1.26
 
 require (
+	github.com/byteness/keyring v1.11.0
 	github.com/fatih/color v1.18.0
 	github.com/gohugoio/hugo-goldmark-extensions/extras v0.6.0
-	github.com/open-cli-collective/cli-common v0.3.2
+	github.com/open-cli-collective/cli-common v0.4.1-0.20260620115552-351effa2004b
 	github.com/yuin/goldmark v1.7.16
 	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -16,7 +17,6 @@ require (
 	github.com/1password/onepassword-sdk-go v0.4.1-beta.1 // indirect
 	github.com/byteness/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/byteness/go-libsecret v0.0.0-20260108215642-107379d3dee0 // indirect
-	github.com/byteness/keyring v1.11.0 // indirect
 	github.com/byteness/percent v0.2.2 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dvsekhvalnov/jose2go v1.8.0 // indirect

--- a/shared/go.sum
+++ b/shared/go.sum
@@ -49,8 +49,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.3.2 h1:jj3swzbzmZE9xALMOzTpCQXPylXDxuxWoSTT96G0Q84=
-github.com/open-cli-collective/cli-common v0.3.2/go.mod h1:3AzjCT0V8xgslHlGi1+rUkcV+Vf5wONGwISQkufLZLQ=
+github.com/open-cli-collective/cli-common v0.4.1-0.20260620115552-351effa2004b h1:85ps+R5ae8xyipytCzmyQLMQVDm1xMh+dQrEKCv9Hto=
+github.com/open-cli-collective/cli-common v0.4.1-0.20260620115552-351effa2004b/go.mod h1:3AzjCT0V8xgslHlGi1+rUkcV+Vf5wONGwISQkufLZLQ=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/shared/keyring/keychain_metadata_darwin_test.go
+++ b/shared/keyring/keychain_metadata_darwin_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -109,12 +108,6 @@ func runKeychainMetadataScenario(t *testing.T, kr rawkeyring.Keyring, profile st
 
 func writeToken(t *testing.T, ref, key, value string) {
 	t.Helper()
-	if ref == Ref {
-		if err := SetCredential(strings.NewReader(value+"\n"), ""); err != nil {
-			t.Fatalf("SetCredential(%s): %v", key, err)
-		}
-		return
-	}
 	s, err := openRef(ref, allowedKeys)
 	if err != nil {
 		t.Fatalf("open shared keyring: %v", err)

--- a/shared/keyring/keychain_metadata_darwin_test.go
+++ b/shared/keyring/keychain_metadata_darwin_test.go
@@ -54,13 +54,14 @@ func TestKeychainMetadataGated(t *testing.T) {
 	}
 	t.Logf("backed up existing Keychain item: %v", hadOriginal)
 	t.Cleanup(func() {
-		if err := removeRawItem(kr, account); err != nil {
-			t.Errorf("cleanup synthetic Keychain item: %v", err)
-		}
 		if hadOriginal {
 			if err := kr.Set(original); err != nil {
 				t.Errorf("restore original Keychain item: %v", err)
 			}
+			return
+		}
+		if err := removeRawItem(kr, account); err != nil {
+			t.Errorf("cleanup synthetic Keychain item: %v", err)
 		}
 	})
 

--- a/shared/keyring/keychain_metadata_darwin_test.go
+++ b/shared/keyring/keychain_metadata_darwin_test.go
@@ -1,0 +1,171 @@
+//go:build darwin && cgo
+
+package keyring
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	rawkeyring "github.com/byteness/keyring"
+	cccredstore "github.com/open-cli-collective/cli-common/credstore"
+)
+
+func TestKeychainMetadataGated(t *testing.T) {
+	if os.Getenv("ATLASSIAN_KEYCHAIN_METADATA_TEST") != "1" {
+		t.Skip("set ATLASSIAN_KEYCHAIN_METADATA_TEST=1 to run real macOS Keychain metadata tests")
+	}
+
+	realHome := os.Getenv("HOME")
+	hermetic(t)
+	t.Setenv("HOME", realHome)
+	SetBackendSelection(cccredstore.BackendKeychain, "")
+	t.Cleanup(func() { SetBackendSelection("", "") })
+
+	profile := Profile
+	account := profile + "/" + KeyAPIToken
+	ref := Service + "/" + profile
+	t.Logf("target Keychain item service=%q account=%q", Service, account)
+	kr, err := rawkeyring.Open(rawkeyring.Config{
+		ServiceName:              Service,
+		AllowedBackends:          []rawkeyring.BackendType{rawkeyring.KeychainBackend},
+		KeychainTrustApplication: true,
+	})
+	if err != nil {
+		t.Fatalf("open raw Keychain: %v", err)
+	}
+
+	hadOriginal, err := hasRawMetadata(kr, account)
+	if err != nil {
+		t.Fatalf("inspect existing Keychain item metadata: %v", err)
+	}
+	if hadOriginal && os.Getenv("ATLASSIAN_KEYCHAIN_METADATA_BACKUP_EXISTING") != "1" {
+		profile = "metadata-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+		account = profile + "/" + KeyAPIToken
+		ref = Service + "/" + profile
+		t.Logf("canonical Keychain item already exists; using synthetic account=%q for non-destructive metadata verification", account)
+		hadOriginal = false
+	}
+	original, hadOriginal, err := getRawItem(kr, account)
+	if err != nil {
+		t.Fatalf("backup existing Keychain item data: %v", err)
+	}
+	t.Logf("backed up existing Keychain item: %v", hadOriginal)
+	t.Cleanup(func() {
+		if err := removeRawItem(kr, account); err != nil {
+			t.Errorf("cleanup synthetic Keychain item: %v", err)
+		}
+		if hadOriginal {
+			if err := kr.Set(original); err != nil {
+				t.Errorf("restore original Keychain item: %v", err)
+			}
+		}
+	})
+
+	if err := removeRawItem(kr, account); err != nil {
+		t.Fatalf("clear existing Keychain item before fresh write: %v", err)
+	}
+	t.Logf("cleared Keychain account %q for fresh-write coverage", account)
+
+	wantLabel := Service + " " + account
+	wantDescription := "Credential for " + Service + " " + account
+
+	writeToken(t, ref, KeyAPIToken, "atlassian-fresh-token")
+	assertStoredToken(t, ref, "atlassian-fresh-token")
+	assertMetadata(t, kr, account, wantLabel, wantDescription)
+	t.Log("verified fresh write metadata")
+
+	if err := removeRawItem(kr, account); err != nil {
+		t.Fatalf("clear fresh Keychain item before repair seed: %v", err)
+	}
+	if err := kr.Set(rawkeyring.Item{
+		Key:         account,
+		Data:        []byte("atlassian-legacy-token"),
+		Label:       "stale Atlassian token",
+		Description: "stale metadata before cli-common repair",
+	}); err != nil {
+		t.Fatalf("seed stale Keychain item: %v", err)
+	}
+	assertMetadata(t, kr, account, "stale Atlassian token", "stale metadata before cli-common repair")
+
+	writeToken(t, ref, KeyAPIToken, "atlassian-repaired-token")
+	assertStoredToken(t, ref, "atlassian-repaired-token")
+	assertMetadata(t, kr, account, wantLabel, wantDescription)
+	t.Log("verified overwrite metadata repair")
+}
+
+func writeToken(t *testing.T, ref, key, value string) {
+	t.Helper()
+	s, err := openRef(ref, allowedKeys)
+	if err != nil {
+		t.Fatalf("open shared keyring: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	if err := s.SetToken(key, value); err != nil {
+		t.Fatalf("SetToken(%s): %v", key, err)
+	}
+}
+
+func assertStoredToken(t *testing.T, ref, want string) {
+	t.Helper()
+	s, err := openRef(ref, allowedKeys)
+	if err != nil {
+		t.Fatalf("open shared keyring for readback: %v", err)
+	}
+	defer func() { _ = s.Close() }()
+	got, ok, err := s.Token()
+	if err != nil || !ok || got != want {
+		t.Fatalf("Token() = (%q,%v,%v), want (%q,true,nil)", got, ok, err, want)
+	}
+}
+
+func assertMetadata(t *testing.T, kr rawkeyring.Keyring, account, wantLabel, wantDescription string) {
+	t.Helper()
+	md, err := kr.GetMetadata(account)
+	if err != nil {
+		t.Fatalf("GetMetadata(%s): %v", account, err)
+	}
+	if md.Item == nil {
+		t.Fatal("metadata item is nil")
+	}
+	if md.Label != wantLabel {
+		t.Fatalf("Label = %q, want %q", md.Label, wantLabel)
+	}
+	if md.Description != wantDescription {
+		t.Fatalf("Description = %q, want %q", md.Description, wantDescription)
+	}
+	if len(md.Data) != 0 {
+		t.Fatalf("metadata unexpectedly included secret data: %q", string(md.Data))
+	}
+}
+
+func getRawItem(kr rawkeyring.Keyring, account string) (rawkeyring.Item, bool, error) {
+	it, err := kr.Get(account)
+	if errors.Is(err, rawkeyring.ErrKeyNotFound) {
+		return rawkeyring.Item{}, false, nil
+	}
+	if err != nil {
+		return rawkeyring.Item{}, false, err
+	}
+	return it, true, nil
+}
+
+func hasRawMetadata(kr rawkeyring.Keyring, account string) (bool, error) {
+	_, err := kr.GetMetadata(account)
+	if errors.Is(err, rawkeyring.ErrKeyNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func removeRawItem(kr rawkeyring.Keyring, account string) error {
+	if err := kr.Remove(account); err != nil && !errors.Is(err, rawkeyring.ErrKeyNotFound) {
+		return err
+	}
+	return nil
+}

--- a/shared/keyring/keychain_metadata_darwin_test.go
+++ b/shared/keyring/keychain_metadata_darwin_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,10 +25,6 @@ func TestKeychainMetadataGated(t *testing.T) {
 	SetBackendSelection(cccredstore.BackendKeychain, "")
 	t.Cleanup(func() { SetBackendSelection("", "") })
 
-	profile := Profile
-	account := profile + "/" + KeyAPIToken
-	ref := Service + "/" + profile
-	t.Logf("target Keychain item service=%q account=%q", Service, account)
 	kr, err := rawkeyring.Open(rawkeyring.Config{
 		ServiceName:              Service,
 		AllowedBackends:          []rawkeyring.BackendType{rawkeyring.KeychainBackend},
@@ -37,17 +34,30 @@ func TestKeychainMetadataGated(t *testing.T) {
 		t.Fatalf("open raw Keychain: %v", err)
 	}
 
-	hadOriginal, err := hasRawMetadata(kr, account)
-	if err != nil {
-		t.Fatalf("inspect existing Keychain item metadata: %v", err)
-	}
-	if hadOriginal && os.Getenv("ATLASSIAN_KEYCHAIN_METADATA_BACKUP_EXISTING") != "1" {
-		profile = "metadata-" + strconv.FormatInt(time.Now().UnixNano(), 10)
-		account = profile + "/" + KeyAPIToken
-		ref = Service + "/" + profile
-		t.Logf("canonical Keychain item already exists; using synthetic account=%q for non-destructive metadata verification", account)
-		hadOriginal = false
-	}
+	t.Run("synthetic profile", func(t *testing.T) {
+		profile := "metadata-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+		runKeychainMetadataScenario(t, kr, profile)
+	})
+
+	t.Run("canonical default profile", func(t *testing.T) {
+		hadOriginal, err := hasRawMetadata(kr, Profile+"/"+KeyAPIToken)
+		if err != nil {
+			t.Fatalf("inspect existing canonical Keychain item metadata: %v", err)
+		}
+		if hadOriginal && os.Getenv("ATLASSIAN_KEYCHAIN_METADATA_BACKUP_EXISTING") != "1" {
+			t.Skip("canonical Keychain item already exists; set ATLASSIAN_KEYCHAIN_METADATA_BACKUP_EXISTING=1 to allow secret-data backup/restore before mutation")
+		}
+		runKeychainMetadataScenario(t, kr, Profile)
+	})
+}
+
+func runKeychainMetadataScenario(t *testing.T, kr rawkeyring.Keyring, profile string) {
+	t.Helper()
+
+	account := profile + "/" + KeyAPIToken
+	ref := Service + "/" + profile
+	t.Logf("using Keychain item service=%q account=%q", Service, account)
+
 	original, hadOriginal, err := getRawItem(kr, account)
 	if err != nil {
 		t.Fatalf("backup existing Keychain item data: %v", err)
@@ -99,6 +109,12 @@ func TestKeychainMetadataGated(t *testing.T) {
 
 func writeToken(t *testing.T, ref, key, value string) {
 	t.Helper()
+	if ref == Ref {
+		if err := SetCredential(strings.NewReader(value+"\n"), ""); err != nil {
+			t.Fatalf("SetCredential(%s): %v", key, err)
+		}
+		return
+	}
 	s, err := openRef(ref, allowedKeys)
 	if err != nil {
 		t.Fatalf("open shared keyring: %v", err)

--- a/tools/cfl/go.mod
+++ b/tools/cfl/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0
 	github.com/charmbracelet/huh v0.8.0
 	github.com/open-cli-collective/atlassian-go v0.0.0-00010101000000-000000000000
-	github.com/open-cli-collective/cli-common v0.3.2
+	github.com/open-cli-collective/cli-common v0.4.1-0.20260620115552-351effa2004b
 	github.com/spf13/cobra v1.8.1
 	github.com/yuin/goldmark v1.7.16
 	golang.org/x/text v0.37.0

--- a/tools/cfl/go.sum
+++ b/tools/cfl/go.sum
@@ -118,8 +118,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.3.2 h1:jj3swzbzmZE9xALMOzTpCQXPylXDxuxWoSTT96G0Q84=
-github.com/open-cli-collective/cli-common v0.3.2/go.mod h1:3AzjCT0V8xgslHlGi1+rUkcV+Vf5wONGwISQkufLZLQ=
+github.com/open-cli-collective/cli-common v0.4.1-0.20260620115552-351effa2004b h1:85ps+R5ae8xyipytCzmyQLMQVDm1xMh+dQrEKCv9Hto=
+github.com/open-cli-collective/cli-common v0.4.1-0.20260620115552-351effa2004b/go.mod h1:3AzjCT0V8xgslHlGi1+rUkcV+Vf5wONGwISQkufLZLQ=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/tools/jtk/go.mod
+++ b/tools/jtk/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/charmbracelet/huh v0.8.0
 	github.com/open-cli-collective/atlassian-go v0.0.0-00010101000000-000000000000
-	github.com/open-cli-collective/cli-common v0.3.2
+	github.com/open-cli-collective/cli-common v0.4.1-0.20260620115552-351effa2004b
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/tools/jtk/go.sum
+++ b/tools/jtk/go.sum
@@ -114,8 +114,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.3.2 h1:jj3swzbzmZE9xALMOzTpCQXPylXDxuxWoSTT96G0Q84=
-github.com/open-cli-collective/cli-common v0.3.2/go.mod h1:3AzjCT0V8xgslHlGi1+rUkcV+Vf5wONGwISQkufLZLQ=
+github.com/open-cli-collective/cli-common v0.4.1-0.20260620115552-351effa2004b h1:85ps+R5ae8xyipytCzmyQLMQVDm1xMh+dQrEKCv9Hto=
+github.com/open-cli-collective/cli-common v0.4.1-0.20260620115552-351effa2004b/go.mod h1:3AzjCT0V8xgslHlGi1+rUkcV+Vf5wONGwISQkufLZLQ=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
## Summary

- Bumps `github.com/open-cli-collective/cli-common` to the Keychain metadata fix in `shared`, `tools/cfl`, and `tools/jtk`.
- Adds a Darwin+cgo-gated real macOS Keychain regression test for Atlassian credential metadata writes and overwrite repair.
- Preserves existing canonical `atlassian-cli/default/api_token` state: the test backs it up/restores it when explicitly enabled, and otherwise uses an isolated Atlassian profile for non-destructive empirical verification when a protected default item already exists.

Closes #417

## Verification

- `GOWORK=off go list -m github.com/open-cli-collective/cli-common` in `shared`, `tools/cfl`, and `tools/jtk`
- `go mod tidy -diff` in `shared`, `tools/cfl`, and `tools/jtk`
- `go test ./shared/keyring`
- `ATLASSIAN_KEYCHAIN_METADATA_TEST=1 go test ./shared/keyring -run TestKeychainMetadataGated -count=1 -v`
- `make test`
- `make lint`
- `make build`
- `make check`

Note: local canonical Keychain item `atlassian-cli/default/api_token` already existed and had null description metadata, so the gated empirical test used its non-destructive synthetic-profile fallback and confirmed the synthetic item was removed afterward.
