### PR TITLE
fix(cfl): resolve --config split-brain resolution

### DIFF
--- a/tools/cfl/internal/cmd/configcmd/show.go
+++ b/tools/cfl/internal/cmd/configcmd/show.go
@@ -35,7 +35,7 @@ command to confirm effective configuration.`,
 }
 
 func runShow(opts *root.Options) error {
-	configPath := config.DefaultConfigPath()
+	configPath := opts.ResolvedConfigPath()
 
 	// Load config file (if exists)
 	fileCfg, fileErr := config.Load(configPath)

--- a/tools/cfl/internal/cmd/configcmd/show_test.go
+++ b/tools/cfl/internal/cmd/configcmd/show_test.go
@@ -81,6 +81,22 @@ func TestRunShow_ExactOutput(t *testing.T) {
 	testutil.Equal(t, "\nConfig file: "+cfgPath+"\n", errBuf.String())
 }
 
+func TestRunShow_UsesConfiguredPath(t *testing.T) {
+	credtest.Hermetic(t)
+	defaultPath := cflconfig.DefaultConfigPath()
+	explicitPath := filepath.Join(t.TempDir(), "explicit.yml")
+	testutil.RequireNoError(t, (&cflconfig.Config{URL: "https://default.atlassian.net/wiki", Email: "default@example.com"}).Save(defaultPath))
+	testutil.RequireNoError(t, (&cflconfig.Config{URL: "https://explicit.atlassian.net/wiki", Email: "explicit@example.com"}).Save(explicitPath))
+
+	out, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
+	opts := &root.Options{ConfigPath: explicitPath, Output: "table", NoColor: true, Stdout: out, Stderr: errBuf}
+	testutil.RequireNoError(t, runShow(opts))
+
+	testutil.Contains(t, out.String(), "URL: https://explicit.atlassian.net/wiki  (source: config)")
+	testutil.NotContains(t, out.String(), "default.atlassian.net")
+	testutil.Equal(t, "\nConfig file: "+explicitPath+"\n", errBuf.String())
+}
+
 func TestRunShow_UnreadableConfigNote(t *testing.T) {
 	credtest.Hermetic(t)
 	cfgDir := t.TempDir()

--- a/tools/cfl/internal/cmd/init/init.go
+++ b/tools/cfl/internal/cmd/init/init.go
@@ -111,7 +111,7 @@ func runInit(ctx context.Context, opts *root.Options, prefillURL, prefillEmail s
 		}
 	}
 
-	legacyPath := config.DefaultConfigPath()
+	legacyPath := opts.ResolvedConfigPath()
 	sharedPath, err := credstore.DefaultPath()
 	if err != nil {
 		v.Error("Cannot resolve the shared credential store path: %v", err)

--- a/tools/cfl/internal/cmd/init/init_test.go
+++ b/tools/cfl/internal/cmd/init/init_test.go
@@ -221,6 +221,35 @@ func TestRunInit_NonInteractive_MissingToken_RecommendsAllPaths(t *testing.T) {
 	}
 }
 
+func TestRunInit_UsesConfiguredPathForReconciliation(t *testing.T) {
+	credtest.Hermetic(t)
+	defaultPath := config.DefaultConfigPath()
+	explicitPath := filepath.Join(t.TempDir(), "explicit.yml")
+	testutil.RequireNoError(t, (&config.Config{
+		URL: "https://default.atlassian.net/wiki", Email: "default@example.com", DefaultSpace: "DEFAULT",
+	}).Save(defaultPath))
+	testutil.RequireNoError(t, (&config.Config{
+		URL: "https://explicit.atlassian.net/wiki", Email: "explicit@example.com", DefaultSpace: "EXPLICIT",
+	}).Save(explicitPath))
+
+	opts := &root.Options{
+		ConfigPath:     explicitPath,
+		Output:         "table",
+		NoColor:        true,
+		NonInteractive: true,
+		Stdin:          strings.NewReader(cflInitSentinel + "\n"),
+		Stdout:         &bytes.Buffer{},
+		Stderr:         &bytes.Buffer{},
+	}
+	testutil.RequireNoError(t, runInit(context.Background(), opts,
+		"https://configured.atlassian.net", "configured@example.com", true, "", "", "", true))
+
+	store, err := credstore.Load(credtest.SharedConfigPath(t))
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, "EXPLICIT", store.CFL.DefaultSpace)
+	testutil.Equal(t, "https://configured.atlassian.net", store.Default.URL)
+}
+
 // finalizeInit tests use t.TempDir() for paths and an httptest-backed
 // clientBuilder so the user's real config is never touched and no real
 // network call is made.

--- a/tools/cfl/internal/cmd/root/root.go
+++ b/tools/cfl/internal/cmd/root/root.go
@@ -36,8 +36,9 @@ type Options struct {
 	testClient *api.Client
 
 	// cachedConfig stores loaded config for reuse
-	cachedConfig  *config.Config
-	tokenResolved bool
+	cachedConfig   *config.Config
+	tokenResolved  bool
+	configExplicit bool
 }
 
 // View returns a configured View instance.
@@ -117,7 +118,7 @@ func (o *Options) loadConfig() (*config.Config, error) {
 	}
 	// Defer token resolution until after PersistentPreRunE wires the
 	// backend selected by this same config.
-	cfg, err := config.LoadWithEnv(o.ResolvedConfigPath(), false)
+	cfg, err := config.LoadWithEnv(o.ResolvedConfigPath(), false, !o.configExplicit)
 	if err != nil {
 		return nil, err
 	}
@@ -181,6 +182,7 @@ Get started by running: cfl init`,
 			if err := validateOutputFormat(opts.Output); err != nil {
 				return err
 			}
