### PR TITLE
feat(jtk): INT-668 add Jira Development pull request lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ jtk remotelinks list PROJ-123
 jtk remotelinks add PROJ-123 --url "https://github.com/owner/repo/issues/456" --title "GitHub #456"
 jtk remotelinks delete PROJ-123 12345
 
+# Development panel pull requests
+jtk development get PROJ-123
+jtk development get PROJ-123 --id
+
 # Dashboards
 jtk dashboards list
 jtk dashboards create --name "Sprint Board"

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -698,6 +698,22 @@ jtk links types --id
 
 ---
 
+### `jtk development get <issue-key>`
+
+Show the summary and deduplicated pull requests from an issue's Jira Development panel. This command uses Jira's private `/rest/dev-status/1.0` API, which may change without notice.
+
+```bash
+jtk development get PROJ-123
+jtk development get PROJ-123 --id
+```
+
+Normal output prints one pull request and one URL per row. `--id` prints canonical pull request URLs only, one per line. This is separate from `jtk remotelinks`, which manages external web links attached to an issue.
+
+**Arguments:**
+- `<issue-key>` - The issue key (**required**)
+
+---
+
 ### `jtk transitions list <issue-key>`
 
 List available transitions for an issue.

--- a/tools/jtk/README.md
+++ b/tools/jtk/README.md
@@ -189,7 +189,7 @@ jtk init --auth-method bearer --url https://mycompany.atlassian.net \
 
 > **Bearer Auth:** For [Atlassian service accounts](https://support.atlassian.com/user-management/docs/manage-api-tokens-for-service-accounts/) with scoped API tokens. Email is not required. Requests route through the `api.atlassian.com` gateway.
 >
-> **Scope limitations:** Scoped tokens don't have scopes for Agile (boards/sprints), Automation, or Dashboards. These commands are unavailable with bearer auth — this is an Atlassian platform limitation.
+> **Scope limitations:** Scoped tokens don't have scopes for Agile (boards/sprints), Automation, Dashboards, or the private Development API. These commands are unavailable with bearer auth — this is an Atlassian platform limitation.
 
 ---
 
@@ -701,6 +701,8 @@ jtk links types --id
 ### `jtk development get <issue-key>`
 
 Show the summary and deduplicated pull requests from an issue's Jira Development panel. This command uses Jira's private `/rest/dev-status/1.0` API, which may change without notice.
+
+> Requires classic Basic authentication; Jira's private Development API is unavailable with bearer/scoped-token authentication.
 
 ```bash
 jtk development get PROJ-123

--- a/tools/jtk/api/client.go
+++ b/tools/jtk/api/client.go
@@ -151,6 +151,10 @@ var ErrAutomationUnavailable = stderrors.New("this command requires the Automati
 // but the client does not support it (e.g., bearer auth with scoped tokens).
 var ErrDashboardUnavailable = stderrors.New("this command requires the Dashboard API, which is not available with bearer auth (scoped tokens lack the Dashboard scope)")
 
+// ErrDevelopmentUnavailable is returned when a command requires Jira's private
+// Development API, which is unavailable through the scoped-token gateway.
+var ErrDevelopmentUnavailable = stderrors.New("this command requires Jira's private Development API, which is not available with bearer auth")
+
 // buildURL builds a URL with query parameters
 func buildURL(base string, params map[string]string) string {
 	if len(params) == 0 {

--- a/tools/jtk/api/development.go
+++ b/tools/jtk/api/development.go
@@ -1,0 +1,257 @@
+package api //nolint:revive // package name is intentional
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Development is the issue-centric data shown in Jira's Development panel.
+// Jira exposes this through a private API, so the response types intentionally
+// contain only the fields jtk presents.
+type Development struct {
+	IssueKey         string
+	PullRequestState string
+	Commits          int
+	Builds           int
+	SuccessfulBuilds int
+	Providers        []string
+	PullRequests     []DevelopmentPullRequest
+}
+
+// DevelopmentPullRequest is a pull request associated with a Jira issue.
+type DevelopmentPullRequest struct {
+	ID         string
+	Title      string
+	URL        string
+	Status     string
+	LastUpdate string
+	Repository string
+	Provider   string
+}
+
+type developmentSummaryResponse struct {
+	Summary struct {
+		PullRequest developmentSummaryItem `json:"pullrequest"`
+		Repository  developmentSummaryItem `json:"repository"`
+		Build       developmentSummaryItem `json:"build"`
+	} `json:"summary"`
+	Errors       []json.RawMessage `json:"errors"`
+	ConfigErrors []json.RawMessage `json:"configErrors"`
+}
+
+type developmentSummaryItem struct {
+	Overall struct {
+		Count                int    `json:"count"`
+		State                string `json:"state"`
+		SuccessfulBuildCount int    `json:"successfulBuildCount"`
+	} `json:"overall"`
+	ByInstanceType map[string]struct {
+		Name string `json:"name"`
+	} `json:"byInstanceType"`
+}
+
+type developmentDetailResponse struct {
+	Detail []struct {
+		PullRequests []struct {
+			ID         string `json:"id"`
+			Name       string `json:"name"`
+			URL        string `json:"url"`
+			Status     string `json:"status"`
+			LastUpdate string `json:"lastUpdate"`
+		} `json:"pullRequests"`
+		Repositories []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"repositories"`
+		Instance struct {
+			Type string `json:"type"`
+			Name string `json:"name"`
+		} `json:"_instance"`
+	} `json:"detail"`
+	Errors []json.RawMessage `json:"errors"`
+}
+
+// GetDevelopment returns the pull requests and summary counts shown in an
+// issue's Jira Development panel. The /rest/dev-status API is private and may
+// change without notice.
+func (c *Client) GetDevelopment(ctx context.Context, issueKey string) (*Development, error) {
+	if issueKey == "" {
+		return nil, ErrIssueKeyRequired
+	}
+
+	issue, err := c.GetIssue(ctx, issueKey)
+	if err != nil {
+		return nil, err
+	}
+	if issue.ID == "" {
+		return nil, fmt.Errorf("issue %s returned an empty numeric ID", issueKey)
+	}
+
+	summaryURL := buildURL(c.URL+"/rest/dev-status/1.0/issue/summary", map[string]string{"issueId": issue.ID})
+	body, err := c.Get(ctx, summaryURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching development summary: %w", err)
+	}
+
+	var summary developmentSummaryResponse
+	if err := json.Unmarshal(body, &summary); err != nil {
+		return nil, fmt.Errorf("parsing development summary: %w", err)
+	}
+	if len(summary.Errors) > 0 || len(summary.ConfigErrors) > 0 {
+		return nil, fmt.Errorf("development summary returned provider errors")
+	}
+
+	result := &Development{
+		IssueKey:         issue.Key,
+		PullRequestState: summary.Summary.PullRequest.Overall.State,
+		Commits:          summary.Summary.Repository.Overall.Count,
+		Builds:           summary.Summary.Build.Overall.Count,
+		SuccessfulBuilds: summary.Summary.Build.Overall.SuccessfulBuildCount,
+	}
+
+	providerTypes := make([]string, 0, len(summary.Summary.PullRequest.ByInstanceType))
+	providerNames := make(map[string]string, len(summary.Summary.PullRequest.ByInstanceType))
+	for providerType, instance := range summary.Summary.PullRequest.ByInstanceType {
+		providerTypes = append(providerTypes, providerType)
+		providerNames[providerType] = instance.Name
+	}
+	sort.Strings(providerTypes)
+
+	type keyedPullRequest struct {
+		pr DevelopmentPullRequest
+	}
+	byKey := make(map[string]keyedPullRequest)
+
+	for _, providerType := range providerTypes {
+		detailURL := buildURL(c.URL+"/rest/dev-status/1.0/issue/detail", map[string]string{
+			"issueId":         issue.ID,
+			"applicationType": providerType,
+			"dataType":        "pullrequest",
+		})
+		body, err := c.Get(ctx, detailURL)
+		if err != nil {
+			return nil, fmt.Errorf("fetching development pull requests for %s: %w", providerType, err)
+		}
+
+		var response developmentDetailResponse
+		if err := json.Unmarshal(body, &response); err != nil {
+			return nil, fmt.Errorf("parsing development pull requests for %s: %w", providerType, err)
+		}
+		if len(response.Errors) > 0 {
+			return nil, fmt.Errorf("development pull requests for %s returned provider errors", providerType)
+		}
+
+		for _, detail := range response.Detail {
+			providerName := providerNames[providerType]
+			if detail.Instance.Name != "" {
+				providerName = detail.Instance.Name
+			}
+			if providerName != "" {
+				result.Providers = append(result.Providers, providerName)
+			}
+
+			repositoryID, repositoryName := "", ""
+			if len(detail.Repositories) > 0 {
+				repositoryID = detail.Repositories[0].ID
+				repositoryName = detail.Repositories[0].Name
+			}
+
+			for _, raw := range detail.PullRequests {
+				normalizedURL := normalizeDevelopmentURL(raw.URL)
+				if repositoryName == "" {
+					repositoryName = developmentRepositoryFromURL(normalizedURL)
+				}
+				key := normalizedURL
+				if key == "" {
+					key = strings.Join([]string{providerType, repositoryID, raw.ID}, "\x00")
+				}
+				candidate := DevelopmentPullRequest{
+					ID:         raw.ID,
+					Title:      raw.Name,
+					URL:        normalizedURL,
+					Status:     raw.Status,
+					LastUpdate: raw.LastUpdate,
+					Repository: repositoryName,
+					Provider:   providerName,
+				}
+				current, ok := byKey[key]
+				if !ok || developmentTime(candidate.LastUpdate).After(developmentTime(current.pr.LastUpdate)) {
+					byKey[key] = keyedPullRequest{pr: candidate}
+				}
+			}
+		}
+	}
+
+	if summary.Summary.PullRequest.Overall.Count > 0 && len(byKey) == 0 {
+		return nil, fmt.Errorf("development summary reports pull requests but detail returned none")
+	}
+
+	seenProviders := make(map[string]struct{}, len(result.Providers))
+	providers := result.Providers[:0]
+	for _, provider := range result.Providers {
+		if _, ok := seenProviders[provider]; ok {
+			continue
+		}
+		seenProviders[provider] = struct{}{}
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+	result.Providers = providers
+
+	result.PullRequests = make([]DevelopmentPullRequest, 0, len(byKey))
+	for _, item := range byKey {
+		result.PullRequests = append(result.PullRequests, item.pr)
+	}
+	sort.Slice(result.PullRequests, func(i, j int) bool {
+		left, right := result.PullRequests[i], result.PullRequests[j]
+		leftTime, rightTime := developmentTime(left.LastUpdate), developmentTime(right.LastUpdate)
+		if !leftTime.Equal(rightTime) {
+			return leftTime.After(rightTime)
+		}
+		return left.URL < right.URL
+	})
+
+	return result, nil
+}
+
+func normalizeDevelopmentURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return strings.TrimRight(raw, "/")
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+	u.Fragment = ""
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String()
+}
+
+func developmentRepositoryFromURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || !strings.EqualFold(u.Hostname(), "github.com") {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
+}
+
+func developmentTime(raw string) time.Time {
+	for _, layout := range []string{time.RFC3339Nano, "2006-01-02T15:04:05.000-0700", "2006-01-02T15:04:05-0700"} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}

