### PR TITLE
feat(cfl): migrate list and search output to presenters

### DIFF
--- a/docs/proofs/271-432-cfl-list-search.md
+++ b/docs/proofs/271-432-cfl-list-search.md
@@ -1,0 +1,206 @@
+# Proof: #432 `cfl` List/Search Presenter Migration
+
+## Scope Delivered
+
+- Added presenter-owned list/search output models at
+  `tools/cfl/internal/present/lists.go` for:
+  - `space list`
+  - `page list`
+  - `page history list`
+  - `search`
+  - `attachment list`
+- Routed migrated commands through `tools/cfl/internal/present.Emit(...)` so
+  commands fetch data, call presenters, and emit.
+- Moved `-o plain` list rendering onto the shared pure renderer by adding
+  `StyleHumanPlain` handling in:
+  - `shared/present/model.go`
+  - `shared/present/render.go`
+  - `tools/cfl/internal/cmd/root/root.go`
+- Added presenter tests that assert exact `present.OutputModel` sections,
+  headers, row values, empty states, pagination hints, and ID-only output.
+- Added command tests that assert exact stdout/stderr for representative
+  `table` and `plain` outputs in every migrated command package.
+
+## Verification Commands
+
+Executed:
+
+```bash
+rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/space ./tools/cfl/internal/cmd/page ./tools/cfl/internal/cmd/search ./tools/cfl/internal/cmd/attachment ./tools/cfl/internal/cmd/root ./shared/present
+```
+
+Result:
+
+```text
+Go test: 371 passed in 7 packages
+```
+
+Executed:
+
+```bash
+rtk go test ./tools/cfl/... ./shared/...
+```
+
+Result:
+
+```text
+Go test: 1600 passed in 33 packages
+```
+
+Executed:
+
+```bash
+rtk git diff --check
+```
+
+Result: no output, no whitespace or patch-format errors.
+
+## Grep Evidence
+
+Executed:
+
+```bash
+rtk sh -lc 'if rtk rg -n "v\\.Table|v\\.RenderKeyValue|v\\.Success|view\\.ValidateFormat|opts\\.View\\(|fmt\\.F(print|printf|println)\\(" tools/cfl/internal/cmd/space/list.go tools/cfl/internal/cmd/page/list.go tools/cfl/internal/cmd/page/history.go tools/cfl/internal/cmd/search/search.go tools/cfl/internal/cmd/attachment/list.go tools/cfl/internal/present/lists.go --glob "!**/*_test.go"; then :; else printf "no legacy view/output matches in migrated #432 files\n"; fi'
+```
+
+Result:
+
+```text
+no legacy view/output matches in migrated #432 files
+```
+
+Executed:
+
+```bash
+rtk proxy go test ./tools/cfl/internal/present -run 'TestSpacePresenter_PresentList|TestSpacePresenter_PresentEmpty|TestPagePresenter_PresentList|TestPagePresenter_PresentEmpty|TestPageHistoryPresenter_PresentListAndIDs|TestSearchPresenter_PresentList|TestAttachmentPresenter_PresentListAndEmpty|TestListPresenterHelpers' -count=1 -v
+```
+
+Result:
+
+```text
+=== RUN   TestSpacePresenter_PresentList
+=== RUN   TestSpacePresenter_PresentEmpty
+=== RUN   TestPagePresenter_PresentList
+=== RUN   TestPagePresenter_PresentEmpty
+=== RUN   TestPageHistoryPresenter_PresentListAndIDs
+=== RUN   TestSearchPresenter_PresentList
+=== RUN   TestAttachmentPresenter_PresentListAndEmpty
+=== RUN   TestListPresenterHelpers
+--- PASS: TestSpacePresenter_PresentList (0.00s)
+--- PASS: TestPagePresenter_PresentEmpty (0.00s)
+--- PASS: TestPagePresenter_PresentList (0.00s)
+--- PASS: TestSpacePresenter_PresentEmpty (0.00s)
+--- PASS: TestPageHistoryPresenter_PresentListAndIDs (0.00s)
+--- PASS: TestListPresenterHelpers (0.00s)
+--- PASS: TestAttachmentPresenter_PresentListAndEmpty (0.00s)
+--- PASS: TestSearchPresenter_PresentList (0.00s)
+PASS
+```
+
+These tests assert exact presenter-owned:
+
+- table headers and row cells
+- empty-state message wording and stream routing
+- `--full` field expansion
+- pagination wording
+- history `--id` stdout behavior
+- helper extraction/formatting used by the commands
+
+## Deterministic CLI Proof
+
+Live smoke for the following user-facing commands was not recorded in this
+proof note because no stable CI-safe Confluence credentials were provisioned
+for the repo-local run:
+
+```bash
+bin/cfl --no-color space list --limit 2
+bin/cfl --no-color -o plain space list --limit 2
+bin/cfl --no-color page list --space $CFL_SMOKE_SPACE --limit 2
+bin/cfl --no-color page history list $CFL_SMOKE_PAGE_ID --limit 2
+bin/cfl --no-color search --type page --limit 1
+bin/cfl --no-color attachment list --page $CFL_SMOKE_PAGE_ID --limit 2
+```
+
+Instead, deterministic httptest-backed command execution covered the same
+externally visible output shapes:
+
+Executed:
+
+```bash
+rtk proxy go test ./tools/cfl/internal/cmd/space ./tools/cfl/internal/cmd/page ./tools/cfl/internal/cmd/search ./tools/cfl/internal/cmd/attachment -run 'TestRunList_PlainOutputExact|TestRunList_TableOutputExact|TestRunList_PageList_PlainFullExact|TestRunList_PageList_TableOutputExact|TestRunHistoryList_PlainOutputExact|TestRunHistoryList_TableOutputExact|TestRunSearch_PlainOutput|TestRunSearch_TableOutputExact|TestRunList_PlainFullExact|TestRunList_TableOutputExact' -count=1 -v
+```
+
+Result:
+
+```text
+=== RUN   TestRunList_PlainOutputExact
+=== RUN   TestRunList_TableOutputExact
+--- PASS: TestRunList_PlainOutputExact (0.00s)
+--- PASS: TestRunList_TableOutputExact (0.00s)
+PASS
+ok  	github.com/open-cli-collective/confluence-cli/internal/cmd/space
+=== RUN   TestRunHistoryList_PlainOutputExact
+=== RUN   TestRunHistoryList_TableOutputExact
+=== RUN   TestRunList_PageList_PlainFullExact
+=== RUN   TestRunList_PageList_TableOutputExact
+--- PASS: TestRunHistoryList_TableOutputExact (0.00s)
+--- PASS: TestRunHistoryList_PlainOutputExact (0.00s)
+--- PASS: TestRunList_PageList_PlainFullExact (0.00s)
+--- PASS: TestRunList_PageList_TableOutputExact (0.00s)
+PASS
+ok  	github.com/open-cli-collective/confluence-cli/internal/cmd/page
+=== RUN   TestRunSearch_PlainOutput
+=== RUN   TestRunSearch_TableOutputExact
+--- PASS: TestRunSearch_PlainOutput (0.00s)
+--- PASS: TestRunSearch_TableOutputExact (0.00s)
+PASS
+ok  	github.com/open-cli-collective/confluence-cli/internal/cmd/search
+=== RUN   TestRunList_PlainFullExact
+=== RUN   TestRunList_TableOutputExact
+--- PASS: TestRunList_PlainFullExact (0.00s)
+--- PASS: TestRunList_TableOutputExact (0.00s)
+PASS
+ok  	github.com/open-cli-collective/confluence-cli/internal/cmd/attachment
+```
+
+Those tests assert these exact stdout/stderr contracts:
+
+- `space list` table:
+  - stdout: `ID      KEY  TYPE    NAME\n123456  DEV  global  Development\n`
+  - stderr: empty
+- `space list -o plain`:
+  - stdout: `ID\tKEY\tTYPE\tNAME\n123456\tDEV\tglobal\tDevelopment\n`
+  - stderr: `Next page: cfl space list --cursor "cursor-123"\n`
+- `page list --full -o plain`:
+  - stdout: `ID\tTITLE\tSTATUS\tVERSION\tPARENT ID\n11111\tPage One\tcurrent\tv1\t999\n`
+  - stderr: `(showing first 1 results, use --limit to see more)\n`
+- `page list` table:
+  - stdout: `ID     TITLE     STATUS\n11111  Page One  current\n`
+  - stderr: empty
+- `page history list` table:
+  - stdout: `VERSION  CREATED               AUTHOR\n15       2024-01-02T03:04:05Z  author-1\n`
+  - stderr: empty
+- `page history list -o plain`:
+  - stdout: `VERSION\tCREATED\tAUTHOR\n15\t2024-01-02T03:04:05Z\tauthor-1\n`
+  - stderr: `Next page: cfl page history list 12345 --cursor "cursor-out"\n`
+- `search` table:
+  - stdout: `ID     TYPE  SPACE  TITLE\n12345  page  DEV    Test Page\n`
+  - stderr: empty
+- `search -o plain`:
+  - stdout: `ID\tTYPE\tSPACE\tTITLE\n12345\tpage\tDEV\tTest Page\n`
+  - stderr: `(showing 1 of 2 results, use --limit to see more)\n`
+- `attachment list` table:
+  - stdout: `ID    TITLE    MEDIA TYPE       FILE SIZE\natt1  doc.pdf  application/pdf  1.0 KB\n`
+  - stderr: empty
+- `attachment list --full -o plain`:
+  - stdout: `ID\tTITLE\tMEDIA TYPE\tFILE SIZE\tSTATUS\tCOMMENT\natt1\tdoc.pdf\tapplication/pdf\t1.0 KB\tcurrent\tlatest\n`
+  - stderr: `(showing first 1 results, use --limit to see more)\n`
+
+## Residual Notes
+
+- This ticket intentionally does not cover `page view`, mutation success
+  output, or remaining diagnostics/advisories. Those are split into follow-on
+  child issues `#433` through `#437`.
+- The `attachment list --full` columns shipped here as
+  `STATUS` and `COMMENT` so `--full` is a real presenter-owned expansion rather
+  than a silent no-op.

--- a/docs/proofs/271-432-cfl-list-search.md
+++ b/docs/proofs/271-432-cfl-list-search.md
@@ -32,7 +32,7 @@ rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/space ./tools/
 Result:
 
 ```text
-Go test: 365 passed in 7 packages
+Go test: 367 passed in 7 packages
 ```
 
 Executed:
@@ -44,7 +44,7 @@ rtk go test ./tools/cfl/... ./shared/...
 Result:
 
 ```text
-Go test: 1594 passed in 33 packages
+Go test: 1596 passed in 33 packages
 ```
 
 Executed:
@@ -169,6 +169,9 @@ Those tests assert these exact stdout/stderr contracts:
 - `space list` table:
   - stdout: `ID      KEY  TYPE    NAME\n123456  DEV  global  Development\n`
   - stderr: empty