+			opts.configExplicit = cmd.Flags().Changed("config")
 			cfg, err := opts.loadConfig()
 			if err != nil {
 				return err

--- a/tools/cfl/internal/cmd/root/root.go
+++ b/tools/cfl/internal/cmd/root/root.go
@@ -102,17 +102,22 @@ func (o *Options) Config() (*config.Config, error) {
 	return cfg, nil
 }
 
+// ResolvedConfigPath returns the config path selected by --config, or the
+// default path when no explicit value was supplied.
+func (o *Options) ResolvedConfigPath() string {
+	if o.ConfigPath != "" {
+		return o.ConfigPath
+	}
+	return config.DefaultConfigPath()
+}
+
 func (o *Options) loadConfig() (*config.Config, error) {
 	if o.cachedConfig != nil {
 		return o.cachedConfig, nil
 	}
-	path := o.ConfigPath
-	if path == "" {
-		path = config.DefaultConfigPath()
-	}
 	// Defer token resolution until after PersistentPreRunE wires the
 	// backend selected by this same config.
-	cfg, err := config.LoadWithEnv(path, false)
+	cfg, err := config.LoadWithEnv(o.ResolvedConfigPath(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/cfl/internal/cmd/root/root.go
+++ b/tools/cfl/internal/cmd/root/root.go
@@ -23,6 +23,7 @@ import (
 
 // Options contains global options for commands
 type Options struct {
+	ConfigPath     string
 	Output         string
 	NoColor        bool
 	Full           bool
@@ -35,7 +36,8 @@ type Options struct {
 	testClient *api.Client
 
 	// cachedConfig stores loaded config for reuse
-	cachedConfig *config.Config
+	cachedConfig  *config.Config
+	tokenResolved bool
 }
 
 // View returns a configured View instance.
@@ -75,20 +77,44 @@ func (o *Options) RenderStyle() present.Style {
 // If a test client is set and no config is cached, returns an empty config
 // (since tests inject their own client and typically don't need real config).
 func (o *Options) Config() (*config.Config, error) {
-	if o.cachedConfig != nil {
+	if o.cachedConfig != nil && o.tokenResolved {
 		return o.cachedConfig, nil
 	}
 	// If test client is set, return empty config since tests inject their own client
 	if o.testClient != nil {
 		o.cachedConfig = &config.Config{}
+		o.tokenResolved = true
 		return o.cachedConfig, nil
 	}
-	cfg, err := config.LoadWithEnv(config.DefaultConfigPath())
+	cfg, err := o.loadConfig()
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %w (run 'cfl init' to configure)", err)
 	}
+	if !o.tokenResolved {
+		if err := config.ResolveToken(cfg); err != nil {
+			return nil, fmt.Errorf("loading config: %w (run 'cfl init' to configure)", err)
+		}
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w (run 'cfl init' to configure)", err)
+	}
+	o.tokenResolved = true
+	return cfg, nil
+}
+
+func (o *Options) loadConfig() (*config.Config, error) {
+	if o.cachedConfig != nil {
+		return o.cachedConfig, nil
+	}
+	path := o.ConfigPath
+	if path == "" {
+		path = config.DefaultConfigPath()
+	}
+	// Defer token resolution until after PersistentPreRunE wires the
+	// backend selected by this same config.
+	cfg, err := config.LoadWithEnv(path, false)
+	if err != nil {
+		return nil, err
 	}
 	o.cachedConfig = cfg
 	return cfg, nil
@@ -97,6 +123,7 @@ func (o *Options) Config() (*config.Config, error) {
 // SetConfig sets a test config (for testing only)
 func (o *Options) SetConfig(cfg *config.Config) {
 	o.cachedConfig = cfg
+	o.tokenResolved = true
 }
 
 // APIClient creates a new API client from config
@@ -149,12 +176,16 @@ Get started by running: cfl init`,
 			if err := validateOutputFormat(opts.Output); err != nil {
 				return err
 			}
-			return wireBackendSelection(cmd)
+			cfg, err := opts.loadConfig()
+			if err != nil {
+				return err
+			}
+			return wireBackendSelection(cmd, cfg)
 		},
 	}
 
 	// Global flags - bound to opts struct
-	cmd.PersistentFlags().StringP("config", "c", "", "config file (default: ~/.config/cfl/config.yml)")
+	cmd.PersistentFlags().StringVarP(&opts.ConfigPath, "config", "c", config.DefaultConfigPath(), "config file")
 	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "table", "output format: table, plain")
 	cmd.PersistentFlags().BoolVar(&opts.NoColor, "no-color", false, "disable colored output")
 	cmd.PersistentFlags().BoolVar(&opts.Full, "full", false, "show full inspection-oriented output (default: agent)")
@@ -189,7 +220,7 @@ func validateOutputFormat(format string) error {
 // Best-effort config load: commands that don't need credentials (e.g.,
 // `cfl completion`) must not fail just because config is missing or
 // malformed; commands that do need them handle their own load errors.
-func wireBackendSelection(cmd *cobra.Command) error {
+func wireBackendSelection(cmd *cobra.Command, cfg *config.Config) error {
 	var flagValue string
 	var flagSet bool
 	if bf := cmd.Flag(cccredstore.BackendFlagName); bf != nil {
@@ -197,17 +228,8 @@ func wireBackendSelection(cmd *cobra.Command) error {
 		flagSet = bf.Changed
 	}
 
-	var configBackend string
-	cfgPath, _ := cmd.Root().PersistentFlags().GetString("config")
-	if cfgPath == "" {
-		cfgPath = config.DefaultConfigPath()
-	}
-	if cfg, err := config.Load(cfgPath); err == nil && cfg != nil {
-		configBackend = cfg.Keyring.Backend
-	}
-
 	opts := &cccredstore.Options{}
-	if err := cccredstore.BindBackendFlag(opts, flagValue, flagSet, configBackend); err != nil {
+	if err := cccredstore.BindBackendFlag(opts, flagValue, flagSet, cfg.Keyring.Backend); err != nil {
 		return fmt.Errorf("--%s: %w", cccredstore.BackendFlagName, err)
 	}
 	keyring.SetBackendSelection(opts.Backend, opts.ConfigBackend)

--- a/tools/cfl/internal/cmd/root/root_test.go
+++ b/tools/cfl/internal/cmd/root/root_test.go
@@ -2,13 +2,23 @@ package root
 
 import (
 	"bytes"
+	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/open-cli-collective/atlassian-go/artifact"
+	"github.com/open-cli-collective/atlassian-go/auth"
+	sharedclient "github.com/open-cli-collective/atlassian-go/client"
+	"github.com/open-cli-collective/atlassian-go/credtest"
+	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/present"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 	"github.com/open-cli-collective/atlassian-go/view"
+	cccredstore "github.com/open-cli-collective/cli-common/credstore"
 	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/config"
 )
 
 func TestNewCmd(t *testing.T) {
@@ -246,5 +256,127 @@ func TestOptions_RenderStyle_PlainOutput(t *testing.T) {
 	opts := &Options{Output: "plain"}
 	if got := opts.RenderStyle(); got != present.StyleHumanPlain {
 		t.Errorf("RenderStyle() = %v, want StyleHumanPlain", got)
+	}
+}
+
+func TestConfigFlagIsAuthoritative(t *testing.T) {
+	tests := []struct {
+		name        string
+		authMethod  string
+		url         string
+		email       string
+		cloudID     string
+		checkClient func(*testing.T, *api.Client, string)
+	}{
+		{
+			name:       "basic",
+			authMethod: auth.AuthMethodBasic,
+			url:        "https://explicit-basic.atlassian.net/wiki",
+			email:      "explicit-basic@example.com",
+			cloudID:    "explicit-basic-cloud",
+			checkClient: func(t *testing.T, client *api.Client, token string) {
+				t.Helper()
+				if client.GetBaseURL() != "https://explicit-basic.atlassian.net/wiki" ||
+					client.GetAuthHeader() != auth.BasicAuthHeader("explicit-basic@example.com", token) {
+					t.Fatal("basic client did not use the explicit config and resolved token")
+				}
+			},
+		},
+		{
+			name:       "bearer",
+			authMethod: auth.AuthMethodBearer,
+			url:        "https://explicit-bearer.atlassian.net/wiki",
+			email:      "explicit-bearer@example.com",
+			cloudID:    "explicit-bearer-cloud",
+			checkClient: func(t *testing.T, client *api.Client, token string) {
+				t.Helper()
+				wantURL := fmt.Sprintf("%s/ex/confluence/explicit-bearer-cloud/wiki", sharedclient.GatewayBaseURL)
+				if client.GetBaseURL() != wantURL || client.GetAuthHeader() != auth.BearerAuthHeader(token) {
+					t.Fatal("bearer client did not use the explicit config and resolved token")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			credtest.Hermetic(t)
+			keyring.SetBackendSelection("", "")
+			t.Cleanup(func() { keyring.SetBackendSelection("", "") })
+			for _, name := range []string{
+				"CFL_URL", "ATLASSIAN_URL", "CFL_EMAIL", "ATLASSIAN_EMAIL",
+				"CFL_AUTH_METHOD", "ATLASSIAN_AUTH_METHOD", "CFL_CLOUD_ID",
+				"ATLASSIAN_CLOUD_ID", "CFL_DEFAULT_SPACE",
+			} {
+				t.Setenv(name, "")
+			}
+
+			defaultCfg := &config.Config{
+				URL:          "https://default.atlassian.net/wiki",
+				Email:        "default@example.com",
+				AuthMethod:   auth.AuthMethodBasic,
+				CloudID:      "default-cloud",
+				DefaultSpace: "DEFAULT",
+				OutputFormat: "default-output",
+				Keyring:      config.KeyringConfig{Backend: "file"},
+			}
+			testutil.RequireNoError(t, defaultCfg.Save(config.DefaultConfigPath()))
+
+			explicitPath := filepath.Join(t.TempDir(), "explicit.yml")
+			explicitCfg := &config.Config{
+				URL:          tt.url,
+				Email:        tt.email,
+				AuthMethod:   tt.authMethod,
+				CloudID:      tt.cloudID,
+				DefaultSpace: "EXPLICIT",
+				OutputFormat: "explicit-output",
+				Keyring:      config.KeyringConfig{Backend: "memory"},
+			}
+			testutil.RequireNoError(t, explicitCfg.Save(explicitPath))
+
+			secret := "explicit-token-" + tt.name
+			t.Setenv("CFL_API_TOKEN", secret)
+			var stdout, stderr bytes.Buffer
+			rootCmd, opts := NewCmd()
+			rootCmd.SetOut(&stdout)
+			rootCmd.SetErr(&stderr)
+			rootCmd.AddCommand(&cobra.Command{
+				Use: "probe",
+				RunE: func(*cobra.Command, []string) error {
+					cfg, err := opts.Config()
+					if err != nil {
+						return err
+					}
+					if cfg.URL != explicitCfg.URL || cfg.Email != explicitCfg.Email ||
+						cfg.AuthMethod != explicitCfg.AuthMethod || cfg.CloudID != explicitCfg.CloudID ||
+						cfg.DefaultSpace != explicitCfg.DefaultSpace || cfg.OutputFormat != explicitCfg.OutputFormat ||
+						cfg.Keyring.Backend != explicitCfg.Keyring.Backend || cfg.APIToken != secret {
+						t.Fatal("resolved config did not use every explicit setting and the authoritative token resolver")
+					}
+					client, err := opts.APIClient()
+					if err != nil {
+						return err
+					}
+					tt.checkClient(t, client, secret)
+					return nil
+				},
+			})
+			rootCmd.SetArgs([]string{"--config", explicitPath, "probe"})
+
+			err := rootCmd.Execute()
+			if err != nil {
+				t.Fatalf("Execute failed without exposing credentials: %v", err)
+			}
+			if opts.ConfigPath != explicitPath {
+				t.Fatal("--config did not set the authoritative path")
+			}
+			_, configBackend := keyring.GetBackendSelection()
+			if configBackend != cccredstore.BackendMemory {
+				t.Fatal("keyring backend did not come from the explicit config")
+			}
+			if bytes.Contains(stdout.Bytes(), []byte(secret)) || bytes.Contains(stderr.Bytes(), []byte(secret)) {
+				t.Fatal("command output exposed the API token")
+			}
+		})
 	}
 }

--- a/tools/cfl/internal/cmd/root/root_test.go
+++ b/tools/cfl/internal/cmd/root/root_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-cli-collective/atlassian-go/artifact"
 	"github.com/open-cli-collective/atlassian-go/auth"
 	sharedclient "github.com/open-cli-collective/atlassian-go/client"
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/credtest"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/present"
@@ -321,6 +322,15 @@ func TestConfigFlagIsAuthoritative(t *testing.T) {
 				Keyring:      config.KeyringConfig{Backend: "file"},
 			}
 			testutil.RequireNoError(t, defaultCfg.Save(config.DefaultConfigPath()))
+			testutil.RequireNoError(t, (&credstore.Store{
+				Default: credstore.Section{
+					URL:        "https://shared.atlassian.net",
+					Email:      "shared@example.com",
+					AuthMethod: auth.AuthMethodBearer,
+					CloudID:    "shared-cloud",
+				},
+				CFL: credstore.ToolSection{DefaultSpace: "SHARED", OutputFormat: "shared-output"},
+			}).Save(credtest.SharedConfigPath(t)))
 
 			explicitPath := filepath.Join(t.TempDir(), "explicit.yml")
 			explicitCfg := &config.Config{
@@ -378,5 +388,52 @@ func TestConfigFlagIsAuthoritative(t *testing.T) {
 				t.Fatal("command output exposed the API token")
 			}
 		})
+	}
+}
+
+func TestDefaultConfigLayersSharedValues(t *testing.T) {
+	credtest.Hermetic(t)
+	keyring.SetBackendSelection("", "")
+	t.Cleanup(func() { keyring.SetBackendSelection("", "") })
+	t.Setenv("CFL_API_TOKEN", "token")
+
+	legacy := &config.Config{
+		URL:          "https://legacy.atlassian.net/wiki",
+		Email:        "legacy@example.com",
+		AuthMethod:   auth.AuthMethodBasic,
+		CloudID:      "legacy-cloud",
+		DefaultSpace: "LEGACY",
+		OutputFormat: "legacy-output",
+	}
+	testutil.RequireNoError(t, legacy.Save(config.DefaultConfigPath()))
+	testutil.RequireNoError(t, (&credstore.Store{
+		Default: credstore.Section{
+			URL:        "https://shared.atlassian.net",
+			Email:      "shared@example.com",
+			AuthMethod: auth.AuthMethodBearer,
+			CloudID:    "shared-cloud",
+		},
+		CFL: credstore.ToolSection{DefaultSpace: "SHARED", OutputFormat: "shared-output"},
+	}).Save(credtest.SharedConfigPath(t)))
+
+	rootCmd, opts := NewCmd()
+	rootCmd.AddCommand(&cobra.Command{
+		Use: "probe",
+		RunE: func(*cobra.Command, []string) error {
+			cfg, err := opts.Config()
+			if err != nil {
+				return err
+			}
+			if cfg.URL != "https://shared.atlassian.net/wiki" || cfg.Email != "shared@example.com" ||
+				cfg.AuthMethod != auth.AuthMethodBearer || cfg.CloudID != "shared-cloud" ||
+				cfg.DefaultSpace != "SHARED" || cfg.OutputFormat != "shared-output" {
+				t.Fatal("default config did not layer shared values")
+			}
+			return nil
+		},
+	})
+	rootCmd.SetArgs([]string{"probe"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute failed: %v", err)
 	}
 }

--- a/tools/cfl/internal/config/config.go
+++ b/tools/cfl/internal/config/config.go
@@ -223,7 +223,8 @@ func warnCorruptSharedOnce(err error) {
 	})
 }
 
-// LoadWithEnv loads configuration with full precedence.
+// LoadWithEnv loads configuration with full precedence. Callers may defer
+// token resolution until after applying the loaded keyring backend.
 //
 // Non-secret fields (url, email, auth_method, cloud_id, default_space,
 // output_format):
@@ -242,7 +243,7 @@ func warnCorruptSharedOnce(err error) {
 // + env so a broken shared file doesn't crash every cfl command. Init
 // uses credstore.Load directly so it can surface the error and refuse
 // to overwrite.
-func LoadWithEnv(path string) (*Config, error) {
+func LoadWithEnv(path string, resolveToken bool) (*Config, error) {
 	cfg, err := Load(path)
 	if err != nil {
 		// Legacy file missing or corrupt: start empty. cfl init has a
@@ -267,13 +268,22 @@ func LoadWithEnv(path string) (*Config, error) {
 	}
 
 	cfg.LoadFromEnv()
+	if resolveToken {
+		if err := ResolveToken(cfg); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
+}
 
+// ResolveToken applies the authoritative token source to cfg.
+func ResolveToken(cfg *Config) error {
 	// Authoritative token resolution: overwrites any token a legacy-file
 	// parse may have populated, so plaintext can never reach the client.
 	tok, _, kErr := keyring.ResolveToken(credstore.ToolCFL)
 	if kErr != nil {
-		return nil, kErr
+		return kErr
 	}
 	cfg.APIToken = tok
-	return cfg, nil
+	return nil
 }

--- a/tools/cfl/internal/config/config.go
+++ b/tools/cfl/internal/config/config.go
@@ -243,7 +243,7 @@ func warnCorruptSharedOnce(err error) {
 // + env so a broken shared file doesn't crash every cfl command. Init
 // uses credstore.Load directly so it can surface the error and refuse
 // to overwrite.
-func LoadWithEnv(path string, resolveToken bool) (*Config, error) {
+func LoadWithEnv(path string, resolveToken, loadShared bool) (*Config, error) {
 	cfg, err := Load(path)
 	if err != nil {
 		// Legacy file missing or corrupt: start empty. cfl init has a
@@ -259,12 +259,14 @@ func LoadWithEnv(path string, resolveToken bool) (*Config, error) {
 	// command keeps working while the conflict is surfaced once. A nil
 	// store (unresolvable/corrupt) → fall back to legacy + env. `cfl
 	// init` uses the fail-loud detect/gated-copy path instead.
-	store, sErr := credstore.LoadSharedRuntime()
-	if sErr != nil {
-		warnCorruptSharedOnce(sErr)
-	}
-	if store != nil {
-		cfg.LoadFromShared(store)
+	if loadShared {
+		store, sErr := credstore.LoadSharedRuntime()
+		if sErr != nil {
+			warnCorruptSharedOnce(sErr)
+		}
+		if store != nil {
+			cfg.LoadFromShared(store)
+		}
 	}
 
 	cfg.LoadFromEnv()

--- a/tools/cfl/internal/config/config_test.go
+++ b/tools/cfl/internal/config/config_test.go
@@ -557,7 +557,7 @@ func TestLoadWithEnv_PrecedenceLegacyToSharedToEnv(t *testing.T) {
 	// Set CFL_API_TOKEN env (highest precedence).
 	t.Setenv("CFL_API_TOKEN", "env-tok")
 
-	cfg, err := LoadWithEnv(legacyPath)
+	cfg, err := LoadWithEnv(legacyPath, true)
 	testutil.RequireNoError(t, err)
 
 	// URL: shared wins over legacy (env not set for URL).
@@ -585,7 +585,7 @@ func TestLoadWithEnv_CorruptSharedFallsBackToLegacy(t *testing.T) {
 	legacy := &Config{URL: "https://x.atlassian.net/wiki", Email: "e@x", APIToken: "t"}
 	testutil.RequireNoError(t, legacy.Save(legacyPath))
 
-	cfg, err := LoadWithEnv(legacyPath)
+	cfg, err := LoadWithEnv(legacyPath, true)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, "https://x.atlassian.net/wiki", cfg.URL)
 	// Corrupt shared store defers migration; keyring is empty → no token,

--- a/tools/cfl/internal/config/config_test.go
+++ b/tools/cfl/internal/config/config_test.go
@@ -557,7 +557,7 @@ func TestLoadWithEnv_PrecedenceLegacyToSharedToEnv(t *testing.T) {
 	// Set CFL_API_TOKEN env (highest precedence).
 	t.Setenv("CFL_API_TOKEN", "env-tok")
 
-	cfg, err := LoadWithEnv(legacyPath, true)
+	cfg, err := LoadWithEnv(legacyPath, true, true)
 	testutil.RequireNoError(t, err)
 
 	// URL: shared wins over legacy (env not set for URL).
@@ -585,7 +585,7 @@ func TestLoadWithEnv_CorruptSharedFallsBackToLegacy(t *testing.T) {
 	legacy := &Config{URL: "https://x.atlassian.net/wiki", Email: "e@x", APIToken: "t"}
 	testutil.RequireNoError(t, legacy.Save(legacyPath))
 
-	cfg, err := LoadWithEnv(legacyPath, true)
+	cfg, err := LoadWithEnv(legacyPath, true, true)
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, "https://x.atlassian.net/wiki", cfg.URL)
 	// Corrupt shared store defers migration; keyring is empty → no token,


### PR DESCRIPTION
Implements item 2 of #455.

- `--config PATH` now resolves one authoritative config consumed everywhere: URL, email/account, auth method, cloud ID, defaults, token resolution, and keyring backend selection.
- Backend wiring (`wireBackendSelection`) now receives the same loaded config instead of doing its own bare `config.Load` of a separately-resolved path.
- Token resolution is deferred until after the backend selected by that config is wired, preserving init's fail-loud/no-mutation behavior.
- Tests: distinct default vs. explicit config files proving every setting comes from the explicit file, covering basic and bearer auth without exposing secrets.