### PR TITLE
feat(cfl): INT-725 verify page writes by reading back what was stored

### DIFF
--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -403,6 +403,8 @@ Content can be provided via:
 
 **Markdown is the default format.** It is converted to ADF, or to storage XHTML with `--legacy`.
 
+**Writes are read back.** With `--body-format adf` or `xhtml` the page is fetched again after a write and the stored body compared against what was sent, because Confluence can store something other than what it was given — it drops `__confluenceMetadata` from link marks, for example. Losing content is an error and exits non-zero; attributes the server normalizes away are reported on stderr and tolerated. Markdown is converted before sending, so there is nothing to compare it against and the check is skipped. Use `--no-verify` to skip the extra read.
+
 ```bash
 # Open editor with existing page content
 cfl page edit 12345

--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -352,6 +352,8 @@ Content can be provided via:
 
 **Markdown is the default format.** It is converted to ADF, or to storage XHTML with `--legacy`.
 
+**Writes are read back.** With `--body-format adf` or `xhtml` the page is fetched again after a write and the stored body compared against what was sent, because Confluence can store something other than what it was given — it drops `__confluenceMetadata` from link marks, for example. Losing content is an error and exits non-zero; attributes the server normalizes away are reported on stderr and tolerated. Markdown is converted before sending, so there is nothing to compare it against and the check is skipped. Use `--no-verify` to skip the extra read.
+
 ```bash
 # Open markdown editor
 cfl page create --space DEV --title "My Page"
@@ -384,6 +386,7 @@ cfl page create -s DEV -t "Legacy Page" --file content.md --legacy
 | `--editor` | | `false` | Force open in $EDITOR |
 | `--body-format` | | `markdown` | Input format: `markdown`, exact `adf` JSON, or exact storage `xhtml` |
 | `--legacy` | | `false` | Convert Markdown to storage XHTML instead of ADF; invalid with `adf` or `xhtml` |
+| `--no-verify` | | `false` | Skip reading the page back after writing to confirm what Confluence stored (`adf`/`xhtml` only) |
 
 The selected format applies equally to files, stdin, and editor input; file extensions do not override it.
 
@@ -438,6 +441,7 @@ cfl page view 12345 --body-format xhtml --content-only | \
 | `--editor` | | `false` | Force open in $EDITOR |
 | `--body-format` | | `markdown` | Input/editor format: `markdown`, exact `adf` JSON, or exact storage `xhtml` |
 | `--legacy` | | `false` | Convert Markdown to storage XHTML instead of ADF; invalid with `adf` or `xhtml` |
+| `--no-verify` | | `false` | Skip reading the page back after writing to confirm what Confluence stored (`adf`/`xhtml` only) |
 
 **Arguments:**
 - `<page-id>` - The page ID (**required**)

--- a/tools/cfl/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/cfl/internal/cmd/OUTPUT_SPEC.md
@@ -245,6 +245,10 @@ ID: <id>
 URL: <url>
 ```
 
+With `--body-format adf` or `xhtml` the page is read back after the write and
+compared with what was sent, exactly as `page edit` does. See that section for
+the stderr blocks emitted on normalization and on content loss.
+
 ## `page edit <page-id>`
 
 Success:

--- a/tools/cfl/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/cfl/internal/cmd/OUTPUT_SPEC.md
@@ -256,6 +256,24 @@ Version: <version>
 URL: <url>
 ```
 
+With `--body-format adf` or `xhtml` the page is read back and compared with
+what was sent. When the stored body differs, a warning is written to stderr
+after the success block. Attribute normalization is reported and the command
+still succeeds:
+
+```text
+Confluence normalized the stored <format> body. Content is intact; these attributes were dropped:
+  - <node>.attrs.<name> (<before>→<after>)
+```
+
+Content loss is reported the same way and the command exits non-zero:
+
+```text
+Stored <format> body does not match what was sent: content differs (<n> chars sent, <n> stored).
+The page was updated, but it does not hold the content supplied. Re-read the page before treating the change as applied.
+  first difference: at offset <n> — sent "<excerpt>", stored "<excerpt>"
+```
+
 ## `page copy <page-id>`
 
 Success:

--- a/tools/cfl/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/cfl/internal/cmd/OUTPUT_SPEC.md
@@ -291,6 +291,8 @@ followed by:
 ```text
 The page was updated, but it does not hold the content supplied. Re-read the page before treating the change as applied.
   first difference at offset <n> — sent "<excerpt>", stored "<excerpt>"
+  embedded content changed:
+    ~ <nodeType> (<before>→<after>)
   attributes dropped:
     - <node>.attrs.<name> (<before>→<after>)
   attributes added:
@@ -298,7 +300,9 @@ The page was updated, but it does not hold the content supplied. Re-read the pag
 ```
 
 The offset line is omitted when the visible text is identical and only
-embedded content changed; the attribute lines then identify what moved.
+embedded content changed. The embedded-content lines identify what moved in
+that case, including for node types such as `hardBreak` and `rule` that carry
+no attributes of their own.
 
 Counts are characters a reader sees and the offset is a character position,
 both measured on the document rather than on any internal representation.

--- a/tools/cfl/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/cfl/internal/cmd/OUTPUT_SPEC.md
@@ -270,6 +270,13 @@ Confluence normalized the stored <format> body. Content is intact; these attribu
   - <node>.attrs.<name> (<before>→<after>)
 ```
 
+Attributes the server added rather than dropped are reported the same way:
+
+```text
+Confluence added attributes that were not sent:
+  + <node>.attrs.<name> (<before>→<after>)
+```
+
 Content loss is reported the same way and the command exits non-zero. The
 first line names what moved in the document — one of three shapes:
 
@@ -284,7 +291,14 @@ followed by:
 ```text
 The page was updated, but it does not hold the content supplied. Re-read the page before treating the change as applied.
   first difference at offset <n> — sent "<excerpt>", stored "<excerpt>"
+  attributes dropped:
+    - <node>.attrs.<name> (<before>→<after>)
+  attributes added:
+    + <node>.attrs.<name> (<before>→<after>)
 ```
+
+The offset line is omitted when the visible text is identical and only
+embedded content changed; the attribute lines then identify what moved.
 
 Counts are characters a reader sees and the offset is a character position,
 both measured on the document rather than on any internal representation.

--- a/tools/cfl/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/cfl/internal/cmd/OUTPUT_SPEC.md
@@ -270,13 +270,24 @@ Confluence normalized the stored <format> body. Content is intact; these attribu
   - <node>.attrs.<name> (<before>→<after>)
 ```
 
-Content loss is reported the same way and the command exits non-zero:
+Content loss is reported the same way and the command exits non-zero. The
+first line names what moved in the document — one of three shapes:
 
 ```text
-Stored <format> body does not match what was sent: content differs (<n> chars sent, <n> stored).
-The page was updated, but it does not hold the content supplied. Re-read the page before treating the change as applied.
-  first difference: at offset <n> — sent "<excerpt>", stored "<excerpt>"
+Stored <format> body does not match what was sent: visible text went from <n> to <n> characters.
+Stored <format> body does not match what was sent: visible text is unchanged at <n> characters, but embedded content differs.
+Stored <format> body does not match what was sent: content differs at the same length of <n> characters.
 ```
+
+followed by:
+
+```text
+The page was updated, but it does not hold the content supplied. Re-read the page before treating the change as applied.
+  first difference at offset <n> — sent "<excerpt>", stored "<excerpt>"
+```
+
+Counts are characters a reader sees and the offset is a character position,
+both measured on the document rather than on any internal representation.
 
 ## `page copy <page-id>`
 