--- a/tools/jtk/api/development.go
+++ b/tools/jtk/api/development.go
@@ -83,6 +83,9 @@ func (c *Client) GetDevelopment(ctx context.Context, issueKey string) (*Developm
 	if issueKey == "" {
 		return nil, ErrIssueKeyRequired
 	}
+	if c.IsBearerAuth() {
+		return nil, ErrDevelopmentUnavailable
+	}
 
 	issue, err := c.GetIssue(ctx, issueKey)
 	if err != nil {
@@ -230,6 +233,8 @@ func normalizeDevelopmentURL(raw string) string {
 	}
 	u.Scheme = strings.ToLower(u.Scheme)
 	u.Host = strings.ToLower(u.Host)
+	u.RawQuery = ""
+	u.ForceQuery = false
 	u.Fragment = ""
 	u.Path = strings.TrimRight(u.Path, "/")
 	return u.String()

--- a/tools/jtk/api/development_test.go
+++ b/tools/jtk/api/development_test.go
@@ -57,6 +57,7 @@ func TestGetDevelopment_DeduplicatesPullRequests(t *testing.T) {
 
 	client, err := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
 	testutil.RequireNoError(t, err)
+	client.HTTPClient = server.Client()
 
 	development, err := client.GetDevelopment(context.Background(), "PROJ-123")
 	testutil.RequireNoError(t, err)

--- a/tools/jtk/api/development_test.go
+++ b/tools/jtk/api/development_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,7 +39,7 @@ func TestGetDevelopment_DeduplicatesPullRequests(t *testing.T) {
 			switch r.URL.Query().Get("applicationType") {
 			case "provider-a":
 				writeDevelopmentDetail(t, w, "repo-a", "owner/repo-a", []map[string]any{
-					{"id": "42", "name": "Older duplicate", "url": "HTTPS://GitHub.com/owner/repo-a/pull/42/#fragment", "status": "OPEN", "lastUpdate": "2026-07-30T12:00:00Z"},
+					{"id": "42", "name": "Older duplicate", "url": "HTTPS://GitHub.com/owner/repo-a/pull/42/?utm_source=provider-a#fragment", "status": "OPEN", "lastUpdate": "2026-07-30T12:00:00Z"},
 					{"id": "7", "name": "Repo A seven", "url": "https://github.com/owner/repo-a/pull/7", "status": "OPEN", "lastUpdate": "2026-07-29T12:00:00Z"},
 				})
 			case "provider-b":
@@ -72,6 +73,21 @@ func TestGetDevelopment_DeduplicatesPullRequests(t *testing.T) {
 	testutil.Equal(t, development.PullRequests[1].URL, "https://github.com/owner/repo-a/pull/7")
 	testutil.Equal(t, development.PullRequests[2].URL, "https://github.com/owner/repo-b/pull/7")
 	testutil.Len(t, development.Providers, 1)
+}
+
+func TestGetDevelopment_BearerAuthUnavailable(t *testing.T) {
+	t.Parallel()
+
+	client, err := New(ClientConfig{
+		URL:        "https://example.atlassian.net",
+		APIToken:   "scoped-token",
+		AuthMethod: "bearer",
+		CloudID:    "cloud-id",
+	})
+	testutil.RequireNoError(t, err)
+
+	_, err = client.GetDevelopment(context.Background(), "PROJ-123")
+	testutil.True(t, errors.Is(err, ErrDevelopmentUnavailable))
 }
 
 func TestDevelopmentRepositoryFromURL(t *testing.T) {

--- a/tools/jtk/api/development_test.go
+++ b/tools/jtk/api/development_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+)
+
+func TestGetDevelopment_DeduplicatesPullRequests(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/issue/PROJ-123":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "10001", "key": "PROJ-123"})
+		case "/rest/dev-status/1.0/issue/summary":
+			testutil.Equal(t, r.URL.Query().Get("issueId"), "10001")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"summary": map[string]any{
+					"pullrequest": map[string]any{
+						"overall": map[string]any{"count": 4, "state": "OPEN"},
+						"byInstanceType": map[string]any{
+							"provider-a": map[string]any{"name": "GitHub"},
+							"provider-b": map[string]any{"name": "GitHub"},
+						},
+					},
+					"repository": map[string]any{"overall": map[string]any{"count": 5}},
+					"build":      map[string]any{"overall": map[string]any{"count": 3, "successfulBuildCount": 2}},
+				},
+			})
+		case "/rest/dev-status/1.0/issue/detail":
+			testutil.Equal(t, r.URL.Query().Get("issueId"), "10001")
+			testutil.Equal(t, r.URL.Query().Get("dataType"), "pullrequest")
+			switch r.URL.Query().Get("applicationType") {
+			case "provider-a":
+				writeDevelopmentDetail(t, w, "repo-a", "owner/repo-a", []map[string]any{
+					{"id": "42", "name": "Older duplicate", "url": "HTTPS://GitHub.com/owner/repo-a/pull/42/#fragment", "status": "OPEN", "lastUpdate": "2026-07-30T12:00:00Z"},
+					{"id": "7", "name": "Repo A seven", "url": "https://github.com/owner/repo-a/pull/7", "status": "OPEN", "lastUpdate": "2026-07-29T12:00:00Z"},
+				})
+			case "provider-b":
+				writeDevelopmentDetail(t, w, "repo-b", "owner/repo-b", []map[string]any{
+					{"id": "42", "name": "Newer duplicate", "url": "https://github.com/owner/repo-a/pull/42", "status": "MERGED", "lastUpdate": "2026-07-31T12:00:00Z"},
+					{"id": "7", "name": "Repo B seven", "url": "https://github.com/owner/repo-b/pull/7", "status": "OPEN", "lastUpdate": "2026-07-28T12:00:00Z"},
+				})
+			default:
+				http.Error(w, "unexpected provider", http.StatusBadRequest)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := New(ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	development, err := client.GetDevelopment(context.Background(), "PROJ-123")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, development.IssueKey, "PROJ-123")
+	testutil.Equal(t, development.Commits, 5)
+	testutil.Equal(t, development.Builds, 3)
+	testutil.Equal(t, development.SuccessfulBuilds, 2)
+	testutil.Len(t, development.PullRequests, 3)
+	testutil.Equal(t, development.PullRequests[0].Title, "Newer duplicate")
+	testutil.Equal(t, development.PullRequests[0].URL, "https://github.com/owner/repo-a/pull/42")
+	testutil.Equal(t, development.PullRequests[0].Repository, "owner/repo-b")
+	testutil.Equal(t, development.PullRequests[1].URL, "https://github.com/owner/repo-a/pull/7")
+	testutil.Equal(t, development.PullRequests[2].URL, "https://github.com/owner/repo-b/pull/7")
+	testutil.Len(t, development.Providers, 1)
+}
+
+func TestDevelopmentRepositoryFromURL(t *testing.T) {
+	t.Parallel()
+	testutil.Equal(t, developmentRepositoryFromURL("https://github.com/owner/repo/pull/42"), "owner/repo")
+	testutil.Equal(t, developmentRepositoryFromURL("https://gitlab.example/owner/repo/pull/42"), "")
+}
+
+func writeDevelopmentDetail(t *testing.T, w http.ResponseWriter, repositoryID, repositoryName string, pullRequests []map[string]any) {
+	t.Helper()
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"detail": []map[string]any{{
+			"pullRequests": pullRequests,
+			"repositories": []map[string]any{{"id": repositoryID, "name": repositoryName}},
+			"_instance":    map[string]any{"name": "GitHub"},
+		}},
+	})
+}

--- a/tools/jtk/api/field_management_test.go
+++ b/tools/jtk/api/field_management_test.go
@@ -21,6 +21,7 @@ func newTestClient(t *testing.T, server *httptest.Server) *Client {
 	testutil.RequireNoError(t, err)
 	if server != nil {
 		client.BaseURL = server.URL + "/rest/api/3"
+		client.HTTPClient = server.Client()
 	}
 	return client
 }

--- a/tools/jtk/cmd/jtk/main.go
+++ b/tools/jtk/cmd/jtk/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/completion"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/configcmd"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/dashboards"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/development"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/fields"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/initcmd"
 	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/issues"
@@ -69,6 +70,7 @@ func run(ctx context.Context) error {
 	comments.Register(rootCmd, opts)
 	links.Register(rootCmd, opts)
 	remotelinks.Register(rootCmd, opts)
+	development.Register(rootCmd, opts)
 	attachments.Register(rootCmd, opts)
 	automation.Register(rootCmd, opts)
 	boards.Register(rootCmd, opts)

--- a/tools/jtk/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/jtk/internal/cmd/OUTPUT_SPEC.md
@@ -726,6 +726,7 @@ All aliases produce identical output to their canonical form.
 | `jtk field`, `jtk f` | `jtk fields` |
 | `jtk link`, `jtk l` | `jtk links` |
 | `jtk dash`, `jtk dashboard` | `jtk dashboards` |
+| `jtk dev` | `jtk development` |
 
 ### Subcommand aliases
 

--- a/tools/jtk/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/jtk/internal/cmd/OUTPUT_SPEC.md
@@ -325,6 +325,23 @@ ID | NAME | INWARD | OUTWARD
 
 Cached during init/refresh. `links create` accepts the type name ("Blocker"), the outward verb ("blocks"), or the inward verb ("is blocked by").
 
+### `development`
+
+Development data is the issue-centric summary and pull requests shown in Jira's Development panel. It comes from Jira's private `/rest/dev-status/1.0` API, not issue remote (web) links.
+
+**`development get PROJ-123`** — default:
+```
+PROJ-123  Development
+Pull Requests: 2 (MERGED)   Commits: 5   Builds: 3 (3 successful)
+Providers: GitHub
+
+PR | REPOSITORY | STATUS | UPDATED | TITLE | URL
+#42 | owner/repo | MERGED | 2026-07-31 | Add feature | https://github.com/owner/repo/pull/42
+#41 | owner/repo | MERGED | 2026-07-30 | Fix edge | https://github.com/owner/repo/pull/41
+```
+
+Each pull request occupies one row and therefore has one URL cell; multiple URLs are never joined with a delimiter. `--id` emits the deduplicated canonical PR URLs, one per line. When no pull requests are associated, the summary reports `Pull Requests: 0` and no table is emitted.
+
 ### `remotelinks`
 
 Remote (web) links are external URLs attached to an issue and shown in the Jira links sidebar — distinct from `links`, which connect two Jira issues.

--- a/tools/jtk/internal/cmd/development/development.go
+++ b/tools/jtk/internal/cmd/development/development.go
@@ -14,9 +14,10 @@ import (
 // Register registers the development command.
 func Register(parent *cobra.Command, opts *root.Options) {
 	cmd := &cobra.Command{
-		Use:   "development",
-		Short: "Read issue development data",
-		Long:  "Read the pull requests shown in an issue's Jira Development panel. This uses a private Jira API that may change without notice.",
+		Use:     "development",
+		Aliases: []string{"dev"},
+		Short:   "Read issue development data",
+		Long:    "Read the pull requests shown in an issue's Jira Development panel. This uses a private Jira API that may change without notice.",
 	}
 	cmd.AddCommand(newGetCmd(opts))
 	parent.AddCommand(cmd)

--- a/tools/jtk/internal/cmd/development/development.go
+++ b/tools/jtk/internal/cmd/development/development.go
@@ -1,0 +1,62 @@
+// Package development provides read-only access to Jira's Development panel.
+package development
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+	jtkpresent "github.com/open-cli-collective/jira-ticket-cli/internal/present"
+)
+
+// Register registers the development command.
+func Register(parent *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "development",
+		Short: "Read issue development data",
+		Long:  "Read the pull requests shown in an issue's Jira Development panel. This uses a private Jira API that may change without notice.",
+	}
+	cmd.AddCommand(newGetCmd(opts))
+	parent.AddCommand(cmd)
+}
+
+func newGetCmd(opts *root.Options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <issue-key>",
+		Short: "Get pull requests from an issue's Development panel",
+		Long:  "Get the summary and deduplicated pull requests shown in an issue's Jira Development panel.",
+		Example: `  jtk development get PROJ-123
+  jtk development get PROJ-123 --id`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGet(cmd.Context(), opts, args[0])
+		},
+	}
+}
+
+func runGet(ctx context.Context, opts *root.Options, issueKey string) error {
+	client, err := opts.APIClient()
+	if err != nil {
+		return err
+	}
+
+	development, err := client.GetDevelopment(ctx, issueKey)
+	if err != nil {
+		return err
+	}
+
+	if opts.EmitIDOnly() {
+		urls := make([]string, len(development.PullRequests))
+		for i, pr := range development.PullRequests {
+			if pr.URL == "" {
+				return fmt.Errorf("pull request %s has no URL", pr.ID)
+			}
+			urls[i] = pr.URL
+		}
+		return jtkpresent.EmitIDs(opts, urls)
+	}
+
+	return jtkpresent.Emit(opts, jtkpresent.DevelopmentPresenter{}.Present(development))
+}

--- a/tools/jtk/internal/cmd/development/development_test.go
+++ b/tools/jtk/internal/cmd/development/development_test.go
@@ -1,0 +1,86 @@
+package development
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+	"github.com/open-cli-collective/jira-ticket-cli/internal/cmd/root"
+)
+
+func TestRegister_DevelopmentGet(t *testing.T) {
+	t.Parallel()
+
+	server := developmentServer(t)
+	defer server.Close()
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	rootCmd, opts := root.NewCmd()
+	var stdout bytes.Buffer
+	opts.Stdout = &stdout
+	opts.Stderr = &bytes.Buffer{}
+	opts.SetAPIClient(client)
+	Register(rootCmd, opts)
+	rootCmd.SetArgs([]string{"development", "get", "PROJ-123"})
+
+	err = rootCmd.Execute()
+	testutil.RequireNoError(t, err)
+	testutil.Contains(t, stdout.String(), "PROJ-123  Development")
+	testutil.Contains(t, stdout.String(), "Pull Requests: 1 (MERGED)")
+	testutil.Contains(t, stdout.String(), "https://github.com/owner/repo/pull/42")
+}
+
+func TestRunGet_IDOnly(t *testing.T) {
+	t.Parallel()
+
+	server := developmentServer(t)
+	defer server.Close()
+	client, err := api.New(api.ClientConfig{URL: server.URL, Email: "t@t.com", APIToken: "tok"})
+	testutil.RequireNoError(t, err)
+
+	var stdout bytes.Buffer
+	opts := &root.Options{Stdout: &stdout, Stderr: &bytes.Buffer{}, IDOnly: true}
+	opts.SetAPIClient(client)
+
+	err = runGet(t.Context(), opts, "PROJ-123")
+	testutil.RequireNoError(t, err)
+	testutil.Equal(t, stdout.String(), "https://github.com/owner/repo/pull/42\n")
+}
+
+func developmentServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/issue/PROJ-123":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "10001", "key": "PROJ-123"})
+		case "/rest/dev-status/1.0/issue/summary":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"summary": map[string]any{
+					"pullrequest": map[string]any{
+						"overall":        map[string]any{"count": 1, "state": "MERGED"},
+						"byInstanceType": map[string]any{"github": map[string]any{"name": "GitHub"}},
+					},
+				},
+			})
+		case "/rest/dev-status/1.0/issue/detail":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"detail": []map[string]any{{
+					"pullRequests": []map[string]any{{
+						"id": "42", "name": "Add feature", "url": "https://github.com/owner/repo/pull/42",
+						"status": "MERGED", "lastUpdate": "2026-07-31T12:00:00Z",
+					}},
+					"repositories": []map[string]any{{"id": "repo", "name": "owner/repo"}},
+					"_instance":    map[string]any{"name": "GitHub"},
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}

--- a/tools/jtk/internal/present/development.go
+++ b/tools/jtk/internal/present/development.go
@@ -1,0 +1,67 @@
+package present
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+// DevelopmentPresenter renders Jira Development-panel pull requests.
+type DevelopmentPresenter struct{}
+
+// Present renders the issue summary followed by one row per pull request.
+func (DevelopmentPresenter) Present(development *api.Development) *present.OutputModel {
+	state := ""
+	if len(development.PullRequests) > 0 && development.PullRequestState != "" {
+		state = " (" + development.PullRequestState + ")"
+	}
+	builds := fmt.Sprintf("%d", development.Builds)
+	if development.Builds > 0 {
+		builds += fmt.Sprintf(" (%d successful)", development.SuccessfulBuilds)
+	}
+
+	sections := []present.Section{
+		msg(fmt.Sprintf("%s  Development", development.IssueKey)),
+		msg(fmt.Sprintf(
+			"Pull Requests: %d%s   Commits: %d   Builds: %s",
+			len(development.PullRequests), state, development.Commits, builds,
+		)),
+	}
+	if len(development.Providers) > 0 {
+		sections = append(sections, msg("Providers: "+strings.Join(development.Providers, ", ")))
+	}
+	if len(development.PullRequests) == 0 {
+		return &present.OutputModel{Sections: sections}
+	}
+
+	rows := make([]present.Row, len(development.PullRequests))
+	for i, pr := range development.PullRequests {
+		id := pr.ID
+		if id != "" && !strings.HasPrefix(id, "#") {
+			id = "#" + id
+		}
+		updated := pr.LastUpdate
+		if len(updated) >= 10 {
+			updated = updated[:10]
+		}
+		rows[i] = present.Row{Cells: []string{
+			OrDash(id),
+			OrDash(pr.Repository),
+			OrDash(pr.Status),
+			OrDash(updated),
+			OrDash(pr.Title),
+			OrDash(pr.URL),
+		}}
+	}
+	sections = append(sections,
+		msg(""),
+		&present.TableSection{
+			Headers: []string{"PR", "REPOSITORY", "STATUS", "UPDATED", "TITLE", "URL"},
+			Rows:    rows,
+		},
+	)
+	return &present.OutputModel{Sections: sections}
+}

--- a/tools/jtk/internal/present/development_test.go
+++ b/tools/jtk/internal/present/development_test.go
@@ -1,0 +1,50 @@
+package present
+
+import (
+	"testing"
+
+	"github.com/open-cli-collective/atlassian-go/present"
+	"github.com/open-cli-collective/atlassian-go/testutil"
+
+	"github.com/open-cli-collective/jira-ticket-cli/api"
+)
+
+func TestDevelopmentPresenter(t *testing.T) {
+	t.Parallel()
+
+	model := DevelopmentPresenter{}.Present(&api.Development{
+		IssueKey:         "PROJ-123",
+		PullRequestState: "MERGED",
+		Commits:          5,
+		Builds:           3,
+		SuccessfulBuilds: 3,
+		Providers:        []string{"GitHub"},
+		PullRequests: []api.DevelopmentPullRequest{{
+			ID:         "42",
+			Title:      "Add feature",
+			URL:        "https://github.com/owner/repo/pull/42",
+			Status:     "MERGED",
+			LastUpdate: "2026-07-31T12:00:00Z",
+			Repository: "owner/repo",
+		}},
+	})
+
+	testutil.Len(t, model.Sections, 5)
+	summary := model.Sections[1].(*present.MessageSection)
+	testutil.Equal(t, summary.Message, "Pull Requests: 1 (MERGED)   Commits: 5   Builds: 3 (3 successful)")
+	table := model.Sections[4].(*present.TableSection)
+	testutil.Equal(t, table.Headers[0], "PR")
+	testutil.Equal(t, table.Headers[5], "URL")
+	testutil.Equal(t, table.Rows[0].Cells[0], "#42")
+	testutil.Equal(t, table.Rows[0].Cells[3], "2026-07-31")
+	testutil.Equal(t, table.Rows[0].Cells[5], "https://github.com/owner/repo/pull/42")
+}
+
+func TestDevelopmentPresenter_NoPullRequests(t *testing.T) {
+	t.Parallel()
+
+	model := DevelopmentPresenter{}.Present(&api.Development{IssueKey: "PROJ-123"})
+	testutil.Len(t, model.Sections, 2)
+	summary := model.Sections[1].(*present.MessageSection)
+	testutil.Equal(t, summary.Message, "Pull Requests: 0   Commits: 0   Builds: 0")
+}


### PR DESCRIPTION
Closes #468

## Summary

- add `jtk development get <issue-key>` for Jira Development-panel pull requests
- deduplicate provider records by canonical PR URL and keep the newest copy
- emit one PR URL per line with `--id`
- document the private Jira API dependency and output contract

## Test plan

- `go test -race ./tools/jtk/api ./tools/jtk/internal/cmd/development ./tools/jtk/internal/present -run Development`
- `make -C tools/jtk check`
- live multiple-PR, single-PR, zero-PR, and URL-only output checks against Jira