+- `space list --full -o plain`:
+  - stdout: `ID\tKEY\tTYPE\tSTATUS\tNAME\n123456\tDEV\tglobal\tcurrent\tDevelopment\n`
+  - stderr: empty
 - `space list -o plain`:
   - stdout: `ID\tKEY\tTYPE\tNAME\n123456\tDEV\tglobal\tDevelopment\n`
   - stderr: `Next page: cfl space list --cursor "cursor-123"\n`
@@ -190,6 +193,9 @@ Those tests assert these exact stdout/stderr contracts:
 - `search -o plain`:
   - stdout: `ID\tTYPE\tSPACE\tTITLE\n12345\tpage\tDEV\tTest Page\n`
   - stderr: `(showing 1 of 2 results, use --limit to see more)\n`
+- `search --full -o plain`:
+  - stdout: `ID\tTYPE\tSPACE\tTITLE\tMODIFIED\tURL\n12345\tpage\tDEV\tTest Page\t2024-02-03\t/wiki/spaces/DEV/pages/12345\n`
+  - stderr: empty
 - `attachment list` table:
   - stdout: `ID    TITLE    MEDIA TYPE       FILE SIZE\natt1  doc.pdf  application/pdf  1.0 KB\n`
   - stderr: empty

--- a/docs/proofs/271-432-cfl-list-search.md
+++ b/docs/proofs/271-432-cfl-list-search.md
@@ -32,7 +32,7 @@ rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/space ./tools/
 Result:
 
 ```text
-Go test: 371 passed in 7 packages
+Go test: 365 passed in 7 packages
 ```
 
 Executed:
@@ -44,7 +44,7 @@ rtk go test ./tools/cfl/... ./shared/...
 Result:
 
 ```text
-Go test: 1600 passed in 33 packages
+Go test: 1594 passed in 33 packages
 ```
 
 Executed:
@@ -101,6 +101,7 @@ These tests assert exact presenter-owned:
 
 - table headers and row cells
 - empty-state message wording and stream routing
+- fallback pagination wording when the API reports more results but no cursor is parseable
 - `--full` field expansion
 - pagination wording
 - history `--id` stdout behavior

--- a/shared/present/model.go
+++ b/shared/present/model.go
@@ -28,8 +28,9 @@ type Style int
 
 // Style constants.
 const (
-	StyleHuman Style = iota // Padded tables, decorators (checkmark, warning)
-	StyleAgent              // Pipe-delimited, plain text, token-efficient
+	StyleHuman      Style = iota // Padded tables, decorators (checkmark, warning)
+	StyleAgent                   // Pipe-delimited, plain text, token-efficient
+	StyleHumanPlain              // Human-oriented detail/message text plus TSV tables
 )
 
 // StyleFromMode converts RenderMode to Style.

--- a/shared/present/render.go
+++ b/shared/present/render.go
@@ -69,6 +69,9 @@ func renderTable(sec *TableSection, style Style) string {
 	if style == StyleAgent {
 		return renderAgentTable(sec)
 	}
+	if style == StyleHumanPlain {
+		return renderTSVTable(sec)
+	}
 	return renderHumanTable(sec)
 }
 
@@ -111,6 +114,35 @@ func renderHumanTable(sec *TableSection) string {
 		_, _ = w.Write([]byte(strings.Join(row.Cells, "\t") + "\n"))
 	}
 	_ = w.Flush()
+	return buf.String()
+}
+
+func renderTSVTable(sec *TableSection) string {
+	var buf bytes.Buffer
+	sanitize := func(s string) string {
+		s = strings.ReplaceAll(s, "\r\n", " ")
+		s = strings.ReplaceAll(s, "\n", " ")
+		s = strings.ReplaceAll(s, "\r", " ")
+		s = strings.ReplaceAll(s, "\t", " ")
+		return s
+	}
+
+	headers := make([]string, len(sec.Headers))
+	for i, h := range sec.Headers {
+		headers[i] = sanitize(h)
+	}
+	buf.WriteString(strings.Join(headers, "\t"))
+	buf.WriteByte('\n')
+
+	for _, row := range sec.Rows {
+		cells := make([]string, len(row.Cells))
+		for i, cell := range row.Cells {
+			cells[i] = sanitize(cell)
+		}
+		buf.WriteString(strings.Join(cells, "\t"))
+		buf.WriteByte('\n')
+	}
+
 	return buf.String()
 }
 

--- a/shared/present/render_test.go
+++ b/shared/present/render_test.go
@@ -105,6 +105,30 @@ func TestRender_TableSection_Human(t *testing.T) {
 	}
 }
 