--- a/tools/cfl/internal/cmd/page/create.go
+++ b/tools/cfl/internal/cmd/page/create.go
@@ -16,6 +16,7 @@ import (
 )
 
 type createOptions struct {
+	noVerify bool
 	*root.Options
 	space              string
 	title              string
@@ -95,6 +96,7 @@ without conversion.`,
 	cmd.Flags().BoolVar(&opts.editor, "editor", false, "Open editor for content")
 	cmd.Flags().StringVar(&opts.bodyFormat, "body-format", bodyFormatMarkdown, "Input format: markdown, adf, or xhtml")
 	cmd.Flags().BoolVar(&opts.legacy, "legacy", false, "Create page in legacy editor format (Markdown input only)")
+	cmd.Flags().BoolVar(&opts.noVerify, "no-verify", false, "Skip reading the page back to confirm what Confluence stored (adf/xhtml input)")
 
 	_ = cmd.MarkFlagRequired("title")
 
@@ -128,6 +130,7 @@ func runCreate(ctx context.Context, opts *createOptions) error {
 	if strings.TrimSpace(content) == "" {
 		return fmt.Errorf("page content cannot be empty")
 	}
+	sentContent := content
 	body, err := bodyForInput(content, bodyFormat, opts.legacy)
 	if err != nil {
 		return err
@@ -173,7 +176,20 @@ func runCreate(ctx context.Context, opts *createOptions) error {
 		return err
 	}
 
-	return cflpresent.Emit(opts.Options, cflpresent.PagePresenter{}.PresentCreate(page, cfg.URL))
+	if err := cflpresent.Emit(opts.Options, cflpresent.PagePresenter{}.PresentCreate(page, cfg.URL)); err != nil {
+		return err
+	}
+
+	// A create writes the same verbatim body an edit does, so it can suffer
+	// the same unseen server-side loss.
+	return verifyStoredBody(ctx, verifyRequest{
+		opts:        opts.Options,
+		client:      client,
+		pageID:      page.ID,
+		bodyFormat:  bodyFormat,
+		sentContent: sentContent,
+		enabled:     !opts.noVerify,
+	})
 }
 
 func getContent(opts *createOptions, bodyFormat string) (string, error) {

--- a/tools/cfl/internal/cmd/page/create_test.go
+++ b/tools/cfl/internal/cmd/page/create_test.go
@@ -100,6 +100,9 @@ func TestRunCreate_HTMLFile_Legacy(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -147,6 +150,9 @@ func TestRunCreate_NoMarkdownFlag_Legacy(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -304,6 +310,9 @@ func TestRunCreate_WithParent(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -347,6 +356,9 @@ func TestRunCreate_MarkdownConversion_Legacy(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -396,6 +408,9 @@ func TestRunCreate_MarkdownToADF(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -462,6 +477,9 @@ func TestRunCreate_Stdin_ADF(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -505,6 +523,9 @@ func TestRunCreate_Stdin_Legacy(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -548,6 +569,9 @@ func TestRunCreate_Stdin_NoMarkdown_Legacy(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -590,6 +614,9 @@ func TestRunCreate_StorageFlag_Stdin(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -639,6 +666,9 @@ func TestRunCreate_StorageFlag_File(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -681,6 +711,9 @@ func TestRunCreate_ComplexMarkdown_ADF(t *testing.T) {
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(receivedBody)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -831,6 +864,9 @@ func mockCreateBodyServer(t *testing.T, received *map[string]any) *httptest.Serv
 		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"results": [{"id": "123456", "key": "DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(storedCreatedPageJSON(*received)))
 		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, received)
@@ -986,4 +1022,21 @@ func TestRunCreate_FileDash_Stdin_Legacy(t *testing.T) {
 	testutil.Contains(t, content, "<h1")
 	testutil.Contains(t, content, "<strong>bold</strong>")
 	testutil.Nil(t, bodyMap["atlas_doc_format"])
+}
+
+// storedCreatedPageJSON reports a created page the way Confluence does: a GET
+// after the write returns the body that was stored. runCreate now reads the
+// page back to verify the write, so a fake without this branch answers 404
+// for a create that in fact succeeded.
+func storedCreatedPageJSON(received map[string]any) string {
+	fallback := `{"id":"99999","title":"Test","version":{"number":1}}`
+	body, ok := received["body"].(map[string]any)
+	if !ok {
+		return fallback
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fallback
+	}
+	return `{"id":"99999","title":"Test","version":{"number":1},"body":` + string(raw) + `}`
 }

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -26,6 +26,7 @@ type editOptions struct {
 	bodyFormatExplicit bool
 	legacy             bool
 	parent             string
+	noVerify           bool
 }
 
 func newEditCmd(rootOpts *root.Options) *cobra.Command {
@@ -46,7 +47,14 @@ Content can be provided via:
 
 Content format is selected with --body-format markdown|adf|xhtml.
 Omitting --body-format means Markdown. ADF and XHTML are validated or sent
-without conversion.`,
+without conversion.
+
+For --body-format adf or xhtml the page is read back after writing and the
+stored body compared against what was sent, because Confluence can store
+something other than what it was given. Losing text is an error; attributes
+the server normalizes away are reported and tolerated. Markdown is converted
+before sending, so there is nothing to compare it against and the check is
+skipped. Use --no-verify to skip the read.`,
 		Example: `  # Edit a page in the editor with current content
   cfl page edit 12345 --editor
 
@@ -103,6 +111,7 @@ without conversion.`,
 	cmd.Flags().BoolVar(&opts.editor, "editor", false, "Open editor for content")
 	cmd.Flags().StringVar(&opts.bodyFormat, "body-format", bodyFormatMarkdown, "Input format: markdown, adf, or xhtml")
 	cmd.Flags().BoolVar(&opts.legacy, "legacy", false, "Edit page in legacy editor format (Markdown input only)")
+	cmd.Flags().BoolVar(&opts.noVerify, "no-verify", false, "Skip reading the page back to confirm what Confluence stored (adf/xhtml input)")
 
 	return cmd
 }
@@ -132,6 +141,7 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	hasStdinData := (opts.Stdin != nil && opts.Stdin != os.Stdin) || hasPipedOSStdin(opts.Options)
 	hasNewContent := opts.file != "" || opts.editor || hasStdinData
 	var newBody *api.Body
+	var sentContent string
 	if hasNewContent && !opts.editor {
 		content, err := getEditContent(opts, nil, bodyFormat)
 		if err != nil {
@@ -140,6 +150,7 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 		if strings.TrimSpace(content) == "" {
 			return fmt.Errorf("page content cannot be empty")
 		}
+		sentContent = content
 		newBody, err = bodyForInput(content, bodyFormat, opts.legacy)
 		if err != nil {
 			return err
@@ -181,6 +192,7 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 			return fmt.Errorf("page content cannot be empty")
 		}
 
+		sentContent = content
 		newBody, err = bodyForInput(content, bodyFormat, opts.legacy)
 		if err != nil {
 			return err
@@ -214,7 +226,18 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 		}
 	}
 
-	return cflpresent.Emit(opts.Options, cflpresent.PagePresenter{}.PresentEdit(page, cfg.URL, opts.legacy && hasNewContent))
+	if err := cflpresent.Emit(opts.Options, cflpresent.PagePresenter{}.PresentEdit(page, cfg.URL, opts.legacy && hasNewContent)); err != nil {
+		return err
+	}
+
+	return verifyStoredBody(ctx, verifyRequest{
+		opts:        opts.Options,
+		client:      client,
+		pageID:      opts.pageID,
+		bodyFormat:  bodyFormat,
+		sentContent: sentContent,
+		enabled:     hasNewContent && !opts.noVerify,
+	})
 }
 
 func getEditContent(opts *editOptions, existingPage *api.Page, bodyFormat string) (string, error) {

--- a/tools/cfl/internal/cmd/page/edit_test.go
+++ b/tools/cfl/internal/cmd/page/edit_test.go
@@ -288,13 +288,13 @@ func TestRunEdit_HTMLFile(t *testing.T) {
 		switch r.Method {
 		case "GET":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{
+			_, _ = w.Write([]byte(storedPageJSON(receivedBody, `{
 				"id": "12345",
 				"title": "Test",
 				"version": {"number": 1},
 				"body": {"storage": {"value": "<p>Old</p>"}},
 				"_links": {"webui": "/pages/12345"}
-			}`))
+			}`)))
 		case "PUT":
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -344,13 +344,13 @@ func TestRunEdit_NoMarkdownFlag(t *testing.T) {
 		switch r.Method {
 		case "GET":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{
+			_, _ = w.Write([]byte(storedPageJSON(receivedBody, `{
 				"id": "12345",
 				"title": "Test",
 				"version": {"number": 1},
 				"body": {"storage": {"value": "<p>Old</p>"}},
 				"_links": {"webui": "/pages/12345"}
-			}`))
+			}`)))
 		case "PUT":
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -1265,13 +1265,13 @@ func TestRunEdit_StorageFlag_Stdin(t *testing.T) {
 		switch r.Method {
 		case "GET":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{
+			_, _ = w.Write([]byte(storedPageJSON(receivedBody, `{
 				"id": "12345",
 				"title": "Test",
 				"version": {"number": 1},
 				"body": {"storage": {"value": "<p>Old</p>"}},
 				"_links": {"webui": "/pages/12345"}
-			}`))
+			}`)))
 		case "PUT":
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -1326,13 +1326,13 @@ func TestRunEdit_StorageFlag_File(t *testing.T) {
 		switch r.Method {
 		case "GET":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{
+			_, _ = w.Write([]byte(storedPageJSON(receivedBody, `{
 				"id": "12345",
 				"title": "Test",
 				"version": {"number": 1},
 				"body": {"storage": {"value": "<p>Old</p>"}},
 				"_links": {"webui": "/pages/12345"}
-			}`))
+			}`)))
 		case "PUT":
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, &receivedBody)
@@ -1566,13 +1566,13 @@ func mockEditBodyServer(t *testing.T, received *map[string]any) *httptest.Server
 		switch r.Method {
 		case "GET":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{
+			_, _ = w.Write([]byte(storedPageJSON(*received, `{
 				"id": "12345",
 				"title": "Test",
 				"version": {"number": 1},
 				"body": {"storage": {"value": "<p>Old</p>"}},
 				"_links": {"webui": "/pages/12345"}
-			}`))
+			}`)))
 		case "PUT":
 			body, _ := io.ReadAll(r.Body)
 			_ = json.Unmarshal(body, received)
@@ -1820,4 +1820,21 @@ func TestRunEdit_EditorBodyFormats(t *testing.T) {
 			}
 		})
 	}
+}
+
+// storedPageJSON reports the page the way Confluence would after a write:
+// a GET reflects what was stored, not the body the page had beforehand. The
+// post-write verification in runEdit compares against this, so a fake that
+// kept returning its original body would report drift on every exact-format
+// write.
+func storedPageJSON(received map[string]any, before string) string {
+	body, ok := received["body"].(map[string]any)
+	if !ok {
+		return before
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return before
+	}
+	return `{"id":"12345","title":"Test","version":{"number":2},"body":` + string(raw) + `,"_links":{"webui":"/pages/12345"}}`
 }

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -39,6 +39,10 @@ type writeDrift struct {
 	// to the operator.
 	SentVisible   string
 	StoredVisible string
+	// AtomChanges names embedded node types whose counts moved. Attribute
+	// diffs cannot cover this: hardBreak and rule carry no attributes, so
+	// without it a change confined to them has nothing to report.
+	AtomChanges []string
 
 	// TextChanged reports that the document's text content differs. This is
 	// a failed write, not a normalization.
@@ -101,6 +105,7 @@ func compareADF(sent, stored string) (writeDrift, error) {
 		AtomsChanged:  sentText != storedText && sentVisible == storedVisible,
 		SentVisible:   sentVisible,
 		StoredVisible: storedVisible,
+		AtomChanges:   diffAtomProfiles(atomProfile(sentDoc), atomProfile(storedDoc)),
 		DroppedAttrs:  dropped,
 		AddedAttrs:    added,
 	}, nil
@@ -169,6 +174,54 @@ func adfContent(node any) string {
 	}
 	walk(node)
 	return b.String()
+}
+
+// atomProfile counts content-bearing atoms by type.
+func atomProfile(node any) map[string]int {
+	profile := map[string]int{}
+	var walk func(any)
+	walk = func(n any) {
+		switch v := n.(type) {
+		case map[string]any:
+			if t, _ := v["type"].(string); contentAtoms[t] {
+				profile[t]++
+			}
+			if content, ok := v["content"].([]any); ok {
+				for _, c := range content {
+					walk(c)
+				}
+			}
+		case []any:
+			for _, c := range v {
+				walk(c)
+			}
+		}
+	}
+	walk(node)
+	return profile
+}
+
+// diffAtomProfiles names atom types whose counts moved, in sorted order.
+func diffAtomProfiles(sent, stored map[string]int) []string {
+	seen := map[string]bool{}
+	var out []string
+	for k := range sent {
+		seen[k] = true
+	}
+	for k := range stored {
+		seen[k] = true
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if sent[k] != stored[k] {
+			out = append(out, fmt.Sprintf("%s (%d→%d)", k, sent[k], stored[k]))
+		}
+	}
+	return out
 }
 
 // visibleText is only the characters a reader sees, with no atom markers, so
@@ -346,6 +399,7 @@ func verifyStoredBody(ctx context.Context, req verifyRequest) error {
 		DiffOffset:    off,
 		SentExcerpt:   readableExcerpt(drift.SentVisible, off),
 		StoredExcerpt: readableExcerpt(drift.StoredVisible, off),
+		AtomChanges:   drift.AtomChanges,
 		DroppedAttrs:  drift.DroppedAttrs,
 		AddedAttrs:    drift.AddedAttrs,
 	}
@@ -396,9 +450,8 @@ func diffOffset(sent, stored string) int {
 	return i
 }
 
