### PR TITLE
feat(cfl): migrate me to presenter pipeline

### DIFF
--- a/docs/proofs/271-431-cfl-me.md
+++ b/docs/proofs/271-431-cfl-me.md
@@ -1,0 +1,142 @@
+# Proof: #431 `cfl me` Presenter Canary
+
+## Scope Delivered
+
+- Added the first real cfl presenter at `tools/cfl/internal/present/user.go`.
+- Migrated `tools/cfl/internal/cmd/me` to presenter-backed rendering through
+  `present.Emit(opts, model)`.
+- Removed the legacy `RenderUserOneLiner` helper contract from `cmd/me`.
+- Updated `tools/cfl/internal/cmd/init` to reuse the presenter-backed one-line
+  path instead of a `view.View`-based helper.
+
+## Render-Policy Decision
+
+For this canary, `table` and `plain` remain semantically identical because the
+output is a single stdout message line, not a tabular section. The command does
+not branch on format; root render policy still flows through
+`root.Options.RenderMode()` / `RenderStyle()` into `present.Emit(...)`.
+
+Follow-on constraint for `#432`:
+
+- list presenters must stay presenter-backed
+- `present.Emit(...)` remains the single writer
+- preservation of `-o plain` TSV semantics belongs in presenter/render
+  infrastructure, not command-local branching or a return to `shared/view`
+
+## Verification Commands
+
+Executed:
+
+```bash
+rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/me ./tools/cfl/internal/cmd/root ./shared/present
+```
+
+Result:
+
+```text
+Go test: 84 passed in 4 packages
+```
+
+Executed:
+
+```bash
+rtk go test ./tools/cfl/... 
+```
+
+Result:
+
+```text
+Go test: 1089 passed in 16 packages
+```
+
+Executed:
+
+```bash
+rtk git diff --check
+```
+
+Result: no output, no whitespace or patch-format errors.
+
+## Grep Evidence
+
+Executed:
+
+```bash
+rtk sh -lc 'if rtk rg -n "github.com/open-cli-collective/atlassian-go/view|opts\\.View\\(|v\\." tools/cfl/internal/cmd/me --glob "!**/*_test.go"; then :; else printf "no matches in tools/cfl/internal/cmd/me\n"; fi'
+```
+
+Result:
+
+```text
+no matches in tools/cfl/internal/cmd/me
+```
+
+Executed:
+
+```bash
+rtk sh -lc 'if rtk rg -n "RenderUserOneLiner" tools/cfl/internal/cmd/init tools/cfl/internal/cmd/me --glob "!**/*_test.go"; then :; else printf "no RenderUserOneLiner references remain in init/me non-test files\n"; fi'
+```
+
+Result:
+
+```text
+no RenderUserOneLiner references remain in init/me non-test files
+```
+
+Executed:
+
+```bash
+rtk rg -n 'type UserPresenter|PresentUserOneLiner|PresentUserIDOnly|normalizeMeField' tools/cfl/internal/present
+```
+
+Result:
+
+```text
+tools/cfl/internal/present/user.go:13:type UserPresenter struct{}
+tools/cfl/internal/present/user.go:17:func (UserPresenter) PresentUserOneLiner(user *api.User) *sharedpresent.OutputModel {
+tools/cfl/internal/present/user.go:31:func (UserPresenter) PresentUserIDOnly(user *api.User) *sharedpresent.OutputModel {
+tools/cfl/internal/present/user.go:52:func normalizeMeField(value string) string {
+```
+
+## Deterministic CLI Proof
+
+Live smoke for the following user-facing commands was not recorded in this
+proof note because no stable CI-safe Confluence credentials were provisioned for
+the repo-local run:
+
+```bash
+bin/cfl --no-color me
+bin/cfl --no-color me --id
+bin/cfl --no-color -o plain me
+bin/cfl --no-color -o plain me --id
+```
+
+Instead, deterministic httptest-backed Cobra execution covered the same
+externally visible command forms:
+
+Executed:
+
+```bash
+rtk proxy go test ./tools/cfl/internal/cmd/me -run 'TestExecute_DefaultOutputWiredThroughCobra|TestExecute_IDFlagWiredThroughCobra|TestExecute_PlainOutputWiredThroughRootFlag|TestExecute_PlainIDOutputWiredThroughRootFlag' -count=1 -v
+```
+
+Result:
+
+```text
+=== RUN   TestExecute_IDFlagWiredThroughCobra
+=== RUN   TestExecute_DefaultOutputWiredThroughCobra
+=== RUN   TestExecute_PlainOutputWiredThroughRootFlag
+=== RUN   TestExecute_PlainIDOutputWiredThroughRootFlag
+--- PASS: TestExecute_IDFlagWiredThroughCobra (0.00s)
+--- PASS: TestExecute_DefaultOutputWiredThroughCobra (0.00s)
+--- PASS: TestExecute_PlainOutputWiredThroughRootFlag (0.00s)
+--- PASS: TestExecute_PlainIDOutputWiredThroughRootFlag (0.00s)
+PASS
+```
+
+Those tests assert the exact stdout/stderr contract for the command matrix:
+
+- `me` -> `abc123 | Rian Stockbower | rian@example.com\n`, stderr empty
+- `me --id` -> `abc123\n`, stderr empty
+- `-o plain me` -> `abc123 | Rian Stockbower | rian@example.com\n`, stderr empty
+- `-o plain me --id` -> `abc123\n`, stderr empty

