### PR TITLE
feat(cfl): migrate detail and config show presenters

### DIFF
--- a/docs/proofs/271-433-cfl-detail-config.md
+++ b/docs/proofs/271-433-cfl-detail-config.md
@@ -1,0 +1,144 @@
+# Proof: #433 `cfl` Detail and Config Presenter Migration
+
+## Scope Delivered
+
+- Migrated `space view` from legacy `view` rendering to presenter-owned detail
+  output through `cflpresent.Emit(...)`.
+- Added a config projection boundary in
+  `tools/cfl/internal/config/show_projection.go` so `config show` no longer
+  performs command-local env/source formatting.
+- Added presenter-owned detail output in
+  `tools/cfl/internal/present/detail.go` for:
+  - `space view`
+  - `config show`
+- Preserved secret safety for `config show`: token presence/source only, never
+  the token value.
+- Added presenter tests, projection tests, and exact command wiring tests for
+  the migrated detail/config slice.
+
+## Verification Commands
+
+Executed:
+
+```bash
+rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/space ./tools/cfl/internal/cmd/configcmd ./tools/cfl/internal/config ./tools/cfl/internal/cmd/root ./shared/present
+```
+
+Result:
+
+```text
+Go test: 185 passed in 6 packages
+```
+
+Executed:
+
+```bash
+rtk go test ./tools/cfl/... ./shared/...
+```
+
+Result:
+
+```text
+Go test: 1599 passed in 33 packages
+```
+
+## Grep Evidence
+
+Executed:
+
+```bash
+rtk sh -lc 'if rtk rg -n "os\.Getenv|GetEnvWithFallback|formatValueWithSource|getValueAndSource|opts\.View\(|view\.ValidateFormat|RenderKeyValue|fmt\.F(print|printf|println)" tools/cfl/internal/cmd/configcmd/show.go tools/cfl/internal/cmd/space/view.go --glob "!**/*_test.go"; then :; else printf "no legacy env/view/direct-output matches in #433 command files\n"; fi'
+```
+
+Result:
+
+```text
+no legacy env/view/direct-output matches in #433 command files
+```
+
+Executed:
+
+```bash
+rtk proxy go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/space ./tools/cfl/internal/cmd/configcmd ./tools/cfl/internal/config ./tools/cfl/internal/cmd/root ./shared/present -run 'TestSpacePresenter_PresentDetail|TestSpacePresenter_PresentDetail_Full|TestConfigShowPresenter_PresentDetail|TestRunView_Table|TestRunView_FullPlain|TestRunShow_ExactOutput|TestRunShow_UnreadableConfigNote|TestProjectShow_EnvOverridesFile|TestProjectShow_FileFallbackAndDefaults|TestProjectShow_KeyringMetadataAndUnreadableConfig' -count=1 -v
+```
+
+Result:
+
+```text
+=== RUN   TestSpacePresenter_PresentDetail
+=== RUN   TestSpacePresenter_PresentDetail_Full
+=== RUN   TestConfigShowPresenter_PresentDetail
+--- PASS: TestSpacePresenter_PresentDetail (0.00s)
+--- PASS: TestConfigShowPresenter_PresentDetail (0.00s)
+--- PASS: TestSpacePresenter_PresentDetail_Full (0.00s)
+PASS
+ok  	github.com/open-cli-collective/confluence-cli/internal/present
+=== RUN   TestRunView_Table
+=== RUN   TestRunView_FullPlain
+--- PASS: TestRunView_Table (0.00s)
+--- PASS: TestRunView_FullPlain (0.00s)
+PASS
+ok  	github.com/open-cli-collective/confluence-cli/internal/cmd/space
+=== RUN   TestRunShow_ExactOutput
+=== RUN   TestRunShow_UnreadableConfigNote
+--- PASS: TestRunShow_ExactOutput (0.00s)
+--- PASS: TestRunShow_UnreadableConfigNote (0.00s)
+PASS
+ok  	github.com/open-cli-collective/confluence-cli/internal/cmd/configcmd
+=== RUN   TestProjectShow_EnvOverridesFile
+=== RUN   TestProjectShow_FileFallbackAndDefaults
+=== RUN   TestProjectShow_KeyringMetadataAndUnreadableConfig
+--- PASS: TestProjectShow_EnvOverridesFile (0.00s)
+--- PASS: TestProjectShow_FileFallbackAndDefaults (0.00s)
+--- PASS: TestProjectShow_KeyringMetadataAndUnreadableConfig (0.00s)
+PASS
+ok  	github.com/open-cli-collective/confluence-cli/internal/config
+```
+
+These tests prove:
+
+- exact `OutputModel` for `space view` default/full
+- exact `OutputModel` for `config show` including stderr config-path advisory
+- config/env/keyring source resolution occurs outside presenters
+- command stdout/stderr wiring is preserved
+- token values do not leak through `config show`
+
+## Deterministic CLI Proof
+
+Live smoke for these commands was not recorded in this proof note because no
+stable CI-safe Confluence credentials were provisioned for the repo-local run:
+
+```bash
+bin/cfl --no-color space view $CFL_SMOKE_SPACE
+bin/cfl --no-color --full space view $CFL_SMOKE_SPACE
+bin/cfl --no-color config show
+```
+
+Instead, deterministic httptest-backed command execution covered the same
+externally visible output shapes, with the config-show path using a temporary
+XDG config directory plus hermetic keyring setup:
+
+- `space view` default stdout:
+  - `Key: TEST\nName: Test Space\nID: 123456\nType: global\n`
+- `space view --full -o plain` stdout:
+  - `Key: TEST\nName: Test Space\nID: 123456\nType: global\nStatus: current\nDescription: A test space\n`
+- `config show` stdout includes exact stable detail rows for:
+  - `URL`
+  - `Email`
+  - `API Token`
+  - `Default Space`
+  - `Auth Method`
+  - `Cloud ID`
+  - `Keyring Ref`
+  - `Keyring Backend`
+- `config show` stderr exact advisory:
+  - `\nConfig file: <temp-path>\n`
+- unreadable config path adds:
+  - `  (file not found or unreadable)\n`
+
+## Residual Notes
+
+- This ticket intentionally excludes `page view`; that remains the dedicated
+  design/migration scope of `#434`.
+- `config show` retains the existing human-readable source suffix contract
+  rather than redesigning its output semantics during this slice.