+func TestRender_TableSection_HumanPlain(t *testing.T) {
+	t.Parallel()
+	model := &OutputModel{
+		Sections: []Section{
+			&TableSection{
+				Headers: []string{"KEY", "SUMMARY"},
+				Rows: []Row{
+					{Cells: []string{"PROJ-1", "First\tissue"}},
+					{Cells: []string{"PROJ-2", "Second\nissue"}},
+				},
+			},
+		},
+	}
+
+	out := Render(model, StyleHumanPlain)
+	want := "KEY\tSUMMARY\nPROJ-1\tFirst issue\nPROJ-2\tSecond issue\n"
+	if out.Stdout != want {
+		t.Errorf("table human plain stdout:\ngot:\n%s\nwant:\n%s", out.Stdout, want)
+	}
+	if out.Stderr != "" {
+		t.Errorf("table human plain stderr should be empty, got: %q", out.Stderr)
+	}
+}
+
 func TestRender_MessageSection_Success_Agent(t *testing.T) {
 	t.Parallel()
 	model := &OutputModel{

--- a/tools/cfl/internal/cmd/attachment/download.go
+++ b/tools/cfl/internal/cmd/attachment/download.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 type downloadOptions struct {
@@ -87,7 +88,7 @@ func runDownload(ctx context.Context, attachmentID string, opts *downloadOptions
 	v := opts.View()
 
 	v.Success("Downloaded: %s", outputPath)
-	v.RenderKeyValue("Size", formatFileSize(bytesWritten))
+	v.RenderKeyValue("Size", cflpresent.FormatAttachmentFileSize(bytesWritten))
 
 	return nil
 }

--- a/tools/cfl/internal/cmd/attachment/download.go
+++ b/tools/cfl/internal/cmd/attachment/download.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
-	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 type downloadOptions struct {
@@ -88,7 +87,7 @@ func runDownload(ctx context.Context, attachmentID string, opts *downloadOptions
 	v := opts.View()
 
 	v.Success("Downloaded: %s", outputPath)
-	v.RenderKeyValue("Size", cflpresent.FormatAttachmentFileSize(bytesWritten))
+	v.RenderKeyValue("Size", formatFileSize(bytesWritten))
 
 	return nil
 }

--- a/tools/cfl/internal/cmd/attachment/list.go
+++ b/tools/cfl/internal/cmd/attachment/list.go
@@ -3,15 +3,13 @@ package attachment
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/view"
-
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 type listOptions struct {
@@ -52,10 +50,6 @@ func newListCmd(rootOpts *root.Options) *cobra.Command {
 }
 
 func runList(ctx context.Context, opts *listOptions) error {
-	if err := view.ValidateFormat(opts.Output); err != nil {
-		return err
-	}
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -88,31 +82,11 @@ func runList(ctx context.Context, opts *listOptions) error {
 		attachments = filterUnusedAttachments(attachments, pageContent)
 	}
 
-	v := opts.View()
-
-	headers := []string{"ID", "Title", "Media Type", "File Size"}
-	rows := make([][]string, 0, len(attachments))
-	for _, att := range attachments {
-		size := formatFileSize(att.FileSize)
-		rows = append(rows, []string{att.ID, att.Title, att.MediaType, size})
-	}
-
 	if len(attachments) == 0 {
-		if opts.unused {
-			_, _ = fmt.Fprintln(opts.Stderr, "No unused attachments found.")
-		} else {
-			_, _ = fmt.Fprintln(opts.Stderr, "No attachments found.")
-		}
-		return nil
+		return cflpresent.Emit(opts.Options, cflpresent.AttachmentPresenter{}.PresentEmpty(opts.unused))
 	}
 
-	_ = v.RenderList(headers, rows, result.HasMore())
-
-	if result.HasMore() {
-		fmt.Fprintf(os.Stderr, "\n(showing first %d results, use --limit to see more)\n", len(attachments))
-	}
-
-	return nil
+	return cflpresent.Emit(opts.Options, cflpresent.AttachmentPresenter{}.PresentList(attachments, opts.Full, result.HasMore()))
 }
 
 // filterUnusedAttachments returns attachments that are not referenced in the page content.

--- a/tools/cfl/internal/cmd/attachment/list.go
+++ b/tools/cfl/internal/cmd/attachment/list.go
@@ -120,22 +120,3 @@ func isAttachmentReferenced(filename, content string) bool {
 
 	return false
 }
-
-func formatFileSize(bytes int64) string {
-	const (
-		KB = 1024
-		MB = KB * 1024
-		GB = MB * 1024
-	)
-
-	switch {
-	case bytes >= GB:
-		return fmt.Sprintf("%.1f GB", float64(bytes)/GB)
-	case bytes >= MB:
-		return fmt.Sprintf("%.1f MB", float64(bytes)/MB)
-	case bytes >= KB:
-		return fmt.Sprintf("%.1f KB", float64(bytes)/KB)
-	default:
-		return fmt.Sprintf("%d B", bytes)
-	}
-}

--- a/tools/cfl/internal/cmd/attachment/list_test.go
+++ b/tools/cfl/internal/cmd/attachment/list_test.go
@@ -156,31 +156,6 @@ func TestRunList_APIError(t *testing.T) {
 	testutil.Contains(t, err.Error(), "listing attachments")
 }
 
-func TestFormatFileSize(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		bytes    int64
-		expected string
-	}{
-		{0, "0 B"},
-		{500, "500 B"},
-		{1024, "1.0 KB"},
-		{1536, "1.5 KB"},
-		{1048576, "1.0 MB"},
-		{1572864, "1.5 MB"},
-		{1073741824, "1.0 GB"},
-		{1610612736, "1.5 GB"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.expected, func(t *testing.T) {
-			t.Parallel()
-			result := formatFileSize(tt.bytes)
-			testutil.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestIsAttachmentReferenced(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/tools/cfl/internal/cmd/attachment/list_test.go
+++ b/tools/cfl/internal/cmd/attachment/list_test.go
@@ -49,6 +49,65 @@ func TestRunList_Success(t *testing.T) {
 	testutil.RequireNoError(t, err)
 }
 
+func TestRunList_PlainFullExact(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{"id": "att1", "title": "doc.pdf", "mediaType": "application/pdf", "fileSize": 1024, "status": "current", "comment": "latest"}
+			],
+			"_links": {"next": "/api/v2/pages/12345/attachments?cursor=abc"}
+		}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newListTestRootOptions()
+	rootOpts.Output = "plain"
+	rootOpts.Full = true
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &listOptions{
+		Options: rootOpts,
+		pageID:  "12345",
+		limit:   25,
+	}
+
+	err := runList(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "ID\tTITLE\tMEDIA TYPE\tFILE SIZE\tSTATUS\tCOMMENT\natt1\tdoc.pdf\tapplication/pdf\t1.0 KB\tcurrent\tlatest\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "(showing first 1 results, use --limit to see more)\n", rootOpts.Stderr.(*bytes.Buffer).String())
+}
+
+func TestRunList_TableOutputExact(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{"id": "att1", "title": "doc.pdf", "mediaType": "application/pdf", "fileSize": 1024}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newListTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &listOptions{
+		Options: rootOpts,
+		pageID:  "12345",
+		limit:   25,
+	}
+
+	err := runList(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "ID    TITLE    MEDIA TYPE       FILE SIZE\natt1  doc.pdf  application/pdf  1.0 KB\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", rootOpts.Stderr.(*bytes.Buffer).String())
+}
+
 func TestRunList_Empty(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -95,22 +154,6 @@ func TestRunList_APIError(t *testing.T) {
 	err := runList(context.Background(), opts)
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "listing attachments")
-}
-
-func TestRunList_InvalidOutputFormat(t *testing.T) {
-	t.Parallel()
-	// Don't need a server - should fail before API call
-	rootOpts := newListTestRootOptions()
-	rootOpts.Output = "invalid"
-
-	opts := &listOptions{
-		Options: rootOpts,
-		pageID:  "12345",
-	}
-
-	err := runList(context.Background(), opts)
-	testutil.RequireError(t, err)
-	testutil.Contains(t, err.Error(), "invalid output format")
 }
 
 func TestFormatFileSize(t *testing.T) {

--- a/tools/cfl/internal/cmd/attachment/size.go
+++ b/tools/cfl/internal/cmd/attachment/size.go
@@ -1,0 +1,22 @@
+package attachment
+
+import "fmt"
+
+func formatFileSize(bytes int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+
+	switch {
+	case bytes >= gb:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/gb)
+	case bytes >= mb:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/mb)
+	case bytes >= kb:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/kb)
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}

--- a/tools/cfl/internal/cmd/attachment/upload.go
+++ b/tools/cfl/internal/cmd/attachment/upload.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
-	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 type uploadOptions struct {
@@ -78,7 +77,7 @@ func runUpload(ctx context.Context, opts *uploadOptions) error {
 	v.Success("Uploaded: %s", filename)
 	v.RenderKeyValue("ID", attachment.ID)
 	v.RenderKeyValue("Title", attachment.Title)
-	v.RenderKeyValue("Size", cflpresent.FormatAttachmentFileSize(reportedSize))
+	v.RenderKeyValue("Size", formatFileSize(reportedSize))
 
 	return nil
 }

--- a/tools/cfl/internal/cmd/attachment/upload.go
+++ b/tools/cfl/internal/cmd/attachment/upload.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 type uploadOptions struct {
@@ -77,7 +78,7 @@ func runUpload(ctx context.Context, opts *uploadOptions) error {
 	v.Success("Uploaded: %s", filename)
 	v.RenderKeyValue("ID", attachment.ID)
 	v.RenderKeyValue("Title", attachment.Title)
-	v.RenderKeyValue("Size", formatFileSize(reportedSize))
+	v.RenderKeyValue("Size", cflpresent.FormatAttachmentFileSize(reportedSize))
 
 	return nil
 }

--- a/tools/cfl/internal/cmd/page/history.go
+++ b/tools/cfl/internal/cmd/page/history.go
@@ -3,19 +3,13 @@ package page
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/atime"
-	"github.com/open-cli-collective/atlassian-go/view"
-
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
-
-const historyMessageMaxChars = 80
 
 type historyListOptions struct {
 	*root.Options
@@ -65,17 +59,11 @@ func newHistoryListCmd(rootOpts *root.Options) *cobra.Command {
 }
 
 func runHistoryList(ctx context.Context, pageID string, opts *historyListOptions) error {
-	if err := view.ValidateFormat(opts.Output); err != nil {
-		return err
-	}
 	if opts.limit < 0 {
 		return fmt.Errorf("invalid limit: %d (must be >= 0)", opts.limit)
 	}
-
-	v := opts.View()
 	if opts.limit == 0 {
-		v.RenderText("No page versions found.")
-		return nil
+		return cflpresent.Emit(opts.Options, cflpresent.PageHistoryPresenter{}.PresentEmpty())
 	}
 
 	client, err := opts.APIClient()
@@ -93,80 +81,11 @@ func runHistoryList(ctx context.Context, pageID string, opts *historyListOptions
 	}
 
 	if len(result.Results) == 0 {
-		v.RenderText("No page versions found.")
-		return nil
+		return cflpresent.Emit(opts.Options, cflpresent.PageHistoryPresenter{}.PresentEmpty())
 	}
-
+	nextCursor := cflpresent.ExtractCursor(result.Links.Next)
 	if opts.idOnly {
-		for _, version := range result.Results {
-			_, _ = fmt.Fprintln(v.Out, version.Number)
-		}
-	} else {
-		headers := []string{"VERSION", "CREATED", "AUTHOR", "MINOR", "MESSAGE"}
-		rows := make([][]string, 0, len(result.Results))
-
-		for _, version := range result.Results {
-			rows = append(rows, []string{
-				strconv.Itoa(version.Number),
-				formatHistoryTime(version.CreatedAt),
-				emptyDash(version.AuthorID),
-				formatHistoryBool(version.MinorEdit),
-				formatHistoryMessage(version.Message),
-			})
-		}
-
-		if err := v.Table(headers, rows); err != nil {
-			return err
-		}
+		return cflpresent.Emit(opts.Options, cflpresent.PageHistoryPresenter{}.PresentIDs(result.Results, nextCursor, pageID))
 	}
-
-	if result.HasMore() {
-		nextCursor := extractHistoryCursor(result.Links.Next)
-		if nextCursor != "" {
-			_, _ = fmt.Fprintf(opts.Stderr, "\nNext page: cfl page history list %s --cursor %q\n", pageID, nextCursor)
-		} else {
-			_, _ = fmt.Fprintf(opts.Stderr, "\n(showing first %d results, use --limit to see more)\n", len(result.Results))
-		}
-	}
-
-	return nil
-}
-
-func formatHistoryTime(t *atime.AtlassianTime) string {
-	if t == nil || t.IsZero() {
-		return "-"
-	}
-	return t.UTC().Format("2006-01-02T15:04:05Z07:00")
-}
-
-func formatHistoryBool(value bool) string {
-	if value {
-		return "yes"
-	}
-	return "no"
-}
-
-func formatHistoryMessage(message string) string {
-	if message == "" {
-		return "-"
-	}
-	return view.Truncate(message, historyMessageMaxChars)
-}
-
-func emptyDash(value string) string {
-	if value == "" {
-		return "-"
-	}
-	return value
-}
-
-func extractHistoryCursor(nextLink string) string {
-	if nextLink == "" {
-		return ""
-	}
-	parsed, err := url.Parse(nextLink)
-	if err != nil {
-		return ""
-	}
-	return parsed.Query().Get("cursor")
+	return cflpresent.Emit(opts.Options, cflpresent.PageHistoryPresenter{}.PresentList(result.Results, nextCursor, pageID))
 }

--- a/tools/cfl/internal/cmd/page/history.go
+++ b/tools/cfl/internal/cmd/page/history.go
@@ -85,7 +85,7 @@ func runHistoryList(ctx context.Context, pageID string, opts *historyListOptions
 	}
 	nextCursor := cflpresent.ExtractCursor(result.Links.Next)
 	if opts.idOnly {
-		return cflpresent.Emit(opts.Options, cflpresent.PageHistoryPresenter{}.PresentIDs(result.Results, nextCursor, pageID))
+		return cflpresent.Emit(opts.Options, cflpresent.PageHistoryPresenter{}.PresentIDs(result.Results, nextCursor, pageID, result.HasMore()))
 	}
-	return cflpresent.Emit(opts.Options, cflpresent.PageHistoryPresenter{}.PresentList(result.Results, nextCursor, pageID))
+	return cflpresent.Emit(opts.Options, cflpresent.PageHistoryPresenter{}.PresentList(result.Results, nextCursor, pageID, result.HasMore()))
 }

--- a/tools/cfl/internal/cmd/page/history_test.go
+++ b/tools/cfl/internal/cmd/page/history_test.go
@@ -88,6 +88,7 @@ func TestRunHistoryList_IDOnly(t *testing.T) {
 	err := runHistoryList(context.Background(), "12345", opts)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, "3\n2\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", rootOpts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRunHistoryList_PlainOutputExact(t *testing.T) {

--- a/tools/cfl/internal/cmd/page/history_test.go
+++ b/tools/cfl/internal/cmd/page/history_test.go
@@ -204,6 +204,29 @@ func TestRunHistoryList_CursorAndNextHint(t *testing.T) {
 	testutil.Contains(t, stderr, "Next page: cfl page history list 12345 --cursor \"cursor-out\"")
 }
 
+func TestRunHistoryList_HasMoreWithoutCursorFallback(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [{"number": 4}],
+			"_links": {"next": "/api/v2/pages/12345/versions?limit=25"}
+		}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newHistoryTestRootOptions()
+	rootOpts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+	opts := &historyListOptions{
+		Options: rootOpts,
+		limit:   25,
+	}
+
+	err := runHistoryList(context.Background(), "12345", opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "(showing first 1 results, use --limit to see more)\n", rootOpts.Stderr.(*bytes.Buffer).String())
+}
+
 func TestRunHistoryList_NegativeLimit(t *testing.T) {
 	t.Parallel()
 	rootOpts := newHistoryTestRootOptions()

--- a/tools/cfl/internal/cmd/page/history_test.go
+++ b/tools/cfl/internal/cmd/page/history_test.go
@@ -59,9 +59,9 @@ func TestRunHistoryList_RendersTableAndTruncatesMessage(t *testing.T) {
 	testutil.Contains(t, stdout, "VERSION")
 	testutil.Contains(t, stdout, "15")
 	testutil.Contains(t, stdout, "author-1")
-	testutil.Contains(t, stdout, "yes")
-	testutil.Contains(t, stdout, strings.Repeat("a", 77)+"...")
-	testutil.False(t, strings.Contains(stdout, "tail-marker"), "message tail should be truncated")
+	testutil.NotContains(t, stdout, "MESSAGE")
+	testutil.NotContains(t, stdout, "MINOR")
+	testutil.False(t, strings.Contains(stdout, "tail-marker"), "message should not be rendered in default history output")
 }
 
 func TestRunHistoryList_IDOnly(t *testing.T) {
@@ -88,6 +88,54 @@ func TestRunHistoryList_IDOnly(t *testing.T) {
 	err := runHistoryList(context.Background(), "12345", opts)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, "3\n2\n", rootOpts.Stdout.(*bytes.Buffer).String())
+}
+
+func TestRunHistoryList_PlainOutputExact(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [{"number": 15, "createdAt": "2024-01-02T03:04:05Z", "authorId": "author-1"}],
+			"_links": {"next": "/api/v2/pages/12345/versions?cursor=cursor-out"}
+		}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newHistoryTestRootOptions()
+	rootOpts.Output = "plain"
+	rootOpts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+	opts := &historyListOptions{
+		Options: rootOpts,
+		limit:   25,
+	}
+
+	err := runHistoryList(context.Background(), "12345", opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "VERSION\tCREATED\tAUTHOR\n15\t2024-01-02T03:04:05Z\tauthor-1\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "Next page: cfl page history list 12345 --cursor \"cursor-out\"\n", rootOpts.Stderr.(*bytes.Buffer).String())
+}
+
+func TestRunHistoryList_TableOutputExact(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [{"number": 15, "createdAt": "2024-01-02T03:04:05Z", "authorId": "author-1"}]
+		}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newHistoryTestRootOptions()
+	rootOpts.SetAPIClient(api.NewClient(server.URL, "test@example.com", "token"))
+	opts := &historyListOptions{
+		Options: rootOpts,
+		limit:   25,
+	}
+
+	err := runHistoryList(context.Background(), "12345", opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "VERSION  CREATED               AUTHOR\n15       2024-01-02T03:04:05Z  author-1\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", rootOpts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestExecuteHistoryListAliasWiredThroughCobra(t *testing.T) {
@@ -127,7 +175,7 @@ func TestRunHistoryList_LimitZeroDoesNotCallAPI(t *testing.T) {
 
 	err := runHistoryList(context.Background(), "12345", opts)
 	testutil.RequireNoError(t, err)
-	testutil.Contains(t, rootOpts.Stdout.(*bytes.Buffer).String(), "No page versions found.")
+	testutil.Contains(t, rootOpts.Stderr.(*bytes.Buffer).String(), "No page versions found.")
 }
 
 func TestRunHistoryList_CursorAndNextHint(t *testing.T) {

--- a/tools/cfl/internal/cmd/page/list.go
+++ b/tools/cfl/internal/cmd/page/list.go
@@ -3,14 +3,12 @@ package page
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/view"
-
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 type listOptions struct {
@@ -58,10 +56,6 @@ var validStatuses = map[string]bool{
 }
 
 func runList(ctx context.Context, opts *listOptions) error {
-	if err := view.ValidateFormat(opts.Output); err != nil {
-		return err
-	}
-
 	if !validStatuses[opts.status] {
 		return fmt.Errorf("invalid status %q: must be one of current, archived, trashed", opts.status)
 	}
@@ -70,11 +64,8 @@ func runList(ctx context.Context, opts *listOptions) error {
 		return fmt.Errorf("invalid limit: %d (must be >= 0)", opts.limit)
 	}
 
-	v := opts.View()
-
 	if opts.limit == 0 {
-		v.RenderText("No pages found.")
-		return nil
+		return cflpresent.Emit(opts.Options, cflpresent.PagePresenter{}.PresentEmpty(""))
 	}
 
 	cfg, err := opts.Config()
@@ -112,33 +103,7 @@ func runList(ctx context.Context, opts *listOptions) error {
 	}
 
 	if len(result.Results) == 0 {
-		v.RenderText(fmt.Sprintf("No pages found in space %s.", spaceKey))
-		return nil
+		return cflpresent.Emit(opts.Options, cflpresent.PagePresenter{}.PresentEmpty(spaceKey))
 	}
-
-	headers := []string{"ID", "TITLE", "STATUS", "VERSION"}
-	rows := make([][]string, 0, len(result.Results))
-
-	for _, page := range result.Results {
-		version := ""
-		if page.Version != nil {
-			version = fmt.Sprintf("v%d", page.Version.Number)
-		}
-		rows = append(rows, []string{
-			page.ID,
-			view.Truncate(page.Title, 60),
-			page.Status,
-			version,
-		})
-	}
-
-	if err := v.Table(headers, rows); err != nil {
-		return err
-	}
-
-	if result.HasMore() {
-		fmt.Fprintf(os.Stderr, "\n(showing first %d results, use --limit to see more)\n", len(result.Results))
-	}
-
-	return nil
+	return cflpresent.Emit(opts.Options, cflpresent.PagePresenter{}.PresentList(result.Results, opts.Full, result.HasMore()))
 }

--- a/tools/cfl/internal/cmd/page/list_test.go
+++ b/tools/cfl/internal/cmd/page/list_test.go
@@ -144,6 +144,8 @@ func TestRunList_PageList_EmptyResults(t *testing.T) {
 
 	err := runList(context.Background(), opts)
 	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "No pages found in space DEV.\n", rootOpts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRunList_PageList_NegativeLimit(t *testing.T) {

--- a/tools/cfl/internal/cmd/page/list_test.go
+++ b/tools/cfl/internal/cmd/page/list_test.go
@@ -71,6 +71,61 @@ func TestRunList_PageList_Success(t *testing.T) {
 	testutil.RequireNoError(t, err)
 }
 
+func TestRunList_PageList_PlainFullExact(t *testing.T) {
+	t.Parallel()
+	server := mockListServer(t, "DEV", "123456", `{
+		"results": [
+			{"id": "11111", "title": "Page One", "status": "current", "version": {"number": 1}, "parentId": "999"}
+		],
+		"_links": {"next": "/wiki/api/v2/spaces/123456/pages?cursor=abc"}
+	}`)
+	defer server.Close()
+
+	rootOpts := newListPageTestRootOptions()
+	rootOpts.Output = "plain"
+	rootOpts.Full = true
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &listOptions{
+		Options: rootOpts,
+		space:   "DEV",
+		limit:   25,
+		status:  "current",
+	}
+
+	err := runList(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "ID\tTITLE\tSTATUS\tVERSION\tPARENT ID\n11111\tPage One\tcurrent\tv1\t999\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "(showing first 1 results, use --limit to see more)\n", rootOpts.Stderr.(*bytes.Buffer).String())
+}
+
+func TestRunList_PageList_TableOutputExact(t *testing.T) {
+	t.Parallel()
+	server := mockListServer(t, "DEV", "123456", `{
+		"results": [
+			{"id": "11111", "title": "Page One", "status": "current"}
+		]
+	}`)
+	defer server.Close()
+
+	rootOpts := newListPageTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &listOptions{
+		Options: rootOpts,
+		space:   "DEV",
+		limit:   25,
+		status:  "current",
+	}
+
+	err := runList(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "ID     TITLE     STATUS\n11111  Page One  current\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", rootOpts.Stderr.(*bytes.Buffer).String())
+}
+
 func TestRunList_PageList_EmptyResults(t *testing.T) {
 	t.Parallel()
 	server := mockListServer(t, "DEV", "123456", `{"results": []}`)
@@ -89,22 +144,6 @@ func TestRunList_PageList_EmptyResults(t *testing.T) {
 
 	err := runList(context.Background(), opts)
 	testutil.RequireNoError(t, err)
-}
-
-func TestRunList_PageList_InvalidOutputFormat(t *testing.T) {
-	t.Parallel()
-	rootOpts := newListPageTestRootOptions()
-	rootOpts.Output = "invalid"
-
-	opts := &listOptions{
-		Options: rootOpts,
-		space:   "DEV",
-		limit:   25,
-	}
-
-	err := runList(context.Background(), opts)
-	testutil.RequireError(t, err)
-	testutil.Contains(t, err.Error(), "invalid output format")
 }
 
 func TestRunList_PageList_NegativeLimit(t *testing.T) {

--- a/tools/cfl/internal/cmd/root/root.go
+++ b/tools/cfl/internal/cmd/root/root.go
@@ -65,6 +65,9 @@ func (o *Options) RenderMode() present.RenderMode {
 
 // RenderStyle returns the pure-renderer style derived from RenderMode().
 func (o *Options) RenderStyle() present.Style {
+	if o.RenderMode() == present.RenderModeHuman && o.Output == "plain" {
+		return present.StyleHumanPlain
+	}
 	return present.StyleFromMode(o.RenderMode())
 }
 

--- a/tools/cfl/internal/cmd/root/root_test.go
+++ b/tools/cfl/internal/cmd/root/root_test.go
@@ -240,3 +240,11 @@ func TestOptions_RenderStyle(t *testing.T) {
 		t.Errorf("RenderStyle() = %v, want StyleHuman", got)
 	}
 }
+
+func TestOptions_RenderStyle_PlainOutput(t *testing.T) {
+	t.Parallel()
+	opts := &Options{Output: "plain"}
+	if got := opts.RenderStyle(); got != present.StyleHumanPlain {
+		t.Errorf("RenderStyle() = %v, want StyleHumanPlain", got)
+	}
+}

--- a/tools/cfl/internal/cmd/search/search.go
+++ b/tools/cfl/internal/cmd/search/search.go
@@ -4,15 +4,13 @@ package search
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/view"
-
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 type searchOptions struct {
@@ -97,11 +95,6 @@ convenient flags for common filters, or provide raw CQL for advanced queries.`,
 }
 
 func runSearch(ctx context.Context, opts *searchOptions) error {
-	// Validate output format
-	if err := view.ValidateFormat(opts.Output); err != nil {
-		return err
-	}
-
 	// Validate type if provided
 	if opts.contentType != "" && !validTypes[opts.contentType] {
 		validList := []string{"page", "blogpost", "attachment", "comment"}
@@ -118,11 +111,8 @@ func runSearch(ctx context.Context, opts *searchOptions) error {
 		return fmt.Errorf("invalid limit: %d (must be >= 0)", opts.limit)
 	}
 
-	v := opts.View()
-
 	if opts.limit == 0 {
-		v.RenderText("No results.")
-		return nil
+		return cflpresent.Emit(opts.Options, cflpresent.SearchPresenter{}.PresentEmpty())
 	}
 
 	// Get config for default space
@@ -159,44 +149,7 @@ func runSearch(ctx context.Context, opts *searchOptions) error {
 	}
 
 	if len(result.Results) == 0 {
-		v.RenderText("No results found.")
-		return nil
+		return cflpresent.Emit(opts.Options, cflpresent.SearchPresenter{}.PresentEmpty())
 	}
-
-	headers := []string{"ID", "TYPE", "SPACE", "TITLE"}
-	rows := make([][]string, 0, len(result.Results))
-
-	for _, r := range result.Results {
-		spaceKey := extractSpaceKey(r.ResultGlobalContainer.DisplayURL)
-		rows = append(rows, []string{
-			r.Content.ID,
-			r.Content.Type,
-			spaceKey,
-			view.Truncate(r.Content.Title, 50),
-		})
-	}
-
-	if err := v.Table(headers, rows); err != nil {
-		return err
-	}
-
-	if result.HasMore() {
-		_, _ = fmt.Fprintf(opts.Stderr, "\n(showing %d of %d results, use --limit to see more)\n",
-			len(result.Results), result.TotalSize)
-	}
-
-	return nil
-}
-
-// spaceKeyRegex matches space keys in Confluence URLs.
-// Patterns: /spaces/SPACEKEY/... or /wiki/spaces/SPACEKEY/...
-var spaceKeyRegex = regexp.MustCompile(`/spaces/([^/]+)`)
-
-// extractSpaceKey extracts the space key from a Confluence displayUrl.
-func extractSpaceKey(displayURL string) string {
-	matches := spaceKeyRegex.FindStringSubmatch(displayURL)
-	if len(matches) >= 2 {
-		return matches[1]
-	}
-	return ""
+	return cflpresent.Emit(opts.Options, cflpresent.SearchPresenter{}.PresentList(result.Results, opts.Full, result.TotalSize, result.HasMore()))
 }

--- a/tools/cfl/internal/cmd/search/search_test.go
+++ b/tools/cfl/internal/cmd/search/search_test.go
@@ -94,6 +94,8 @@ func TestRunSearch_EmptyResults(t *testing.T) {
 
 	err := runSearch(context.Background(), opts)
 	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "No results found.\n", rootOpts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRunSearch_PlainOutput(t *testing.T) {
@@ -126,6 +128,41 @@ func TestRunSearch_PlainOutput(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, "ID\tTYPE\tSPACE\tTITLE\n12345\tpage\tDEV\tTest Page\n", rootOpts.Stdout.(*bytes.Buffer).String())
 	testutil.Equal(t, "(showing 1 of 2 results, use --limit to see more)\n", rootOpts.Stderr.(*bytes.Buffer).String())
+}
+
+func TestRunSearch_FullPlainOutputExact(t *testing.T) {
+	t.Parallel()
+	server := mockSearchServer(t, `{
+		"results": [
+			{
+				"content": {"id": "12345", "type": "page", "status": "current", "title": "Test Page"},
+				"resultGlobalContainer": {"title": "DEV", "displayUrl": "/spaces/DEV/pages/12345"},
+				"lastModified": "2024-02-03",
+				"url": "/wiki/spaces/DEV/pages/12345"
+			}
+		],
+		"start": 0,
+		"size": 1,
+		"totalSize": 1
+	}`)
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	rootOpts.Output = "plain"
+	rootOpts.Full = true
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &searchOptions{
+		Options: rootOpts,
+		query:   "test",
+		limit:   25,
+	}
+
+	err := runSearch(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "ID\tTYPE\tSPACE\tTITLE\tMODIFIED\tURL\n12345\tpage\tDEV\tTest Page\t2024-02-03\t/wiki/spaces/DEV/pages/12345\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", rootOpts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRunSearch_TableOutputExact(t *testing.T) {

--- a/tools/cfl/internal/cmd/search/search_test.go
+++ b/tools/cfl/internal/cmd/search/search_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	"github.com/open-cli-collective/confluence-cli/internal/config"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 // mockSearchServer creates a test server for search operations
@@ -101,12 +102,12 @@ func TestRunSearch_PlainOutput(t *testing.T) {
 		"results": [
 			{
 				"content": {"id": "12345", "type": "page", "status": "current", "title": "Test Page"},
-				"resultGlobalContainer": {"title": "DEV"}
+				"resultGlobalContainer": {"title": "DEV", "displayUrl": "/spaces/DEV/pages/12345"}
 			}
 		],
 		"start": 0,
 		"size": 1,
-		"totalSize": 1
+		"totalSize": 2
 	}`)
 	defer server.Close()
 
@@ -123,12 +124,28 @@ func TestRunSearch_PlainOutput(t *testing.T) {
 
 	err := runSearch(context.Background(), opts)
 	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "ID\tTYPE\tSPACE\tTITLE\n12345\tpage\tDEV\tTest Page\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "(showing 1 of 2 results, use --limit to see more)\n", rootOpts.Stderr.(*bytes.Buffer).String())
 }
 
-func TestRunSearch_InvalidOutputFormat(t *testing.T) {
+func TestRunSearch_TableOutputExact(t *testing.T) {
 	t.Parallel()
+	server := mockSearchServer(t, `{
+		"results": [
+			{
+				"content": {"id": "12345", "type": "page", "status": "current", "title": "Test Page"},
+				"resultGlobalContainer": {"title": "DEV", "displayUrl": "/spaces/DEV/pages/12345"}
+			}
+		],
+		"start": 0,
+		"size": 1,
+		"totalSize": 1
+	}`)
+	defer server.Close()
+
 	rootOpts := newTestRootOptions()
-	rootOpts.Output = "invalid"
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
 
 	opts := &searchOptions{
 		Options: rootOpts,
@@ -137,8 +154,9 @@ func TestRunSearch_InvalidOutputFormat(t *testing.T) {
 	}
 
 	err := runSearch(context.Background(), opts)
-	testutil.RequireError(t, err)
-	testutil.Contains(t, err.Error(), "invalid output format")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "ID     TYPE  SPACE  TITLE\n12345  page  DEV    Test Page\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", rootOpts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRunSearch_InvalidType(t *testing.T) {
@@ -590,7 +608,7 @@ func TestExtractSpaceKey(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := extractSpaceKey(tt.displayURL)
+			got := cflpresent.ExtractSpaceKey(tt.displayURL)
 			testutil.Equal(t, tt.want, got)
 		})
 	}

--- a/tools/cfl/internal/cmd/space/list.go
+++ b/tools/cfl/internal/cmd/space/list.go
@@ -3,14 +3,12 @@ package space
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/view"
-
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 type listOptions struct {
@@ -49,19 +47,12 @@ func newListCmd(rootOpts *root.Options) *cobra.Command {
 }
 
 func runList(ctx context.Context, opts *listOptions) error {
-	if err := view.ValidateFormat(opts.Output); err != nil {
-		return err
-	}
-
 	if opts.limit < 0 {
 		return fmt.Errorf("invalid limit: %d (must be >= 0)", opts.limit)
 	}
 
-	v := opts.View()
-
 	if opts.limit == 0 {
-		v.RenderText("No spaces found.")
-		return nil
+		return cflpresent.Emit(opts.Options, cflpresent.SpacePresenter{}.PresentEmpty())
 	}
 
 	client, err := opts.APIClient()
@@ -81,50 +72,7 @@ func runList(ctx context.Context, opts *listOptions) error {
 	}
 
 	if len(result.Results) == 0 {
-		v.RenderText("No spaces found.")
-		return nil
+		return cflpresent.Emit(opts.Options, cflpresent.SpacePresenter{}.PresentEmpty())
 	}
-
-	headers := []string{"KEY", "NAME", "TYPE", "DESCRIPTION"}
-	rows := make([][]string, 0, len(result.Results))
-
-	for _, space := range result.Results {
-		desc := ""
-		if space.Description != nil && space.Description.Plain != nil {
-			desc = view.Truncate(space.Description.Plain.Value, 50)
-		}
-		rows = append(rows, []string{
-			space.Key,
-			space.Name,
-			space.Type,
-			desc,
-		})
-	}
-
-	if err := v.Table(headers, rows); err != nil {
-		return err
-	}
-
-	if result.HasMore() {
-		nextCursor := extractCursor(result.Links.Next)
-		if nextCursor != "" {
-			_, _ = fmt.Fprintf(opts.Stderr, "\nNext page: cfl space list --cursor %q\n", nextCursor)
-		} else {
-			_, _ = fmt.Fprintf(opts.Stderr, "\n(showing first %d results, use --limit to see more)\n", len(result.Results))
-		}
-	}
-
-	return nil
-}
-
-// extractCursor parses the cursor query parameter from a next link URL.
-func extractCursor(nextLink string) string {
-	if nextLink == "" {
-		return ""
-	}
-	parsed, err := url.Parse(nextLink)
-	if err != nil {
-		return ""
-	}
-	return parsed.Query().Get("cursor")
+	return cflpresent.Emit(opts.Options, cflpresent.SpacePresenter{}.PresentList(result.Results, opts.Full, cflpresent.ExtractCursor(result.Links.Next)))
 }

--- a/tools/cfl/internal/cmd/space/list.go
+++ b/tools/cfl/internal/cmd/space/list.go
@@ -74,5 +74,5 @@ func runList(ctx context.Context, opts *listOptions) error {
 	if len(result.Results) == 0 {
 		return cflpresent.Emit(opts.Options, cflpresent.SpacePresenter{}.PresentEmpty())
 	}
-	return cflpresent.Emit(opts.Options, cflpresent.SpacePresenter{}.PresentList(result.Results, opts.Full, cflpresent.ExtractCursor(result.Links.Next)))
+	return cflpresent.Emit(opts.Options, cflpresent.SpacePresenter{}.PresentList(result.Results, opts.Full, cflpresent.ExtractCursor(result.Links.Next), result.HasMore()))
 }

--- a/tools/cfl/internal/cmd/space/list_test.go
+++ b/tools/cfl/internal/cmd/space/list_test.go
@@ -135,6 +135,8 @@ func TestRunList_EmptyResults(t *testing.T) {
 
 	err := runList(context.Background(), opts)
 	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "No spaces found.\n", rootOpts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRunList_NegativeLimit(t *testing.T) {
@@ -340,6 +342,33 @@ func TestRunList_HasMore(t *testing.T) {
 
 	err := runList(context.Background(), opts)
 	testutil.RequireNoError(t, err)
+}
+
+func TestRunList_HasMoreWithoutCursorFallback(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{"id": "123456", "key": "DEV", "name": "Development", "type": "global"}
+			],
+			"_links": {"next": "/wiki/api/v2/spaces?limit=25"}
+		}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &listOptions{
+		Options: rootOpts,
+		limit:   25,
+	}
+
+	err := runList(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "(showing first 1 results, use --limit to see more)\n", rootOpts.Stderr.(*bytes.Buffer).String())
 }
 
 func TestRunList_NullDescription(t *testing.T) {

--- a/tools/cfl/internal/cmd/space/list_test.go
+++ b/tools/cfl/internal/cmd/space/list_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 func newTestRootOptions() *root.Options {
@@ -65,6 +66,56 @@ func TestRunList_Success(t *testing.T) {
 	testutil.RequireNoError(t, err)
 }
 
+func TestRunList_PlainOutputExact(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{"id": "123456", "key": "DEV", "name": "Development", "type": "global", "status": "current"}
+			],
+			"_links": {"next": "/wiki/api/v2/spaces?cursor=cursor-123"}
+		}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	rootOpts.Output = "plain"
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &listOptions{Options: rootOpts, limit: 25}
+
+	err := runList(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "ID\tKEY\tTYPE\tNAME\n123456\tDEV\tglobal\tDevelopment\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "Next page: cfl space list --cursor \"cursor-123\"\n", rootOpts.Stderr.(*bytes.Buffer).String())
+}
+
+func TestRunList_TableOutputExact(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{"id": "123456", "key": "DEV", "name": "Development", "type": "global", "status": "current"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &listOptions{Options: rootOpts, limit: 25}
+
+	err := runList(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "ID      KEY  TYPE    NAME\n123456  DEV  global  Development\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", rootOpts.Stderr.(*bytes.Buffer).String())
+}
+
 func TestRunList_EmptyResults(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -84,21 +135,6 @@ func TestRunList_EmptyResults(t *testing.T) {
 
 	err := runList(context.Background(), opts)
 	testutil.RequireNoError(t, err)
-}
-
-func TestRunList_InvalidOutputFormat(t *testing.T) {
-	t.Parallel()
-	rootOpts := newTestRootOptions()
-	rootOpts.Output = "invalid"
-
-	opts := &listOptions{
-		Options: rootOpts,
-		limit:   25,
-	}
-
-	err := runList(context.Background(), opts)
-	testutil.RequireError(t, err)
-	testutil.Contains(t, err.Error(), "invalid output format")
 }
 
 func TestRunList_NegativeLimit(t *testing.T) {
@@ -219,28 +255,18 @@ func TestRunList_PreservesRawSpaceTypes(t *testing.T) {
 func spaceTypesByKey(output string) map[string]string {
 	types := make(map[string]string)
 	lines := strings.Split(output, "\n")
-	if len(lines) == 0 {
-		return types
-	}
-	header := lines[0]
-	typeStart := strings.Index(header, "TYPE")
-	descStart := strings.Index(header, "DESCRIPTION")
-	if typeStart < 0 || descStart < 0 || descStart <= typeStart {
+	if len(lines) <= 1 {
 		return types
 	}
 	for _, line := range lines[1:] {
-		if strings.TrimSpace(line) == "" || len(line) <= typeStart {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
 		fields := strings.Fields(line)
-		if len(fields) == 0 {
+		if len(fields) < 3 {
 			continue
 		}
-		end := descStart
-		if len(line) < end {
-			end = len(line)
-		}
-		types[fields[0]] = strings.TrimSpace(line[typeStart:end])
+		types[fields[1]] = fields[2]
 	}
 	return types
 }
@@ -431,7 +457,7 @@ func TestExtractCursor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := extractCursor(tt.nextLink)
+			got := cflpresent.ExtractCursor(tt.nextLink)
 			testutil.Equal(t, tt.want, got)
 		})
 	}

--- a/tools/cfl/internal/cmd/space/list_test.go
+++ b/tools/cfl/internal/cmd/space/list_test.go
@@ -92,6 +92,32 @@ func TestRunList_PlainOutputExact(t *testing.T) {
 	testutil.Equal(t, "Next page: cfl space list --cursor \"cursor-123\"\n", rootOpts.Stderr.(*bytes.Buffer).String())
 }
 
+func TestRunList_FullPlainOutputExact(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{"id": "123456", "key": "DEV", "name": "Development", "type": "global", "status": "current"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	rootOpts := newTestRootOptions()
+	rootOpts.Output = "plain"
+	rootOpts.Full = true
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &listOptions{Options: rootOpts, limit: 25}
+
+	err := runList(context.Background(), opts)
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "ID\tKEY\tTYPE\tSTATUS\tNAME\n123456\tDEV\tglobal\tcurrent\tDevelopment\n", rootOpts.Stdout.(*bytes.Buffer).String())
+	testutil.Equal(t, "", rootOpts.Stderr.(*bytes.Buffer).String())
+}
+
 func TestRunList_TableOutputExact(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/tools/cfl/internal/present/emit.go
+++ b/tools/cfl/internal/present/emit.go
@@ -9,10 +9,7 @@ import (
 )
 
 // Emit renders a presentation model and writes the split streams to the root
-// writers. This is intentionally narrow prework for #271: it is safe today for
-// detail/message shapes whose table/plain behavior is semantically identical.
-// List/search migrations that must preserve `-o plain` TSV semantics should stay
-// on legacy view helpers until cfl has a presenter-backed TSV decision.
+// writers using cfl's root-derived render style.
 func Emit(opts *root.Options, model *sharedpresent.OutputModel) error {
 	out := sharedpresent.Render(model, opts.RenderStyle())
 	_, _ = fmt.Fprint(opts.Stdout, out.Stdout)

--- a/tools/cfl/internal/present/lists.go
+++ b/tools/cfl/internal/present/lists.go
@@ -166,7 +166,7 @@ func (AttachmentPresenter) PresentList(attachments []api.Attachment, full, hasMo
 			orDash(attachment.ID),
 			orDash(attachment.Title),
 			orDash(attachment.MediaType),
-			FormatAttachmentFileSize(attachment.FileSize),
+			formatAttachmentFileSize(attachment.FileSize),
 		}
 		if full {
 			cells = append(cells, orDash(attachment.Status), orDash(attachment.Comment))
@@ -262,7 +262,7 @@ func ExtractCursor(nextLink string) string {
 	return parsed.Query().Get("cursor")
 }
 
-func FormatAttachmentFileSize(bytes int64) string {
+func formatAttachmentFileSize(bytes int64) string {
 	const (
 		kb = 1024
 		mb = kb * 1024

--- a/tools/cfl/internal/present/lists.go
+++ b/tools/cfl/internal/present/lists.go
@@ -1,0 +1,276 @@
+package present
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+
+	"github.com/open-cli-collective/atlassian-go/atime"
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+)
+
+type SpacePresenter struct{}
+type PagePresenter struct{}
+type PageHistoryPresenter struct{}
+type SearchPresenter struct{}
+type AttachmentPresenter struct{}
+
+var spaceKeyRegex = regexp.MustCompile(`/spaces/([^/]+)`)
+
+func (SpacePresenter) PresentList(spaces []api.Space, full bool, nextCursor string) *sharedpresent.OutputModel {
+	headers := []string{"ID", "KEY", "TYPE", "NAME"}
+	if full {
+		headers = []string{"ID", "KEY", "TYPE", "STATUS", "NAME"}
+	}
+
+	rows := make([]sharedpresent.Row, 0, len(spaces))
+	for _, space := range spaces {
+		cells := []string{orDash(space.ID), orDash(space.Key), orDash(space.Type), orDash(space.Name)}
+		if full {
+			cells = []string{orDash(space.ID), orDash(space.Key), orDash(space.Type), orDash(space.Status), orDash(space.Name)}
+		}
+		rows = append(rows, sharedpresent.Row{Cells: cells})
+	}
+
+	sections := []sharedpresent.Section{&sharedpresent.TableSection{Headers: headers, Rows: rows}}
+	if nextCursor != "" {
+		sections = append(sections, stderrInfo(fmt.Sprintf(`Next page: cfl space list --cursor %q`, nextCursor)))
+	}
+
+	return &sharedpresent.OutputModel{Sections: sections}
+}
+
+func (SpacePresenter) PresentEmpty() *sharedpresent.OutputModel {
+	return stderrOnly("No spaces found.")
+}
+
+func (PagePresenter) PresentList(pages []api.Page, full, hasMore bool) *sharedpresent.OutputModel {
+	headers := []string{"ID", "TITLE", "STATUS"}
+	if full {
+		headers = []string{"ID", "TITLE", "STATUS", "VERSION", "PARENT ID"}
+	}
+
+	rows := make([]sharedpresent.Row, 0, len(pages))
+	for _, page := range pages {
+		cells := []string{orDash(page.ID), truncateText(page.Title, 60), orDash(page.Status)}
+		if full {
+			cells = append(cells, pageVersionCell(page.Version), orDash(page.ParentID))
+		}
+		rows = append(rows, sharedpresent.Row{Cells: cells})
+	}
+
+	sections := []sharedpresent.Section{&sharedpresent.TableSection{Headers: headers, Rows: rows}}
+	if hasMore {
+		sections = append(sections, stderrInfo(fmt.Sprintf("(showing first %d results, use --limit to see more)", len(pages))))
+	}
+
+	return &sharedpresent.OutputModel{Sections: sections}
+}
+
+func (PagePresenter) PresentEmpty(spaceKey string) *sharedpresent.OutputModel {
+	if spaceKey == "" {
+		return stderrOnly("No pages found.")
+	}
+	return stderrOnly(fmt.Sprintf("No pages found in space %s.", spaceKey))
+}
+
+func (PageHistoryPresenter) PresentList(versions []api.Version, nextCursor, pageID string) *sharedpresent.OutputModel {
+	rows := make([]sharedpresent.Row, 0, len(versions))
+	for _, version := range versions {
+		rows = append(rows, sharedpresent.Row{Cells: []string{
+			strconv.Itoa(version.Number),
+			formatHistoryTime(version.CreatedAt),
+			orDash(version.AuthorID),
+		}})
+	}
+
+	sections := []sharedpresent.Section{
+		&sharedpresent.TableSection{
+			Headers: []string{"VERSION", "CREATED", "AUTHOR"},
+			Rows:    rows,
+		},
+	}
+	if nextCursor != "" {
+		sections = append(sections, stderrInfo(fmt.Sprintf(`Next page: cfl page history list %s --cursor %q`, pageID, nextCursor)))
+	}
+
+	return &sharedpresent.OutputModel{Sections: sections}
+}
+
+func (PageHistoryPresenter) PresentIDs(versions []api.Version, nextCursor, pageID string) *sharedpresent.OutputModel {
+	sections := make([]sharedpresent.Section, 0, len(versions)+1)
+	for _, version := range versions {
+		sections = append(sections, stdoutInfo(strconv.Itoa(version.Number)))
+	}
+	if nextCursor != "" {
+		sections = append(sections, stderrInfo(fmt.Sprintf(`Next page: cfl page history list %s --cursor %q`, pageID, nextCursor)))
+	}
+
+	return &sharedpresent.OutputModel{Sections: sections}
+}
+
+func (PageHistoryPresenter) PresentEmpty() *sharedpresent.OutputModel {
+	return stderrOnly("No page versions found.")
+}
+
+func (SearchPresenter) PresentList(results []api.SearchResult, full bool, totalSize int, hasMore bool) *sharedpresent.OutputModel {
+	headers := []string{"ID", "TYPE", "SPACE", "TITLE"}
+	if full {
+		headers = []string{"ID", "TYPE", "SPACE", "TITLE", "MODIFIED", "URL"}
+	}
+
+	rows := make([]sharedpresent.Row, 0, len(results))
+	for _, result := range results {
+		cells := []string{
+			orDash(result.Content.ID),
+			orDash(result.Content.Type),
+			orDash(ExtractSpaceKey(result.ResultGlobalContainer.DisplayURL)),
+			truncateText(result.Content.Title, 50),
+		}
+		if full {
+			cells = append(cells, orDash(result.LastModified), orDash(result.URL))
+		}
+		rows = append(rows, sharedpresent.Row{Cells: cells})
+	}
+
+	sections := []sharedpresent.Section{&sharedpresent.TableSection{Headers: headers, Rows: rows}}
+	if hasMore {
+		sections = append(sections, stderrInfo(fmt.Sprintf("(showing %d of %d results, use --limit to see more)", len(results), totalSize)))
+	}
+
+	return &sharedpresent.OutputModel{Sections: sections}
+}
+
+func (SearchPresenter) PresentEmpty() *sharedpresent.OutputModel {
+	return stderrOnly("No results found.")
+}
+
+func (AttachmentPresenter) PresentList(attachments []api.Attachment, full, hasMore bool) *sharedpresent.OutputModel {
+	headers := []string{"ID", "TITLE", "MEDIA TYPE", "FILE SIZE"}
+	if full {
+		headers = []string{"ID", "TITLE", "MEDIA TYPE", "FILE SIZE", "STATUS", "COMMENT"}
+	}
+
+	rows := make([]sharedpresent.Row, 0, len(attachments))
+	for _, attachment := range attachments {
+		cells := []string{
+			orDash(attachment.ID),
+			orDash(attachment.Title),
+			orDash(attachment.MediaType),
+			formatAttachmentFileSize(attachment.FileSize),
+		}
+		if full {
+			cells = append(cells, orDash(attachment.Status), orDash(attachment.Comment))
+		}
+		rows = append(rows, sharedpresent.Row{Cells: cells})
+	}
+
+	sections := []sharedpresent.Section{&sharedpresent.TableSection{Headers: headers, Rows: rows}}
+	if hasMore {
+		sections = append(sections, stderrInfo(fmt.Sprintf("(showing first %d results, use --limit to see more)", len(attachments))))
+	}
+
+	return &sharedpresent.OutputModel{Sections: sections}
+}
+
+func (AttachmentPresenter) PresentEmpty(unused bool) *sharedpresent.OutputModel {
+	if unused {
+		return stderrOnly("No unused attachments found.")
+	}
+	return stderrOnly("No attachments found.")
+}
+
+func stderrOnly(message string) *sharedpresent.OutputModel {
+	return &sharedpresent.OutputModel{Sections: []sharedpresent.Section{stderrInfo(message)}}
+}
+
+func stderrInfo(message string) *sharedpresent.MessageSection {
+	return &sharedpresent.MessageSection{
+		Kind:    sharedpresent.MessageInfo,
+		Message: message,
+		Stream:  sharedpresent.StreamStderr,
+	}
+}
+
+func stdoutInfo(message string) *sharedpresent.MessageSection {
+	return &sharedpresent.MessageSection{
+		Kind:    sharedpresent.MessageInfo,
+		Message: message,
+		Stream:  sharedpresent.StreamStdout,
+	}
+}
+
+func orDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func truncateText(value string, max int) string {
+	if value == "" {
+		return "-"
+	}
+	if max <= 0 || len(value) <= max {
+		return value
+	}
+	if max <= 3 {
+		return value[:max]
+	}
+	return value[:max-3] + "..."
+}
+
+func pageVersionCell(version *api.Version) string {
+	if version == nil {
+		return "-"
+	}
+	return fmt.Sprintf("v%d", version.Number)
+}
+
+func formatHistoryTime(t *atime.AtlassianTime) string {
+	if t == nil || t.IsZero() {
+		return "-"
+	}
+	return t.UTC().Format("2006-01-02T15:04:05Z07:00")
+}
+
+func ExtractSpaceKey(displayURL string) string {
+	matches := spaceKeyRegex.FindStringSubmatch(displayURL)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+	return ""
+}
+
+func ExtractCursor(nextLink string) string {
+	if nextLink == "" {
+		return ""
+	}
+	parsed, err := url.Parse(nextLink)
+	if err != nil {
+		return ""
+	}
+	return parsed.Query().Get("cursor")
+}
+
+func formatAttachmentFileSize(bytes int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+
+	switch {
+	case bytes >= gb:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/gb)
+	case bytes >= mb:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/mb)
+	case bytes >= kb:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/kb)
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}

--- a/tools/cfl/internal/present/lists.go
+++ b/tools/cfl/internal/present/lists.go
@@ -20,7 +20,7 @@ type AttachmentPresenter struct{}
 
 var spaceKeyRegex = regexp.MustCompile(`/spaces/([^/]+)`)
 
-func (SpacePresenter) PresentList(spaces []api.Space, full bool, nextCursor string) *sharedpresent.OutputModel {
+func (SpacePresenter) PresentList(spaces []api.Space, full bool, nextCursor string, hasMore bool) *sharedpresent.OutputModel {
 	headers := []string{"ID", "KEY", "TYPE", "NAME"}
 	if full {
 		headers = []string{"ID", "KEY", "TYPE", "STATUS", "NAME"}
@@ -38,6 +38,8 @@ func (SpacePresenter) PresentList(spaces []api.Space, full bool, nextCursor stri
 	sections := []sharedpresent.Section{&sharedpresent.TableSection{Headers: headers, Rows: rows}}
 	if nextCursor != "" {
 		sections = append(sections, stderrInfo(fmt.Sprintf(`Next page: cfl space list --cursor %q`, nextCursor)))
+	} else if hasMore {
+		sections = append(sections, stderrInfo(fmt.Sprintf("(showing first %d results, use --limit to see more)", len(spaces))))
 	}
 
 	return &sharedpresent.OutputModel{Sections: sections}
@@ -77,7 +79,7 @@ func (PagePresenter) PresentEmpty(spaceKey string) *sharedpresent.OutputModel {
 	return stderrOnly(fmt.Sprintf("No pages found in space %s.", spaceKey))
 }
 
-func (PageHistoryPresenter) PresentList(versions []api.Version, nextCursor, pageID string) *sharedpresent.OutputModel {
+func (PageHistoryPresenter) PresentList(versions []api.Version, nextCursor, pageID string, hasMore bool) *sharedpresent.OutputModel {
 	rows := make([]sharedpresent.Row, 0, len(versions))
 	for _, version := range versions {
 		rows = append(rows, sharedpresent.Row{Cells: []string{
@@ -95,18 +97,22 @@ func (PageHistoryPresenter) PresentList(versions []api.Version, nextCursor, page
 	}
 	if nextCursor != "" {
 		sections = append(sections, stderrInfo(fmt.Sprintf(`Next page: cfl page history list %s --cursor %q`, pageID, nextCursor)))
+	} else if hasMore {
+		sections = append(sections, stderrInfo(fmt.Sprintf("(showing first %d results, use --limit to see more)", len(versions))))
 	}
 
 	return &sharedpresent.OutputModel{Sections: sections}
 }
 
-func (PageHistoryPresenter) PresentIDs(versions []api.Version, nextCursor, pageID string) *sharedpresent.OutputModel {
+func (PageHistoryPresenter) PresentIDs(versions []api.Version, nextCursor, pageID string, hasMore bool) *sharedpresent.OutputModel {
 	sections := make([]sharedpresent.Section, 0, len(versions)+1)
 	for _, version := range versions {
 		sections = append(sections, stdoutInfo(strconv.Itoa(version.Number)))
 	}
 	if nextCursor != "" {
 		sections = append(sections, stderrInfo(fmt.Sprintf(`Next page: cfl page history list %s --cursor %q`, pageID, nextCursor)))
+	} else if hasMore {
+		sections = append(sections, stderrInfo(fmt.Sprintf("(showing first %d results, use --limit to see more)", len(versions))))
 	}
 
 	return &sharedpresent.OutputModel{Sections: sections}
@@ -160,7 +166,7 @@ func (AttachmentPresenter) PresentList(attachments []api.Attachment, full, hasMo
 			orDash(attachment.ID),
 			orDash(attachment.Title),
 			orDash(attachment.MediaType),
-			formatAttachmentFileSize(attachment.FileSize),
+			FormatAttachmentFileSize(attachment.FileSize),
 		}
 		if full {
 			cells = append(cells, orDash(attachment.Status), orDash(attachment.Comment))
@@ -256,7 +262,7 @@ func ExtractCursor(nextLink string) string {
 	return parsed.Query().Get("cursor")
 }
 
-func formatAttachmentFileSize(bytes int64) string {
+func FormatAttachmentFileSize(bytes int64) string {
 	const (
 		kb = 1024
 		mb = kb * 1024

--- a/tools/cfl/internal/present/lists_test.go
+++ b/tools/cfl/internal/present/lists_test.go
@@ -149,8 +149,8 @@ func TestListPresenterHelpers(t *testing.T) {
 	testutil.Equal(t, "-", pageVersionCell(nil))
 	testutil.Equal(t, "v2", pageVersionCell(&api.Version{Number: 2}))
 	testutil.Equal(t, "-", formatHistoryTime(nil))
-	testutil.Equal(t, "0 B", FormatAttachmentFileSize(0))
-	testutil.Equal(t, "1.0 KB", FormatAttachmentFileSize(1024))
+	testutil.Equal(t, "0 B", formatAttachmentFileSize(0))
+	testutil.Equal(t, "1.0 KB", formatAttachmentFileSize(1024))
 }
 
 func requireTableSection(t *testing.T, model *sharedpresent.OutputModel, idx int) *sharedpresent.TableSection {

--- a/tools/cfl/internal/present/lists_test.go
+++ b/tools/cfl/internal/present/lists_test.go
@@ -1,0 +1,173 @@
+package present
+
+import (
+	"testing"
+	"time"
+
+	"github.com/open-cli-collective/atlassian-go/atime"
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+)
+
+func TestSpacePresenter_PresentList(t *testing.T) {
+	t.Parallel()
+
+	model := SpacePresenter{}.PresentList([]api.Space{
+		{ID: "100", Key: "DEV", Type: "global", Name: "Development", Status: "current"},
+	}, true, "cursor-123")
+
+	table := requireTableSection(t, model, 0)
+	testutil.Equal(t, []string{"ID", "KEY", "TYPE", "STATUS", "NAME"}, table.Headers)
+	testutil.Equal(t, []string{"100", "DEV", "global", "current", "Development"}, table.Rows[0].Cells)
+
+	msg := requireMessageSection(t, model, 1)
+	testutil.Equal(t, sharedpresent.MessageInfo, msg.Kind)
+	testutil.Equal(t, sharedpresent.StreamStderr, msg.Stream)
+	testutil.Equal(t, `Next page: cfl space list --cursor "cursor-123"`, msg.Message)
+}
+
+func TestSpacePresenter_PresentEmpty(t *testing.T) {
+	t.Parallel()
+
+	model := SpacePresenter{}.PresentEmpty()
+	msg := requireMessageSection(t, model, 0)
+	testutil.Equal(t, "No spaces found.", msg.Message)
+	testutil.Equal(t, sharedpresent.StreamStderr, msg.Stream)
+}
+
+func TestPagePresenter_PresentList(t *testing.T) {
+	t.Parallel()
+
+	model := PagePresenter{}.PresentList([]api.Page{
+		{ID: "200", Title: "Release Plan", Status: "current", ParentID: "100", Version: &api.Version{Number: 7}},
+	}, true, true)
+
+	table := requireTableSection(t, model, 0)
+	testutil.Equal(t, []string{"ID", "TITLE", "STATUS", "VERSION", "PARENT ID"}, table.Headers)
+	testutil.Equal(t, []string{"200", "Release Plan", "current", "v7", "100"}, table.Rows[0].Cells)
+
+	msg := requireMessageSection(t, model, 1)
+	testutil.Equal(t, "(showing first 1 results, use --limit to see more)", msg.Message)
+	testutil.Equal(t, sharedpresent.StreamStderr, msg.Stream)
+}
+
+func TestPagePresenter_PresentEmpty(t *testing.T) {
+	t.Parallel()
+
+	model := PagePresenter{}.PresentEmpty("DEV")
+	msg := requireMessageSection(t, model, 0)
+	testutil.Equal(t, "No pages found in space DEV.", msg.Message)
+}
+
+func TestPageHistoryPresenter_PresentListAndIDs(t *testing.T) {
+	t.Parallel()
+
+	createdAt := atlassianTime(t, "2024-01-02T03:04:05Z")
+	versions := []api.Version{{Number: 15, AuthorID: "user-1", CreatedAt: createdAt}}
+
+	model := PageHistoryPresenter{}.PresentList(versions, "next-1", "12345")
+	table := requireTableSection(t, model, 0)
+	testutil.Equal(t, []string{"VERSION", "CREATED", "AUTHOR"}, table.Headers)
+	testutil.Equal(t, []string{"15", "2024-01-02T03:04:05Z", "user-1"}, table.Rows[0].Cells)
+
+	msg := requireMessageSection(t, model, 1)
+	testutil.Equal(t, `Next page: cfl page history list 12345 --cursor "next-1"`, msg.Message)
+
+	idModel := PageHistoryPresenter{}.PresentIDs(versions, "next-1", "12345")
+	idMsg := requireMessageSection(t, idModel, 0)
+	testutil.Equal(t, "15", idMsg.Message)
+	testutil.Equal(t, sharedpresent.StreamStdout, idMsg.Stream)
+	nextMsg := requireMessageSection(t, idModel, 1)
+	testutil.Equal(t, sharedpresent.StreamStderr, nextMsg.Stream)
+}
+
+func TestSearchPresenter_PresentList(t *testing.T) {
+	t.Parallel()
+
+	model := SearchPresenter{}.PresentList([]api.SearchResult{
+		{
+			Content:               api.SearchContent{ID: "300", Type: "page", Title: "Deploy Guide"},
+			ResultGlobalContainer: api.SearchContainer{DisplayURL: "/spaces/DEV/pages/300"},
+			LastModified:          "2024-03-04",
+			URL:                   "/wiki/spaces/DEV/pages/300",
+		},
+	}, true, 20, true)
+
+	table := requireTableSection(t, model, 0)
+	testutil.Equal(t, []string{"ID", "TYPE", "SPACE", "TITLE", "MODIFIED", "URL"}, table.Headers)
+	testutil.Equal(t, []string{"300", "page", "DEV", "Deploy Guide", "2024-03-04", "/wiki/spaces/DEV/pages/300"}, table.Rows[0].Cells)
+
+	msg := requireMessageSection(t, model, 1)
+	testutil.Equal(t, "(showing 1 of 20 results, use --limit to see more)", msg.Message)
+}
+
+func TestAttachmentPresenter_PresentListAndEmpty(t *testing.T) {
+	t.Parallel()
+
+	model := AttachmentPresenter{}.PresentList([]api.Attachment{
+		{ID: "att-1", Title: "design.pdf", MediaType: "application/pdf", FileSize: 1536, Status: "current", Comment: "latest"},
+	}, true, true)
+
+	table := requireTableSection(t, model, 0)
+	testutil.Equal(t, []string{"ID", "TITLE", "MEDIA TYPE", "FILE SIZE", "STATUS", "COMMENT"}, table.Headers)
+	testutil.Equal(t, []string{"att-1", "design.pdf", "application/pdf", "1.5 KB", "current", "latest"}, table.Rows[0].Cells)
+
+	msg := requireMessageSection(t, model, 1)
+	testutil.Equal(t, "(showing first 1 results, use --limit to see more)", msg.Message)
+
+	emptyModel := AttachmentPresenter{}.PresentEmpty(true)
+	emptyMsg := requireMessageSection(t, emptyModel, 0)
+	testutil.Equal(t, "No unused attachments found.", emptyMsg.Message)
+}
+
+func TestListPresenterHelpers(t *testing.T) {
+	t.Parallel()
+
+	testutil.Equal(t, "DEV", ExtractSpaceKey("/spaces/DEV/pages/123"))
+	testutil.Equal(t, "cursor-1", ExtractCursor("/wiki/api/v2/spaces?cursor=cursor-1"))
+	testutil.Equal(t, "", ExtractCursor("://bad-url"))
+	testutil.Equal(t, "-", truncateText("", 5))
+	testutil.Equal(t, "abc...", truncateText("abcdefghi", 6))
+	testutil.Equal(t, "-", pageVersionCell(nil))
+	testutil.Equal(t, "v2", pageVersionCell(&api.Version{Number: 2}))
+	testutil.Equal(t, "-", formatHistoryTime(nil))
+	testutil.Equal(t, "0 B", formatAttachmentFileSize(0))
+	testutil.Equal(t, "1.0 KB", formatAttachmentFileSize(1024))
+}
+
+func requireTableSection(t *testing.T, model *sharedpresent.OutputModel, idx int) *sharedpresent.TableSection {
+	t.Helper()
+
+	if len(model.Sections) <= idx {
+		t.Fatalf("expected section index %d, got %d sections", idx, len(model.Sections))
+	}
+	sec, ok := model.Sections[idx].(*sharedpresent.TableSection)
+	if !ok {
+		t.Fatalf("expected TableSection at %d, got %T", idx, model.Sections[idx])
+	}
+	return sec
+}
+
+func requireMessageSection(t *testing.T, model *sharedpresent.OutputModel, idx int) *sharedpresent.MessageSection {
+	t.Helper()
+
+	if len(model.Sections) <= idx {
+		t.Fatalf("expected section index %d, got %d sections", idx, len(model.Sections))
+	}
+	sec, ok := model.Sections[idx].(*sharedpresent.MessageSection)
+	if !ok {
+		t.Fatalf("expected MessageSection at %d, got %T", idx, model.Sections[idx])
+	}
+	return sec
+}
+
+func atlassianTime(t *testing.T, value string) *atime.AtlassianTime {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	testutil.RequireNoError(t, err)
+	at := atime.AtlassianTime{Time: parsed}
+	return &at
+}

--- a/tools/cfl/internal/present/lists_test.go
+++ b/tools/cfl/internal/present/lists_test.go
@@ -16,7 +16,7 @@ func TestSpacePresenter_PresentList(t *testing.T) {
 
 	model := SpacePresenter{}.PresentList([]api.Space{
 		{ID: "100", Key: "DEV", Type: "global", Name: "Development", Status: "current"},
-	}, true, "cursor-123")
+	}, true, "cursor-123", true)
 
 	table := requireTableSection(t, model, 0)
 	testutil.Equal(t, []string{"ID", "KEY", "TYPE", "STATUS", "NAME"}, table.Headers)
@@ -67,7 +67,7 @@ func TestPageHistoryPresenter_PresentListAndIDs(t *testing.T) {
 	createdAt := atlassianTime(t, "2024-01-02T03:04:05Z")
 	versions := []api.Version{{Number: 15, AuthorID: "user-1", CreatedAt: createdAt}}
 
-	model := PageHistoryPresenter{}.PresentList(versions, "next-1", "12345")
+	model := PageHistoryPresenter{}.PresentList(versions, "next-1", "12345", true)
 	table := requireTableSection(t, model, 0)
 	testutil.Equal(t, []string{"VERSION", "CREATED", "AUTHOR"}, table.Headers)
 	testutil.Equal(t, []string{"15", "2024-01-02T03:04:05Z", "user-1"}, table.Rows[0].Cells)
@@ -75,7 +75,7 @@ func TestPageHistoryPresenter_PresentListAndIDs(t *testing.T) {
 	msg := requireMessageSection(t, model, 1)
 	testutil.Equal(t, `Next page: cfl page history list 12345 --cursor "next-1"`, msg.Message)
 
-	idModel := PageHistoryPresenter{}.PresentIDs(versions, "next-1", "12345")
+	idModel := PageHistoryPresenter{}.PresentIDs(versions, "next-1", "12345", true)
 	idMsg := requireMessageSection(t, idModel, 0)
 	testutil.Equal(t, "15", idMsg.Message)
 	testutil.Equal(t, sharedpresent.StreamStdout, idMsg.Stream)
@@ -122,6 +122,22 @@ func TestAttachmentPresenter_PresentListAndEmpty(t *testing.T) {
 	testutil.Equal(t, "No unused attachments found.", emptyMsg.Message)
 }
 
+func TestListPresenters_FallbackPaginationHintWithoutCursor(t *testing.T) {
+	t.Parallel()
+
+	spaceModel := SpacePresenter{}.PresentList([]api.Space{{ID: "100", Key: "DEV", Type: "global", Name: "Development"}}, false, "", true)
+	spaceMsg := requireMessageSection(t, spaceModel, 1)
+	testutil.Equal(t, "(showing first 1 results, use --limit to see more)", spaceMsg.Message)
+
+	historyModel := PageHistoryPresenter{}.PresentList([]api.Version{{Number: 3}}, "", "12345", true)
+	historyMsg := requireMessageSection(t, historyModel, 1)
+	testutil.Equal(t, "(showing first 1 results, use --limit to see more)", historyMsg.Message)
+
+	idModel := PageHistoryPresenter{}.PresentIDs([]api.Version{{Number: 3}}, "", "12345", true)
+	idMsg := requireMessageSection(t, idModel, 1)
+	testutil.Equal(t, "(showing first 1 results, use --limit to see more)", idMsg.Message)
+}
+
 func TestListPresenterHelpers(t *testing.T) {
 	t.Parallel()
 
@@ -133,8 +149,8 @@ func TestListPresenterHelpers(t *testing.T) {
 	testutil.Equal(t, "-", pageVersionCell(nil))
 	testutil.Equal(t, "v2", pageVersionCell(&api.Version{Number: 2}))
 	testutil.Equal(t, "-", formatHistoryTime(nil))
-	testutil.Equal(t, "0 B", formatAttachmentFileSize(0))
-	testutil.Equal(t, "1.0 KB", formatAttachmentFileSize(1024))
+	testutil.Equal(t, "0 B", FormatAttachmentFileSize(0))
+	testutil.Equal(t, "1.0 KB", FormatAttachmentFileSize(1024))
 }
 
 func requireTableSection(t *testing.T, model *sharedpresent.OutputModel, idx int) *sharedpresent.TableSection {


### PR DESCRIPTION
## Summary
- migrate cfl list/search commands to presenter-owned output models
- add shared plain-table TSV rendering through root render style
- add exact presenter, command, and proof coverage for the list/search slice

## Verification
- rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/space ./tools/cfl/internal/cmd/page ./tools/cfl/internal/cmd/search ./tools/cfl/internal/cmd/attachment ./tools/cfl/internal/cmd/root ./shared/present
- rtk go test ./tools/cfl/... ./shared/...
- rtk sh -lc 'if rtk rg -n "v\\.Table|v\\.RenderKeyValue|v\\.Success|view\\.ValidateFormat|opts\\.View\\(|fmt\\.F(print|printf|println)\\(" tools/cfl/internal/cmd/space/list.go tools/cfl/internal/cmd/page/list.go tools/cfl/internal/cmd/page/history.go tools/cfl/internal/cmd/search/search.go tools/cfl/internal/cmd/attachment/list.go tools/cfl/internal/present/lists.go --glob "!**/*_test.go"; then :; else printf "no legacy view/output matches in migrated #432 files\\n"; fi'
- rtk git diff --check

## Proof
- docs/proofs/271-432-cfl-list-search.md

Closes #432