### PR TITLE
feat(jtk): INT-693 clear fields with an empty value; none/null clear numbers

### DIFF
--- a/tools/jtk/api/fields.go
+++ b/tools/jtk/api/fields.go
@@ -114,6 +114,10 @@ func IsNullValue(v string) bool {
 //   - number fields: converts string to float64
 //   - issuelink fields (e.g., parent): wraps value as {"key": "..."} or {"id": "..."}
 //   - textarea custom fields: converts to ADF document
+//
+// Clearing: an empty value returns nil (JSON null) for every structured
+// type; "none"/"null" additionally clear number and user fields. Free-text
+// fields keep the verbatim value.
 func FormatFieldValue(field *Field, value string) any {
 	if field == nil {
 		return value
@@ -128,9 +132,23 @@ func FormatFieldValue(field *Field, value string) any {
 	// preserve the original value.
 	trimmed := strings.TrimSpace(value)
 
+	// Structured fields clear to JSON null. An empty value ("key=") is an
+	// explicit clear for every structured type — no structured field has a
+	// meaningful empty-string value, and the Jira update API otherwise
+	// rejects it with an unhelpful per-type validation error. The
+	// "none"/"null" spellings additionally clear the types where those
+	// strings can never be legitimate values (number, user); option-like
+	// and name-addressed types keep them as values because a select list or
+	// priority scheme may legitimately contain an entry named "None".
+	// Free-text fields (textarea above, default below) always keep the
+	// verbatim value — for text, empty string IS the idiomatic clear.
+
 	// The parent field requires {"key": "..."} format but Jira reports an empty
 	// schema type for it, so handle it before the type switch.
 	if field.ID == "parent" {
+		if trimmed == "" {
+			return nil
+		}
 		if _, err := strconv.Atoi(trimmed); err == nil {
 			return map[string]string{"id": trimmed}
 		}
@@ -139,8 +157,14 @@ func FormatFieldValue(field *Field, value string) any {
 
 	switch field.Schema.Type {
 	case "option":
+		if trimmed == "" {
+			return nil
+		}
 		return map[string]string{"value": trimmed}
 	case "array":
+		if trimmed == "" {
+			return nil
+		}
 		if field.Schema.Items == "option" {
 			return []map[string]string{{"value": trimmed}}
 		}
@@ -157,16 +181,25 @@ func FormatFieldValue(field *Field, value string) any {
 		}
 		return map[string]string{"accountId": trimmed}
 	case "number":
+		if IsNullValue(trimmed) {
+			return nil
+		}
 		if n, err := strconv.ParseFloat(trimmed, 64); err == nil {
 			return n
 		}
 		return trimmed
 	case "issuelink":
+		if trimmed == "" {
+			return nil
+		}
 		if _, err := strconv.Atoi(trimmed); err == nil {
 			return map[string]string{"id": trimmed}
 		}
 		return map[string]string{"key": trimmed}
 	case "priority", "resolution", "status", "issuetype", "securitylevel":
+		if trimmed == "" {
+			return nil
+		}
 		if _, err := strconv.Atoi(trimmed); err == nil {
 			return map[string]string{"id": trimmed}
 		}

--- a/tools/jtk/api/fields_test.go
+++ b/tools/jtk/api/fields_test.go
@@ -934,6 +934,16 @@ func TestFormatFieldValue_Clearing(t *testing.T) {
 			want:  nil,
 		},
 		{
+			name: "issuelink clears on empty",
+			field: &Field{
+				ID:     "customfield_10014",
+				Name:   "Epic Link",
+				Schema: FieldSchema{Type: "issuelink"},
+			},
+			value: "",
+			want:  nil,
+		},
+		{
 			name: "priority clears on empty",
 			field: &Field{
 				ID:     "priority",

--- a/tools/jtk/api/fields_test.go
+++ b/tools/jtk/api/fields_test.go
@@ -890,3 +890,88 @@ func TestResolveFieldArg(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatFieldValue_Clearing(t *testing.T) {
+	t.Parallel()
+
+	numberField := &Field{
+		ID:     "customfield_10035",
+		Name:   "Story Points",
+		Schema: FieldSchema{Type: "number"},
+	}
+	optionField := &Field{
+		ID:     "customfield_10005",
+		Name:   "Change type",
+		Schema: FieldSchema{Type: "option"},
+	}
+
+	tests := []struct {
+		name  string
+		field *Field
+		value string
+		want  any
+	}{
+		{name: "number clears on empty", field: numberField, value: "", want: nil},
+		{name: "number clears on none", field: numberField, value: "none", want: nil},
+		{name: "number clears on null", field: numberField, value: "NULL", want: nil},
+		{name: "option clears on empty", field: optionField, value: "", want: nil},
+		{
+			// A select list may legitimately contain an option named "None" —
+			// only the empty value clears option-like fields.
+			name:  "option keeps the literal string None",
+			field: optionField,
+			value: "None",
+			want:  map[string]string{"value": "None"},
+		},
+		{
+			name: "array clears on empty",
+			field: &Field{
+				ID:     "labels",
+				Name:   "Labels",
+				Schema: FieldSchema{Type: "array", Items: "string"},
+			},
+			value: "",
+			want:  nil,
+		},
+		{
+			name: "priority clears on empty",
+			field: &Field{
+				ID:     "priority",
+				Name:   "Priority",
+				Schema: FieldSchema{Type: "priority"},
+			},
+			value: "",
+			want:  nil,
+		},
+		{
+			name: "parent clears on empty",
+			field: &Field{
+				ID:     "parent",
+				Name:   "Parent",
+				Schema: FieldSchema{},
+			},
+			value: "",
+			want:  nil,
+		},
+		{
+			// Free-text keeps the verbatim value — empty string IS the
+			// idiomatic clear for text, not JSON null.
+			name: "default string field keeps empty string",
+			field: &Field{
+				ID:     "summary",
+				Name:   "Summary",
+				Schema: FieldSchema{Type: "string"},
+			},
+			value: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatFieldValue(tt.field, tt.value)
+			testutil.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/tools/jtk/internal/cmd/issues/update.go
+++ b/tools/jtk/internal/cmd/issues/update.go
@@ -64,7 +64,12 @@ preceding field edit must be performed as a separate command.`,
   jtk issues update PROJ-123 --assignee none
 
   # Update custom fields
-  jtk issues update PROJ-123 --field priority=High --field "Story Points"=5`,
+  jtk issues update PROJ-123 --field priority=High --field "Story Points"=5
+
+  # Clear a field (structured types clear on an empty value; number and
+  # user fields also accept none/null)
+  jtk issues update PROJ-123 --field "Story Points"=
+  jtk issues update PROJ-123 --field "Story Points"=none`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(cmd.Context(), opts, args[0], summary, description, parent, assignee, issueType, status, fields)


### PR DESCRIPTION
## [INT-693]

`jtk issues update -f 'Story Points='` (or `=none`) fails with Jira's per-type validation error — `Specify a number for the custom field` — because `FormatFieldValue` only honors null-intent for **user** fields. A number value falls through to `ParseFloat`, fails, and ships the raw string. There is no way to unset a custom field from the CLI at all, while `--assignee none` has worked forever.

### The contract

- **Empty value clears every structured type** — number, option, array, priority-like, issuelink, parent → JSON `null`. No structured field has a meaningful empty-string value.
- **`none`/`null` additionally clear number fields**, matching the existing user-field behavior — those strings can never be legitimate numbers.
- **Option-like fields deliberately do NOT treat `None` as a clear** — a select list may legitimately contain an option named "None"; only the empty value clears them.
- **Free-text unchanged** — verbatim value; empty string is the idiomatic text clear.

Wire shape confirmed: `UpdateIssueRequest.Fields` is `map[string]any`, so a nil value marshals as JSON null — the shape Jira's update API requires for clearing.

### Motivating incident

An accidental Story Points + Change type write to the wrong ticket could not be reverted from the CLI — the operator had to fall back to the Jira UI.

### Validation

- New `TestFormatFieldValue_Clearing` table: clears per type, the literal-`None` option case, free-text passthrough.
- Full `tools/jtk` suite green; `gofmt` clean.
- `--help` examples document the clear syntax.