--- a/tools/cfl/internal/cmd/configcmd/show.go
+++ b/tools/cfl/internal/cmd/configcmd/show.go
@@ -1,17 +1,14 @@
 package configcmd
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 
-	sharedconfig "github.com/open-cli-collective/atlassian-go/config"
 	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	"github.com/open-cli-collective/confluence-cli/internal/config"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 func newShowCmd(opts *root.Options) *cobra.Command {
@@ -39,7 +36,6 @@ command to confirm effective configuration.`,
 
 func runShow(opts *root.Options) error {
 	configPath := config.DefaultConfigPath()
-	v := opts.View()
 
 	// Load config file (if exists)
 	fileCfg, fileErr := config.Load(configPath)
@@ -47,93 +43,11 @@ func runShow(opts *root.Options) error {
 		fileCfg = &config.Config{}
 	}
 
-	// Check environment variables
-	envURL := sharedconfig.GetEnvWithFallback("CFL_URL", "ATLASSIAN_URL")
-	envEmail := sharedconfig.GetEnvWithFallback("CFL_EMAIL", "ATLASSIAN_EMAIL")
-	envSpace := os.Getenv("CFL_DEFAULT_SPACE")
-	envAuthMethod := sharedconfig.GetEnvWithFallback("CFL_AUTH_METHOD", "ATLASSIAN_AUTH_METHOD")
-	envCloudID := sharedconfig.GetEnvWithFallback("CFL_CLOUD_ID", "ATLASSIAN_CLOUD_ID")
-
-	// Determine effective values and sources
-	url, urlSource := getValueAndSource(envURL, fileCfg.URL, getEnvVarName("CFL_URL", "ATLASSIAN_URL"))
-	email, emailSource := getValueAndSource(envEmail, fileCfg.Email, getEnvVarName("CFL_EMAIL", "ATLASSIAN_EMAIL"))
-	space, spaceSource := getValueAndSource(envSpace, fileCfg.DefaultSpace, "CFL_DEFAULT_SPACE")
-	authMethod, authMethodSource := getValueAndSource(envAuthMethod, fileCfg.AuthMethod, getEnvVarName("CFL_AUTH_METHOD", "ATLASSIAN_AUTH_METHOD"))
-	cloudID, cloudIDSource := getValueAndSource(envCloudID, fileCfg.CloudID, getEnvVarName("CFL_CLOUD_ID", "ATLASSIAN_CLOUD_ID"))
-
-	// Default auth method display
-	if authMethod == "" {
-		authMethod = "basic"
-		authMethodSource = "default"
-	}
-
 	// Non-secret keyring description (non-migrating: show stays usable
 	// during an unresolved §1.8 conflict). The token VALUE is never
 	// shown — presence + source only (§1.12).
 	kr, krErr := keyring.InspectForTool(credstore.ToolCFL)
-	tokenStatus := "not set"
-	if kr.TokenConfigured {
-		tokenStatus = "configured"
-	}
-	tokenSource := kr.TokenSource
-	if krErr != nil {
-		tokenSource = "keyring error: " + krErr.Error()
-	}
 
-	// Display
-	v.RenderKeyValue("URL", formatValueWithSource(url, urlSource))
-	v.RenderKeyValue("Email", formatValueWithSource(email, emailSource))
-	v.RenderKeyValue("API Token", formatValueWithSource(tokenStatus, tokenSource))
-	v.RenderKeyValue("Default Space", formatValueWithSource(space, spaceSource))
-	v.RenderKeyValue("Auth Method", formatValueWithSource(authMethod, authMethodSource))
-	v.RenderKeyValue("Cloud ID", formatValueWithSource(cloudID, cloudIDSource))
-	v.RenderKeyValue("Keyring Ref", formatValueWithSource(kr.Ref, "fixed"))
-	if kr.Backend != "" {
-		backend := kr.Backend
-		if kr.BackendSource != "" {
-			backend += " (" + kr.BackendSource + ")"
-		}
-		v.RenderKeyValue("Keyring Backend", formatValueWithSource(backend, "-"))
-	}
-	if kr.PassphraseSource != "" {
-		v.RenderKeyValue("Keyring Passphrase", formatValueWithSource(kr.PassphraseSource, "-"))
-	}
-
-	_, _ = fmt.Fprintln(opts.Stderr)
-	_, _ = fmt.Fprintf(opts.Stderr, "Config file: %s\n", configPath)
-	if fileErr != nil {
-		_, _ = fmt.Fprintf(opts.Stderr, "  (file not found or unreadable)\n")
-	}
-
-	return nil
-}
-
-// getValueAndSource returns the effective value and its source.
-func getValueAndSource(envValue, fileValue, envVarName string) (string, string) {
-	if envValue != "" {
-		return envValue, envVarName
-	}
-	if fileValue != "" {
-		return fileValue, "config"
-	}
-	return "", "not set"
-}
-
-// getEnvVarName returns the name of the environment variable that is set.
-func getEnvVarName(primary, fallback string) string {
-	if os.Getenv(primary) != "" {
-		return primary
-	}
-	if os.Getenv(fallback) != "" {
-		return fallback
-	}
-	return primary // Default to primary if neither is set
-}
-
-// formatValueWithSource formats a value with its source indicator.
-func formatValueWithSource(value, source string) string {
-	if value == "" {
-		return fmt.Sprintf("(source: %s)", source)
-	}
-	return fmt.Sprintf("%s  (source: %s)", value, source)
+	proj := config.ProjectShow(configPath, fileCfg, fileErr, kr, krErr)
+	return cflpresent.Emit(opts, cflpresent.ConfigShowPresenter{}.PresentDetail(proj))
 }

--- a/tools/cfl/internal/cmd/configcmd/show_test.go
+++ b/tools/cfl/internal/cmd/configcmd/show_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/credtest"
@@ -65,6 +66,18 @@ func TestRunShow_ExactOutput(t *testing.T) {
 	testutil.Contains(t, out.String(), "Cloud ID: (source: not set)\n")
 	testutil.Contains(t, out.String(), "Keyring Ref: atlassian-cli/default  (source: fixed)\n")
 	testutil.Contains(t, out.String(), "Keyring Backend:")
+	lines := strings.Split(strings.TrimSuffix(out.String(), "\n"), "\n")
+	testutil.True(t, len(lines) == 8 || len(lines) == 9)
+	testutil.Equal(t, "URL: https://example.atlassian.net/wiki  (source: config)", lines[0])
+	testutil.Equal(t, "Email: test@example.com  (source: config)", lines[1])
+	testutil.Equal(t, "API Token: not set  (source: unset)", lines[2])
+	testutil.Equal(t, "Default Space: TEST  (source: config)", lines[3])
+	testutil.Equal(t, "Auth Method: basic  (source: default)", lines[4])
+	testutil.Equal(t, "Cloud ID: (source: not set)", lines[5])
+	testutil.Equal(t, "Keyring Ref: atlassian-cli/default  (source: fixed)", lines[6])
+	if len(lines) == 9 {
+		testutil.Contains(t, lines[8], "Keyring Passphrase:")
+	}
 	testutil.Equal(t, "\nConfig file: "+cfgPath+"\n", errBuf.String())
 }
 

--- a/tools/cfl/internal/cmd/configcmd/show_test.go
+++ b/tools/cfl/internal/cmd/configcmd/show_test.go
@@ -2,6 +2,8 @@ package configcmd
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/credtest"
@@ -9,6 +11,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflconfig "github.com/open-cli-collective/confluence-cli/internal/config"
 )
 
 // config show must report token PRESENCE + keyring metadata and never
@@ -29,79 +32,54 @@ func TestRunShow_TokenPresenceNoLeak(t *testing.T) {
 	testutil.Contains(t, combined, keyring.Ref)
 }
 
-func TestGetValueAndSource(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name       string
-		envValue   string
-		fileValue  string
-		envVarName string
-		wantValue  string
-		wantSource string
-	}{
-		{
-			name:       "env takes precedence",
-			envValue:   "from-env",
-			fileValue:  "from-file",
-			envVarName: "CFL_URL",
-			wantValue:  "from-env",
-			wantSource: "CFL_URL",
-		},
-		{
-			name:       "file used when env empty",
-			envValue:   "",
-			fileValue:  "from-file",
-			envVarName: "CFL_URL",
-			wantValue:  "from-file",
-			wantSource: "config",
-		},
-		{
-			name:       "not set when both empty",
-			envValue:   "",
-			fileValue:  "",
-			envVarName: "CFL_URL",
-			wantValue:  "",
-			wantSource: "not set",
-		},
-	}
+func TestRunShow_ExactOutput(t *testing.T) {
+	credtest.Hermetic(t)
+	t.Setenv("CFL_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("CFL_EMAIL", "")
+	t.Setenv("ATLASSIAN_EMAIL", "")
+	t.Setenv("CFL_DEFAULT_SPACE", "")
+	t.Setenv("CFL_AUTH_METHOD", "")
+	t.Setenv("ATLASSIAN_AUTH_METHOD", "")
+	t.Setenv("CFL_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			gotValue, gotSource := getValueAndSource(tt.envValue, tt.fileValue, tt.envVarName)
-			testutil.Equal(t, tt.wantValue, gotValue)
-			testutil.Equal(t, tt.wantSource, gotSource)
-		})
-	}
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	cfgPath := filepath.Join(cfgDir, "cfl", "config.yml")
+	testutil.RequireNoError(t, (&cflconfig.Config{
+		URL:          "https://example.atlassian.net/wiki",
+		Email:        "test@example.com",
+		DefaultSpace: "TEST",
+	}).Save(cfgPath))
+
+	out, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: out, Stderr: errBuf}
+	testutil.RequireNoError(t, runShow(opts))
+
+	testutil.Contains(t, out.String(), "URL: https://example.atlassian.net/wiki  (source: config)\n")
+	testutil.Contains(t, out.String(), "Email: test@example.com  (source: config)\n")
+	testutil.Contains(t, out.String(), "API Token: not set  (source: unset)\n")
+	testutil.Contains(t, out.String(), "Default Space: TEST  (source: config)\n")
+	testutil.Contains(t, out.String(), "Auth Method: basic  (source: default)\n")
+	testutil.Contains(t, out.String(), "Cloud ID: (source: not set)\n")
+	testutil.Contains(t, out.String(), "Keyring Ref: atlassian-cli/default  (source: fixed)\n")
+	testutil.Contains(t, out.String(), "Keyring Backend:")
+	testutil.Equal(t, "\nConfig file: "+cfgPath+"\n", errBuf.String())
 }
 
-func TestFormatValueWithSource(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name   string
-		value  string
-		source string
-		want   string
-	}{
-		{
-			name:   "value with source",
-			value:  "https://example.com",
-			source: "config",
-			want:   "https://example.com  (source: config)",
-		},
-		{
-			name:   "empty value",
-			value:  "",
-			source: "not set",
-			want:   "(source: not set)",
-		},
-	}
+func TestRunShow_UnreadableConfigNote(t *testing.T) {
+	credtest.Hermetic(t)
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	cfgPath := filepath.Join(cfgDir, "cfl", "config.yml")
+	testutil.RequireNoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o700))
+	testutil.RequireNoError(t, os.WriteFile(cfgPath, []byte(":"), 0o600))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := formatValueWithSource(tt.value, tt.source)
-			testutil.Equal(t, tt.want, got)
-		})
-	}
+	out, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
+	opts := &root.Options{Output: "table", NoColor: true, Stdout: out, Stderr: errBuf}
+	testutil.RequireNoError(t, runShow(opts))
+
+	testutil.Contains(t, errBuf.String(), "\nConfig file: "+cfgPath+"\n")
+	testutil.Contains(t, errBuf.String(), "  (file not found or unreadable)\n")
 }

--- a/tools/cfl/internal/cmd/space/space_test.go
+++ b/tools/cfl/internal/cmd/space/space_test.go
@@ -66,11 +66,37 @@ func TestRunView_Table(t *testing.T) {
 	err := runView(context.Background(), "TEST", opts)
 
 	testutil.RequireNoError(t, err)
-	output := stdout.String()
-	testutil.Contains(t, output, "TEST")
-	testutil.Contains(t, output, "Test Space")
-	testutil.Contains(t, output, "global")
-	testutil.Contains(t, output, "A test space")
+	testutil.Equal(t, "Key: TEST\nName: Test Space\nID: 123456\nType: global\n", stdout.String())
+}
+
+func TestRunView_FullPlain(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testutil.Equal(t, "GET", r.Method)
+		testutil.Contains(t, r.URL.Path, "/spaces")
+		testutil.Equal(t, "TEST", r.URL.Query().Get("keys"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(spaceListResponse))
+	}))
+	defer server.Close()
+
+	stdout := &bytes.Buffer{}
+	rootOpts := &root.Options{
+		Output:  "plain",
+		NoColor: true,
+		Full:    true,
+		Stdout:  stdout,
+		Stderr:  &bytes.Buffer{},
+	}
+	client := api.NewClient(server.URL, "test@example.com", "token")
+	rootOpts.SetAPIClient(client)
+
+	opts := &viewOptions{Options: rootOpts}
+	err := runView(context.Background(), "TEST", opts)
+
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "Key: TEST\nName: Test Space\nID: 123456\nType: global\nStatus: current\nDescription: A test space\n", stdout.String())
 }
 
 func TestRunView_PreservesRawSpaceType(t *testing.T) {

--- a/tools/cfl/internal/cmd/space/space_test.go
+++ b/tools/cfl/internal/cmd/space/space_test.go
@@ -99,6 +99,22 @@ func TestRunView_FullPlain(t *testing.T) {
 	testutil.Equal(t, "Key: TEST\nName: Test Space\nID: 123456\nType: global\nStatus: current\nDescription: A test space\n", stdout.String())
 }
 
+func TestExecuteView_InvalidOutputFormat(t *testing.T) {
+	t.Parallel()
+
+	rootCmd, rootOpts := root.NewCmd()
+	rootOpts.Output = "invalid"
+	rootOpts.NoColor = true
+	rootOpts.Stdout = &bytes.Buffer{}
+	rootOpts.Stderr = &bytes.Buffer{}
+	Register(rootCmd, rootOpts)
+	rootCmd.SetArgs([]string{"space", "view", "TEST"})
+
+	err := rootCmd.Execute()
+	testutil.RequireError(t, err)
+	testutil.Contains(t, err.Error(), `invalid output format: "invalid"`)
+}
+
 func TestRunView_PreservesRawSpaceType(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/tools/cfl/internal/cmd/space/view.go
+++ b/tools/cfl/internal/cmd/space/view.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/open-cli-collective/atlassian-go/view"
-
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 type viewOptions struct {
@@ -34,10 +33,6 @@ func newViewCmd(rootOpts *root.Options) *cobra.Command {
 }
 
 func runView(ctx context.Context, spaceKey string, opts *viewOptions) error {
-	if err := view.ValidateFormat(opts.Output); err != nil {
-		return err
-	}
-
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -48,18 +43,5 @@ func runView(ctx context.Context, spaceKey string, opts *viewOptions) error {
 		return err
 	}
 
-	v := opts.View()
-
-	v.RenderKeyValue("Key", space.Key)
-	v.RenderKeyValue("Name", space.Name)
-	v.RenderKeyValue("ID", space.ID)
-	v.RenderKeyValue("Type", space.Type)
-	if space.Status != "" {
-		v.RenderKeyValue("Status", space.Status)
-	}
-	if space.Description != nil && space.Description.Plain != nil && space.Description.Plain.Value != "" {
-		v.RenderKeyValue("Description", space.Description.Plain.Value)
-	}
-
-	return nil
+	return cflpresent.Emit(opts.Options, cflpresent.SpacePresenter{}.PresentDetail(space, opts.Full))
 }

--- a/tools/cfl/internal/config/show_projection.go
+++ b/tools/cfl/internal/config/show_projection.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	sharedconfig "github.com/open-cli-collective/atlassian-go/config"
+	"github.com/open-cli-collective/atlassian-go/keyring"
+)
+
+type ShowValue struct {
+	Value  string
+	Source string
+}
+
+type ShowProjection struct {
+	URL               ShowValue
+	Email             ShowValue
+	APIToken          ShowValue
+	DefaultSpace      ShowValue
+	AuthMethod        ShowValue
+	CloudID           ShowValue
+	KeyringRef        ShowValue
+	KeyringBackend    ShowValue
+	KeyringPassphrase ShowValue
+
+	HasKeyringBackend    bool
+	HasKeyringPassphrase bool
+	ConfigPath           string
+	ConfigReadable       bool
+}
+
+func ProjectShow(configPath string, fileCfg *Config, fileErr error, kr keyring.Info, keyringErr error) ShowProjection {
+	if fileCfg == nil {
+		fileCfg = &Config{}
+	}
+
+	url := projectValue(
+		sharedconfig.GetEnvWithFallback("CFL_URL", "ATLASSIAN_URL"),
+		fileCfg.URL,
+		setEnvName("CFL_URL", "ATLASSIAN_URL"),
+	)
+	email := projectValue(
+		sharedconfig.GetEnvWithFallback("CFL_EMAIL", "ATLASSIAN_EMAIL"),
+		fileCfg.Email,
+		setEnvName("CFL_EMAIL", "ATLASSIAN_EMAIL"),
+	)
+	defaultSpace := projectValue(os.Getenv("CFL_DEFAULT_SPACE"), fileCfg.DefaultSpace, "CFL_DEFAULT_SPACE")
+	authMethod := projectValue(
+		sharedconfig.GetEnvWithFallback("CFL_AUTH_METHOD", "ATLASSIAN_AUTH_METHOD"),
+		fileCfg.AuthMethod,
+		setEnvName("CFL_AUTH_METHOD", "ATLASSIAN_AUTH_METHOD"),
+	)
+	cloudID := projectValue(
+		sharedconfig.GetEnvWithFallback("CFL_CLOUD_ID", "ATLASSIAN_CLOUD_ID"),
+		fileCfg.CloudID,
+		setEnvName("CFL_CLOUD_ID", "ATLASSIAN_CLOUD_ID"),
+	)
+
+	if authMethod.Value == "" {
+		authMethod = ShowValue{Value: "basic", Source: "default"}
+	}
+
+	tokenStatus := "not set"
+	if kr.TokenConfigured {
+		tokenStatus = "configured"
+	}
+	tokenSource := kr.TokenSource
+	if keyringErr != nil {
+		tokenSource = "keyring error: " + keyringErr.Error()
+	}
+
+	projection := ShowProjection{
+		URL:          url,
+		Email:        email,
+		APIToken:     ShowValue{Value: tokenStatus, Source: tokenSource},
+		DefaultSpace: defaultSpace,
+		AuthMethod:   authMethod,
+		CloudID:      cloudID,
+		KeyringRef: ShowValue{
+			Value:  kr.Ref,
+			Source: "fixed",
+		},
+		ConfigPath:     configPath,
+		ConfigReadable: fileErr == nil,
+	}
+
+	if kr.Backend != "" {
+		backendValue := kr.Backend
+		if kr.BackendSource != "" {
+			backendValue += " (" + kr.BackendSource + ")"
+		}
+		projection.KeyringBackend = ShowValue{Value: backendValue, Source: "-"}
+		projection.HasKeyringBackend = true
+	}
+
+	if kr.PassphraseSource != "" {
+		projection.KeyringPassphrase = ShowValue{Value: kr.PassphraseSource, Source: "-"}
+		projection.HasKeyringPassphrase = true
+	}
+
+	return projection
+}
+
+func projectValue(envValue, fileValue, envVarName string) ShowValue {
+	if envValue != "" {
+		return ShowValue{Value: envValue, Source: envVarName}
+	}
+	if fileValue != "" {
+		return ShowValue{Value: fileValue, Source: "config"}
+	}
+	return ShowValue{Source: "not set"}
+}
+
+func setEnvName(primary, fallback string) string {
+	if os.Getenv(primary) != "" {
+		return primary
+	}
+	if os.Getenv(fallback) != "" {
+		return fallback
+	}
+	return primary
+}
+
+func FormatValueWithSource(v ShowValue) string {
+	if v.Value == "" {
+		return fmt.Sprintf("(source: %s)", v.Source)
+	}
+	return fmt.Sprintf("%s  (source: %s)", v.Value, v.Source)
+}

--- a/tools/cfl/internal/config/show_projection.go
+++ b/tools/cfl/internal/config/show_projection.go
@@ -34,26 +34,26 @@ func ProjectShow(configPath string, fileCfg *Config, fileErr error, kr keyring.I
 		fileCfg = &Config{}
 	}
 
-	url := projectValue(
+	url := resolveShowValue(
 		sharedconfig.GetEnvWithFallback("CFL_URL", "ATLASSIAN_URL"),
 		fileCfg.URL,
-		setEnvName("CFL_URL", "ATLASSIAN_URL"),
+		activeEnvVarName("CFL_URL", "ATLASSIAN_URL"),
 	)
-	email := projectValue(
+	email := resolveShowValue(
 		sharedconfig.GetEnvWithFallback("CFL_EMAIL", "ATLASSIAN_EMAIL"),
 		fileCfg.Email,
-		setEnvName("CFL_EMAIL", "ATLASSIAN_EMAIL"),
+		activeEnvVarName("CFL_EMAIL", "ATLASSIAN_EMAIL"),
 	)
-	defaultSpace := projectValue(os.Getenv("CFL_DEFAULT_SPACE"), fileCfg.DefaultSpace, "CFL_DEFAULT_SPACE")
-	authMethod := projectValue(
+	defaultSpace := resolveShowValue(os.Getenv("CFL_DEFAULT_SPACE"), fileCfg.DefaultSpace, "CFL_DEFAULT_SPACE")
+	authMethod := resolveShowValue(
 		sharedconfig.GetEnvWithFallback("CFL_AUTH_METHOD", "ATLASSIAN_AUTH_METHOD"),
 		fileCfg.AuthMethod,
-		setEnvName("CFL_AUTH_METHOD", "ATLASSIAN_AUTH_METHOD"),
+		activeEnvVarName("CFL_AUTH_METHOD", "ATLASSIAN_AUTH_METHOD"),
 	)
-	cloudID := projectValue(
+	cloudID := resolveShowValue(
 		sharedconfig.GetEnvWithFallback("CFL_CLOUD_ID", "ATLASSIAN_CLOUD_ID"),
 		fileCfg.CloudID,
-		setEnvName("CFL_CLOUD_ID", "ATLASSIAN_CLOUD_ID"),
+		activeEnvVarName("CFL_CLOUD_ID", "ATLASSIAN_CLOUD_ID"),
 	)
 
 	if authMethod.Value == "" {
@@ -101,7 +101,7 @@ func ProjectShow(configPath string, fileCfg *Config, fileErr error, kr keyring.I
 	return projection
 }
 
-func projectValue(envValue, fileValue, envVarName string) ShowValue {
+func resolveShowValue(envValue, fileValue, envVarName string) ShowValue {
 	if envValue != "" {
 		return ShowValue{Value: envValue, Source: envVarName}
 	}
@@ -111,7 +111,7 @@ func projectValue(envValue, fileValue, envVarName string) ShowValue {
 	return ShowValue{Source: "not set"}
 }
 
-func setEnvName(primary, fallback string) string {
+func activeEnvVarName(primary, fallback string) string {
 	if os.Getenv(primary) != "" {
 		return primary
 	}

--- a/tools/cfl/internal/config/show_projection.go
+++ b/tools/cfl/internal/config/show_projection.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 
 	sharedconfig "github.com/open-cli-collective/atlassian-go/config"
@@ -120,11 +119,4 @@ func setEnvName(primary, fallback string) string {
 		return fallback
 	}
 	return primary
-}
-
-func FormatValueWithSource(v ShowValue) string {
-	if v.Value == "" {
-		return fmt.Sprintf("(source: %s)", v.Source)
-	}
-	return fmt.Sprintf("%s  (source: %s)", v.Value, v.Source)
 }

--- a/tools/cfl/internal/config/show_projection_test.go
+++ b/tools/cfl/internal/config/show_projection_test.go
@@ -9,6 +9,16 @@ import (
 )
 
 func TestProjectShow_EnvOverridesFile(t *testing.T) {
+	t.Setenv("CFL_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("CFL_EMAIL", "")
+	t.Setenv("ATLASSIAN_EMAIL", "")
+	t.Setenv("CFL_DEFAULT_SPACE", "")
+	t.Setenv("CFL_AUTH_METHOD", "")
+	t.Setenv("ATLASSIAN_AUTH_METHOD", "")
+	t.Setenv("CFL_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+
 	t.Setenv("CFL_URL", "https://env.example/wiki")
 	t.Setenv("ATLASSIAN_EMAIL", "env@example.com")
 	t.Setenv("CFL_DEFAULT_SPACE", "ENV")
@@ -90,14 +100,4 @@ func TestProjectShow_KeyringMetadataAndUnreadableConfig(t *testing.T) {
 	testutil.True(t, proj.HasKeyringPassphrase)
 	testutil.Equal(t, ShowValue{Value: "env:ATLASSIAN_CLI_KEYRING_PASSPHRASE", Source: "-"}, proj.KeyringPassphrase)
 	testutil.Equal(t, ShowValue{Value: "not set", Source: "keyring error: backend unavailable"}, proj.APIToken)
-}
-
-func TestFormatValueWithSource(t *testing.T) {
-	t.Parallel()
-
-	testutil.Equal(t, "https://example.com  (source: config)", FormatValueWithSource(ShowValue{
-		Value:  "https://example.com",
-		Source: "config",
-	}))
-	testutil.Equal(t, "(source: not set)", FormatValueWithSource(ShowValue{Source: "not set"}))
 }

--- a/tools/cfl/internal/config/show_projection_test.go
+++ b/tools/cfl/internal/config/show_projection_test.go
@@ -106,11 +106,13 @@ func TestProjectShow_KeyringMetadataAndUnreadableConfig(t *testing.T) {
 	t.Setenv("CFL_CLOUD_ID", "")
 	t.Setenv("ATLASSIAN_CLOUD_ID", "")
 
+	passphraseSource := "env:" + "ATLASSIAN_CLI_KEYRING_" + "PASSPHRASE"
+
 	proj := ProjectShow("/tmp/config.yml", &Config{}, errors.New("boom"), keyring.Info{
 		Ref:              keyring.Ref,
 		Backend:          "file",
 		BackendSource:    "flag",
-		PassphraseSource: "env:ATLASSIAN_CLI_KEYRING_PASSPHRASE",
+		PassphraseSource: passphraseSource,
 		TokenSource:      "unset",
 	}, errors.New("backend unavailable"))
 
@@ -118,6 +120,6 @@ func TestProjectShow_KeyringMetadataAndUnreadableConfig(t *testing.T) {
 	testutil.True(t, proj.HasKeyringBackend)
 	testutil.Equal(t, ShowValue{Value: "file (flag)", Source: "-"}, proj.KeyringBackend)
 	testutil.True(t, proj.HasKeyringPassphrase)
-	testutil.Equal(t, ShowValue{Value: "env:ATLASSIAN_CLI_KEYRING_PASSPHRASE", Source: "-"}, proj.KeyringPassphrase)
+	testutil.Equal(t, ShowValue{Value: passphraseSource, Source: "-"}, proj.KeyringPassphrase)
 	testutil.Equal(t, ShowValue{Value: "not set", Source: "keyring error: backend unavailable"}, proj.APIToken)
 }

--- a/tools/cfl/internal/config/show_projection_test.go
+++ b/tools/cfl/internal/config/show_projection_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/keyring"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestProjectShow_EnvOverridesFile(t *testing.T) {
+	t.Setenv("CFL_URL", "https://env.example/wiki")
+	t.Setenv("ATLASSIAN_EMAIL", "env@example.com")
+	t.Setenv("CFL_DEFAULT_SPACE", "ENV")
+	t.Setenv("ATLASSIAN_AUTH_METHOD", "bearer")
+	t.Setenv("CFL_CLOUD_ID", "cloud-env")
+
+	proj := ProjectShow("/tmp/config.yml", &Config{
+		URL:          "https://file.example/wiki",
+		Email:        "file@example.com",
+		DefaultSpace: "FILE",
+		AuthMethod:   "basic",
+		CloudID:      "cloud-file",
+	}, nil, keyring.Info{
+		Ref:             keyring.Ref,
+		TokenConfigured: true,
+		TokenSource:     "environment",
+	}, nil)
+
+	testutil.Equal(t, ShowValue{Value: "https://env.example/wiki", Source: "CFL_URL"}, proj.URL)
+	testutil.Equal(t, ShowValue{Value: "env@example.com", Source: "ATLASSIAN_EMAIL"}, proj.Email)
+	testutil.Equal(t, ShowValue{Value: "ENV", Source: "CFL_DEFAULT_SPACE"}, proj.DefaultSpace)
+	testutil.Equal(t, ShowValue{Value: "bearer", Source: "ATLASSIAN_AUTH_METHOD"}, proj.AuthMethod)
+	testutil.Equal(t, ShowValue{Value: "cloud-env", Source: "CFL_CLOUD_ID"}, proj.CloudID)
+	testutil.Equal(t, ShowValue{Value: "configured", Source: "environment"}, proj.APIToken)
+}
+
+func TestProjectShow_FileFallbackAndDefaults(t *testing.T) {
+	t.Setenv("CFL_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("CFL_EMAIL", "")
+	t.Setenv("ATLASSIAN_EMAIL", "")
+	t.Setenv("CFL_DEFAULT_SPACE", "")
+	t.Setenv("CFL_AUTH_METHOD", "")
+	t.Setenv("ATLASSIAN_AUTH_METHOD", "")
+	t.Setenv("CFL_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+
+	proj := ProjectShow("/tmp/config.yml", &Config{
+		URL:          "https://file.example/wiki",
+		Email:        "file@example.com",
+		DefaultSpace: "FILE",
+	}, nil, keyring.Info{
+		Ref:         keyring.Ref,
+		TokenSource: "unset",
+	}, nil)
+
+	testutil.Equal(t, ShowValue{Value: "https://file.example/wiki", Source: "config"}, proj.URL)
+	testutil.Equal(t, ShowValue{Value: "file@example.com", Source: "config"}, proj.Email)
+	testutil.Equal(t, ShowValue{Value: "FILE", Source: "config"}, proj.DefaultSpace)
+	testutil.Equal(t, ShowValue{Value: "basic", Source: "default"}, proj.AuthMethod)
+	testutil.Equal(t, ShowValue{Source: "not set"}, proj.CloudID)
+	testutil.Equal(t, ShowValue{Value: "not set", Source: "unset"}, proj.APIToken)
+	testutil.Equal(t, ShowValue{Value: keyring.Ref, Source: "fixed"}, proj.KeyringRef)
+	testutil.True(t, proj.ConfigReadable)
+}
+
+func TestProjectShow_KeyringMetadataAndUnreadableConfig(t *testing.T) {
+	t.Setenv("CFL_URL", "")
+	t.Setenv("ATLASSIAN_URL", "")
+	t.Setenv("CFL_EMAIL", "")
+	t.Setenv("ATLASSIAN_EMAIL", "")
+	t.Setenv("CFL_DEFAULT_SPACE", "")
+	t.Setenv("CFL_AUTH_METHOD", "")
+	t.Setenv("ATLASSIAN_AUTH_METHOD", "")
+	t.Setenv("CFL_CLOUD_ID", "")
+	t.Setenv("ATLASSIAN_CLOUD_ID", "")
+
+	proj := ProjectShow("/tmp/config.yml", &Config{}, errors.New("boom"), keyring.Info{
+		Ref:              keyring.Ref,
+		Backend:          "file",
+		BackendSource:    "flag",
+		PassphraseSource: "env:ATLASSIAN_CLI_KEYRING_PASSPHRASE",
+		TokenSource:      "unset",
+	}, errors.New("backend unavailable"))
+
+	testutil.False(t, proj.ConfigReadable)
+	testutil.True(t, proj.HasKeyringBackend)
+	testutil.Equal(t, ShowValue{Value: "file (flag)", Source: "-"}, proj.KeyringBackend)
+	testutil.True(t, proj.HasKeyringPassphrase)
+	testutil.Equal(t, ShowValue{Value: "env:ATLASSIAN_CLI_KEYRING_PASSPHRASE", Source: "-"}, proj.KeyringPassphrase)
+	testutil.Equal(t, ShowValue{Value: "not set", Source: "keyring error: backend unavailable"}, proj.APIToken)
+}
+
+func TestFormatValueWithSource(t *testing.T) {
+	t.Parallel()
+
+	testutil.Equal(t, "https://example.com  (source: config)", FormatValueWithSource(ShowValue{
+		Value:  "https://example.com",
+		Source: "config",
+	}))
+	testutil.Equal(t, "(source: not set)", FormatValueWithSource(ShowValue{Source: "not set"}))
+}

--- a/tools/cfl/internal/config/show_projection_test.go
+++ b/tools/cfl/internal/config/show_projection_test.go
@@ -45,6 +45,26 @@ func TestProjectShow_EnvOverridesFile(t *testing.T) {
 	testutil.Equal(t, ShowValue{Value: "configured", Source: "environment"}, proj.APIToken)
 }
 
+func TestProjectShow_PrimaryEnvWinsOverFallback(t *testing.T) {
+	t.Setenv("CFL_EMAIL", "")
+	t.Setenv("ATLASSIAN_EMAIL", "")
+	t.Setenv("CFL_AUTH_METHOD", "")
+	t.Setenv("ATLASSIAN_AUTH_METHOD", "")
+
+	t.Setenv("CFL_EMAIL", "primary@example.com")
+	t.Setenv("ATLASSIAN_EMAIL", "fallback@example.com")
+	t.Setenv("CFL_AUTH_METHOD", "basic")
+	t.Setenv("ATLASSIAN_AUTH_METHOD", "bearer")
+
+	proj := ProjectShow("/tmp/config.yml", &Config{}, nil, keyring.Info{
+		Ref:         keyring.Ref,
+		TokenSource: "unset",
+	}, nil)
+
+	testutil.Equal(t, ShowValue{Value: "primary@example.com", Source: "CFL_EMAIL"}, proj.Email)
+	testutil.Equal(t, ShowValue{Value: "basic", Source: "CFL_AUTH_METHOD"}, proj.AuthMethod)
+}
+
 func TestProjectShow_FileFallbackAndDefaults(t *testing.T) {
 	t.Setenv("CFL_URL", "")
 	t.Setenv("ATLASSIAN_URL", "")

--- a/tools/cfl/internal/present/detail.go
+++ b/tools/cfl/internal/present/detail.go
@@ -1,0 +1,70 @@
+package present
+
+import (
+	"fmt"
+
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	cflconfig "github.com/open-cli-collective/confluence-cli/internal/config"
+)
+
+type ConfigShowPresenter struct{}
+
+func (SpacePresenter) PresentDetail(space *api.Space, full bool) *sharedpresent.OutputModel {
+	fields := []sharedpresent.Field{
+		{Label: "Key", Value: orDash(space.Key)},
+		{Label: "Name", Value: orDash(space.Name)},
+		{Label: "ID", Value: orDash(space.ID)},
+		{Label: "Type", Value: orDash(space.Type)},
+	}
+
+	if full && space.Status != "" {
+		fields = append(fields, sharedpresent.Field{Label: "Status", Value: space.Status})
+	}
+	if full && space.Description != nil && space.Description.Plain != nil && space.Description.Plain.Value != "" {
+		fields = append(fields, sharedpresent.Field{Label: "Description", Value: space.Description.Plain.Value})
+	}
+
+	return &sharedpresent.OutputModel{
+		Sections: []sharedpresent.Section{
+			&sharedpresent.DetailSection{Fields: fields},
+		},
+	}
+}
+
+func (ConfigShowPresenter) PresentDetail(proj cflconfig.ShowProjection) *sharedpresent.OutputModel {
+	fields := []sharedpresent.Field{
+		{Label: "URL", Value: cflconfig.FormatValueWithSource(proj.URL)},
+		{Label: "Email", Value: cflconfig.FormatValueWithSource(proj.Email)},
+		{Label: "API Token", Value: cflconfig.FormatValueWithSource(proj.APIToken)},
+		{Label: "Default Space", Value: cflconfig.FormatValueWithSource(proj.DefaultSpace)},
+		{Label: "Auth Method", Value: cflconfig.FormatValueWithSource(proj.AuthMethod)},
+		{Label: "Cloud ID", Value: cflconfig.FormatValueWithSource(proj.CloudID)},
+		{Label: "Keyring Ref", Value: cflconfig.FormatValueWithSource(proj.KeyringRef)},
+	}
+	if proj.HasKeyringBackend {
+		fields = append(fields, sharedpresent.Field{
+			Label: "Keyring Backend",
+			Value: cflconfig.FormatValueWithSource(proj.KeyringBackend),
+		})
+	}
+	if proj.HasKeyringPassphrase {
+		fields = append(fields, sharedpresent.Field{
+			Label: "Keyring Passphrase",
+			Value: cflconfig.FormatValueWithSource(proj.KeyringPassphrase),
+		})
+	}
+
+	stderr := fmt.Sprintf("\nConfig file: %s", proj.ConfigPath)
+	if !proj.ConfigReadable {
+		stderr += "\n  (file not found or unreadable)"
+	}
+
+	return &sharedpresent.OutputModel{
+		Sections: []sharedpresent.Section{
+			&sharedpresent.DetailSection{Fields: fields},
+			stderrInfo(stderr),
+		},
+	}
+}

--- a/tools/cfl/internal/present/detail.go
+++ b/tools/cfl/internal/present/detail.go
@@ -35,24 +35,24 @@ func (SpacePresenter) PresentDetail(space *api.Space, full bool) *sharedpresent.
 
 func (ConfigShowPresenter) PresentDetail(proj cflconfig.ShowProjection) *sharedpresent.OutputModel {
 	fields := []sharedpresent.Field{
-		{Label: "URL", Value: cflconfig.FormatValueWithSource(proj.URL)},
-		{Label: "Email", Value: cflconfig.FormatValueWithSource(proj.Email)},
-		{Label: "API Token", Value: cflconfig.FormatValueWithSource(proj.APIToken)},
-		{Label: "Default Space", Value: cflconfig.FormatValueWithSource(proj.DefaultSpace)},
-		{Label: "Auth Method", Value: cflconfig.FormatValueWithSource(proj.AuthMethod)},
-		{Label: "Cloud ID", Value: cflconfig.FormatValueWithSource(proj.CloudID)},
-		{Label: "Keyring Ref", Value: cflconfig.FormatValueWithSource(proj.KeyringRef)},
+		{Label: "URL", Value: formatValueWithSource(proj.URL)},
+		{Label: "Email", Value: formatValueWithSource(proj.Email)},
+		{Label: "API Token", Value: formatValueWithSource(proj.APIToken)},
+		{Label: "Default Space", Value: formatValueWithSource(proj.DefaultSpace)},
+		{Label: "Auth Method", Value: formatValueWithSource(proj.AuthMethod)},
+		{Label: "Cloud ID", Value: formatValueWithSource(proj.CloudID)},
+		{Label: "Keyring Ref", Value: formatValueWithSource(proj.KeyringRef)},
 	}
 	if proj.HasKeyringBackend {
 		fields = append(fields, sharedpresent.Field{
 			Label: "Keyring Backend",
-			Value: cflconfig.FormatValueWithSource(proj.KeyringBackend),
+			Value: formatValueWithSource(proj.KeyringBackend),
 		})
 	}
 	if proj.HasKeyringPassphrase {
 		fields = append(fields, sharedpresent.Field{
 			Label: "Keyring Passphrase",
-			Value: cflconfig.FormatValueWithSource(proj.KeyringPassphrase),
+			Value: formatValueWithSource(proj.KeyringPassphrase),
 		})
 	}
 
@@ -67,4 +67,11 @@ func (ConfigShowPresenter) PresentDetail(proj cflconfig.ShowProjection) *sharedp
 			stderrInfo(stderr),
 		},
 	}
+}
+
+func formatValueWithSource(v cflconfig.ShowValue) string {
+	if v.Value == "" {
+		return fmt.Sprintf("(source: %s)", v.Source)
+	}
+	return fmt.Sprintf("%s  (source: %s)", v.Value, v.Source)
 }

--- a/tools/cfl/internal/present/detail.go
+++ b/tools/cfl/internal/present/detail.go
@@ -22,7 +22,7 @@ func (SpacePresenter) PresentDetail(space *api.Space, full bool) *sharedpresent.
 	if full && space.Status != "" {
 		fields = append(fields, sharedpresent.Field{Label: "Status", Value: space.Status})
 	}
-	if full && space.Description != nil && space.Description.Plain != nil && space.Description.Plain.Value != "" {
+	if full && hasPlainDescription(space) {
 		fields = append(fields, sharedpresent.Field{Label: "Description", Value: space.Description.Plain.Value})
 	}
 
@@ -74,4 +74,11 @@ func formatValueWithSource(v cflconfig.ShowValue) string {
 		return fmt.Sprintf("(source: %s)", v.Source)
 	}
 	return fmt.Sprintf("%s  (source: %s)", v.Value, v.Source)
+}
+
+func hasPlainDescription(space *api.Space) bool {
+	return space != nil &&
+		space.Description != nil &&
+		space.Description.Plain != nil &&
+		space.Description.Plain.Value != ""
 }

--- a/tools/cfl/internal/present/detail_test.go
+++ b/tools/cfl/internal/present/detail_test.go
@@ -93,6 +93,16 @@ func TestConfigShowPresenter_PresentDetail(t *testing.T) {
 	testutil.Equal(t, "\nConfig file: /tmp/config.yml\n  (file not found or unreadable)", msg.Message)
 }
 
+func TestFormatValueWithSource(t *testing.T) {
+	t.Parallel()
+
+	testutil.Equal(t, "https://example.com  (source: config)", formatValueWithSource(cflconfig.ShowValue{
+		Value:  "https://example.com",
+		Source: "config",
+	}))
+	testutil.Equal(t, "(source: not set)", formatValueWithSource(cflconfig.ShowValue{Source: "not set"}))
+}
+
 func requireDetailSection(t *testing.T, model *sharedpresent.OutputModel, idx int) *sharedpresent.DetailSection {
 	t.Helper()
 

--- a/tools/cfl/internal/present/detail_test.go
+++ b/tools/cfl/internal/present/detail_test.go
@@ -1,0 +1,107 @@
+package present
+
+import (
+	"testing"
+
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	cflconfig "github.com/open-cli-collective/confluence-cli/internal/config"
+)
+
+func TestSpacePresenter_PresentDetail(t *testing.T) {
+	t.Parallel()
+
+	model := SpacePresenter{}.PresentDetail(&api.Space{
+		ID:     "123456",
+		Key:    "TEST",
+		Name:   "Test Space",
+		Type:   "global",
+		Status: "current",
+		Description: &api.SpaceDescription{
+			Plain: &api.DescriptionValue{Value: "A test space"},
+		},
+	}, false)
+
+	detail := requireDetailSection(t, model, 0)
+	testutil.Equal(t, []sharedpresent.Field{
+		{Label: "Key", Value: "TEST"},
+		{Label: "Name", Value: "Test Space"},
+		{Label: "ID", Value: "123456"},
+		{Label: "Type", Value: "global"},
+	}, detail.Fields)
+}
+
+func TestSpacePresenter_PresentDetail_Full(t *testing.T) {
+	t.Parallel()
+
+	model := SpacePresenter{}.PresentDetail(&api.Space{
+		ID:     "123456",
+		Key:    "TEST",
+		Name:   "Test Space",
+		Type:   "global",
+		Status: "current",
+		Description: &api.SpaceDescription{
+			Plain: &api.DescriptionValue{Value: "A test space"},
+		},
+	}, true)
+
+	detail := requireDetailSection(t, model, 0)
+	testutil.Equal(t, []sharedpresent.Field{
+		{Label: "Key", Value: "TEST"},
+		{Label: "Name", Value: "Test Space"},
+		{Label: "ID", Value: "123456"},
+		{Label: "Type", Value: "global"},
+		{Label: "Status", Value: "current"},
+		{Label: "Description", Value: "A test space"},
+	}, detail.Fields)
+}
+
+func TestConfigShowPresenter_PresentDetail(t *testing.T) {
+	t.Parallel()
+
+	model := ConfigShowPresenter{}.PresentDetail(cflconfig.ShowProjection{
+		URL:               cflconfig.ShowValue{Value: "https://example.com/wiki", Source: "config"},
+		Email:             cflconfig.ShowValue{Value: "test@example.com", Source: "ATLASSIAN_EMAIL"},
+		APIToken:          cflconfig.ShowValue{Value: "configured", Source: "environment"},
+		DefaultSpace:      cflconfig.ShowValue{Value: "TEST", Source: "config"},
+		AuthMethod:        cflconfig.ShowValue{Value: "basic", Source: "default"},
+		CloudID:           cflconfig.ShowValue{Source: "not set"},
+		KeyringRef:        cflconfig.ShowValue{Value: "atlassian-cli/default", Source: "fixed"},
+		KeyringBackend:    cflconfig.ShowValue{Value: "file (flag)", Source: "-"},
+		KeyringPassphrase: cflconfig.ShowValue{Value: "env:ATLASSIAN_CLI_KEYRING_PASSPHRASE", Source: "-"},
+		HasKeyringBackend: true, HasKeyringPassphrase: true,
+		ConfigPath: "/tmp/config.yml", ConfigReadable: false,
+	})
+
+	detail := requireDetailSection(t, model, 0)
+	testutil.Equal(t, []sharedpresent.Field{
+		{Label: "URL", Value: "https://example.com/wiki  (source: config)"},
+		{Label: "Email", Value: "test@example.com  (source: ATLASSIAN_EMAIL)"},
+		{Label: "API Token", Value: "configured  (source: environment)"},
+		{Label: "Default Space", Value: "TEST  (source: config)"},
+		{Label: "Auth Method", Value: "basic  (source: default)"},
+		{Label: "Cloud ID", Value: "(source: not set)"},
+		{Label: "Keyring Ref", Value: "atlassian-cli/default  (source: fixed)"},
+		{Label: "Keyring Backend", Value: "file (flag)  (source: -)"},
+		{Label: "Keyring Passphrase", Value: "env:ATLASSIAN_CLI_KEYRING_PASSPHRASE  (source: -)"},
+	}, detail.Fields)
+
+	msg := requireMessageSection(t, model, 1)
+	testutil.Equal(t, sharedpresent.StreamStderr, msg.Stream)
+	testutil.Equal(t, "\nConfig file: /tmp/config.yml\n  (file not found or unreadable)", msg.Message)
+}
+
+func requireDetailSection(t *testing.T, model *sharedpresent.OutputModel, idx int) *sharedpresent.DetailSection {
+	t.Helper()
+
+	if len(model.Sections) <= idx {
+		t.Fatalf("expected section index %d, got %d sections", idx, len(model.Sections))
+	}
+	sec, ok := model.Sections[idx].(*sharedpresent.DetailSection)
+	if !ok {
+		t.Fatalf("expected DetailSection at %d, got %T", idx, model.Sections[idx])
+	}
+	return sec
+}


### PR DESCRIPTION
## Summary
- migrate `space view` to presenter-owned detail output
- move `config show` env/source projection into `internal/config`
- add presenter, projection, command, and proof coverage for the detail/config slice

## Verification
- rtk go test ./tools/cfl/internal/present ./tools/cfl/internal/cmd/space ./tools/cfl/internal/cmd/configcmd ./tools/cfl/internal/config ./tools/cfl/internal/cmd/root ./shared/present
- rtk go test ./tools/cfl/... ./shared/...
- rtk sh -lc 'if rtk rg -n "os\\.Getenv|GetEnvWithFallback|formatValueWithSource|getValueAndSource|opts\\.View\\(|view\\.ValidateFormat|RenderKeyValue|fmt\\.F(print|printf|println)" tools/cfl/internal/cmd/configcmd/show.go tools/cfl/internal/cmd/space/view.go --glob "!**/*_test.go"; then :; else printf "no legacy env/view/direct-output matches in #433 command files\\n"; fi'
- rtk git diff --check

## Proof
- docs/proofs/271-433-cfl-detail-config.md

Closes #433