### PR TITLE
feat(jtk): advise eventual consistency after automation rule update

### DIFF
--- a/tools/jtk/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/jtk/internal/cmd/OUTPUT_SPEC.md
@@ -838,6 +838,15 @@ Components: 5 total — 1 condition, 4 actions
 ```
 
 ```
+$ jtk automation update 019e1234-abcd-7000-8888-112233445566 --file rule.json
+019e1234-abcd-7000-8888-112233445566  [Test] My Rule
+State: ENABLED
+Components: 5 total — 1 condition, 4 actions
+```
+
+Post-state mirrors `automation get`. On success `update` also writes an advisory to **stderr** — automation reads are eventually consistent, so a re-export/get run immediately afterward may show the prior definition even though the update applied. The advisory is suppressed under `--id`, which emits only the rule UUID.
+
+```
 $ jtk automation delete 019e1234-abcd-7000-8888-112233445566
 Deleted automation 019e1234-abcd-7000-8888-112233445566
 ```

--- a/tools/jtk/internal/cmd/automation/update.go
+++ b/tools/jtk/internal/cmd/automation/update.go
@@ -36,7 +36,13 @@ does, do not change it.
 The safest edits are to rule metadata: name, description, labels, and
 enabled/disabled state (prefer 'jtk auto enable/disable' for state changes).
 Component-level edits require understanding of the specific Jira instance's
-field mappings and workflow configuration.`,
+field mappings and workflow configuration.
+
+Automation reads are eventually consistent. The write is applied on success,
+but an 'export'/'get' issued immediately afterward may briefly return the
+prior definition — so a re-export run right away (e.g. to refresh a backup)
+can look like the update was dropped when it was not. Re-read after a moment
+to confirm.`,
 		Example: `  jtk automation update 12345 --file rule.json
   jtk auto update 12345 --file updated-rule.json`,
 		Args: cobra.ExactArgs(1),
@@ -72,6 +78,17 @@ func runUpdate(ctx context.Context, opts *root.Options, ruleID, filePath string)
 
 	if opts.EmitIDOnly() {
 		return jtkpresent.EmitIDs(opts, []string{ruleID})
+	}
+
+	// Automation reads are eventually consistent: a re-export/get issued right
+	// after this write can briefly return the prior definition even though the
+	// update was applied. Surface that so callers (and scripts that re-export
+	// to a backup) don't mistake replication lag for a dropped update. The
+	// post-state shown below is fetched with bounded retries but can itself
+	// land on a lagging replica.
+	if opts.Stderr != nil {
+		fmt.Fprintln(opts.Stderr,
+			"Note: automation reads are eventually consistent — an immediate re-export/get may briefly show the prior rule definition even though this update was applied. Re-read after a moment to confirm.")
 	}
 
 	return mutation.WriteAndPresent(ctx, opts, mutation.Config{

--- a/tools/jtk/internal/cmd/automation/update_test.go
+++ b/tools/jtk/internal/cmd/automation/update_test.go
@@ -3,12 +3,16 @@ package automation
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/testutil"
 
+	"github.com/open-cli-collective/jira-ticket-cli/api"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
 )
 
@@ -57,5 +61,69 @@ func TestRunUpdate(t *testing.T) {
 		err := runUpdate(context.Background(), opts, "12345", "/nonexistent/path/rule.json")
 		testutil.RequireError(t, err)
 		testutil.Contains(t, err.Error(), "no such file or directory")
+	})
+
+	t.Run("emits eventual-consistency advisory to stderr on success", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/_edge/tenant_info" {
+				_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+				return
+			}
+			switch r.Method {
+			case http.MethodPut:
+				_, _ = w.Write([]byte(`{"ruleUuid":"12345"}`))
+			case http.MethodGet:
+				_ = json.NewEncoder(w).Encode(struct {
+					Rule api.AutomationRule `json:"rule"`
+				}{Rule: api.AutomationRule{UUID: "12345", Name: "Test Rule", State: "ENABLED"}})
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		}))
+		defer server.Close()
+
+		client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@example.com", APIToken: "token"})
+		testutil.RequireNoError(t, err)
+
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "rule.json")
+		testutil.RequireNoError(t, os.WriteFile(filePath, []byte(`{"rule":{"name":"Test Rule"}}`), 0600))
+
+		var stdout, stderr bytes.Buffer
+		opts := &root.Options{Stdout: &stdout, Stderr: &stderr}
+		opts.SetAPIClient(client)
+
+		err = runUpdate(context.Background(), opts, "12345", filePath)
+		testutil.RequireNoError(t, err)
+		testutil.Contains(t, stderr.String(), "eventually consistent")
+		testutil.Contains(t, stderr.String(), "Re-read after a moment")
+	})
+
+	t.Run("no advisory in id-only mode", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/_edge/tenant_info" {
+				_, _ = w.Write([]byte(`{"cloudId":"test-cloud"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"ruleUuid":"12345"}`))
+		}))
+		defer server.Close()
+
+		client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@example.com", APIToken: "token"})
+		testutil.RequireNoError(t, err)
+
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "rule.json")
+		testutil.RequireNoError(t, os.WriteFile(filePath, []byte(`{"rule":{"name":"Test Rule"}}`), 0600))
+
+		var stdout, stderr bytes.Buffer
+		opts := &root.Options{Stdout: &stdout, Stderr: &stderr, IDOnly: true}
+		opts.SetAPIClient(client)
+
+		err = runUpdate(context.Background(), opts, "12345", filePath)
+		testutil.RequireNoError(t, err)
+		testutil.Equal(t, stderr.String(), "")
 	})
 }


### PR DESCRIPTION
## What

`jtk automation update` now tells the user, on success, that automation reads are eventually consistent — an `export`/`get` issued immediately afterward may briefly return the prior rule definition even though the write was applied. The note goes to stderr (human mode only; suppressed under `--id`), and the same guidance is added to the command's `--help`.

## Why

I filed #453 believing `update` silently dropped component-level edits. It doesn't — on a clean cycle the edit applies and persists. The false signal was replication lag: my write landed (the rule's `updated` timestamp advanced), but the re-export I ran seconds later hit a lagging replica still serving the old definition. Closed #453 as not-a-bug.

The trip-wire is real and easy to hit, especially in the common "update, then re-export to refresh a checked-in backup" workflow — the immediate re-export is exactly the read most likely to be stale. A one-line advisory turns a confusing 20-minute misdiagnosis into a non-event.

## Notes

- The post-write detail this command already prints (via the shared write→fetch→present retry) can itself land on a lagging replica; the advisory covers that too.
- No behavior change to the update itself, JSON/`--id` output, or exit codes.

## Tests

- New success test asserts the advisory reaches stderr; a `--id` test asserts stderr stays empty. Existing error-path tests unchanged. `go test ./internal/cmd/automation/` green.

Closes the follow-up discussion on #453.