-// readableExcerpt renders part of a fingerprint for a person. The fingerprint
-// separates atoms with NUL so they cannot collide with document text, which
-// is an internal detail an operator should never be shown.
+// readableExcerpt returns part of the reader-visible text, starting at a
+// character position, for quoting back in a report.
 func readableExcerpt(s string, at int) string {
 	r := []rune(s)
 	if at < 0 || at > len(r) {

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -99,11 +99,20 @@ var contentAtoms = map[string]bool{
 	"extension":       true,
 	"inlineExtension": true,
 	"bodiedExtension": true,
+	// Attribute-less atoms: dropping one moves neither the text nor the
+	// attribute profile, so without naming them here the loss is invisible.
+	"hardBreak": true,
+	"rule":      true,
 }
 
 // adfContent renders a document's content fingerprint in document order:
-// text as itself, and each content-bearing atom as a marker. Two documents
-// with the same fingerprint hold the same content for a reader.
+// text as itself, and each atom named in contentAtoms as a marker carrying
+// its identifying attributes.
+//
+// The atom set is an allowlist, so the fingerprint is a sound signal and not
+// a complete one: a differing fingerprint always means the content changed,
+// while an identical one means nothing outside the allowlist moved. A node
+// type ADF gains later goes unnoticed until it is added here.
 func adfContent(node any) string {
 	var b strings.Builder
 	var walk func(any)
@@ -276,13 +285,15 @@ func verifyStoredBody(ctx context.Context, req verifyRequest) error {
 	}
 
 	finding := cflpresent.WriteDrift{
-		BodyFormat:   req.bodyFormat,
-		TextChanged:  drift.TextChanged,
-		SentLen:      len(drift.SentText),
-		StoredLen:    len(drift.StoredText),
-		Difference:   firstTextDifference(drift.SentText, drift.StoredText),
-		DroppedAttrs: drift.DroppedAttrs,
-		AddedAttrs:   drift.AddedAttrs,
+		BodyFormat:    req.bodyFormat,
+		TextChanged:   drift.TextChanged,
+		SentLen:       len(drift.SentText),
+		StoredLen:     len(drift.StoredText),
+		DiffOffset:    diffOffset(drift.SentText, drift.StoredText),
+		SentExcerpt:   readableExcerpt(drift.SentText, diffOffset(drift.SentText, drift.StoredText)),
+		StoredExcerpt: readableExcerpt(drift.StoredText, diffOffset(drift.SentText, drift.StoredText)),
+		DroppedAttrs:  drift.DroppedAttrs,
+		AddedAttrs:    drift.AddedAttrs,
 	}
 	if emitErr := cflpresent.Emit(req.opts, cflpresent.PagePresenter{}.PresentWriteDrift(finding)); emitErr != nil {
 		return emitErr
@@ -311,9 +322,9 @@ func bodyValue(page *api.Page, bodyFormat string) string {
 	return ""
 }
 
-// firstTextDifference locates where two content fingerprints diverge so the
-// report points at the change rather than restating both documents.
-func firstTextDifference(sent, stored string) string {
+// diffOffset reports where two content fingerprints first diverge, or -1
+// when they match.
+func diffOffset(sent, stored string) int {
 	limit := len(sent)
 	if len(stored) < limit {
 		limit = len(stored)
@@ -323,18 +334,21 @@ func firstTextDifference(sent, stored string) string {
 		i++
 	}
 	if i == limit && len(sent) == len(stored) {
-		return ""
+		return -1
 	}
-	return fmt.Sprintf("at offset %d — sent %q, stored %q", i, excerpt(sent, i), excerpt(stored, i))
+	return i
 }
 
-func excerpt(s string, at int) string {
-	if at > len(s) {
+// readableExcerpt renders part of a fingerprint for a person. The fingerprint
+// separates atoms with NUL so they cannot collide with document text, which
+// is an internal detail an operator should never be shown.
+func readableExcerpt(s string, at int) string {
+	if at < 0 || at > len(s) {
 		return ""
 	}
 	end := at + 40
 	if end > len(s) {
 		end = len(s)
 	}
-	return s[at:end]
+	return strings.ReplaceAll(s[at:end], "\x00", "")
 }

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -26,6 +26,15 @@ import (
 
 // writeDrift describes how a stored body differs from the body that was sent.
 type writeDrift struct {
+	// VisibleSent and VisibleStored count the characters a reader sees, so
+	// the numbers reported are facts about the document rather than
+	// positions in the internal fingerprint.
+	VisibleSent   int
+	VisibleStored int
+	// AtomsChanged reports that embedded content (cards, images, mentions,
+	// breaks) differs even where the visible text does not.
+	AtomsChanged bool
+
 	// TextChanged reports that the document's text content differs. This is
 	// a failed write, not a normalization.
 	TextChanged bool
@@ -72,13 +81,17 @@ func compareADF(sent, stored string) (writeDrift, error) {
 	}
 
 	sentText, storedText := adfContent(sentDoc), adfContent(storedDoc)
+	sentVisible, storedVisible := visibleText(sentDoc), visibleText(storedDoc)
 	dropped, added := diffAttrProfiles(adfAttrProfile(sentDoc), adfAttrProfile(storedDoc))
 	return writeDrift{
-		TextChanged:  sentText != storedText,
-		SentText:     sentText,
-		StoredText:   storedText,
-		DroppedAttrs: dropped,
-		AddedAttrs:   added,
+		TextChanged:   sentText != storedText,
+		SentText:      sentText,
+		StoredText:    storedText,
+		VisibleSent:   len([]rune(sentVisible)),
+		VisibleStored: len([]rune(storedVisible)),
+		AtomsChanged:  sentText != storedText && sentVisible == storedVisible,
+		DroppedAttrs:  dropped,
+		AddedAttrs:    added,
 	}, nil
 }
 
@@ -132,6 +145,34 @@ func adfContent(node any) string {
 			}
 			// Content order is what makes this comparable, so walk it
 			// explicitly rather than ranging over the map.
+			if content, ok := v["content"].([]any); ok {
+				for _, c := range content {
+					walk(c)
+				}
+			}
+		case []any:
+			for _, c := range v {
+				walk(c)
+			}
+		}
+	}
+	walk(node)
+	return b.String()
+}
+
+// visibleText is only the characters a reader sees, with no atom markers, so
+// a length taken from it is a statement about the document.
+func visibleText(node any) string {
+	var b strings.Builder
+	var walk func(any)
+	walk = func(n any) {
+		switch v := n.(type) {
+		case map[string]any:
+			if v["type"] == "text" {
+				if s, ok := v["text"].(string); ok {
+					b.WriteString(s)
+				}
+			}
 			if content, ok := v["content"].([]any); ok {
 				for _, c := range content {
 					walk(c)
@@ -287,8 +328,9 @@ func verifyStoredBody(ctx context.Context, req verifyRequest) error {
 	finding := cflpresent.WriteDrift{
 		BodyFormat:    req.bodyFormat,
 		TextChanged:   drift.TextChanged,
-		SentLen:       len(drift.SentText),
-		StoredLen:     len(drift.StoredText),
+		VisibleSent:   drift.VisibleSent,
+		VisibleStored: drift.VisibleStored,
+		AtomsChanged:  drift.AtomsChanged,
 		DiffOffset:    diffOffset(drift.SentText, drift.StoredText),
 		SentExcerpt:   readableExcerpt(drift.SentText, diffOffset(drift.SentText, drift.StoredText)),
 		StoredExcerpt: readableExcerpt(drift.StoredText, diffOffset(drift.SentText, drift.StoredText)),
@@ -325,30 +367,39 @@ func bodyValue(page *api.Page, bodyFormat string) string {
 // diffOffset reports where two content fingerprints first diverge, or -1
 // when they match.
 func diffOffset(sent, stored string) int {
-	limit := len(sent)
-	if len(stored) < limit {
-		limit = len(stored)
+	a, b := []rune(scrubFingerprint(sent)), []rune(scrubFingerprint(stored))
+	limit := len(a)
+	if len(b) < limit {
+		limit = len(b)
 	}
 	i := 0
-	for i < limit && sent[i] == stored[i] {
+	for i < limit && a[i] == b[i] {
 		i++
 	}
-	if i == limit && len(sent) == len(stored) {
+	if i == limit && len(a) == len(b) {
 		return -1
 	}
 	return i
+}
+
+// scrubFingerprint removes the NUL separators that keep atom markers from
+// colliding with document text. They are an internal device and must not
+// reach a reader.
+func scrubFingerprint(s string) string {
+	return strings.ReplaceAll(s, "\x00", "")
 }
 
 // readableExcerpt renders part of a fingerprint for a person. The fingerprint
 // separates atoms with NUL so they cannot collide with document text, which
 // is an internal detail an operator should never be shown.
 func readableExcerpt(s string, at int) string {
-	if at < 0 || at > len(s) {
+	r := []rune(scrubFingerprint(s))
+	if at < 0 || at > len(r) {
 		return ""
 	}
 	end := at + 40
-	if end > len(s) {
-		end = len(s)
+	if end > len(r) {
+		end = len(r)
 	}
-	return strings.ReplaceAll(s[at:end], "\x00", "")
+	return string(r[at:end])
 }

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -396,13 +396,6 @@ func diffOffset(sent, stored string) int {
 	return i
 }
 
-// scrubFingerprint removes the NUL separators that keep atom markers from
-// colliding with document text. They are an internal device and must not
-// reach a reader.
-func scrubFingerprint(s string) string {
-	return strings.ReplaceAll(s, "\x00", "")
-}
-
 // readableExcerpt renders part of a fingerprint for a person. The fingerprint
 // separates atoms with NUL so they cannot collide with document text, which
 // is an internal detail an operator should never be shown.

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
-
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
 	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
@@ -73,7 +71,7 @@ func compareADF(sent, stored string) (writeDrift, error) {
 		return writeDrift{}, fmt.Errorf("parsing stored ADF: %w", err)
 	}
 
-	sentText, storedText := adfText(sentDoc), adfText(storedDoc)
+	sentText, storedText := adfContent(sentDoc), adfContent(storedDoc)
 	dropped, added := diffAttrProfiles(adfAttrProfile(sentDoc), adfAttrProfile(storedDoc))
 	return writeDrift{
 		TextChanged:  sentText != storedText,
@@ -84,17 +82,44 @@ func compareADF(sent, stored string) (writeDrift, error) {
 	}, nil
 }
 
-// adfText concatenates every text node in document order.
-func adfText(node any) string {
+// contentAtoms are ADF leaf nodes that carry content the reader sees but
+// hold no text of their own. They must count toward the content fingerprint:
+// otherwise dropping an entire card, image or mention leaves the text
+// identical and the loss is reported as harmless attribute normalization.
+var contentAtoms = map[string]bool{
+	"inlineCard":      true,
+	"blockCard":       true,
+	"embedCard":       true,
+	"media":           true,
+	"mediaInline":     true,
+	"mention":         true,
+	"emoji":           true,
+	"status":          true,
+	"date":            true,
+	"extension":       true,
+	"inlineExtension": true,
+	"bodiedExtension": true,
+}
+
+// adfContent renders a document's content fingerprint in document order:
+// text as itself, and each content-bearing atom as a marker. Two documents
+// with the same fingerprint hold the same content for a reader.
+func adfContent(node any) string {
 	var b strings.Builder
 	var walk func(any)
 	walk = func(n any) {
 		switch v := n.(type) {
 		case map[string]any:
-			if v["type"] == "text" {
+			nodeType, _ := v["type"].(string)
+			switch {
+			case nodeType == "text":
 				if s, ok := v["text"].(string); ok {
 					b.WriteString(s)
 				}
+			case contentAtoms[nodeType]:
+				// Identity, not just presence: swapping one card for another
+				// keeps the count identical.
+				b.WriteString("\x00" + nodeType + "(" + atomIdentity(v) + ")")
 			}
 			// Content order is what makes this comparable, so walk it
 			// explicitly rather than ranging over the map.
@@ -111,6 +136,25 @@ func adfText(node any) string {
 	}
 	walk(node)
 	return b.String()
+}
+
+// atomIdentity summarizes an atom's identifying attributes so a substitution
+// is visible, using a stable order.
+func atomIdentity(node map[string]any) string {
+	attrs, ok := node["attrs"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%v", k, attrs[k]))
+	}
+	return strings.Join(parts, ",")
 }
 
 // adfAttrProfile counts "nodeType.attrName" occurrences, including the
@@ -188,66 +232,8 @@ func xhtmlText(s string) string {
 	return strings.Join(strings.Fields(b.String()), " ")
 }
 
-// describeDrift renders drift for an operator: what was lost, and whether it
-// cost them content or only normalization.
-func describeDrift(d writeDrift, bodyFormat string) []string {
-	var lines []string
-	if d.TextChanged {
-		lines = append(lines,
-			fmt.Sprintf("Stored %s body does not match what was sent: text content differs (%d chars sent, %d stored).",
-				bodyFormat, len(d.SentText), len(d.StoredText)),
-			"The page was updated, but it does not contain the content supplied. Re-read the page before assuming the change landed.",
-		)
-		if diff := firstTextDifference(d.SentText, d.StoredText); diff != "" {
-			lines = append(lines, "  first difference: "+diff)
-		}
-		return lines
-	}
-	if len(d.DroppedAttrs) > 0 {
-		lines = append(lines, fmt.Sprintf("Confluence normalized the stored %s body. Text content is intact; these attributes were dropped:", bodyFormat))
-		for _, a := range d.DroppedAttrs {
-			lines = append(lines, "  - "+a)
-		}
-	}
-	if len(d.AddedAttrs) > 0 {
-		lines = append(lines, "Confluence added attributes that were not sent:")
-		for _, a := range d.AddedAttrs {
-			lines = append(lines, "  + "+a)
-		}
-	}
-	return lines
-}
-
-// firstTextDifference locates where two texts diverge so the report points at
-// the change rather than restating both documents.
-func firstTextDifference(sent, stored string) string {
-	limit := len(sent)
-	if len(stored) < limit {
-		limit = len(stored)
-	}
-	i := 0
-	for i < limit && sent[i] == stored[i] {
-		i++
-	}
-	if i == limit && len(sent) == len(stored) {
-		return ""
-	}
-	return fmt.Sprintf("at offset %d — sent %q, stored %q", i, excerpt(sent, i), excerpt(stored, i))
-}
-
-func excerpt(s string, at int) string {
-	if at > len(s) {
-		return ""
-	}
-	end := at + 40
-	if end > len(s) {
-		end = len(s)
-	}
-	return s[at:end]
-}
-
-// verifyRequest carries what a post-write readback needs, so edit and create
-// share one verification path.
+// verifyRequest carries what a post-write readback needs, so page edit and
+// page create share one verification path.
 type verifyRequest struct {
 	opts        *root.Options
 	client      *api.Client
@@ -289,24 +275,22 @@ func verifyStoredBody(ctx context.Context, req verifyRequest) error {
 		return nil
 	}
 
-	lines := describeDrift(drift, req.bodyFormat)
-	if emitErr := cflpresent.Emit(req.opts, stderrLines(lines)); emitErr != nil {
+	finding := cflpresent.WriteDrift{
+		BodyFormat:   req.bodyFormat,
+		TextChanged:  drift.TextChanged,
+		SentLen:      len(drift.SentText),
+		StoredLen:    len(drift.StoredText),
+		Difference:   firstTextDifference(drift.SentText, drift.StoredText),
+		DroppedAttrs: drift.DroppedAttrs,
+		AddedAttrs:   drift.AddedAttrs,
+	}
+	if emitErr := cflpresent.Emit(req.opts, cflpresent.PagePresenter{}.PresentWriteDrift(finding)); emitErr != nil {
 		return emitErr
 	}
 	if drift.TextChanged {
 		return fmt.Errorf("stored page content does not match what was sent")
 	}
 	return nil
-}
-
-func stderrLines(lines []string) *sharedpresent.OutputModel {
-	return &sharedpresent.OutputModel{Sections: []sharedpresent.Section{
-		&sharedpresent.MessageSection{
-			Kind:    sharedpresent.MessageWarning,
-			Message: strings.Join(lines, "\n"),
-			Stream:  sharedpresent.StreamStderr,
-		},
-	}}
 }
 
 // bodyValue returns the page body in the requested representation.
@@ -325,4 +309,32 @@ func bodyValue(page *api.Page, bodyFormat string) string {
 		}
 	}
 	return ""
+}
+
+// firstTextDifference locates where two content fingerprints diverge so the
+// report points at the change rather than restating both documents.
+func firstTextDifference(sent, stored string) string {
+	limit := len(sent)
+	if len(stored) < limit {
+		limit = len(stored)
+	}
+	i := 0
+	for i < limit && sent[i] == stored[i] {
+		i++
+	}
+	if i == limit && len(sent) == len(stored) {
+		return ""
+	}
+	return fmt.Sprintf("at offset %d — sent %q, stored %q", i, excerpt(sent, i), excerpt(stored, i))
+}
+
+func excerpt(s string, at int) string {
+	if at > len(s) {
+		return ""
+	}
+	end := at + 40
+	if end > len(s) {
+		end = len(s)
+	}
+	return s[at:end]
 }

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -34,6 +34,11 @@ type writeDrift struct {
 	// AtomsChanged reports that embedded content (cards, images, mentions,
 	// breaks) differs even where the visible text does not.
 	AtomsChanged bool
+	// SentVisible and StoredVisible are the reader-visible text, which is
+	// where a reported position has to be measured for it to mean anything
+	// to the operator.
+	SentVisible   string
+	StoredVisible string
 
 	// TextChanged reports that the document's text content differs. This is
 	// a failed write, not a normalization.
@@ -62,9 +67,13 @@ func compareStoredBody(sent, stored, bodyFormat string) (writeDrift, error) {
 	case bodyFormatXHTML:
 		sentText, storedText := xhtmlText(sent), xhtmlText(stored)
 		return writeDrift{
-			TextChanged: sentText != storedText,
-			SentText:    sentText,
-			StoredText:  storedText,
+			TextChanged:   sentText != storedText,
+			SentText:      sentText,
+			StoredText:    storedText,
+			VisibleSent:   len([]rune(sentText)),
+			VisibleStored: len([]rune(storedText)),
+			SentVisible:   sentText,
+			StoredVisible: storedText,
 		}, nil
 	default:
 		return writeDrift{}, fmt.Errorf("cannot verify %s input: it is converted before sending, so the stored body is not comparable to what was supplied", bodyFormat)
@@ -90,6 +99,8 @@ func compareADF(sent, stored string) (writeDrift, error) {
 		VisibleSent:   len([]rune(sentVisible)),
 		VisibleStored: len([]rune(storedVisible)),
 		AtomsChanged:  sentText != storedText && sentVisible == storedVisible,
+		SentVisible:   sentVisible,
+		StoredVisible: storedVisible,
 		DroppedAttrs:  dropped,
 		AddedAttrs:    added,
 	}, nil
@@ -325,15 +336,16 @@ func verifyStoredBody(ctx context.Context, req verifyRequest) error {
 		return nil
 	}
 
+	off := diffOffset(drift.SentVisible, drift.StoredVisible)
 	finding := cflpresent.WriteDrift{
 		BodyFormat:    req.bodyFormat,
 		TextChanged:   drift.TextChanged,
 		VisibleSent:   drift.VisibleSent,
 		VisibleStored: drift.VisibleStored,
 		AtomsChanged:  drift.AtomsChanged,
-		DiffOffset:    diffOffset(drift.SentText, drift.StoredText),
-		SentExcerpt:   readableExcerpt(drift.SentText, diffOffset(drift.SentText, drift.StoredText)),
-		StoredExcerpt: readableExcerpt(drift.StoredText, diffOffset(drift.SentText, drift.StoredText)),
+		DiffOffset:    off,
+		SentExcerpt:   readableExcerpt(drift.SentVisible, off),
+		StoredExcerpt: readableExcerpt(drift.StoredVisible, off),
 		DroppedAttrs:  drift.DroppedAttrs,
 		AddedAttrs:    drift.AddedAttrs,
 	}
@@ -364,10 +376,12 @@ func bodyValue(page *api.Page, bodyFormat string) string {
 	return ""
 }
 
-// diffOffset reports where two content fingerprints first diverge, or -1
-// when they match.
+// diffOffset reports the character position where two reader-visible texts
+// first differ, or -1 when they match. Measuring on the visible text is what
+// makes the number a position in the document rather than in the compared
+// representation.
 func diffOffset(sent, stored string) int {
-	a, b := []rune(scrubFingerprint(sent)), []rune(scrubFingerprint(stored))
+	a, b := []rune(sent), []rune(stored)
 	limit := len(a)
 	if len(b) < limit {
 		limit = len(b)
@@ -393,7 +407,7 @@ func scrubFingerprint(s string) string {
 // separates atoms with NUL so they cannot collide with document text, which
 // is an internal detail an operator should never be shown.
 func readableExcerpt(s string, at int) string {
-	r := []rune(scrubFingerprint(s))
+	r := []rune(s)
 	if at < 0 || at > len(r) {
 		return ""
 	}

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -1,0 +1,328 @@
+package page
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
+)
+
+// Confluence normalizes what it stores. A write can land with parts of the
+// submitted document silently removed — observed with the
+// __confluenceMetadata attributes Confluence strips from link marks — and
+// the update response reports success either way. For an exact body format
+// cfl transmits the caller's content verbatim, so any difference between
+// what was sent and what came back is the server's doing and is precisely
+// what the caller cannot otherwise see.
+//
+// Two kinds of difference carry different weight, so they are reported
+// separately: losing text means the content did not land, while losing
+// attributes means the document was normalized around content that did.
+
+// writeDrift describes how a stored body differs from the body that was sent.
+type writeDrift struct {
+	// TextChanged reports that the document's text content differs. This is
+	// a failed write, not a normalization.
+	TextChanged bool
+	SentText    string
+	StoredText  string
+
+	// DroppedAttrs and AddedAttrs are "nodeType.attrName" keys whose
+	// occurrence counts fell or rose, in sorted order.
+	DroppedAttrs []string
+	AddedAttrs   []string
+}
+
+// Clean reports whether the stored body matched what was sent.
+func (d writeDrift) Clean() bool {
+	return !d.TextChanged && len(d.DroppedAttrs) == 0 && len(d.AddedAttrs) == 0
+}
+
+// compareStoredBody diffs a submitted body against the one Confluence stored.
+// Bodies that cannot be parsed are reported as an error rather than silently
+// treated as matching — an unverifiable write is not a verified one.
+func compareStoredBody(sent, stored, bodyFormat string) (writeDrift, error) {
+	switch bodyFormat {
+	case bodyFormatADF:
+		return compareADF(sent, stored)
+	case bodyFormatXHTML:
+		sentText, storedText := xhtmlText(sent), xhtmlText(stored)
+		return writeDrift{
+			TextChanged: sentText != storedText,
+			SentText:    sentText,
+			StoredText:  storedText,
+		}, nil
+	default:
+		return writeDrift{}, fmt.Errorf("cannot verify %s input: it is converted before sending, so the stored body is not comparable to what was supplied", bodyFormat)
+	}
+}
+
+func compareADF(sent, stored string) (writeDrift, error) {
+	var sentDoc, storedDoc any
+	if err := json.Unmarshal([]byte(sent), &sentDoc); err != nil {
+		return writeDrift{}, fmt.Errorf("parsing submitted ADF: %w", err)
+	}
+	if err := json.Unmarshal([]byte(stored), &storedDoc); err != nil {
+		return writeDrift{}, fmt.Errorf("parsing stored ADF: %w", err)
+	}
+
+	sentText, storedText := adfText(sentDoc), adfText(storedDoc)
+	dropped, added := diffAttrProfiles(adfAttrProfile(sentDoc), adfAttrProfile(storedDoc))
+	return writeDrift{
+		TextChanged:  sentText != storedText,
+		SentText:     sentText,
+		StoredText:   storedText,
+		DroppedAttrs: dropped,
+		AddedAttrs:   added,
+	}, nil
+}
+
+// adfText concatenates every text node in document order.
+func adfText(node any) string {
+	var b strings.Builder
+	var walk func(any)
+	walk = func(n any) {
+		switch v := n.(type) {
+		case map[string]any:
+			if v["type"] == "text" {
+				if s, ok := v["text"].(string); ok {
+					b.WriteString(s)
+				}
+			}
+			// Content order is what makes this comparable, so walk it
+			// explicitly rather than ranging over the map.
+			if content, ok := v["content"].([]any); ok {
+				for _, c := range content {
+					walk(c)
+				}
+			}
+		case []any:
+			for _, c := range v {
+				walk(c)
+			}
+		}
+	}
+	walk(node)
+	return b.String()
+}
+
+// adfAttrProfile counts "nodeType.attrName" occurrences, including the
+// attributes carried by marks, which is where Confluence's link metadata
+// lives.
+func adfAttrProfile(node any) map[string]int {
+	profile := map[string]int{}
+	var walk func(any, string)
+	walk = func(n any, parentType string) {
+		switch v := n.(type) {
+		case map[string]any:
+			nodeType, _ := v["type"].(string)
+			if nodeType == "" {
+				nodeType = parentType
+			}
+			if attrs, ok := v["attrs"].(map[string]any); ok {
+				for k := range attrs {
+					profile[nodeType+".attrs."+k]++
+				}
+			}
+			if marks, ok := v["marks"].([]any); ok {
+				for _, m := range marks {
+					walk(m, nodeType)
+				}
+			}
+			if content, ok := v["content"].([]any); ok {
+				for _, c := range content {
+					walk(c, nodeType)
+				}
+			}
+		case []any:
+			for _, c := range v {
+				walk(c, parentType)
+			}
+		}
+	}
+	walk(node, "")
+	return profile
+}
+
+func diffAttrProfiles(sent, stored map[string]int) (dropped, added []string) {
+	for k, n := range sent {
+		if stored[k] < n {
+			dropped = append(dropped, fmt.Sprintf("%s (%d→%d)", k, n, stored[k]))
+		}
+	}
+	for k, n := range stored {
+		if sent[k] < n {
+			added = append(added, fmt.Sprintf("%s (%d→%d)", k, sent[k], n))
+		}
+	}
+	sort.Strings(dropped)
+	sort.Strings(added)
+	return dropped, added
+}
+
+// xhtmlText strips tags so storage-format bodies compare on their text.
+// Confluence rewrites storage markup freely, so element-level equality would
+// report drift on every write.
+func xhtmlText(s string) string {
+	var b strings.Builder
+	depth := 0
+	for _, r := range s {
+		switch {
+		case r == '<':
+			depth++
+		case r == '>':
+			if depth > 0 {
+				depth--
+			}
+		case depth == 0:
+			b.WriteRune(r)
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+// describeDrift renders drift for an operator: what was lost, and whether it
+// cost them content or only normalization.
+func describeDrift(d writeDrift, bodyFormat string) []string {
+	var lines []string
+	if d.TextChanged {
+		lines = append(lines,
+			fmt.Sprintf("Stored %s body does not match what was sent: text content differs (%d chars sent, %d stored).",
+				bodyFormat, len(d.SentText), len(d.StoredText)),
+			"The page was updated, but it does not contain the content supplied. Re-read the page before assuming the change landed.",
+		)
+		if diff := firstTextDifference(d.SentText, d.StoredText); diff != "" {
+			lines = append(lines, "  first difference: "+diff)
+		}
+		return lines
+	}
+	if len(d.DroppedAttrs) > 0 {
+		lines = append(lines, fmt.Sprintf("Confluence normalized the stored %s body. Text content is intact; these attributes were dropped:", bodyFormat))
+		for _, a := range d.DroppedAttrs {
+			lines = append(lines, "  - "+a)
+		}
+	}
+	if len(d.AddedAttrs) > 0 {
+		lines = append(lines, "Confluence added attributes that were not sent:")
+		for _, a := range d.AddedAttrs {
+			lines = append(lines, "  + "+a)
+		}
+	}
+	return lines
+}
+
+// firstTextDifference locates where two texts diverge so the report points at
+// the change rather than restating both documents.
+func firstTextDifference(sent, stored string) string {
+	limit := len(sent)
+	if len(stored) < limit {
+		limit = len(stored)
+	}
+	i := 0
+	for i < limit && sent[i] == stored[i] {
+		i++
+	}
+	if i == limit && len(sent) == len(stored) {
+		return ""
+	}
+	return fmt.Sprintf("at offset %d — sent %q, stored %q", i, excerpt(sent, i), excerpt(stored, i))
+}
+
+func excerpt(s string, at int) string {
+	if at > len(s) {
+		return ""
+	}
+	end := at + 40
+	if end > len(s) {
+		end = len(s)
+	}
+	return s[at:end]
+}
+
+// verifyRequest carries what a post-write readback needs, so edit and create
+// share one verification path.
+type verifyRequest struct {
+	opts        *root.Options
+	client      *api.Client
+	pageID      string
+	bodyFormat  string
+	sentContent string
+	enabled     bool
+}
+
+// verifyStoredBody re-reads a page after a write and reports what Confluence
+// actually stored. It only runs for exact body formats: markdown input is
+// converted before sending, so the stored body is not comparable to it.
+//
+// Losing text is an error — the caller's content did not land. Normalization
+// is reported and tolerated, because it is the server's prerogative and the
+// content survived it.
+func verifyStoredBody(ctx context.Context, req verifyRequest) error {
+	if !req.enabled || req.sentContent == "" {
+		return nil
+	}
+	if req.bodyFormat != bodyFormatADF && req.bodyFormat != bodyFormatXHTML {
+		return nil
+	}
+
+	stored, err := getPageWithBodyFormat(ctx, req.client, req.pageID, req.bodyFormat)
+	if err != nil {
+		return fmt.Errorf("verifying stored page: %w — the write may have succeeded; re-read the page to confirm", err)
+	}
+	storedContent := bodyValue(stored, req.bodyFormat)
+	if storedContent == "" {
+		return fmt.Errorf("verifying stored page: no %s body returned — re-read the page to confirm the write", req.bodyFormat)
+	}
+
+	drift, err := compareStoredBody(req.sentContent, storedContent, req.bodyFormat)
+	if err != nil {
+		return fmt.Errorf("verifying stored page: %w", err)
+	}
+	if drift.Clean() {
+		return nil
+	}
+
+	lines := describeDrift(drift, req.bodyFormat)
+	if emitErr := cflpresent.Emit(req.opts, stderrLines(lines)); emitErr != nil {
+		return emitErr
+	}
+	if drift.TextChanged {
+		return fmt.Errorf("stored page content does not match what was sent")
+	}
+	return nil
+}
+
+func stderrLines(lines []string) *sharedpresent.OutputModel {
+	return &sharedpresent.OutputModel{Sections: []sharedpresent.Section{
+		&sharedpresent.MessageSection{
+			Kind:    sharedpresent.MessageWarning,
+			Message: strings.Join(lines, "\n"),
+			Stream:  sharedpresent.StreamStderr,
+		},
+	}}
+}
+
+// bodyValue returns the page body in the requested representation.
+func bodyValue(page *api.Page, bodyFormat string) string {
+	if page == nil || page.Body == nil {
+		return ""
+	}
+	switch bodyFormat {
+	case bodyFormatADF:
+		if page.Body.AtlasDocFormat != nil {
+			return page.Body.AtlasDocFormat.Value
+		}
+	case bodyFormatXHTML:
+		if page.Body.Storage != nil {
+			return page.Body.Storage.Value
+		}
+	}
+	return ""
+}

--- a/tools/cfl/internal/cmd/page/verify_test.go
+++ b/tools/cfl/internal/cmd/page/verify_test.go
@@ -181,13 +181,15 @@ func TestDescribeDriftPointsAtTheDifference(t *testing.T) {
 func driftReport(t *testing.T, d writeDrift) string {
 	t.Helper()
 	model := cflpresent.PagePresenter{}.PresentWriteDrift(cflpresent.WriteDrift{
-		BodyFormat:   bodyFormatADF,
-		TextChanged:  d.TextChanged,
-		SentLen:      len(d.SentText),
-		StoredLen:    len(d.StoredText),
-		Difference:   firstTextDifference(d.SentText, d.StoredText),
-		DroppedAttrs: d.DroppedAttrs,
-		AddedAttrs:   d.AddedAttrs,
+		BodyFormat:    bodyFormatADF,
+		TextChanged:   d.TextChanged,
+		SentLen:       len(d.SentText),
+		StoredLen:     len(d.StoredText),
+		DiffOffset:    diffOffset(d.SentText, d.StoredText),
+		SentExcerpt:   readableExcerpt(d.SentText, diffOffset(d.SentText, d.StoredText)),
+		StoredExcerpt: readableExcerpt(d.StoredText, diffOffset(d.SentText, d.StoredText)),
+		DroppedAttrs:  d.DroppedAttrs,
+		AddedAttrs:    d.AddedAttrs,
 	})
 	var b strings.Builder
 	for _, sec := range model.Sections {
@@ -331,5 +333,123 @@ func TestRunEditSkipsVerificationForMarkdown(t *testing.T) {
 	}
 	if after := *gets - before; after != 1 {
 		t.Errorf("GET count = %d, want 1 (no verification read)", after)
+	}
+}
+
+// The fingerprint's NUL atom separators are an internal detail; an operator
+// must never be shown them.
+func TestExcerptHidesFingerprintSeparators(t *testing.T) {
+	sent := adfDoc(`{"type":"text","text":"see "},{"type":"inlineCard","attrs":{"url":"https://example.test/x"}}`)
+	stored := adfDoc(`{"type":"text","text":"see "}`)
+	d, err := compareStoredBody(sent, stored, bodyFormatADF)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := driftReport(t, d)
+	if strings.Contains(report, "\x00") || strings.ContainsRune(report, 0) {
+		t.Errorf("report leaked the fingerprint separator:\n%s", report)
+	}
+	if !strings.Contains(report, "inlineCard") {
+		t.Errorf("report should still name the lost atom:\n%s", report)
+	}
+}
+
+// Attribute-less atoms move neither the text nor the attribute profile, so
+// they have to be named in the fingerprint or their loss is invisible.
+func TestAttributelessAtomLossDetected(t *testing.T) {
+	for _, atom := range []string{"hardBreak", "rule"} {
+		t.Run(atom, func(t *testing.T) {
+			sent := adfDoc(`{"type":"text","text":"a"},{"type":"` + atom + `"},{"type":"text","text":"b"}`)
+			stored := adfDoc(`{"type":"text","text":"a"},{"type":"text","text":"b"}`)
+			d, err := compareStoredBody(sent, stored, bodyFormatADF)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !d.TextChanged {
+				t.Errorf("a dropped %s was not reported as content loss", atom)
+			}
+		})
+	}
+}
+
+// createDriftServer answers a create and then serves whatever storedBody
+// returns on the readback, so a test can make Confluence "store" something
+// other than what was posted.
+func createDriftServer(t *testing.T, storedBody func() string) (*httptest.Server, *int) {
+	t.Helper()
+	gets := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/spaces"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"results":[{"id":"123456","key":"DEV"}]}`))
+		case r.Method == "GET" && strings.Contains(r.URL.Path, "/pages/"):
+			gets++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"99999","title":"Test","version":{"number":1},"body":` + storedBody() + `}`))
+		case r.Method == "POST" && strings.Contains(r.URL.Path, "/pages"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"99999","title":"Test","version":{"number":1}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	return srv, &gets
+}
+
+func createOptsFor(t *testing.T, srv *httptest.Server, content string, noVerify bool) *createOptions {
+	t.Helper()
+	rootOpts := newCreateTestRootOptions()
+	rootOpts.SetAPIClient(api.NewClient(srv.URL, "test@example.com", "token"))
+	rootOpts.Stdin = strings.NewReader(content)
+	return &createOptions{
+		Options:    rootOpts,
+		space:      "DEV",
+		title:      "Test Page",
+		file:       "-",
+		bodyFormat: bodyFormatXHTML,
+		noVerify:   noVerify,
+	}
+}
+
+// A create writes the same verbatim body an edit does, so it must fail the
+// same way when the server stores something else.
+func TestRunCreateFailsWhenStoredContentDiffers(t *testing.T) {
+	srv, _ := createDriftServer(t, func() string {
+		return `{"storage":{"value":"<p>something else entirely</p>"}}`
+	})
+	defer srv.Close()
+
+	err := runCreate(context.Background(), createOptsFor(t, srv, "<p>what we sent</p>", false))
+	if err == nil {
+		t.Fatal("expected an error when the created page does not hold what was sent")
+	}
+	if !strings.Contains(err.Error(), "does not match what was sent") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCreateNoVerifySkipsReadback(t *testing.T) {
+	srv, gets := createDriftServer(t, func() string {
+		return `{"storage":{"value":"<p>something else entirely</p>"}}`
+	})
+	defer srv.Close()
+
+	if err := runCreate(context.Background(), createOptsFor(t, srv, "<p>what we sent</p>", true)); err != nil {
+		t.Fatalf("--no-verify should not fail on drift: %v", err)
+	}
+	if *gets != 0 {
+		t.Errorf("readback GET count = %d, want 0", *gets)
+	}
+}
+
+func TestRunCreateToleratesNormalization(t *testing.T) {
+	srv, _ := createDriftServer(t, func() string {
+		return `{"storage":{"value":"<p class=\"auto\">what we sent</p>"}}`
+	})
+	defer srv.Close()
+
+	if err := runCreate(context.Background(), createOptsFor(t, srv, "<p>what we sent</p>", false)); err != nil {
+		t.Fatalf("normalized markup should not fail the create: %v", err)
 	}
 }

--- a/tools/cfl/internal/cmd/page/verify_test.go
+++ b/tools/cfl/internal/cmd/page/verify_test.go
@@ -186,9 +186,9 @@ func driftReport(t *testing.T, d writeDrift) string {
 		VisibleSent:   d.VisibleSent,
 		VisibleStored: d.VisibleStored,
 		AtomsChanged:  d.AtomsChanged,
-		DiffOffset:    diffOffset(d.SentText, d.StoredText),
-		SentExcerpt:   readableExcerpt(d.SentText, diffOffset(d.SentText, d.StoredText)),
-		StoredExcerpt: readableExcerpt(d.StoredText, diffOffset(d.SentText, d.StoredText)),
+		DiffOffset:    diffOffset(d.SentVisible, d.StoredVisible),
+		SentExcerpt:   readableExcerpt(d.SentVisible, diffOffset(d.SentVisible, d.StoredVisible)),
+		StoredExcerpt: readableExcerpt(d.StoredVisible, diffOffset(d.SentVisible, d.StoredVisible)),
 		DroppedAttrs:  d.DroppedAttrs,
 		AddedAttrs:    d.AddedAttrs,
 	})
@@ -351,7 +351,7 @@ func TestExcerptHidesFingerprintSeparators(t *testing.T) {
 		t.Errorf("report leaked the fingerprint separator:\n%s", report)
 	}
 	if !strings.Contains(report, "inlineCard") {
-		t.Errorf("report should still name the lost atom:\n%s", report)
+		t.Errorf("report should still name the lost atom via its attributes:\n%s", report)
 	}
 }
 
@@ -487,8 +487,41 @@ func TestReportedCountsDescribeTheDocument(t *testing.T) {
 		if d.VisibleSent != 7 || d.VisibleStored != 3 {
 			t.Errorf("visible counts = %d/%d, want 7/3 runes", d.VisibleSent, d.VisibleStored)
 		}
-		if off := diffOffset(d.SentText, d.StoredText); off != 3 {
+		if off := diffOffset(d.SentVisible, d.StoredVisible); off != 3 {
 			t.Errorf("diffOffset = %d, want 3 (runes, not bytes)", off)
 		}
 	})
+}
+
+// The XHTML branch must measure the document too, or the report states a
+// length of zero characters for a body it never counted.
+func TestXHTMLDriftReportsRealCounts(t *testing.T) {
+	d, err := compareStoredBody("<p>hello world</p>", "<p>hello</p>", bodyFormatXHTML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.VisibleSent != len("hello world") || d.VisibleStored != len("hello") {
+		t.Errorf("visible counts = %d/%d, want %d/%d", d.VisibleSent, d.VisibleStored, len("hello world"), len("hello"))
+	}
+	report := driftReport(t, d)
+	if strings.Contains(report, "0 characters") {
+		t.Errorf("report claimed zero characters for a measured body:\n%s", report)
+	}
+}
+
+// An atoms-only change has no position in the visible text, so none is
+// claimed.
+func TestAtomOnlyChangeReportsNoTextOffset(t *testing.T) {
+	sent := adfDoc(`{"type":"text","text":"hello"},{"type":"inlineCard","attrs":{"url":"https://example.test/a"}}`)
+	stored := adfDoc(`{"type":"text","text":"hello"},{"type":"inlineCard","attrs":{"url":"https://example.test/b"}}`)
+	d, err := compareStoredBody(sent, stored, bodyFormatADF)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if off := diffOffset(d.SentVisible, d.StoredVisible); off != -1 {
+		t.Errorf("diffOffset = %d, want -1: the visible text is identical", off)
+	}
+	if r := driftReport(t, d); strings.Contains(r, "first difference at offset") {
+		t.Errorf("report claimed a text position for an atoms-only change:\n%s", r)
+	}
 }

--- a/tools/cfl/internal/cmd/page/verify_test.go
+++ b/tools/cfl/internal/cmd/page/verify_test.go
@@ -1,8 +1,19 @@
 package page
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/open-cli-collective/confluence-cli/api"
+
+	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
+
+	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 )
 
 // adfDoc builds a minimal ADF document around one paragraph's content JSON.
@@ -74,8 +85,8 @@ func TestDroppedAttrIsNotTextLoss(t *testing.T) {
 	if d.TextChanged {
 		t.Error("attribute normalization reported as text loss")
 	}
-	lines := strings.Join(describeDrift(d, bodyFormatADF), "\n")
-	if !strings.Contains(lines, "Text content is intact") {
+	lines := driftReport(t, d)
+	if !strings.Contains(lines, "Content is intact") {
 		t.Errorf("report should say the text survived, got:\n%s", lines)
 	}
 	if !strings.Contains(lines, "__confluenceMetadata") {
@@ -156,11 +167,169 @@ func TestDescribeDriftPointsAtTheDifference(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lines := strings.Join(describeDrift(d, bodyFormatADF), "\n")
-	if !strings.Contains(lines, "does not contain the content supplied") {
+	lines := driftReport(t, d)
+	if !strings.Contains(lines, "does not hold the content supplied") {
 		t.Errorf("report should state the content did not land, got:\n%s", lines)
 	}
 	if !strings.Contains(lines, "offset") {
 		t.Errorf("report should locate the difference, got:\n%s", lines)
+	}
+}
+
+// driftReport renders a finding through the presenter that owns the wording,
+// so the tests assert on what an operator actually reads.
+func driftReport(t *testing.T, d writeDrift) string {
+	t.Helper()
+	model := cflpresent.PagePresenter{}.PresentWriteDrift(cflpresent.WriteDrift{
+		BodyFormat:   bodyFormatADF,
+		TextChanged:  d.TextChanged,
+		SentLen:      len(d.SentText),
+		StoredLen:    len(d.StoredText),
+		Difference:   firstTextDifference(d.SentText, d.StoredText),
+		DroppedAttrs: d.DroppedAttrs,
+		AddedAttrs:   d.AddedAttrs,
+	})
+	var b strings.Builder
+	for _, sec := range model.Sections {
+		if msg, ok := sec.(*sharedpresent.MessageSection); ok {
+			b.WriteString(msg.Message)
+		}
+	}
+	return b.String()
+}
+
+// A dropped content atom is content loss, not normalization: the text is
+// unchanged when an entire card, image or mention disappears.
+func TestContentAtomLossCountsAsContentChange(t *testing.T) {
+	sent := adfDoc(`{"type":"text","text":"see "},{"type":"inlineCard","attrs":{"url":"https://example.test/x"}}`)
+	stored := adfDoc(`{"type":"text","text":"see "}`)
+	d, err := compareStoredBody(sent, stored, bodyFormatADF)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.TextChanged {
+		t.Error("a dropped inlineCard was not reported as content loss")
+	}
+}
+
+// Swapping one atom for another keeps every count identical, so identity has
+// to be part of the fingerprint.
+func TestContentAtomSubstitutionDetected(t *testing.T) {
+	sent := adfDoc(`{"type":"inlineCard","attrs":{"url":"https://example.test/a"}}`)
+	stored := adfDoc(`{"type":"inlineCard","attrs":{"url":"https://example.test/b"}}`)
+	d, err := compareStoredBody(sent, stored, bodyFormatADF)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.TextChanged {
+		t.Error("a substituted inlineCard was not reported as content loss")
+	}
+}
+
+// driftServer serves a page whose GET body is whatever storedBody returns,
+// so a test can make Confluence "store" something other than what was sent.
+func driftServer(t *testing.T, storedBody func(sent map[string]any) string) (*httptest.Server, *int) {
+	t.Helper()
+	gets := 0
+	var received map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			gets++
+			w.WriteHeader(http.StatusOK)
+			body := `{"storage":{"value":"<p>Old</p>"}}`
+			if received != nil {
+				body = storedBody(received)
+			}
+			_, _ = w.Write([]byte(`{"id":"12345","title":"Test","version":{"number":1},"body":` + body + `,"_links":{"webui":"/pages/12345"}}`))
+		case "PUT":
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &received)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"12345","title":"Test","version":{"number":2},"_links":{"webui":"/pages/12345"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	return srv, &gets
+}
+
+func editOptsFor(t *testing.T, srv *httptest.Server, content string, noVerify bool) *editOptions {
+	t.Helper()
+	rootOpts := newEditTestRootOptions()
+	rootOpts.SetAPIClient(api.NewClient(srv.URL, "test@example.com", "token"))
+	rootOpts.Stdin = strings.NewReader(content)
+	return &editOptions{
+		Options:    rootOpts,
+		pageID:     "12345",
+		file:       "-",
+		bodyFormat: bodyFormatXHTML,
+		noVerify:   noVerify,
+	}
+}
+
+// The point of the feature: a write the server quietly altered must fail
+// rather than report the version number and exit zero.
+func TestRunEditFailsWhenStoredContentDiffers(t *testing.T) {
+	srv, _ := driftServer(t, func(map[string]any) string {
+		return `{"storage":{"value":"<p>something else entirely</p>"}}`
+	})
+	defer srv.Close()
+
+	err := runEdit(context.Background(), editOptsFor(t, srv, "<p>what we sent</p>", false))
+	if err == nil {
+		t.Fatal("expected an error when the stored body does not match what was sent")
+	}
+	if !strings.Contains(err.Error(), "does not match what was sent") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// --no-verify keeps the old behavior, including skipping the extra read.
+func TestRunEditNoVerifySkipsReadback(t *testing.T) {
+	srv, gets := driftServer(t, func(map[string]any) string {
+		return `{"storage":{"value":"<p>something else entirely</p>"}}`
+	})
+	defer srv.Close()
+
+	before := *gets
+	if err := runEdit(context.Background(), editOptsFor(t, srv, "<p>what we sent</p>", true)); err != nil {
+		t.Fatalf("--no-verify should not fail on drift: %v", err)
+	}
+	if after := *gets - before; after != 1 {
+		t.Errorf("GET count = %d, want 1 (the pre-write fetch only)", after)
+	}
+}
+
+// Normalization is not failure: the write stands and the drift is reported.
+func TestRunEditToleratesNormalization(t *testing.T) {
+	srv, _ := driftServer(t, func(map[string]any) string {
+		// Same text, markup rewritten — what storage-format normalization
+		// looks like.
+		return `{"storage":{"value":"<p class=\"auto\">what we sent</p>"}}`
+	})
+	defer srv.Close()
+
+	if err := runEdit(context.Background(), editOptsFor(t, srv, "<p>what we sent</p>", false)); err != nil {
+		t.Fatalf("normalized markup should not fail the write: %v", err)
+	}
+}
+
+// Markdown is converted before sending, so verification must not run and
+// must not invent a mismatch.
+func TestRunEditSkipsVerificationForMarkdown(t *testing.T) {
+	srv, gets := driftServer(t, func(map[string]any) string {
+		return `{"storage":{"value":"<p>totally different</p>"}}`
+	})
+	defer srv.Close()
+
+	opts := editOptsFor(t, srv, "# heading", false)
+	opts.bodyFormat = bodyFormatMarkdown
+	before := *gets
+	if err := runEdit(context.Background(), opts); err != nil {
+		t.Fatalf("markdown edit should not be verified: %v", err)
+	}
+	if after := *gets - before; after != 1 {
+		t.Errorf("GET count = %d, want 1 (no verification read)", after)
 	}
 }

--- a/tools/cfl/internal/cmd/page/verify_test.go
+++ b/tools/cfl/internal/cmd/page/verify_test.go
@@ -189,6 +189,7 @@ func driftReport(t *testing.T, d writeDrift) string {
 		DiffOffset:    diffOffset(d.SentVisible, d.StoredVisible),
 		SentExcerpt:   readableExcerpt(d.SentVisible, diffOffset(d.SentVisible, d.StoredVisible)),
 		StoredExcerpt: readableExcerpt(d.StoredVisible, diffOffset(d.SentVisible, d.StoredVisible)),
+		AtomChanges:   d.AtomChanges,
 		DroppedAttrs:  d.DroppedAttrs,
 		AddedAttrs:    d.AddedAttrs,
 	})
@@ -523,5 +524,23 @@ func TestAtomOnlyChangeReportsNoTextOffset(t *testing.T) {
 	}
 	if r := driftReport(t, d); strings.Contains(r, "first difference at offset") {
 		t.Errorf("report claimed a text position for an atoms-only change:\n%s", r)
+	}
+}
+
+// hardBreak and rule carry no attributes, so a change confined to them has
+// no attribute lines to identify it. The atom names have to carry that.
+func TestAttributelessAtomChangeIsNamed(t *testing.T) {
+	sent := adfDoc(`{"type":"text","text":"a"},{"type":"hardBreak"},{"type":"text","text":"b"}`)
+	stored := adfDoc(`{"type":"text","text":"a"},{"type":"text","text":"b"}`)
+	d, err := compareStoredBody(sent, stored, bodyFormatADF)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.DroppedAttrs) != 0 {
+		t.Fatalf("precondition: hardBreak should contribute no attributes, got %v", d.DroppedAttrs)
+	}
+	report := driftReport(t, d)
+	if !strings.Contains(report, "hardBreak") {
+		t.Errorf("report must name the changed atom when no attributes can:\n%s", report)
 	}
 }

--- a/tools/cfl/internal/cmd/page/verify_test.go
+++ b/tools/cfl/internal/cmd/page/verify_test.go
@@ -183,8 +183,9 @@ func driftReport(t *testing.T, d writeDrift) string {
 	model := cflpresent.PagePresenter{}.PresentWriteDrift(cflpresent.WriteDrift{
 		BodyFormat:    bodyFormatADF,
 		TextChanged:   d.TextChanged,
-		SentLen:       len(d.SentText),
-		StoredLen:     len(d.StoredText),
+		VisibleSent:   d.VisibleSent,
+		VisibleStored: d.VisibleStored,
+		AtomsChanged:  d.AtomsChanged,
 		DiffOffset:    diffOffset(d.SentText, d.StoredText),
 		SentExcerpt:   readableExcerpt(d.SentText, diffOffset(d.SentText, d.StoredText)),
 		StoredExcerpt: readableExcerpt(d.StoredText, diffOffset(d.SentText, d.StoredText)),
@@ -452,4 +453,42 @@ func TestRunCreateToleratesNormalization(t *testing.T) {
 	if err := runCreate(context.Background(), createOptsFor(t, srv, "<p>what we sent</p>", false)); err != nil {
 		t.Fatalf("normalized markup should not fail the create: %v", err)
 	}
+}
+
+// The numbers reported must describe the document, not the internal
+// fingerprint: an atom marker must not inflate a character count, and a
+// multibyte change must not report equal lengths as if nothing moved.
+func TestReportedCountsDescribeTheDocument(t *testing.T) {
+	t.Run("atom does not inflate the character count", func(t *testing.T) {
+		sent := adfDoc(`{"type":"text","text":"hello ."},{"type":"inlineCard","attrs":{"url":"https://example.test/a-very-long-url"}}`)
+		stored := adfDoc(`{"type":"text","text":"hello ."}`)
+		d, err := compareStoredBody(sent, stored, bodyFormatADF)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.VisibleSent != 7 {
+			t.Errorf("VisibleSent = %d, want 7 (the characters a reader sees)", d.VisibleSent)
+		}
+		if !d.AtomsChanged {
+			t.Error("AtomsChanged = false, but only the embedded card differs")
+		}
+		if r := driftReport(t, d); !strings.Contains(r, "embedded content differs") {
+			t.Errorf("report should say the embedded content changed:\n%s", r)
+		}
+	})
+
+	t.Run("multibyte text counts runes", func(t *testing.T) {
+		sent := adfDoc(`{"type":"text","text":"日本語テキスト"}`)
+		stored := adfDoc(`{"type":"text","text":"日本語"}`)
+		d, err := compareStoredBody(sent, stored, bodyFormatADF)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.VisibleSent != 7 || d.VisibleStored != 3 {
+			t.Errorf("visible counts = %d/%d, want 7/3 runes", d.VisibleSent, d.VisibleStored)
+		}
+		if off := diffOffset(d.SentText, d.StoredText); off != 3 {
+			t.Errorf("diffOffset = %d, want 3 (runes, not bytes)", off)
+		}
+	})
 }

--- a/tools/cfl/internal/cmd/page/verify_test.go
+++ b/tools/cfl/internal/cmd/page/verify_test.go
@@ -1,0 +1,166 @@
+package page
+
+import (
+	"strings"
+	"testing"
+)
+
+// adfDoc builds a minimal ADF document around one paragraph's content JSON.
+func adfDoc(paragraphContent string) string {
+	return `{"type":"doc","version":1,"content":[{"type":"paragraph","content":[` + paragraphContent + `]}]}`
+}
+
+func TestCompareStoredBodyADF(t *testing.T) {
+	// The case this exists for: Confluence stores the text but drops the
+	// __confluenceMetadata it will not accept back on a link mark.
+	sentLink := adfDoc(`{"type":"text","text":"see A11","marks":[{"type":"link","attrs":{"href":"https://example.test#a11","__confluenceMetadata":{"linkType":"page"}}}]}`)
+	storedLink := adfDoc(`{"type":"text","text":"see A11","marks":[{"type":"link","attrs":{"href":"https://example.test#a11"}}]}`)
+
+	tests := []struct {
+		name            string
+		sent, stored    string
+		wantTextChanged bool
+		wantDropped     int
+		wantClean       bool
+	}{
+		{
+			name:      "identical documents",
+			sent:      adfDoc(`{"type":"text","text":"hello"}`),
+			stored:    adfDoc(`{"type":"text","text":"hello"}`),
+			wantClean: true,
+		},
+		{
+			name:            "text silently changed",
+			sent:            adfDoc(`{"type":"text","text":"hello"}`),
+			stored:          adfDoc(`{"type":"text","text":"hell"}`),
+			wantTextChanged: true,
+		},
+		{
+			name:        "server dropped a link attribute but kept the text",
+			sent:        sentLink,
+			stored:      storedLink,
+			wantDropped: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := compareStoredBody(tc.sent, tc.stored, bodyFormatADF)
+			if err != nil {
+				t.Fatalf("compareStoredBody: %v", err)
+			}
+			if d.TextChanged != tc.wantTextChanged {
+				t.Errorf("TextChanged = %v, want %v", d.TextChanged, tc.wantTextChanged)
+			}
+			if len(d.DroppedAttrs) != tc.wantDropped {
+				t.Errorf("DroppedAttrs = %v, want %d", d.DroppedAttrs, tc.wantDropped)
+			}
+			if d.Clean() != tc.wantClean {
+				t.Errorf("Clean() = %v, want %v", d.Clean(), tc.wantClean)
+			}
+		})
+	}
+}
+
+// Dropping an attribute must not be reported as losing content: the two
+// carry different consequences, and conflating them would either cry wolf on
+// every normalized write or hide a real one.
+func TestDroppedAttrIsNotTextLoss(t *testing.T) {
+	sent := adfDoc(`{"type":"text","text":"same text","marks":[{"type":"link","attrs":{"href":"h","__confluenceMetadata":{"linkType":"page"}}}]}`)
+	stored := adfDoc(`{"type":"text","text":"same text","marks":[{"type":"link","attrs":{"href":"h"}}]}`)
+	d, err := compareStoredBody(sent, stored, bodyFormatADF)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.TextChanged {
+		t.Error("attribute normalization reported as text loss")
+	}
+	lines := strings.Join(describeDrift(d, bodyFormatADF), "\n")
+	if !strings.Contains(lines, "Text content is intact") {
+		t.Errorf("report should say the text survived, got:\n%s", lines)
+	}
+	if !strings.Contains(lines, "__confluenceMetadata") {
+		t.Errorf("report should name the dropped attribute, got:\n%s", lines)
+	}
+}
+
+// Text order matters: two documents with the same words in different order
+// are not the same document.
+func TestADFTextRespectsOrder(t *testing.T) {
+	a := adfDoc(`{"type":"text","text":"one "},{"type":"text","text":"two"}`)
+	b := adfDoc(`{"type":"text","text":"two"},{"type":"text","text":"one "}`)
+	d, err := compareStoredBody(a, b, bodyFormatADF)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.TextChanged {
+		t.Error("reordered text reported as unchanged")
+	}
+}
+
+func TestCompareStoredBodyXHTMLComparesText(t *testing.T) {
+	tests := []struct {
+		name         string
+		sent, stored string
+		wantChanged  bool
+	}{
+		{
+			name:   "markup rewritten, text preserved",
+			sent:   "<p>hello <strong>world</strong></p>",
+			stored: `<p class="auto">hello <b>world</b></p>`,
+		},
+		{
+			name:        "text actually lost",
+			sent:        "<p>hello world</p>",
+			stored:      "<p>hello</p>",
+			wantChanged: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := compareStoredBody(tc.sent, tc.stored, bodyFormatXHTML)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if d.TextChanged != tc.wantChanged {
+				t.Errorf("TextChanged = %v, want %v (sent %q stored %q)", d.TextChanged, tc.wantChanged, xhtmlText(tc.sent), xhtmlText(tc.stored))
+			}
+		})
+	}
+}
+
+// Markdown is converted before it is sent, so there is nothing to compare it
+// against; saying so is better than reporting a false mismatch.
+func TestCompareStoredBodyRejectsMarkdown(t *testing.T) {
+	_, err := compareStoredBody("# hi", "{}", bodyFormatMarkdown)
+	if err == nil {
+		t.Fatal("expected an error for markdown input")
+	}
+	if !strings.Contains(err.Error(), "converted before sending") {
+		t.Errorf("error should explain why markdown is not comparable, got: %v", err)
+	}
+}
+
+// An unparseable body means the write could not be verified, which must not
+// be reported as a verified write.
+func TestCompareStoredBodyUnparseable(t *testing.T) {
+	if _, err := compareStoredBody(`{"type":"doc"}`, "not json", bodyFormatADF); err == nil {
+		t.Fatal("expected an error when the stored body cannot be parsed")
+	}
+}
+
+func TestDescribeDriftPointsAtTheDifference(t *testing.T) {
+	d, err := compareStoredBody(
+		adfDoc(`{"type":"text","text":"alpha bravo charlie"}`),
+		adfDoc(`{"type":"text","text":"alpha bravo"}`),
+		bodyFormatADF)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Join(describeDrift(d, bodyFormatADF), "\n")
+	if !strings.Contains(lines, "does not contain the content supplied") {
+		t.Errorf("report should state the content did not land, got:\n%s", lines)
+	}
+	if !strings.Contains(lines, "offset") {
+		t.Errorf("report should locate the difference, got:\n%s", lines)
+	}
+}

--- a/tools/cfl/internal/present/mutation.go
+++ b/tools/cfl/internal/present/mutation.go
@@ -2,6 +2,7 @@ package present
 
 import (
 	"fmt"
+	"strings"
 
 	sharedpresent "github.com/open-cli-collective/atlassian-go/present"
 
@@ -121,4 +122,56 @@ func pageVersionValue(v *api.Version) string {
 		return "-"
 	}
 	return fmt.Sprintf("%d", v.Number)
+}
+
+// WriteDrift describes how a stored page body differed from the body that
+// was submitted. Commands supply the finding; the wording is owned here.
+type WriteDrift struct {
+	BodyFormat   string
+	TextChanged  bool
+	SentLen      int
+	StoredLen    int
+	Difference   string
+	DroppedAttrs []string
+	AddedAttrs   []string
+}
+
+// PresentWriteDrift reports what Confluence stored versus what was sent.
+// Losing content and normalizing attributes are worded differently because
+// they oblige the reader differently: one means the change did not land, the
+// other means it landed in a document the server tidied.
+func (PagePresenter) PresentWriteDrift(d WriteDrift) *sharedpresent.OutputModel {
+	var lines []string
+	if d.TextChanged {
+		lines = append(lines,
+			fmt.Sprintf("Stored %s body does not match what was sent: content differs (%d chars sent, %d stored).", d.BodyFormat, d.SentLen, d.StoredLen),
+			"The page was updated, but it does not hold the content supplied. Re-read the page before treating the change as applied.",
+		)
+		if d.Difference != "" {
+			lines = append(lines, "  first difference: "+d.Difference)
+		}
+	} else {
+		if len(d.DroppedAttrs) > 0 {
+			lines = append(lines, fmt.Sprintf("Confluence normalized the stored %s body. Content is intact; these attributes were dropped:", d.BodyFormat))
+			for _, a := range d.DroppedAttrs {
+				lines = append(lines, "  - "+a)
+			}
+		}
+		if len(d.AddedAttrs) > 0 {
+			lines = append(lines, "Confluence added attributes that were not sent:")
+			for _, a := range d.AddedAttrs {
+				lines = append(lines, "  + "+a)
+			}
+		}
+	}
+	if len(lines) == 0 {
+		return &sharedpresent.OutputModel{}
+	}
+	return &sharedpresent.OutputModel{Sections: []sharedpresent.Section{
+		&sharedpresent.MessageSection{
+			Kind:    sharedpresent.MessageWarning,
+			Message: strings.Join(lines, "\n"),
+			Stream:  sharedpresent.StreamStderr,
+		},
+	}}
 }

--- a/tools/cfl/internal/present/mutation.go
+++ b/tools/cfl/internal/present/mutation.go
@@ -144,6 +144,25 @@ type WriteDrift struct {
 	AddedAttrs    []string
 }
 
+// attrLines lists attribute changes, which identify the embedded content
+// involved when the visible text cannot.
+func attrLines(d WriteDrift) []string {
+	var lines []string
+	if len(d.DroppedAttrs) > 0 {
+		lines = append(lines, "  attributes dropped:")
+		for _, a := range d.DroppedAttrs {
+			lines = append(lines, "    - "+a)
+		}
+	}
+	if len(d.AddedAttrs) > 0 {
+		lines = append(lines, "  attributes added:")
+		for _, a := range d.AddedAttrs {
+			lines = append(lines, "    + "+a)
+		}
+	}
+	return lines
+}
+
 // describeContentChange states what moved in terms of the document: the
 // characters a reader sees, and whether embedded content changed underneath
 // unchanged text.
@@ -171,6 +190,9 @@ func (PagePresenter) PresentWriteDrift(d WriteDrift) *sharedpresent.OutputModel 
 		if d.DiffOffset >= 0 {
 			lines = append(lines, fmt.Sprintf("  first difference at offset %d — sent %q, stored %q", d.DiffOffset, d.SentExcerpt, d.StoredExcerpt))
 		}
+		// Name what vanished. When only embedded content moved there is no
+		// text position to point at, so this is the only detail available.
+		lines = append(lines, attrLines(d)...)
 	} else {
 		if len(d.DroppedAttrs) > 0 {
 			lines = append(lines, fmt.Sprintf("Confluence normalized the stored %s body. Content is intact; these attributes were dropped:", d.BodyFormat))

--- a/tools/cfl/internal/present/mutation.go
+++ b/tools/cfl/internal/present/mutation.go
@@ -127,13 +127,18 @@ func pageVersionValue(v *api.Version) string {
 // WriteDrift describes how a stored page body differed from the body that
 // was submitted. Commands supply the finding; the wording is owned here.
 type WriteDrift struct {
-	BodyFormat   string
-	TextChanged  bool
-	SentLen      int
-	StoredLen    int
-	Difference   string
-	DroppedAttrs []string
-	AddedAttrs   []string
+	BodyFormat string
+	// TextChanged reports that content differs, not merely formatting.
+	TextChanged bool
+	SentLen     int
+	StoredLen   int
+	// DiffOffset is where the two bodies first diverge, or -1 when they do
+	// not. SentExcerpt and StoredExcerpt are the text from that point.
+	DiffOffset    int
+	SentExcerpt   string
+	StoredExcerpt string
+	DroppedAttrs  []string
+	AddedAttrs    []string
 }
 
 // PresentWriteDrift reports what Confluence stored versus what was sent.
@@ -147,8 +152,8 @@ func (PagePresenter) PresentWriteDrift(d WriteDrift) *sharedpresent.OutputModel 
 			fmt.Sprintf("Stored %s body does not match what was sent: content differs (%d chars sent, %d stored).", d.BodyFormat, d.SentLen, d.StoredLen),
 			"The page was updated, but it does not hold the content supplied. Re-read the page before treating the change as applied.",
 		)
-		if d.Difference != "" {
-			lines = append(lines, "  first difference: "+d.Difference)
+		if d.DiffOffset >= 0 {
+			lines = append(lines, fmt.Sprintf("  first difference at offset %d — sent %q, stored %q", d.DiffOffset, d.SentExcerpt, d.StoredExcerpt))
 		}
 	} else {
 		if len(d.DroppedAttrs) > 0 {

--- a/tools/cfl/internal/present/mutation.go
+++ b/tools/cfl/internal/present/mutation.go
@@ -140,14 +140,22 @@ type WriteDrift struct {
 	DiffOffset    int
 	SentExcerpt   string
 	StoredExcerpt string
-	DroppedAttrs  []string
-	AddedAttrs    []string
+	// AtomChanges names embedded node types whose counts moved.
+	AtomChanges  []string
+	DroppedAttrs []string
+	AddedAttrs   []string
 }
 
 // attrLines lists attribute changes, which identify the embedded content
 // involved when the visible text cannot.
 func attrLines(d WriteDrift) []string {
 	var lines []string
+	if len(d.AtomChanges) > 0 {
+		lines = append(lines, "  embedded content changed:")
+		for _, a := range d.AtomChanges {
+			lines = append(lines, "    ~ "+a)
+		}
+	}
 	if len(d.DroppedAttrs) > 0 {
 		lines = append(lines, "  attributes dropped:")
 		for _, a := range d.DroppedAttrs {

--- a/tools/cfl/internal/present/mutation.go
+++ b/tools/cfl/internal/present/mutation.go
@@ -130,8 +130,11 @@ type WriteDrift struct {
 	BodyFormat string
 	// TextChanged reports that content differs, not merely formatting.
 	TextChanged bool
-	SentLen     int
-	StoredLen   int
+	// VisibleSent and VisibleStored count characters a reader sees.
+	VisibleSent   int
+	VisibleStored int
+	// AtomsChanged reports embedded content differing where the text does not.
+	AtomsChanged bool
 	// DiffOffset is where the two bodies first diverge, or -1 when they do
 	// not. SentExcerpt and StoredExcerpt are the text from that point.
 	DiffOffset    int
@@ -139,6 +142,19 @@ type WriteDrift struct {
 	StoredExcerpt string
 	DroppedAttrs  []string
 	AddedAttrs    []string
+}
+
+// describeContentChange states what moved in terms of the document: the
+// characters a reader sees, and whether embedded content changed underneath
+// unchanged text.
+func describeContentChange(d WriteDrift) string {
+	if d.AtomsChanged {
+		return fmt.Sprintf("visible text is unchanged at %d characters, but embedded content differs", d.VisibleSent)
+	}
+	if d.VisibleSent == d.VisibleStored {
+		return fmt.Sprintf("content differs at the same length of %d characters", d.VisibleSent)
+	}
+	return fmt.Sprintf("visible text went from %d to %d characters", d.VisibleSent, d.VisibleStored)
 }
 
 // PresentWriteDrift reports what Confluence stored versus what was sent.
@@ -149,7 +165,7 @@ func (PagePresenter) PresentWriteDrift(d WriteDrift) *sharedpresent.OutputModel 
 	var lines []string
 	if d.TextChanged {
 		lines = append(lines,
-			fmt.Sprintf("Stored %s body does not match what was sent: content differs (%d chars sent, %d stored).", d.BodyFormat, d.SentLen, d.StoredLen),
+			fmt.Sprintf("Stored %s body does not match what was sent: %s.", d.BodyFormat, describeContentChange(d)),
 			"The page was updated, but it does not hold the content supplied. Re-read the page before treating the change as applied.",
 		)
 		if d.DiffOffset >= 0 {


### PR DESCRIPTION
## [INT-725]

`cfl page edit` reported success from the update response alone. For an exact body format cfl transmits the caller's content **verbatim** (`bodyForInput` passes the string through with no re-serialization), so when Confluence stores something different, nothing surfaced it.

### The failure this came from

Editing a real page with `--body-format adf` silently lost `__confluenceMetadata` on eight link marks. cfl sent them correctly; Confluence dropped them server-side. The command printed `Version: 6` and exited zero.

It was only found later by re-fetching and diffing by hand — by which point those intra-page anchor links (`see also A11`) had degraded to full expanded URLs. Worth noting the loss is **not recoverable through the API**: sending the attributes back gets them stripped again, so the damage outlives the discovery.

### What this adds

After a successful write with `--body-format adf` or `xhtml`, re-read the page in that format and compare what was stored against what was sent.

The two kinds of difference are reported separately because they carry different consequences:

| Difference | Meaning | Result |
|---|---|---|
| **Text content** differs | the caller's content did not land | error, non-zero exit |
| **Attributes** differ | server normalized around content that survived | reported, tolerated |

Conflating them would either cry wolf on every normalized write or hide a real one.

Markdown is converted to ADF before sending, so the stored body isn't comparable to what was supplied — verification is skipped there rather than reporting a false mismatch. An unparseable body is an error, not a pass: an unverifiable write is not a verified one.

`--no-verify` opts out of the extra read.

### Note on the default

This is **on by default** for exact formats, which is a behavior change: one extra GET per write, and a new way for the command to exit non-zero. I think that's right — verification you have to remember to ask for is the failure mode this is fixing — but it's your call and easy to flip to opt-in.

### Test doubles

Six edit tests failed immediately on this change, which was itself informative: their fakes returned the original body on every GET regardless of what was PUT, so verification correctly saw drift on writes that had succeeded. Real Confluence returns what it stored, so `mockEditBodyServer` and five inline handlers now do too. They previously asserted nothing about the server's response.

### Validation

- `make test` and `make lint` green across all three modules (0 issues).
- Unit tests cover: identical documents, silent text change, dropped attribute with text intact, text reordering, XHTML markup rewritten vs text lost, markdown rejection, unparseable body, and that the report names the dropped attribute and locates the first text difference.
- Exercised against live Confluence: a re-save of an unchanged page passes clean with no false positive.