### PR TITLE
test(jtk): INT-693 pin priority keeping the literal name None

### DIFF
--- a/tools/jtk/api/fields_test.go
+++ b/tools/jtk/api/fields_test.go
@@ -954,6 +954,18 @@ func TestFormatFieldValue_Clearing(t *testing.T) {
 			want:  nil,
 		},
 		{
+			// Jira ships a built-in Priority literally named "None" in many
+			// instances — name-addressed types must keep it as a value.
+			name: "priority keeps the literal string None",
+			field: &Field{
+				ID:     "priority",
+				Name:   "Priority",
+				Schema: FieldSchema{Type: "priority"},
+			},
+			value: "None",
+			want:  map[string]string{"name": "None"},
+		},
+		{
 			name: "parent clears on empty",
 			field: &Field{
 				ID:     "parent",


### PR DESCRIPTION
## [INT-693]

Fast-follow to #471, addressing its review finding: the name-addressed branch (priority/resolution/status/issuetype/securitylevel) shares the only-empty-clears contract but had no literal-`None` case — and Jira ships a built-in Priority literally named "None" in many instances, so `--field priority=None` hitting that path is a real scenario.

One test-table case: `priority=None` → `{"name": "None"}`, mirroring the existing option-field case. GitHub-signed commit (the `main` ruleset requires verified signatures).