--- a/docs/proofs/271-431-cfl-me.md
+++ b/docs/proofs/271-431-cfl-me.md
@@ -34,7 +34,7 @@ rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/me ./tools/cfl
 Result:
 
 ```text
-Go test: 88 passed in 4 packages
+Go test: 86 passed in 4 packages
 ```
 
 Executed:
@@ -47,12 +47,6 @@ Result:
 
 ```text
 Go test: 1089 passed in 16 packages
-```
-
-Final rerun after TDD-review follow-up fixes:
-
-```text
-Go test: 1092 passed in 16 packages
 ```
 
 Executed:
@@ -104,20 +98,6 @@ tools/cfl/internal/present/user.go:31:func (UserPresenter) PresentUserIDOnly(use
 tools/cfl/internal/present/user.go:52:func normalizeMeField(value string) string {
 ```
 
-Executed:
-
-```bash
-rtk rg -n 'emitModel|emitVerifiedUserModel|TestRun_UsesPresenterEmitter|TestFinalizeInit_UsesPresenterEmitterForVerifiedUser' tools/cfl/internal/cmd/me tools/cfl/internal/cmd/init
-```
-
-Result:
-
-```text
-tools/cfl/internal/cmd/me/me.go:15:var emitModel = func(opts *root.Options, model *sharedpresent.OutputModel) error {
-tools/cfl/internal/cmd/me/me_test.go:198:func TestRun_UsesPresenterEmitter(t *testing.T) {
-tools/cfl/internal/cmd/init/init.go:30:var emitVerifiedUserModel = func(opts *root.Options, model *sharedpresent.OutputModel) error {
-tools/cfl/internal/cmd/init/init_test.go:373:func TestFinalizeInit_UsesPresenterEmitterForVerifiedUser(t *testing.T) {
-```
 
 ## Deterministic CLI Proof
 

--- a/docs/proofs/271-431-cfl-me.md
+++ b/docs/proofs/271-431-cfl-me.md
@@ -34,7 +34,7 @@ rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/me ./tools/cfl
 Result:
 
 ```text
-Go test: 86 passed in 4 packages
+Go test: 88 passed in 4 packages
 ```
 
 Executed:
@@ -47,6 +47,12 @@ Result:
 
 ```text
 Go test: 1089 passed in 16 packages
+```
+
+Final rerun after TDD-review follow-up fixes:
+
+```text
+Go test: 1092 passed in 16 packages
 ```
 
 Executed:
@@ -96,6 +102,21 @@ tools/cfl/internal/present/user.go:13:type UserPresenter struct{}
 tools/cfl/internal/present/user.go:17:func (UserPresenter) PresentUserOneLiner(user *api.User) *sharedpresent.OutputModel {
 tools/cfl/internal/present/user.go:31:func (UserPresenter) PresentUserIDOnly(user *api.User) *sharedpresent.OutputModel {
 tools/cfl/internal/present/user.go:52:func normalizeMeField(value string) string {
+```
+
+Executed:
+
+```bash
+rtk rg -n 'emitModel|emitVerifiedUserModel|TestRun_UsesPresenterEmitter|TestFinalizeInit_UsesPresenterEmitterForVerifiedUser' tools/cfl/internal/cmd/me tools/cfl/internal/cmd/init
+```
+
+Result:
+
+```text
+tools/cfl/internal/cmd/me/me.go:15:var emitModel = func(opts *root.Options, model *sharedpresent.OutputModel) error {
+tools/cfl/internal/cmd/me/me_test.go:198:func TestRun_UsesPresenterEmitter(t *testing.T) {
+tools/cfl/internal/cmd/init/init.go:30:var emitVerifiedUserModel = func(opts *root.Options, model *sharedpresent.OutputModel) error {
+tools/cfl/internal/cmd/init/init_test.go:373:func TestFinalizeInit_UsesPresenterEmitterForVerifiedUser(t *testing.T) {
 ```
 
 ## Deterministic CLI Proof

--- a/docs/proofs/271-431-cfl-me.md
+++ b/docs/proofs/271-431-cfl-me.md
@@ -34,7 +34,7 @@ rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/me ./tools/cfl
 Result:
 
 ```text
-Go test: 84 passed in 4 packages
+Go test: 86 passed in 4 packages
 ```
 
 Executed:

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -16,9 +16,9 @@ import (
 	"github.com/open-cli-collective/atlassian-go/prompt"
 
 	"github.com/open-cli-collective/confluence-cli/api"
-	"github.com/open-cli-collective/confluence-cli/internal/cmd/me"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	"github.com/open-cli-collective/confluence-cli/internal/config"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 // clientBuilder constructs an *api.Client from a config.
@@ -415,7 +415,9 @@ func finalizeInit(
 	// during verify. No second API call, no opts state mutation.
 	if verifiedUser != nil {
 		v.Println("")
-		me.RenderUserOneLiner(v, verifiedUser)
+		if err := cflpresent.Emit(opts, cflpresent.UserPresenter{}.PresentUserOneLiner(verifiedUser)); err != nil {
+			return err
+		}
 	}
 
 	v.Println("")

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -13,7 +13,6 @@ import (
 	"github.com/open-cli-collective/atlassian-go/auth"
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/keyring"
-	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/prompt"
 
 	"github.com/open-cli-collective/confluence-cli/api"
@@ -26,10 +25,6 @@ import (
 // Pulled out as a parameter so tests can inject an httptest-pointed client
 // without depending on api.NewBearerClient's hardcoded gateway URL.
 type clientBuilder func(cfg *config.Config) (*api.Client, error)
-
-var emitVerifiedUserModel = func(opts *root.Options, model *sharedpresent.OutputModel) error {
-	return cflpresent.Emit(opts, model)
-}
 
 func defaultClientBuilder(cfg *config.Config) (*api.Client, error) {
 	if cfg.AuthMethod == auth.AuthMethodBearer {
@@ -420,7 +415,7 @@ func finalizeInit(
 	// during verify. No second API call, no opts state mutation.
 	if verifiedUser != nil {
 		v.Println("")
-		if err := emitVerifiedUserModel(opts, cflpresent.UserPresenter{}.PresentUserOneLiner(verifiedUser)); err != nil {
+		if err := cflpresent.Emit(opts, cflpresent.UserPresenter{}.PresentUserOneLiner(verifiedUser)); err != nil {
 			return err
 		}
 	}

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/auth"
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/keyring"
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/prompt"
 
 	"github.com/open-cli-collective/confluence-cli/api"
@@ -25,6 +26,10 @@ import (
 // Pulled out as a parameter so tests can inject an httptest-pointed client
 // without depending on api.NewBearerClient's hardcoded gateway URL.
 type clientBuilder func(cfg *config.Config) (*api.Client, error)
+
+var emitVerifiedUserModel = func(opts *root.Options, model *sharedpresent.OutputModel) error {
+	return cflpresent.Emit(opts, model)
+}
 
 func defaultClientBuilder(cfg *config.Config) (*api.Client, error) {
 	if cfg.AuthMethod == auth.AuthMethodBearer {
@@ -415,7 +420,7 @@ func finalizeInit(
 	// during verify. No second API call, no opts state mutation.
 	if verifiedUser != nil {
 		v.Println("")
-		if err := cflpresent.Emit(opts, cflpresent.UserPresenter{}.PresentUserOneLiner(verifiedUser)); err != nil {
+		if err := emitVerifiedUserModel(opts, cflpresent.UserPresenter{}.PresentUserOneLiner(verifiedUser)); err != nil {
 			return err
 		}
 	}

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
-	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/spf13/cobra"
 
@@ -368,45 +367,6 @@ func TestFinalizeInit_BearerHappyPath(t *testing.T) {
 
 	_, err = os.Stat(configPath)
 	testutil.RequireNoError(t, err)
-}
-
-func TestFinalizeInit_UsesPresenterEmitterForVerifiedUser(t *testing.T) {
-	credtest.Hermetic(t)
-	server := userResponseServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`, http.StatusOK)
-	defer server.Close()
-
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.yml")
-	opts := newFinalizeOpts()
-	cfg := &config.Config{
-		URL:      server.URL,
-		Email:    "rian@example.com",
-		APIToken: "test-token",
-	}
-
-	build := func(_ *config.Config) (*api.Client, error) {
-		return api.NewClient(server.URL, "rian@example.com", "test-token"), nil
-	}
-
-	originalEmit := emitVerifiedUserModel
-	t.Cleanup(func() { emitVerifiedUserModel = originalEmit })
-
-	var capturedModel *sharedpresent.OutputModel
-	emitVerifiedUserModel = func(_ *root.Options, model *sharedpresent.OutputModel) error {
-		capturedModel = model
-		return nil
-	}
-
-	err := finalizeInit(context.Background(), opts, cfg, newFinalizeReconcileResult(), configPath, false, build)
-	testutil.RequireNoError(t, err)
-	testutil.NotNil(t, capturedModel)
-
-	msg, ok := capturedModel.Sections[0].(*sharedpresent.MessageSection)
-	if !ok {
-		t.Fatalf("expected MessageSection, got %T", capturedModel.Sections[0])
-	}
-	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com", msg.Message)
-	testutil.Equal(t, sharedpresent.StreamStdout, msg.Stream)
 }
 
 // TestDefaultClientBuilder verifies the production wiring between

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/spf13/cobra"
 
@@ -367,6 +368,45 @@ func TestFinalizeInit_BearerHappyPath(t *testing.T) {
 
 	_, err = os.Stat(configPath)
 	testutil.RequireNoError(t, err)
+}
+
+func TestFinalizeInit_UsesPresenterEmitterForVerifiedUser(t *testing.T) {
+	credtest.Hermetic(t)
+	server := userResponseServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`, http.StatusOK)
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yml")
+	opts := newFinalizeOpts()
+	cfg := &config.Config{
+		URL:      server.URL,
+		Email:    "rian@example.com",
+		APIToken: "test-token",
+	}
+
+	build := func(_ *config.Config) (*api.Client, error) {
+		return api.NewClient(server.URL, "rian@example.com", "test-token"), nil
+	}
+
+	originalEmit := emitVerifiedUserModel
+	t.Cleanup(func() { emitVerifiedUserModel = originalEmit })
+
+	var capturedModel *sharedpresent.OutputModel
+	emitVerifiedUserModel = func(_ *root.Options, model *sharedpresent.OutputModel) error {
+		capturedModel = model
+		return nil
+	}
+
+	err := finalizeInit(context.Background(), opts, cfg, newFinalizeReconcileResult(), configPath, false, build)
+	testutil.RequireNoError(t, err)
+	testutil.NotNil(t, capturedModel)
+
+	msg, ok := capturedModel.Sections[0].(*sharedpresent.MessageSection)
+	if !ok {
+		t.Fatalf("expected MessageSection, got %T", capturedModel.Sections[0])
+	}
+	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com", msg.Message)
+	testutil.Equal(t, sharedpresent.StreamStdout, msg.Stream)
 }
 
 // TestDefaultClientBuilder verifies the production wiring between

--- a/tools/cfl/internal/cmd/me/me.go
+++ b/tools/cfl/internal/cmd/me/me.go
@@ -4,14 +4,11 @@ package me
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/view"
-
-	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 // Register adds the me command to the root command.
@@ -51,37 +48,9 @@ func Run(ctx context.Context, opts *root.Options, idOnly bool) error {
 		return fmt.Errorf("getting current user: %w", err)
 	}
 
-	v := opts.View()
+	presenter := cflpresent.UserPresenter{}
 	if idOnly {
-		v.Println("%s", normalizeField(user.AccountID))
-		return nil
+		return cflpresent.Emit(opts, presenter.PresentUserIDOnly(user))
 	}
-	RenderUserOneLiner(v, user)
-	return nil
-}
-
-// RenderUserOneLiner writes the canonical 3-field user one-liner to v.
-// Exported so cfl init can render the same output after a successful save
-// without re-fetching the user or going through opts.APIClient().
-//
-// Field values are normalized so the output is always exactly three
-// pipe-delimited fields on a single line — newlines collapse to spaces and
-// embedded pipes are escaped to "\|" so downstream parsers can rely on
-// `split('|')` returning three columns.
-func RenderUserOneLiner(v *view.View, user *api.User) {
-	id := normalizeField(user.AccountID)
-	name := normalizeField(user.DisplayName)
-	email := normalizeField(user.Email)
-	v.Println("%s | %s | %s", id, name, email)
-}
-
-func normalizeField(s string) string {
-	if s == "" {
-		return "-"
-	}
-	s = strings.ReplaceAll(s, "\r\n", " ")
-	s = strings.ReplaceAll(s, "\n", " ")
-	s = strings.ReplaceAll(s, "\r", " ")
-	s = strings.ReplaceAll(s, "|", `\|`)
-	return s
+	return cflpresent.Emit(opts, presenter.PresentUserOneLiner(user))
 }

--- a/tools/cfl/internal/cmd/me/me.go
+++ b/tools/cfl/internal/cmd/me/me.go
@@ -5,16 +5,11 @@ import (
 	"context"
 	"fmt"
 
-	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
-
-var emitModel = func(opts *root.Options, model *sharedpresent.OutputModel) error {
-	return cflpresent.Emit(opts, model)
-}
 
 // Register adds the me command to the root command.
 func Register(rootCmd *cobra.Command, opts *root.Options) {
@@ -55,7 +50,7 @@ func Run(ctx context.Context, opts *root.Options, idOnly bool) error {
 
 	presenter := cflpresent.UserPresenter{}
 	if idOnly {
-		return emitModel(opts, presenter.PresentUserIDOnly(user))
+		return cflpresent.Emit(opts, presenter.PresentUserIDOnly(user))
 	}
-	return emitModel(opts, presenter.PresentUserOneLiner(user))
+	return cflpresent.Emit(opts, presenter.PresentUserOneLiner(user))
 }

--- a/tools/cfl/internal/cmd/me/me.go
+++ b/tools/cfl/internal/cmd/me/me.go
@@ -5,11 +5,16 @@ import (
 	"context"
 	"fmt"
 
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
+
+var emitModel = func(opts *root.Options, model *sharedpresent.OutputModel) error {
+	return cflpresent.Emit(opts, model)
+}
 
 // Register adds the me command to the root command.
 func Register(rootCmd *cobra.Command, opts *root.Options) {
@@ -50,7 +55,7 @@ func Run(ctx context.Context, opts *root.Options, idOnly bool) error {
 
 	presenter := cflpresent.UserPresenter{}
 	if idOnly {
-		return cflpresent.Emit(opts, presenter.PresentUserIDOnly(user))
+		return emitModel(opts, presenter.PresentUserIDOnly(user))
 	}
-	return cflpresent.Emit(opts, presenter.PresentUserOneLiner(user))
+	return emitModel(opts, presenter.PresentUserOneLiner(user))
 }

--- a/tools/cfl/internal/cmd/me/me_test.go
+++ b/tools/cfl/internal/cmd/me/me_test.go
@@ -45,6 +45,7 @@ func TestRun_Default(t *testing.T) {
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
 	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com\n", stdout)
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRun_IDOnly(t *testing.T) {
@@ -60,6 +61,7 @@ func TestRun_IDOnly(t *testing.T) {
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
 	testutil.Equal(t, "abc123\n", stdout)
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRun_MissingDisplayName(t *testing.T) {
@@ -75,6 +77,7 @@ func TestRun_MissingDisplayName(t *testing.T) {
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
 	testutil.Equal(t, "abc123 | - | rian@example.com\n", stdout)
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRun_MissingEmail(t *testing.T) {
@@ -90,6 +93,7 @@ func TestRun_MissingEmail(t *testing.T) {
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
 	testutil.Equal(t, "abc123 | Rian Stockbower | -\n", stdout)
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRun_MissingAccountID(t *testing.T) {
@@ -103,6 +107,7 @@ func TestRun_MissingAccountID(t *testing.T) {
 	err := Run(context.Background(), opts, false)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, "- | Joe | joe@example.com\n", opts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRun_NormalizesPipesAndNewlines(t *testing.T) {
@@ -122,6 +127,7 @@ func TestRun_NormalizesPipesAndNewlines(t *testing.T) {
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
 	testutil.Equal(t, "abc123 | Joe \\| Pwn Next End | joe@example.com\n", stdout)
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRun_IDOnly_NormalizesAccountID(t *testing.T) {
@@ -139,6 +145,7 @@ func TestRun_IDOnly_NormalizesAccountID(t *testing.T) {
 		err := Run(context.Background(), opts, true)
 		testutil.RequireNoError(t, err)
 		testutil.Equal(t, "-\n", opts.Stdout.(*bytes.Buffer).String())
+		testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 	})
 
 	t.Run("pathological AccountID is normalized", func(t *testing.T) {
@@ -152,7 +159,38 @@ func TestRun_IDOnly_NormalizesAccountID(t *testing.T) {
 		err := Run(context.Background(), opts, true)
 		testutil.RequireNoError(t, err)
 		testutil.Equal(t, "abc\\|def ghi\n", opts.Stdout.(*bytes.Buffer).String())
+		testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 	})
+}
+
+func TestRun_Default_PlainOutput(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.Output = "plain"
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	err := Run(context.Background(), opts, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com\n", opts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
+}
+
+func TestRun_IDOnly_PlainOutput(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.Output = "plain"
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	err := Run(context.Background(), opts, true)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "abc123\n", opts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRegister_RegistersMeWithIDFlag(t *testing.T) {
@@ -198,6 +236,70 @@ func TestExecute_IDFlagWiredThroughCobra(t *testing.T) {
 
 	stdout := opts.Stdout.(*bytes.Buffer).String()
 	testutil.Equal(t, "abc123\n", stdout)
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
+}
+
+func TestExecute_DefaultOutputWiredThroughCobra(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	rootCmd, opts := root.NewCmd()
+	var stdout, stderr bytes.Buffer
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+	opts.NoColor = true
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	Register(rootCmd, opts)
+	rootCmd.SetArgs([]string{"me"})
+
+	err := rootCmd.Execute()
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com\n", stdout.String())
+	testutil.Equal(t, "", stderr.String())
+}
+
+func TestExecute_PlainOutputWiredThroughRootFlag(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	rootCmd, opts := root.NewCmd()
+	var stdout, stderr bytes.Buffer
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+	opts.NoColor = true
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	Register(rootCmd, opts)
+	rootCmd.SetArgs([]string{"-o", "plain", "me"})
+
+	err := rootCmd.Execute()
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com\n", stdout.String())
+	testutil.Equal(t, "", stderr.String())
+}
+
+func TestExecute_PlainIDOutputWiredThroughRootFlag(t *testing.T) {
+	t.Parallel()
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	rootCmd, opts := root.NewCmd()
+	var stdout, stderr bytes.Buffer
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+	opts.NoColor = true
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	Register(rootCmd, opts)
+	rootCmd.SetArgs([]string{"-o", "plain", "me", "--id"})
+
+	err := rootCmd.Execute()
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "abc123\n", stdout.String())
+	testutil.Equal(t, "", stderr.String())
 }
 
 func TestRun_APIError(t *testing.T) {

--- a/tools/cfl/internal/cmd/me/me_test.go
+++ b/tools/cfl/internal/cmd/me/me_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
@@ -250,9 +251,10 @@ func TestExecute_DefaultOutputWiredThroughCobra(t *testing.T) {
 	opts.Stderr = &stderr
 	opts.NoColor = true
 	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+	configPath := filepath.Join(t.TempDir(), "config.yml")
 
 	Register(rootCmd, opts)
-	rootCmd.SetArgs([]string{"me"})
+	rootCmd.SetArgs([]string{"--config", configPath, "me"})
 
 	err := rootCmd.Execute()
 	testutil.RequireNoError(t, err)
@@ -271,9 +273,10 @@ func TestExecute_PlainOutputWiredThroughRootFlag(t *testing.T) {
 	opts.Stderr = &stderr
 	opts.NoColor = true
 	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+	configPath := filepath.Join(t.TempDir(), "config.yml")
 
 	Register(rootCmd, opts)
-	rootCmd.SetArgs([]string{"-o", "plain", "me"})
+	rootCmd.SetArgs([]string{"--config", configPath, "-o", "plain", "me"})
 
 	err := rootCmd.Execute()
 	testutil.RequireNoError(t, err)
@@ -292,9 +295,10 @@ func TestExecute_PlainIDOutputWiredThroughRootFlag(t *testing.T) {
 	opts.Stderr = &stderr
 	opts.NoColor = true
 	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+	configPath := filepath.Join(t.TempDir(), "config.yml")
 
 	Register(rootCmd, opts)
-	rootCmd.SetArgs([]string{"-o", "plain", "me", "--id"})
+	rootCmd.SetArgs([]string{"--config", configPath, "-o", "plain", "me", "--id"})
 
 	err := rootCmd.Execute()
 	testutil.RequireNoError(t, err)

--- a/tools/cfl/internal/cmd/me/me_test.go
+++ b/tools/cfl/internal/cmd/me/me_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/spf13/cobra"
 
@@ -195,62 +194,6 @@ func TestRun_IDOnly_PlainOutput(t *testing.T) {
 	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 }
 
-func TestRun_UsesPresenterEmitter(t *testing.T) {
-	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
-	defer server.Close()
-
-	opts := newTestRootOptions()
-	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
-
-	originalEmit := emitModel
-	t.Cleanup(func() { emitModel = originalEmit })
-
-	var capturedOpts *root.Options
-	var capturedModel *sharedpresent.OutputModel
-	emitModel = func(gotOpts *root.Options, model *sharedpresent.OutputModel) error {
-		capturedOpts = gotOpts
-		capturedModel = model
-		return nil
-	}
-
-	err := Run(context.Background(), opts, false)
-	testutil.RequireNoError(t, err)
-	testutil.Equal(t, opts, capturedOpts)
-
-	msg := emittedMessage(t, capturedModel)
-	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com", msg.Message)
-	testutil.Equal(t, sharedpresent.StreamStdout, msg.Stream)
-	testutil.Equal(t, "", opts.Stdout.(*bytes.Buffer).String())
-	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
-}
-
-func TestRun_IDOnly_UsesPresenterEmitter(t *testing.T) {
-	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
-	defer server.Close()
-
-	opts := newTestRootOptions()
-	opts.Output = "plain"
-	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
-
-	originalEmit := emitModel
-	t.Cleanup(func() { emitModel = originalEmit })
-
-	var capturedModel *sharedpresent.OutputModel
-	emitModel = func(_ *root.Options, model *sharedpresent.OutputModel) error {
-		capturedModel = model
-		return nil
-	}
-
-	err := Run(context.Background(), opts, true)
-	testutil.RequireNoError(t, err)
-
-	msg := emittedMessage(t, capturedModel)
-	testutil.Equal(t, "abc123", msg.Message)
-	testutil.Equal(t, sharedpresent.StreamStdout, msg.Stream)
-	testutil.Equal(t, "", opts.Stdout.(*bytes.Buffer).String())
-	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
-}
-
 func TestRegister_RegistersMeWithIDFlag(t *testing.T) {
 	t.Parallel()
 	rootCmd := &cobra.Command{Use: "cfl"}
@@ -377,18 +320,4 @@ func TestRun_APIError(t *testing.T) {
 	err := Run(context.Background(), opts, false)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "getting current user")
-}
-
-func emittedMessage(t *testing.T, model *sharedpresent.OutputModel) *sharedpresent.MessageSection {
-	t.Helper()
-
-	testutil.NotNil(t, model)
-	if len(model.Sections) != 1 {
-		t.Fatalf("expected 1 section, got %d", len(model.Sections))
-	}
-	msg, ok := model.Sections[0].(*sharedpresent.MessageSection)
-	if !ok {
-		t.Fatalf("expected MessageSection, got %T", model.Sections[0])
-	}
-	return msg
 }

--- a/tools/cfl/internal/cmd/me/me_test.go
+++ b/tools/cfl/internal/cmd/me/me_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/spf13/cobra"
 
@@ -194,6 +195,62 @@ func TestRun_IDOnly_PlainOutput(t *testing.T) {
 	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
 }
 
+func TestRun_UsesPresenterEmitter(t *testing.T) {
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	originalEmit := emitModel
+	t.Cleanup(func() { emitModel = originalEmit })
+
+	var capturedOpts *root.Options
+	var capturedModel *sharedpresent.OutputModel
+	emitModel = func(gotOpts *root.Options, model *sharedpresent.OutputModel) error {
+		capturedOpts = gotOpts
+		capturedModel = model
+		return nil
+	}
+
+	err := Run(context.Background(), opts, false)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, opts, capturedOpts)
+
+	msg := emittedMessage(t, capturedModel)
+	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com", msg.Message)
+	testutil.Equal(t, sharedpresent.StreamStdout, msg.Stream)
+	testutil.Equal(t, "", opts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
+}
+
+func TestRun_IDOnly_UsesPresenterEmitter(t *testing.T) {
+	server := userServer(t, `{"accountId":"abc123","displayName":"Rian Stockbower","email":"rian@example.com"}`)
+	defer server.Close()
+
+	opts := newTestRootOptions()
+	opts.Output = "plain"
+	opts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+
+	originalEmit := emitModel
+	t.Cleanup(func() { emitModel = originalEmit })
+
+	var capturedModel *sharedpresent.OutputModel
+	emitModel = func(_ *root.Options, model *sharedpresent.OutputModel) error {
+		capturedModel = model
+		return nil
+	}
+
+	err := Run(context.Background(), opts, true)
+	testutil.RequireNoError(t, err)
+
+	msg := emittedMessage(t, capturedModel)
+	testutil.Equal(t, "abc123", msg.Message)
+	testutil.Equal(t, sharedpresent.StreamStdout, msg.Stream)
+	testutil.Equal(t, "", opts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", opts.Stderr.(*bytes.Buffer).String())
+}
+
 func TestRegister_RegistersMeWithIDFlag(t *testing.T) {
 	t.Parallel()
 	rootCmd := &cobra.Command{Use: "cfl"}
@@ -320,4 +377,18 @@ func TestRun_APIError(t *testing.T) {
 	err := Run(context.Background(), opts, false)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "getting current user")
+}
+
+func emittedMessage(t *testing.T, model *sharedpresent.OutputModel) *sharedpresent.MessageSection {
+	t.Helper()
+
+	testutil.NotNil(t, model)
+	if len(model.Sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(model.Sections))
+	}
+	msg, ok := model.Sections[0].(*sharedpresent.MessageSection)
+	if !ok {
+		t.Fatalf("expected MessageSection, got %T", model.Sections[0])
+	}
+	return msg
 }

--- a/tools/cfl/internal/present/user.go
+++ b/tools/cfl/internal/present/user.go
@@ -1,0 +1,61 @@
+package present
+
+import (
+	"fmt"
+	"strings"
+
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+)
+
+// UserPresenter creates presentation models for cfl user output.
+type UserPresenter struct{}
+
+// PresentUserOneLiner builds the canonical `cfl me` output as one normalized
+// pipe-delimited line on stdout.
+func (UserPresenter) PresentUserOneLiner(user *api.User) *sharedpresent.OutputModel {
+	return &sharedpresent.OutputModel{
+		Sections: []sharedpresent.Section{
+			&sharedpresent.MessageSection{
+				Kind:    sharedpresent.MessageInfo,
+				Message: userOneLiner(user),
+				Stream:  sharedpresent.StreamStdout,
+			},
+		},
+	}
+}
+
+// PresentUserIDOnly builds the canonical `cfl me --id` output as one
+// normalized account ID on stdout.
+func (UserPresenter) PresentUserIDOnly(user *api.User) *sharedpresent.OutputModel {
+	return &sharedpresent.OutputModel{
+		Sections: []sharedpresent.Section{
+			&sharedpresent.MessageSection{
+				Kind:    sharedpresent.MessageInfo,
+				Message: normalizeMeField(user.AccountID),
+				Stream:  sharedpresent.StreamStdout,
+			},
+		},
+	}
+}
+
+func userOneLiner(user *api.User) string {
+	return fmt.Sprintf(
+		"%s | %s | %s",
+		normalizeMeField(user.AccountID),
+		normalizeMeField(user.DisplayName),
+		normalizeMeField(user.Email),
+	)
+}
+
+func normalizeMeField(value string) string {
+	if value == "" {
+		return "-"
+	}
+	value = strings.ReplaceAll(value, "\r\n", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "|", `\|`)
+	return value
+}

--- a/tools/cfl/internal/present/user_test.go
+++ b/tools/cfl/internal/present/user_test.go
@@ -1,0 +1,91 @@
+package present
+
+import (
+	"testing"
+
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+)
+
+func TestUserPresenter_PresentUserOneLiner(t *testing.T) {
+	t.Parallel()
+
+	model := UserPresenter{}.PresentUserOneLiner(&api.User{
+		AccountID:   "abc123",
+		DisplayName: "Rian Stockbower",
+		Email:       "rian@example.com",
+	})
+
+	msg := userMessageSection(t, model)
+	testutil.Equal(t, sharedpresent.MessageInfo, msg.Kind)
+	testutil.Equal(t, sharedpresent.StreamStdout, msg.Stream)
+	testutil.Equal(t, "abc123 | Rian Stockbower | rian@example.com", msg.Message)
+}
+
+func TestUserPresenter_PresentUserIDOnly(t *testing.T) {
+	t.Parallel()
+
+	model := UserPresenter{}.PresentUserIDOnly(&api.User{
+		AccountID: "abc123",
+	})
+
+	msg := userMessageSection(t, model)
+	testutil.Equal(t, "abc123", msg.Message)
+}
+
+func TestUserPresenter_NormalizesEmptyFields(t *testing.T) {
+	t.Parallel()
+
+	model := UserPresenter{}.PresentUserOneLiner(&api.User{})
+
+	msg := userMessageSection(t, model)
+	testutil.Equal(t, "- | - | -", msg.Message)
+}
+
+func TestUserPresenter_NormalizesNewlinesAndPipes(t *testing.T) {
+	t.Parallel()
+
+	model := UserPresenter{}.PresentUserOneLiner(&api.User{
+		AccountID:   "abc|123",
+		DisplayName: "Joe | Pwn\nNext\rEnd",
+		Email:       "joe\r\n@example.com",
+	})
+
+	msg := userMessageSection(t, model)
+	testutil.Equal(t, `abc\|123 | Joe \| Pwn Next End | joe @example.com`, msg.Message)
+}
+
+func TestUserPresenter_NormalizesIDOnly(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		model := UserPresenter{}.PresentUserIDOnly(&api.User{})
+		msg := userMessageSection(t, model)
+		testutil.Equal(t, "-", msg.Message)
+	})
+
+	t.Run("pipe and newline", func(t *testing.T) {
+		t.Parallel()
+
+		model := UserPresenter{}.PresentUserIDOnly(&api.User{AccountID: "abc|def\nghi"})
+		msg := userMessageSection(t, model)
+		testutil.Equal(t, `abc\|def ghi`, msg.Message)
+	})
+}
+
+func userMessageSection(t *testing.T, model *sharedpresent.OutputModel) *sharedpresent.MessageSection {
+	t.Helper()
+
+	if len(model.Sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(model.Sections))
+	}
+	msg, ok := model.Sections[0].(*sharedpresent.MessageSection)
+	if !ok {
+		t.Fatalf("expected MessageSection, got %T", model.Sections[0])
+	}
+	return msg
+}

--- a/tools/cfl/internal/present/user_test.go
+++ b/tools/cfl/internal/present/user_test.go
@@ -32,6 +32,8 @@ func TestUserPresenter_PresentUserIDOnly(t *testing.T) {
 	})
 
 	msg := userMessageSection(t, model)
+	testutil.Equal(t, sharedpresent.MessageInfo, msg.Kind)
+	testutil.Equal(t, sharedpresent.StreamStdout, msg.Stream)
 	testutil.Equal(t, "abc123", msg.Message)
 }
 


### PR DESCRIPTION
## Summary
- add the first real cfl user presenter and route `cfl me` through `present.Emit`
- remove the legacy `RenderUserOneLiner` helper path and update `cfl init` to reuse the presenter-backed output
- add deterministic CLI proof coverage and a committed proof note for `#431`

## Verification
- `rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/me ./tools/cfl/internal/cmd/root ./shared/present`
- `rtk go test ./tools/cfl/...`
- `rtk git diff --check`
- `rtk proxy go test ./tools/cfl/internal/cmd/me -run 'TestExecute_DefaultOutputWiredThroughCobra|TestExecute_IDFlagWiredThroughCobra|TestExecute_PlainOutputWiredThroughRootFlag|TestExecute_PlainIDOutputWiredThroughRootFlag' -count=1 -v`

## Proof
- committed note: `docs/proofs/271-431-cfl-me.md`

Closes #431