### PR TITLE
ci: INT-726 let scoped PRs satisfy their required checks

### DIFF
--- a/.github/actions/required-check/action.yml
+++ b/.github/actions/required-check/action.yml
@@ -1,0 +1,47 @@
+name: Required check
+description: >-
+  Report a protected check from the job that did the work. Branch protection
+  does not accept a skipped check as satisfied, so a tool-scoped PR cannot
+  merge while the other tool's jobs skip. A wrapper using this action always
+  runs and passes on that job's behalf.
+
+inputs:
+  job:
+    description: Name of the job whose outcome is being reported.
+    required: true
+  result:
+    description: result of that job (needs.<job>.result).
+    required: true
+  gate-result:
+    description: >-
+      result of the job whose outputs decide whether the work runs. A skip is
+      only meaningful if this succeeded; when it did not, the work was skipped
+      for an unrelated reason and nothing was verified.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        JOB: ${{ inputs.job }}
+        RESULT: ${{ inputs.result }}
+        GATE: ${{ inputs.gate-result }}
+      run: |
+        set -euo pipefail
+        if [ "$GATE" != "success" ]; then
+          echo "::error::change detection did not succeed (result: $GATE), so $JOB was skipped for an unrelated reason and nothing was verified"
+          exit 1
+        fi
+        case "$RESULT" in
+          success)
+            echo "$JOB ran and passed"
+            ;;
+          skipped)
+            echo "$JOB had no relevant changes; nothing to verify"
+            ;;
+          *)
+            echo "::error::$JOB result: $RESULT"
+            exit 1
+            ;;
+        esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,104 +209,82 @@ jobs:
           title: ${{ github.event.pull_request.title }}
 
   # Required-check wrappers (INT-726). Branch protection requires these
-  # names, and GitHub does not accept a skipped check as satisfied, so a
-  # PR touching one tool could not merge without an admin bypass. Each
-  # wrapper always runs and reports the outcome of the job that does the
-  # work, treating "skipped" as a pass because there was nothing to do.
-  # The guard lives here alone, so steps added to the -run jobs need no
-  # per-step condition.
+  # names, and GitHub does not accept a skipped check as satisfied, so a PR
+  # touching one tool could not merge without an admin bypass. Each wrapper
+  # always runs and reports on behalf of the job that does the work, so the
+  # -run jobs stay free of per-step guards.
+  #
+  # detect-changes is in needs so a skip can be told apart from a skip
+  # caused by change detection failing, which would otherwise pass every
+  # required check with nothing verified.
   build-test-cfl:
-    needs: build-test-cfl-run
+    needs: [detect-changes, build-test-cfl-run]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Report build-test-cfl-run outcome
-        env:
-          RESULT: ${{ needs.build-test-cfl-run.result }}
-        run: |
-          set -euo pipefail
-          case "$RESULT" in
-            success) echo "ran and passed" ;;
-            skipped) echo "no changes for this tool; nothing to verify" ;;
-            *) echo "job result: $RESULT"; exit 1 ;;
-          esac
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/required-check
+        with:
+          job: build-test-cfl-run
+          result: ${{ needs.build-test-cfl-run.result }}
+          gate-result: ${{ needs.detect-changes.result }}
 
   build-test-jtk:
-    needs: build-test-jtk-run
+    needs: [detect-changes, build-test-jtk-run]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Report build-test-jtk-run outcome
-        env:
-          RESULT: ${{ needs.build-test-jtk-run.result }}
-        run: |
-          set -euo pipefail
-          case "$RESULT" in
-            success) echo "ran and passed" ;;
-            skipped) echo "no changes for this tool; nothing to verify" ;;
-            *) echo "job result: $RESULT"; exit 1 ;;
-          esac
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/required-check
+        with:
+          job: build-test-jtk-run
+          result: ${{ needs.build-test-jtk-run.result }}
+          gate-result: ${{ needs.detect-changes.result }}
 
   lint-cfl:
-    needs: lint-cfl-run
+    needs: [detect-changes, lint-cfl-run]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Report lint-cfl-run outcome
-        env:
-          RESULT: ${{ needs.lint-cfl-run.result }}
-        run: |
-          set -euo pipefail
-          case "$RESULT" in
-            success) echo "ran and passed" ;;
-            skipped) echo "no changes for this tool; nothing to verify" ;;
-            *) echo "job result: $RESULT"; exit 1 ;;
-          esac
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/required-check
+        with:
+          job: lint-cfl-run
+          result: ${{ needs.lint-cfl-run.result }}
+          gate-result: ${{ needs.detect-changes.result }}
 
   lint-jtk:
-    needs: lint-jtk-run
+    needs: [detect-changes, lint-jtk-run]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Report lint-jtk-run outcome
-        env:
-          RESULT: ${{ needs.lint-jtk-run.result }}
-        run: |
-          set -euo pipefail
-          case "$RESULT" in
-            success) echo "ran and passed" ;;
-            skipped) echo "no changes for this tool; nothing to verify" ;;
-            *) echo "job result: $RESULT"; exit 1 ;;
-          esac
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/required-check
+        with:
+          job: lint-jtk-run
+          result: ${{ needs.lint-jtk-run.result }}
+          gate-result: ${{ needs.detect-changes.result }}
 
   identity-check-cfl:
-    needs: identity-check-cfl-run
+    needs: [detect-changes, identity-check-cfl-run]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Report identity-check-cfl-run outcome
-        env:
-          RESULT: ${{ needs.identity-check-cfl-run.result }}
-        run: |
-          set -euo pipefail
-          case "$RESULT" in
-            success) echo "ran and passed" ;;
-            skipped) echo "no changes for this tool; nothing to verify" ;;
-            *) echo "job result: $RESULT"; exit 1 ;;
-          esac
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/required-check
+        with:
+          job: identity-check-cfl-run
+          result: ${{ needs.identity-check-cfl-run.result }}
+          gate-result: ${{ needs.detect-changes.result }}
 
   identity-check-jtk:
