### PR TITLE
feat(jtk): detect attachment MIME type and add --filename override for #465

### DIFF
--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -824,18 +824,20 @@ jtk attachments list PROJ-123 --id
 
 ### `jtk attachments add <issue-key>`
 
-Upload file(s) to an issue.
+Upload file(s) to an issue. The stored MIME type is detected from each file's extension, so images and PDFs are recognized as such by Jira (thumbnails and inline previews) rather than treated as generic downloads.
 
 **Aliases:** `jtk attachment add`, `jtk att add`
 
 ```bash
 jtk attachments add PROJ-123 --file screenshot.png
 jtk attachments add PROJ-123 --file doc.pdf --file image.png
+jtk attachments add PROJ-123 --file /tmp/out.png --filename before.png
 ```
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--file` | `-F` | | File to attach (**required**, can be repeated) |
+| `--filename` | | | Store the attachment under this name instead of the file's base name (single `--file` only) |
 
 **Arguments:**
 - `<issue-key>` - The issue key (**required**)

--- a/tools/jtk/api/attachments.go
+++ b/tools/jtk/api/attachments.go
@@ -6,13 +6,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"os"
 	"path/filepath"
+	"strings"
 
 	sharederrors "github.com/open-cli-collective/atlassian-go/errors"
 )
+
+// quoteEscaper mirrors the escaping mime/multipart applies to Content-Disposition
+// parameters, so an override filename containing a quote or backslash cannot break
+// out of the header.
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
 // Attachment represents a Jira attachment
 type Attachment struct {
@@ -102,13 +110,22 @@ func (c *Client) GetAttachment(ctx context.Context, attachmentID string) (*Attac
 	return &attachment, nil
 }
 
-// AddAttachment uploads a file as an attachment to an issue
-func (c *Client) AddAttachment(ctx context.Context, issueKey, filePath string) ([]Attachment, error) {
+// AddAttachment uploads a file as an attachment to an issue. When filename is
+// non-empty it overrides the stored attachment name; otherwise the base name of
+// filePath is used. The multipart part is tagged with a Content-Type derived from
+// the stored name's extension so Jira treats images and PDFs as such (rendering
+// thumbnails and inline previews) rather than as generic downloads.
+func (c *Client) AddAttachment(ctx context.Context, issueKey, filePath, filename string) ([]Attachment, error) {
 	if issueKey == "" {
 		return nil, ErrIssueKeyRequired
 	}
 	if filePath == "" {
 		return nil, ErrFilePathRequired
+	}
+
+	storedName := filename
+	if storedName == "" {
+		storedName = filepath.Base(filePath)
 	}
 
 	file, err := os.Open(filePath) //nolint:gosec // CLI tool opens user-provided file paths
@@ -127,7 +144,7 @@ func (c *Client) AddAttachment(ctx context.Context, issueKey, filePath string) (
 		defer pw.Close()
 		defer writer.Close()
 
-		part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+		part, err := writer.CreatePart(attachmentPartHeader(storedName))
 		if err != nil {
 			errChan <- fmt.Errorf("creating form file: %w", err)
 			return
@@ -187,6 +204,23 @@ func (c *Client) AddAttachment(ctx context.Context, issueKey, filePath string) (
 	}
 
 	return attachments, nil
+}
+
+// attachmentPartHeader builds the multipart part header for an attachment upload,
+// setting the Content-Type from the filename extension (falling back to
+// application/octet-stream) so Jira records an accurate MIME type.
+func attachmentPartHeader(filename string) textproto.MIMEHeader {
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition",
+		fmt.Sprintf(`form-data; name="file"; filename="%s"`, quoteEscaper.Replace(filename)))
+
+	contentType := mime.TypeByExtension(filepath.Ext(filename))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	h.Set("Content-Type", contentType)
+
+	return h
 }
 
 // DeleteAttachment deletes an attachment by ID

--- a/tools/jtk/api/attachments_test.go
+++ b/tools/jtk/api/attachments_test.go
@@ -3,6 +3,7 @@ package api //nolint:revive // package name is intentional
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -116,6 +117,91 @@ func TestGetIssueAttachments_EmptyIssueKey(t *testing.T) {
 	_, err := client.GetIssueAttachments(context.Background(), "")
 	testutil.Error(t, err)
 	testutil.Contains(t, err.Error(), "issue key is required")
+}
+
+func TestAddAttachment(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		srcName         string // name of the temp file on disk
+		override        string // value passed as the filename argument
+		wantFilename    string // filename Jira should receive
+		wantContentType string // Content-Type of the multipart part
+	}{
+		{
+			name:            "derives name and detects image mime",
+			srcName:         "screenshot.png",
+			wantFilename:    "screenshot.png",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "override renames and detects mime from override",
+			srcName:         "tmp-9f8a7b.png",
+			override:        "before.png",
+			wantFilename:    "before.png",
+			wantContentType: "image/png",
+		},
+		{
+			name:            "unknown extension falls back to octet-stream",
+			srcName:         "payload.bespoke",
+			wantFilename:    "payload.bespoke",
+			wantContentType: "application/octet-stream",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			content := []byte("attachment bytes")
+			var gotFilename, gotContentType string
+			var gotBody []byte
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				testutil.Equal(t, r.Method, http.MethodPost)
+				testutil.Equal(t, r.URL.Path, "/rest/api/3/issue/PROJ-1/attachments")
+				testutil.Equal(t, r.Header.Get("X-Atlassian-Token"), "no-check")
+
+				reader, err := r.MultipartReader()
+				testutil.RequireNoError(t, err)
+				part, err := reader.NextPart()
+				testutil.RequireNoError(t, err)
+				gotFilename = part.FileName()
+				gotContentType = part.Header.Get("Content-Type")
+				gotBody, _ = io.ReadAll(part)
+
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]Attachment{{ID: "10001", Filename: gotFilename}})
+			}))
+			defer server.Close()
+
+			tmpDir := t.TempDir()
+			path := filepath.Join(tmpDir, tt.srcName)
+			testutil.RequireNoError(t, os.WriteFile(path, content, 0600))
+
+			client, err := New(ClientConfig{URL: server.URL, Email: "test@example.com", APIToken: "token"})
+			testutil.RequireNoError(t, err)
+
+			attachments, err := client.AddAttachment(context.Background(), "PROJ-1", path, tt.override)
+			testutil.RequireNoError(t, err)
+			testutil.Len(t, attachments, 1)
+			testutil.Equal(t, gotFilename, tt.wantFilename)
+			testutil.Equal(t, gotContentType, tt.wantContentType)
+			testutil.Equal(t, gotBody, content)
+		})
+	}
+}
+
+func TestAddAttachment_Validation(t *testing.T) {
+	t.Parallel()
+	client, _ := New(ClientConfig{URL: "http://unused", Email: "test@example.com", APIToken: "token"})
+
+	_, err := client.AddAttachment(context.Background(), "", "/tmp/file.png", "")
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "issue key is required")
+
+	_, err = client.AddAttachment(context.Background(), "PROJ-1", "", "")
+	testutil.Error(t, err)
+	testutil.Contains(t, err.Error(), "file path is required")
 }
 
 func TestGetAttachment(t *testing.T) {

--- a/tools/jtk/api/attachments_test.go
+++ b/tools/jtk/api/attachments_test.go
@@ -147,6 +147,23 @@ func TestAddAttachment(t *testing.T) {
 			wantFilename:    "payload.bespoke",
 			wantContentType: "application/octet-stream",
 		},
+		{
+			// --filename is untrusted input; a quote must be escaped so it
+			// cannot break out of the Content-Disposition header, yet must
+			// round-trip to the literal name Jira should store.
+			name:            "override with quote is escaped and round-trips",
+			srcName:         "tmp.png",
+			override:        `ex"ploit.png`,
+			wantFilename:    `ex"ploit.png`,
+			wantContentType: "image/png",
+		},
+		{
+			name:            "override with backslash is escaped and round-trips",
+			srcName:         "tmp.png",
+			override:        `dir\name.png`,
+			wantFilename:    `dir\name.png`,
+			wantContentType: "image/png",
+		},
 	}
 
 	for _, tt := range tests {
@@ -168,6 +185,10 @@ func TestAddAttachment(t *testing.T) {
 				gotFilename = part.FileName()
 				gotContentType = part.Header.Get("Content-Type")
 				gotBody, _ = io.ReadAll(part)
+
+				// Exactly one part: an escaped filename must not inject a second.
+				_, nextErr := reader.NextPart()
+				testutil.Equal(t, nextErr, io.EOF)
 
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode([]Attachment{{ID: "10001", Filename: gotFilename}})

--- a/tools/jtk/internal/cmd/attachments/attachments.go
+++ b/tools/jtk/internal/cmd/attachments/attachments.go
@@ -106,6 +106,7 @@ func runList(ctx context.Context, opts *root.Options, issueKey, fieldsFlag strin
 
 func newAddCmd(opts *root.Options) *cobra.Command {
 	var files []string
+	var filename string
 
 	cmd := &cobra.Command{
 		Use:   "add <issue-key>",
@@ -115,20 +116,28 @@ func newAddCmd(opts *root.Options) *cobra.Command {
   jtk attachments add PROJ-123 --file screenshot.png
 
   # Add multiple files
-  jtk attachments add PROJ-123 --file doc.pdf --file image.png`,
+  jtk attachments add PROJ-123 --file doc.pdf --file image.png
+
+  # Store under a different name
+  jtk attachments add PROJ-123 --file /tmp/out.png --filename before.png`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAdd(cmd.Context(), opts, args[0], files)
+			return runAdd(cmd.Context(), opts, args[0], files, filename)
 		},
 	}
 
 	cmd.Flags().StringArrayVarP(&files, "file", "F", nil, "File(s) to attach (can be specified multiple times)")
+	cmd.Flags().StringVar(&filename, "filename", "", "Store the attachment under this name instead of the file's base name (single --file only)")
 	_ = cmd.MarkFlagRequired("file")
 
 	return cmd
 }
 
-func runAdd(ctx context.Context, opts *root.Options, issueKey string, files []string) error {
+func runAdd(ctx context.Context, opts *root.Options, issueKey string, files []string, filename string) error {
+	if filename != "" && len(files) != 1 {
+		return fmt.Errorf("--filename can only be used with a single --file")
+	}
+
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -145,7 +154,7 @@ func runAdd(ctx context.Context, opts *root.Options, issueKey string, files []st
 			return fmt.Errorf("file not found: %s", filePath)
 		}
 
-		attachments, err := client.AddAttachment(ctx, issueKey, absPath)
+		attachments, err := client.AddAttachment(ctx, issueKey, absPath, filename)
 		if err != nil {
 			// Emit results for files that succeeded before returning the error
 			if len(allAttachments) > 0 {

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -311,6 +312,38 @@ func TestRunAdd_FilenameRequiresSingleFile(t *testing.T) {
 	err := runAdd(context.Background(), opts, "TEST-1", []string{"a.txt", "b.txt"}, "renamed.txt")
 	testutil.RequireError(t, err)
 	testutil.Contains(t, err.Error(), "single --file")
+}
+
+func TestRunAdd_FilenameOverride(t *testing.T) {
+	t.Parallel()
+	var gotFilename string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reader, err := r.MultipartReader()
+		testutil.RequireNoError(t, err)
+		part, err := reader.NextPart()
+		testutil.RequireNoError(t, err)
+		gotFilename = part.FileName()
+		_, _ = io.ReadAll(part)
+
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]api.Attachment{{ID: "10001", Filename: gotFilename}})
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "raw-9f8a7b.png")
+	testutil.RequireNoError(t, os.WriteFile(src, []byte("img"), 0600))
+
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "test@test.com", APIToken: "token"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
+	opts.SetAPIClient(client)
+
+	err = runAdd(context.Background(), opts, "TEST-1", []string{src}, "before.png")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, gotFilename, "before.png")
 }
 
 func TestRunAdd_IDOnly(t *testing.T) {

--- a/tools/jtk/internal/cmd/attachments/attachments_test.go
+++ b/tools/jtk/internal/cmd/attachments/attachments_test.go
@@ -210,6 +210,11 @@ func TestNewAddCmd(t *testing.T) {
 	testutil.NotNil(t, fileFlag)
 	testutil.Equal(t, fileFlag.Shorthand, "F")
 
+	// --filename is an optional override and stays long-only.
+	filenameFlag := cmd.Flags().Lookup("filename")
+	testutil.NotNil(t, filenameFlag)
+	testutil.Equal(t, filenameFlag.Shorthand, "")
+
 	// -f must not resolve to a registered shorthand on this command.
 	testutil.Nil(t, cmd.Flags().ShorthandLookup("f"))
 	if err := cmd.ParseFlags([]string{"-f", "x.txt"}); err == nil {
@@ -250,7 +255,7 @@ func TestRunAdd_Success(t *testing.T) {
 	opts := &root.Options{NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runAdd(context.Background(), opts, "TEST-1", []string{tmpFile})
+	err = runAdd(context.Background(), opts, "TEST-1", []string{tmpFile}, "")
 	testutil.RequireNoError(t, err)
 
 	output := stdout.String()
@@ -293,10 +298,19 @@ func TestRunAdd_PartialFailure(t *testing.T) {
 	opts := &root.Options{NoColor: true, Stdout: &stdout, Stderr: &bytes.Buffer{}}
 	opts.SetAPIClient(client)
 
-	err = runAdd(context.Background(), opts, "TEST-1", []string{good, bad})
+	err = runAdd(context.Background(), opts, "TEST-1", []string{good, bad}, "")
 	testutil.RequireError(t, err)
 	testutil.Contains(t, stdout.String(), "good.txt")
 	testutil.Contains(t, stdout.String(), "10001")
+}
+
+func TestRunAdd_FilenameRequiresSingleFile(t *testing.T) {
+	t.Parallel()
+	opts := &root.Options{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+
+	err := runAdd(context.Background(), opts, "TEST-1", []string{"a.txt", "b.txt"}, "renamed.txt")
+	testutil.RequireError(t, err)
+	testutil.Contains(t, err.Error(), "single --file")
 }
 
 func TestRunAdd_IDOnly(t *testing.T) {
@@ -320,7 +334,7 @@ func TestRunAdd_IDOnly(t *testing.T) {
 	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
 	opts.SetAPIClient(client)
 
-	err = runAdd(context.Background(), opts, "TEST-1", []string{f})
+	err = runAdd(context.Background(), opts, "TEST-1", []string{f}, "")
 	testutil.RequireNoError(t, err)
 	testutil.Equal(t, stdout.String(), "10001\n")
 }


### PR DESCRIPTION
Closes #465.

## What the issue asked for vs. what already exists

The bulk of #465 — *"attach a file to an issue"* — **already ships today** as `jtk attachments add <issue-key> --file <path>` (list/add/get/delete under the `attachments` group; API in place since #50, registered in `main.go`, documented in the README). So this PR does **not** re-add attach support.

The issue proposed the command as `jtk issues attach …`, which is the likely reason it read as missing: attach lives in the top-level `attachments` group, not under `issues`, so `jtk issues --help` doesn't surface it. That's a findability gap, not a docs-accuracy gap. I deliberately did **not** add a duplicate `jtk issues attach` alias — the repo's `GUARDRAILS.md` defines `attachments`/`add` as the canonical resource/verb, and duplicating it under `issues` would cut against that design language.

What this PR does implement are the two concrete gaps the issue lists as nice-to-haves, which are the only parts of the existing feature that were genuinely absent.

## Changes

- **MIME-type detection on upload.** The multipart part's `Content-Type` is now derived from the file extension (`mime.TypeByExtension`), falling back to `application/octet-stream`.
- **`--filename` override** on `jtk attachments add` — store the attachment under a chosen name instead of the file's base name. Valid with a single `--file` only (errors clearly otherwise).
- **Test coverage** for `AddAttachment`, which previously had none — asserts the wire filename, the detected `Content-Type`, the octet-stream fallback, and the empty-arg guards.

## Why

The motivating use case in the issue is attaching screenshots. Before this change every upload was sent as `application/octet-stream`, so Jira didn't recognize a `.png`/`.pdf` as an image/document — no thumbnail, no inline preview, it renders as a generic download. Detecting the MIME type from the extension fixes that. `--filename` covers the common case of uploading a temp file with an ugly generated name (`/tmp/out-8f8a7b.png`) but wanting it stored as something meaningful (`before.png`).

## Deliberately deferred

The issue's *optional* ask — referencing an uploaded attachment inline in a comment/description via Jira's `!filename!` media syntax — is not included. jtk renders comments/descriptions as ADF (v3 API), and the shared `adf` package has no media-node support; wiring inline embeds would need new shared node types plus a media-services UUID the v3 attachment API doesn't return, and it can't be verified without a live Jira. That's a larger, separately-scoped change and is left for a follow-up.

## Testing

- `go test -race ./tools/jtk/...` — pass
- `golangci-lint run` (tools/jtk) — 0 issues
- `go mod tidy` — clean; cross-compile release guard (linux/windows) — pass
- Verified on the built binary: `--filename` appears in `attachments add --help`; the single-`--file` validation errors with exit 1 before auth is attempted.