-    needs: identity-check-jtk-run
+    needs: [detect-changes, identity-check-jtk-run]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Report identity-check-jtk-run outcome
-        env:
-          RESULT: ${{ needs.identity-check-jtk-run.result }}
-        run: |
-          set -euo pipefail
-          case "$RESULT" in
-            success) echo "ran and passed" ;;
-            skipped) echo "no changes for this tool; nothing to verify" ;;
-            *) echo "job result: $RESULT"; exit 1 ;;
-          esac
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/required-check
+        with:
+          job: identity-check-jtk-run
+          result: ${{ needs.identity-check-jtk-run.result }}
+          gate-result: ${{ needs.detect-changes.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,18 +40,27 @@ jobs:
 
   build-test-cfl:
     needs: detect-changes
-    if: needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true'
+    # Runs on every PR so the check reports a conclusion; branch
+    # protection requires it, and a skipped check never satisfies that.
+    # The work itself is gated per step (INT-726).
+    env:
+      RELEVANT: ${{ needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: env.RELEVANT == 'true'
       - uses: actions/setup-go@v5
+        if: env.RELEVANT == 'true'
         with:
           go-version: '1.26'
       - name: Tidy cfl
+        if: env.RELEVANT == 'true'
         run: cd tools/cfl && go mod tidy && git diff --exit-code go.mod go.sum
       - name: Build cfl
+        if: env.RELEVANT == 'true'
         run: go build -v ./tools/cfl/...
       - name: Static release build guard cfl
+        if: env.RELEVANT == 'true'
         run: |
           set -euo pipefail
           cd tools/cfl
@@ -70,22 +79,32 @@ jobs:
             fi
           done
       - name: Test cfl
+        if: env.RELEVANT == 'true'
         run: go test -v -race -coverprofile=coverage-cfl.out ./tools/cfl/...
 
   build-test-jtk:
     needs: detect-changes
-    if: needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true'
+    # Runs on every PR so the check reports a conclusion; branch
+    # protection requires it, and a skipped check never satisfies that.
+    # The work itself is gated per step (INT-726).
+    env:
+      RELEVANT: ${{ needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: env.RELEVANT == 'true'
       - uses: actions/setup-go@v5
+        if: env.RELEVANT == 'true'
         with:
           go-version: '1.26'
       - name: Tidy jtk
+        if: env.RELEVANT == 'true'
         run: cd tools/jtk && go mod tidy && git diff --exit-code go.mod go.sum
       - name: Build jtk
+        if: env.RELEVANT == 'true'
         run: go build -v ./tools/jtk/...
       - name: Static release build guard jtk
+        if: env.RELEVANT == 'true'
         run: |
           set -euo pipefail
           cd tools/jtk
@@ -104,32 +123,47 @@ jobs:
             fi
           done
       - name: Test jtk
+        if: env.RELEVANT == 'true'
         run: go test -v -race -coverprofile=coverage-jtk.out ./tools/jtk/...
 
   lint-cfl:
     needs: detect-changes
-    if: needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true'
+    # Runs on every PR so the check reports a conclusion; branch
+    # protection requires it, and a skipped check never satisfies that.
+    # The work itself is gated per step (INT-726).
+    env:
+      RELEVANT: ${{ needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: env.RELEVANT == 'true'
       - uses: actions/setup-go@v5
+        if: env.RELEVANT == 'true'
         with:
           go-version: '1.26'
       - uses: golangci/golangci-lint-action@v7
+        if: env.RELEVANT == 'true'
         with:
           working-directory: tools/cfl
           version: v2.12.2
 
   lint-jtk:
     needs: detect-changes
-    if: needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true'
+    # Runs on every PR so the check reports a conclusion; branch
+    # protection requires it, and a skipped check never satisfies that.
+    # The work itself is gated per step (INT-726).
+    env:
+      RELEVANT: ${{ needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: env.RELEVANT == 'true'
       - uses: actions/setup-go@v5
+        if: env.RELEVANT == 'true'
         with:
           go-version: '1.26'
       - uses: golangci/golangci-lint-action@v7
+        if: env.RELEVANT == 'true'
         with:
           working-directory: tools/jtk
           version: v2.12.2
@@ -182,21 +216,33 @@ jobs:
   # goreleaser_config resolves (distribution.md §8.3 / .github#15).
   identity-check-cfl:
     needs: detect-changes
-    if: needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true'
+    # Runs on every PR so the check reports a conclusion; branch
+    # protection requires it, and a skipped check never satisfies that.
+    # The work itself is gated per step (INT-726).
+    env:
+      RELEVANT: ${{ needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: env.RELEVANT == 'true'
       - uses: open-cli-collective/.github/actions/identity-check@v1
+        if: env.RELEVANT == 'true'
         with:
           working-directory: tools/cfl
 
   identity-check-jtk:
     needs: detect-changes
-    if: needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true'
+    # Runs on every PR so the check reports a conclusion; branch
+    # protection requires it, and a skipped check never satisfies that.
+    # The work itself is gated per step (INT-726).
+    env:
+      RELEVANT: ${{ needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: env.RELEVANT == 'true'
       - uses: open-cli-collective/.github/actions/identity-check@v1
+        if: env.RELEVANT == 'true'
         with:
           working-directory: tools/jtk
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,29 +38,20 @@ jobs:
               - 'Makefile'
               - '.github/workflows/ci.yml'
 
-  build-test-cfl:
+  build-test-cfl-run:
     needs: detect-changes
-    # Runs on every PR so the check reports a conclusion; branch
-    # protection requires it, and a skipped check never satisfies that.
-    # The work itself is gated per step (INT-726).
-    env:
-      RELEVANT: ${{ needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+    if: needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        if: env.RELEVANT == 'true'
       - uses: actions/setup-go@v5
-        if: env.RELEVANT == 'true'
         with:
           go-version: '1.26'
       - name: Tidy cfl
-        if: env.RELEVANT == 'true'
         run: cd tools/cfl && go mod tidy && git diff --exit-code go.mod go.sum
       - name: Build cfl
-        if: env.RELEVANT == 'true'
         run: go build -v ./tools/cfl/...
       - name: Static release build guard cfl
-        if: env.RELEVANT == 'true'
         run: |
           set -euo pipefail
           cd tools/cfl
@@ -79,32 +70,22 @@ jobs:
             fi
           done
       - name: Test cfl
-        if: env.RELEVANT == 'true'
         run: go test -v -race -coverprofile=coverage-cfl.out ./tools/cfl/...
 
-  build-test-jtk:
+  build-test-jtk-run:
     needs: detect-changes
-    # Runs on every PR so the check reports a conclusion; branch
-    # protection requires it, and a skipped check never satisfies that.
-    # The work itself is gated per step (INT-726).
-    env:
-      RELEVANT: ${{ needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+    if: needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        if: env.RELEVANT == 'true'
       - uses: actions/setup-go@v5
-        if: env.RELEVANT == 'true'
         with:
           go-version: '1.26'
       - name: Tidy jtk
-        if: env.RELEVANT == 'true'
         run: cd tools/jtk && go mod tidy && git diff --exit-code go.mod go.sum
       - name: Build jtk
-        if: env.RELEVANT == 'true'
         run: go build -v ./tools/jtk/...
       - name: Static release build guard jtk
-        if: env.RELEVANT == 'true'
         run: |
           set -euo pipefail
           cd tools/jtk
@@ -123,47 +104,32 @@ jobs:
             fi
           done
       - name: Test jtk
-        if: env.RELEVANT == 'true'
         run: go test -v -race -coverprofile=coverage-jtk.out ./tools/jtk/...
 
-  lint-cfl:
+  lint-cfl-run:
     needs: detect-changes
-    # Runs on every PR so the check reports a conclusion; branch
-    # protection requires it, and a skipped check never satisfies that.
-    # The work itself is gated per step (INT-726).
-    env:
-      RELEVANT: ${{ needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+    if: needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        if: env.RELEVANT == 'true'
       - uses: actions/setup-go@v5
-        if: env.RELEVANT == 'true'
         with:
           go-version: '1.26'
       - uses: golangci/golangci-lint-action@v7
-        if: env.RELEVANT == 'true'
         with:
           working-directory: tools/cfl
           version: v2.12.2
 
-  lint-jtk:
+  lint-jtk-run:
     needs: detect-changes
-    # Runs on every PR so the check reports a conclusion; branch
-    # protection requires it, and a skipped check never satisfies that.
-    # The work itself is gated per step (INT-726).
-    env:
-      RELEVANT: ${{ needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+    if: needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        if: env.RELEVANT == 'true'
       - uses: actions/setup-go@v5
-        if: env.RELEVANT == 'true'
         with:
           go-version: '1.26'
       - uses: golangci/golangci-lint-action@v7
-        if: env.RELEVANT == 'true'
         with:
           working-directory: tools/jtk
           version: v2.12.2
@@ -214,35 +180,23 @@ jobs:
   # packaging/identity.yml matches its tool-native files. working-directory is
   # the tool root; repo-root defaults to "." so the root-relative
   # goreleaser_config resolves (distribution.md §8.3 / .github#15).
-  identity-check-cfl:
+  identity-check-cfl-run:
     needs: detect-changes
-    # Runs on every PR so the check reports a conclusion; branch
-    # protection requires it, and a skipped check never satisfies that.
-    # The work itself is gated per step (INT-726).
-    env:
-      RELEVANT: ${{ needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+    if: needs.detect-changes.outputs.cfl == 'true' || needs.detect-changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        if: env.RELEVANT == 'true'
       - uses: open-cli-collective/.github/actions/identity-check@v1
-        if: env.RELEVANT == 'true'
         with:
           working-directory: tools/cfl
 
-  identity-check-jtk:
+  identity-check-jtk-run:
     needs: detect-changes
-    # Runs on every PR so the check reports a conclusion; branch
-    # protection requires it, and a skipped check never satisfies that.
-    # The work itself is gated per step (INT-726).
-    env:
-      RELEVANT: ${{ needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+    if: needs.detect-changes.outputs.jtk == 'true' || needs.detect-changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        if: env.RELEVANT == 'true'
       - uses: open-cli-collective/.github/actions/identity-check@v1
-        if: env.RELEVANT == 'true'
         with:
           working-directory: tools/jtk
 
@@ -253,3 +207,106 @@ jobs:
       - uses: open-cli-collective/.github/actions/pr-title@v1
         with:
           title: ${{ github.event.pull_request.title }}
+
+  # Required-check wrappers (INT-726). Branch protection requires these
+  # names, and GitHub does not accept a skipped check as satisfied, so a
+  # PR touching one tool could not merge without an admin bypass. Each
+  # wrapper always runs and reports the outcome of the job that does the
+  # work, treating "skipped" as a pass because there was nothing to do.
+  # The guard lives here alone, so steps added to the -run jobs need no
+  # per-step condition.
+  build-test-cfl:
+    needs: build-test-cfl-run
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report build-test-cfl-run outcome
+        env:
+          RESULT: ${{ needs.build-test-cfl-run.result }}
+        run: |
+          set -euo pipefail
+          case "$RESULT" in
+            success) echo "ran and passed" ;;
+            skipped) echo "no changes for this tool; nothing to verify" ;;
+            *) echo "job result: $RESULT"; exit 1 ;;
+          esac
+
+  build-test-jtk:
+    needs: build-test-jtk-run
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report build-test-jtk-run outcome
+        env:
+          RESULT: ${{ needs.build-test-jtk-run.result }}
+        run: |
+          set -euo pipefail
+          case "$RESULT" in
+            success) echo "ran and passed" ;;
+            skipped) echo "no changes for this tool; nothing to verify" ;;
+            *) echo "job result: $RESULT"; exit 1 ;;
+          esac
+
+  lint-cfl:
+    needs: lint-cfl-run
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report lint-cfl-run outcome
+        env:
+          RESULT: ${{ needs.lint-cfl-run.result }}
+        run: |
+          set -euo pipefail
+          case "$RESULT" in
+            success) echo "ran and passed" ;;
+            skipped) echo "no changes for this tool; nothing to verify" ;;
+            *) echo "job result: $RESULT"; exit 1 ;;
+          esac
+
+  lint-jtk:
+    needs: lint-jtk-run
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report lint-jtk-run outcome
+        env:
+          RESULT: ${{ needs.lint-jtk-run.result }}
+        run: |
+          set -euo pipefail
+          case "$RESULT" in
+            success) echo "ran and passed" ;;
+            skipped) echo "no changes for this tool; nothing to verify" ;;
+            *) echo "job result: $RESULT"; exit 1 ;;
+          esac
+
+  identity-check-cfl:
+    needs: identity-check-cfl-run
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report identity-check-cfl-run outcome
+        env:
+          RESULT: ${{ needs.identity-check-cfl-run.result }}
+        run: |
+          set -euo pipefail
+          case "$RESULT" in
+            success) echo "ran and passed" ;;
+            skipped) echo "no changes for this tool; nothing to verify" ;;
+            *) echo "job result: $RESULT"; exit 1 ;;
+          esac
+
+  identity-check-jtk:
+    needs: identity-check-jtk-run
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report identity-check-jtk-run outcome
+        env:
+          RESULT: ${{ needs.identity-check-jtk-run.result }}
+        run: |
+          set -euo pipefail
+          case "$RESULT" in
+            success) echo "ran and passed" ;;
+            skipped) echo "no changes for this tool; nothing to verify" ;;
+            *) echo "job result: $RESULT"; exit 1 ;;
+          esac


### PR DESCRIPTION
## [INT-726]

Branch protection requires `build-test-cfl`, `build-test-jtk`, `lint-cfl`, `lint-jtk`, `identity-check-cfl`, `identity-check-jtk`. All six were gated at the **job** level on paths-filter output, so a PR touching one tool skipped the other tool's jobs — and GitHub does not accept a skipped check as a satisfied required check.

**Every single-tool PR in this repo is therefore unmergeable without an admin bypass.** Not an edge case: #464 (cfl-only) and #474 (cfl-only) both hit it, and a jtk-only change hits it in the opposite direction.

The cost isn't the inconvenience. Branch protection works *because* merging over an unmet gate is deliberate and visible. When routine work can't merge without a bypass, the bypass stops being remarkable — and a genuine unmet gate looks exactly like the twenty benign ones before it.

### Change

The six required jobs run on every PR; the paths-filter condition moves to their steps via a job-level `RELEVANT` env. A job with nothing to do now reports **success** instead of **skipped** — an honest result, since the check did run and found no work — and the required checks are satisfied **without touching repository settings**.

`build-test-shared` and `lint-shared` keep their job-level `if`; neither is required, so skipping is fine for them. `pr-title` is unchanged.

### Alternative considered

A rollup gate job with the required list reduced to it also works, but it changes branch protection out of band — settings drift that isn't visible in the repo. The workflow-only fix is self-contained and reviewable.

### Validation — and its limit

`.github/workflows/ci.yml` appears in **all three** paths filters, so changing it marks every tool relevant. **This PR therefore makes all jobs run and cannot demonstrate its own fix.** Green here proves the workflow is valid and non-regressive, not that the skip path now reports success.

What I did verify:
- YAML parses; the six required jobs have no job-level `if` and every step carries the gate; the two non-required shared jobs are untouched.
- `needs` is available to job-level `env`, and `env` is available to step-level `if`, so the condition resolves in both positions.

The real proof is the next tool-scoped PR: its off-tool checks should read **success with all steps skipped** rather than **skipped**. Happy to confirm that with a throwaway cfl-only PR after this merges rather than waiting to find out.