### PR TITLE
feat(cfl): INT-736 refuse a write that would silently degrade the page

### DIFF
--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -352,6 +352,8 @@ Content can be provided via:
 
 **Markdown is the default format.** It is converted to ADF, or to storage XHTML with `--legacy`.
 
+**ADF is lossy.** Confluence's ADF representation does not carry emphasis wrapping an inline code span, nor internal `<ac:link>` elements. Reading a page as ADF and writing it back therefore destroys content you never touched, and you cannot see it — your copy is already missing it. `cfl` refuses such a write and names what would go; use `--body-format xhtml` for those pages, or `--allow-lossy` to proceed anyway.
+
 **Writes are read back.** With `--body-format adf` or `xhtml` the page is fetched again after a write and the stored body compared against what was sent, because Confluence can store something other than what it was given — it drops `__confluenceMetadata` from link marks, for example. Losing content is an error and exits non-zero; attributes the server normalizes away are reported on stderr and tolerated. Markdown is converted before sending, so there is nothing to compare it against and the check is skipped. Use `--no-verify` to skip the extra read.
 
 ```bash
@@ -387,6 +389,7 @@ cfl page create -s DEV -t "Legacy Page" --file content.md --legacy
 | `--body-format` | | `markdown` | Input format: `markdown`, exact `adf` JSON, or exact storage `xhtml` |
 | `--legacy` | | `false` | Convert Markdown to storage XHTML instead of ADF; invalid with `adf` or `xhtml` |
 | `--no-verify` | | `false` | Skip reading the page back after writing to confirm what Confluence stored (`adf`/`xhtml` only) |
+| `--allow-lossy` | | `false` | Write in a body format that cannot carry content the page currently has |
 
 The selected format applies equally to files, stdin, and editor input; file extensions do not override it.
 
@@ -402,6 +405,8 @@ Content can be provided via:
 - Interactive editor (default, opens with existing content)
 
 **Markdown is the default format.** It is converted to ADF, or to storage XHTML with `--legacy`.
+
+**ADF is lossy.** Confluence's ADF representation does not carry emphasis wrapping an inline code span, nor internal `<ac:link>` elements. Reading a page as ADF and writing it back therefore destroys content you never touched, and you cannot see it — your copy is already missing it. `cfl` refuses such a write and names what would go; use `--body-format xhtml` for those pages, or `--allow-lossy` to proceed anyway.
 
 **Writes are read back.** With `--body-format adf` or `xhtml` the page is fetched again after a write and the stored body compared against what was sent, because Confluence can store something other than what it was given — it drops `__confluenceMetadata` from link marks, for example. Losing content is an error and exits non-zero; attributes the server normalizes away are reported on stderr and tolerated. Markdown is converted before sending, so there is nothing to compare it against and the check is skipped. Use `--no-verify` to skip the extra read.
 
@@ -444,6 +449,7 @@ cfl page view 12345 --body-format xhtml --content-only | \
 | `--body-format` | | `markdown` | Input/editor format: `markdown`, exact `adf` JSON, or exact storage `xhtml` |
 | `--legacy` | | `false` | Convert Markdown to storage XHTML instead of ADF; invalid with `adf` or `xhtml` |
 | `--no-verify` | | `false` | Skip reading the page back after writing to confirm what Confluence stored (`adf`/`xhtml` only) |
+| `--allow-lossy` | | `false` | Write in a body format that cannot carry content the page currently has |
 
 **Arguments:**
 - `<page-id>` - The page ID (**required**)

--- a/tools/cfl/README.md
+++ b/tools/cfl/README.md
@@ -352,8 +352,6 @@ Content can be provided via:
 
 **Markdown is the default format.** It is converted to ADF, or to storage XHTML with `--legacy`.
 
-**ADF is lossy.** Confluence's ADF representation does not carry emphasis wrapping an inline code span, nor internal `<ac:link>` elements. Reading a page as ADF and writing it back therefore destroys content you never touched, and you cannot see it — your copy is already missing it. `cfl` refuses such a write and names what would go; use `--body-format xhtml` for those pages, or `--allow-lossy` to proceed anyway.
-
 **Writes are read back.** With `--body-format adf` or `xhtml` the page is fetched again after a write and the stored body compared against what was sent, because Confluence can store something other than what it was given — it drops `__confluenceMetadata` from link marks, for example. Losing content is an error and exits non-zero; attributes the server normalizes away are reported on stderr and tolerated. Markdown is converted before sending, so there is nothing to compare it against and the check is skipped. Use `--no-verify` to skip the extra read.
 
 ```bash
@@ -389,7 +387,6 @@ cfl page create -s DEV -t "Legacy Page" --file content.md --legacy
 | `--body-format` | | `markdown` | Input format: `markdown`, exact `adf` JSON, or exact storage `xhtml` |
 | `--legacy` | | `false` | Convert Markdown to storage XHTML instead of ADF; invalid with `adf` or `xhtml` |
 | `--no-verify` | | `false` | Skip reading the page back after writing to confirm what Confluence stored (`adf`/`xhtml` only) |
-| `--allow-lossy` | | `false` | Write in a body format that cannot carry content the page currently has |
 
 The selected format applies equally to files, stdin, and editor input; file extensions do not override it.
 

--- a/tools/cfl/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/cfl/internal/cmd/OUTPUT_SPEC.md
@@ -254,6 +254,17 @@ comparison-unavailable blocks described there are never emitted here.
 
 ## `page edit <page-id>`
 
+Refused, when the page holds content the requested body format cannot carry
+(exit non-zero, nothing written):
+
+```text
+refusing to write this page as <format>: the <format> representation cannot carry content it currently has, and writing would remove it
+  - <construct> (<count>) — <consequence>
+
+Use --body-format xhtml to edit this page without losing them.
+Pass --allow-lossy to write it as <format> anyway.
+```
+
 Success:
 
 ```text

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -191,16 +191,15 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	// opens. It is the lossy-format guard's evidence and the verification
 	// baseline both, and refusing after an editor session would discard work
 	// the operator had just done.
-	// A title- or parent-only edit resends the body it just read. That is a
-	// write, but only a lossy one if what gets resent is the lossy
-	// representation: getPageWithBodyFallback asks for storage first, so a
-	// page with a storage body is resent losslessly.
+	// A title- or parent-only edit resends the body it just read.
 	resendsExistingBody := !hasNewContent && !opts.editor && (opts.title != "" || opts.parent != "")
 	writesBody := hasNewContent || opts.editor || resendsExistingBody
-	// What gets sent decides, not what was asked for. A resend passes the
-	// page's own body straight back, so nothing is converted and nothing can
-	// be lost; only a caller-supplied ADF payload can drop what the page
-	// currently has.
+	// What gets sent decides, not what was asked for. A resend hands the
+	// page's own body back unchanged, so --body-format is irrelevant to it:
+	// verified against a page carrying both an ac:link and emphasis around a
+	// code span, where a title-only edit with --body-format adf left every
+	// one of them intact. Only a caller-supplied ADF payload can drop what
+	// the page currently has.
 	writesADF := bodyFormat == bodyFormatADF && !resendsExistingBody
 
 	currentStorage := func() (string, string) {

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -187,6 +187,38 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 		return err
 	}
 
+	// One derivation of the page's current storage body, before the editor
+	// opens: it is both the lossy-format guard's evidence and the
+	// verification baseline, and refusing after an editor session would
+	// throw away work the operator just did.
+	var storageBefore, storageBeforeErr string
+	if hasNewContent || opts.editor {
+		storageBefore = bodyValue(existingPage, bodyFormatXHTML)
+		if storageBefore == "" {
+			body, err := readStorageBody(ctx, client, opts.pageID)
+			switch {
+			case err != nil:
+				storageBeforeErr = err.Error()
+			case body == "":
+				storageBeforeErr = "the page returned no storage body"
+			default:
+				storageBefore = body
+			}
+		}
+	}
+
+	// Refuse before writing, and before the editor: once the ADF is written
+	// the content is gone, and the caller's own copy never had it to restore
+	// from.
+	if (hasNewContent || opts.editor) && bodyFormat == bodyFormatADF && !opts.allowLossy {
+		if storageBefore == "" {
+			return fmt.Errorf("cannot confirm this page is safe to write as %s: its current content could not be read (%s)\nUse --body-format xhtml, or --allow-lossy to write anyway", bodyFormat, orUnknown(storageBeforeErr))
+		}
+		if findings := findLossyConstructs(storageBefore); len(findings) > 0 {
+			return lossyFormatError(findings, bodyFormat)
+		}
+	}
+
 	newTitle := opts.title
 	if newTitle == "" {
 		newTitle = existingPage.Title
@@ -229,35 +261,6 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	// caller inherited from a lossy read of their own.
 	// The page was already fetched above, and the non-editor path asks for
 	// the storage representation, so the baseline is usually in hand.
-	// Refuse before writing, not after: once the ADF is written the content
-	// is gone, and the caller's own copy never had it to restore from.
-	if hasNewContent && bodyFormat == bodyFormatADF && !opts.allowLossy {
-		current := bodyValue(existingPage, bodyFormatXHTML)
-		if current == "" {
-			if body, err := readStorageBody(ctx, client, opts.pageID); err == nil {
-				current = body
-			}
-		}
-		if findings := findLossyConstructs(current); len(findings) > 0 {
-			return lossyFormatError(findings, bodyFormat)
-		}
-	}
-
-	var storageBefore, storageBeforeErr string
-	if verificationApplies(bodyFormat, hasNewContent, opts.noVerify) {
-		storageBefore = bodyValue(existingPage, bodyFormatXHTML)
-		if storageBefore == "" {
-			body, err := readStorageBody(ctx, client, opts.pageID)
-			switch {
-			case err != nil:
-				storageBeforeErr = err.Error()
-			case body == "":
-				storageBeforeErr = "the page returned no storage body"
-			default:
-				storageBefore = body
-			}
-		}
-	}
 
 	page, err := client.UpdatePage(ctx, opts.pageID, req)
 	if err != nil {

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -187,12 +187,15 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 		return err
 	}
 
-	// One derivation of the page's current storage body, before the editor
-	// opens: it is both the lossy-format guard's evidence and the
-	// verification baseline, and refusing after an editor session would
-	// throw away work the operator just did.
+	// The page's current storage body, derived once and before the editor
+	// opens. It is the lossy-format guard's evidence and the verification
+	// baseline both, and refusing after an editor session would discard work
+	// the operator had just done.
+	// A title- or parent-only edit still resends the body it just read, so
+	// it rewrites the page and is subject to the same loss.
+	writesBody := hasNewContent || opts.editor || opts.title != "" || opts.parent != ""
 	var storageBefore, storageBeforeErr string
-	if hasNewContent || opts.editor {
+	if writesBody && !opts.noVerify {
 		storageBefore = bodyValue(existingPage, bodyFormatXHTML)
 		if storageBefore == "" {
 			body, err := readStorageBody(ctx, client, opts.pageID)
@@ -210,11 +213,26 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	// Refuse before writing, and before the editor: once the ADF is written
 	// the content is gone, and the caller's own copy never had it to restore
 	// from.
-	if (hasNewContent || opts.editor) && bodyFormat == bodyFormatADF && !opts.allowLossy {
-		if storageBefore == "" {
-			return fmt.Errorf("cannot confirm this page is safe to write as %s: its current content could not be read (%s)\nUse --body-format xhtml, or --allow-lossy to write anyway", bodyFormat, orUnknown(storageBeforeErr))
+	if writesBody && bodyFormat == bodyFormatADF && !opts.allowLossy {
+		// --no-verify silences the readback, not this: skipping the check
+		// that reports damage is a different decision from consenting to
+		// cause it.
+		current, currentErr := storageBefore, storageBeforeErr
+		if current == "" && opts.noVerify {
+			body, err := readStorageBody(ctx, client, opts.pageID)
+			switch {
+			case err != nil:
+				currentErr = err.Error()
+			case body == "":
+				currentErr = "the page returned no storage body"
+			default:
+				current = body
+			}
 		}
-		if findings := findLossyConstructs(storageBefore); len(findings) > 0 {
+		if current == "" {
+			return fmt.Errorf("cannot confirm this page is safe to write as %s: its current content could not be read (%s)\nUse --body-format xhtml, or --allow-lossy to write anyway", bodyFormat, orUnknown(currentErr))
+		}
+		if findings := findLossyConstructs(current); len(findings) > 0 {
 			return lossyFormatError(findings, bodyFormat)
 		}
 	}

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -197,13 +197,10 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	// page with a storage body is resent losslessly.
 	resendsExistingBody := !hasNewContent && !opts.editor && (opts.title != "" || opts.parent != "")
 	writesBody := hasNewContent || opts.editor || resendsExistingBody
-	// What gets sent decides, not what was asked for: a resend of an
-	// ADF-derived body is lossy even without --body-format adf, and a resend
-	// of a storage body is safe even with it.
-	// A resend passes the page's own body straight back, so nothing is
-	// converted and nothing can be lost — an ADF-native page has no storage
-	// body to lose in the first place. Only a caller-supplied ADF payload
-	// can drop what the page currently has.
+	// What gets sent decides, not what was asked for. A resend passes the
+	// page's own body straight back, so nothing is converted and nothing can
+	// be lost; only a caller-supplied ADF payload can drop what the page
+	// currently has.
 	writesADF := bodyFormat == bodyFormatADF && !resendsExistingBody
 
 	currentStorage := func() (string, string) {
@@ -223,14 +220,11 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	// Refuse before writing, and before the editor: once the ADF is written
 	// the content is gone, and the caller's own copy never had it to restore
 	// from.
+	// --no-verify silences the readback, not this: the baseline gate above
+	// includes writesADF for that reason, so the guard always has its
+	// evidence here.
 	if writesBody && writesADF && !opts.allowLossy {
-		// --no-verify silences the readback, not this: skipping the check
-		// that reports damage is a different decision from consenting to
-		// cause it.
 		current, currentErr := storageBefore, storageBeforeErr
-		if current == "" && currentErr == "" {
-			current, currentErr = currentStorage()
-		}
 		if current == "" {
 			return fmt.Errorf("cannot confirm this page is safe to write as %s: its current content could not be read (%s)\nUse --body-format xhtml, or --allow-lossy to write anyway", bodyFormat, orUnknown(currentErr))
 		}

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
-	"github.com/open-cli-collective/confluence-cli/internal/pageview"
 	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 	"github.com/open-cli-collective/confluence-cli/pkg/md"
 )
@@ -198,6 +197,15 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	// page with a storage body is resent losslessly.
 	resendsExistingBody := !hasNewContent && !opts.editor && (opts.title != "" || opts.parent != "")
 	writesBody := hasNewContent || opts.editor || resendsExistingBody
+	// What gets sent decides, not what was asked for: a resend of an
+	// ADF-derived body is lossy even without --body-format adf, and a resend
+	// of a storage body is safe even with it.
+	// A resend passes the page's own body straight back, so nothing is
+	// converted and nothing can be lost — an ADF-native page has no storage
+	// body to lose in the first place. Only a caller-supplied ADF payload
+	// can drop what the page currently has.
+	writesADF := bodyFormat == bodyFormatADF && !resendsExistingBody
+
 	currentStorage := func() (string, string) {
 		if body := bodyValue(existingPage, bodyFormatXHTML); body != "" {
 			return body, ""
@@ -205,18 +213,16 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 		return fetchStorageBody(ctx, client, opts.pageID)
 	}
 
+	// Read it only when a consumer wants it: verification needs it for an
+	// exact body format, and the guard needs it for an ADF payload.
 	var storageBefore, storageBeforeErr string
-	if writesBody && !opts.noVerify {
+	if writesBody && (verificationApplies(bodyFormat, hasNewContent, opts.noVerify) || writesADF) {
 		storageBefore, storageBeforeErr = currentStorage()
 	}
 
 	// Refuse before writing, and before the editor: once the ADF is written
 	// the content is gone, and the caller's own copy never had it to restore
 	// from.
-	// A resend of an existing storage body carries no loss regardless of
-	// --body-format, so only an actual ADF payload is guarded.
-	writesADF := bodyFormat == bodyFormatADF &&
-		(!resendsExistingBody || !pageview.HasStorageContent(existingPage))
 	if writesBody && writesADF && !opts.allowLossy {
 		// --no-verify silences the readback, not this: skipping the check
 		// that reports damage is a different decision from consenting to

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -27,6 +27,7 @@ type editOptions struct {
 	legacy             bool
 	parent             string
 	noVerify           bool
+	allowLossy         bool
 }
 
 func newEditCmd(rootOpts *root.Options) *cobra.Command {
@@ -48,6 +49,14 @@ Content can be provided via:
 Content format is selected with --body-format markdown|adf|xhtml.
 Omitting --body-format means Markdown. ADF and XHTML are validated or sent
 without conversion.
+
+ADF IS LOSSY. Confluence's ADF representation does not carry everything its
+storage representation does: emphasis wrapping an inline code span is
+dropped, and internal links become plain expanded URLs. Reading a page as
+ADF and writing it back therefore destroys content the caller never touched,
+and the caller cannot see it because their copy is already missing it. A
+write that would remove such content is refused; use --body-format xhtml to
+edit those pages, or --allow-lossy to proceed anyway.
 
 For --body-format adf or xhtml the page is read back after writing and the
 stored body compared against what was sent, because Confluence can store
@@ -112,6 +121,7 @@ skipped. Use --no-verify to skip the read.`,
 	cmd.Flags().StringVar(&opts.bodyFormat, "body-format", bodyFormatMarkdown, "Input format: markdown, adf, or xhtml")
 	cmd.Flags().BoolVar(&opts.legacy, "legacy", false, "Edit page in legacy editor format (Markdown input only)")
 	cmd.Flags().BoolVar(&opts.noVerify, "no-verify", false, "Skip reading the page back to confirm what Confluence stored (adf/xhtml input)")
+	cmd.Flags().BoolVar(&opts.allowLossy, "allow-lossy", false, "Write in a body format that cannot carry content the page currently has")
 
 	return cmd
 }
@@ -219,6 +229,20 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	// caller inherited from a lossy read of their own.
 	// The page was already fetched above, and the non-editor path asks for
 	// the storage representation, so the baseline is usually in hand.
+	// Refuse before writing, not after: once the ADF is written the content
+	// is gone, and the caller's own copy never had it to restore from.
+	if hasNewContent && bodyFormat == bodyFormatADF && !opts.allowLossy {
+		current := bodyValue(existingPage, bodyFormatXHTML)
+		if current == "" {
+			if body, err := readStorageBody(ctx, client, opts.pageID); err == nil {
+				current = body
+			}
+		}
+		if findings := findLossyConstructs(current); len(findings) > 0 {
+			return lossyFormatError(findings, bodyFormat)
+		}
+	}
+
 	var storageBefore, storageBeforeErr string
 	if verificationApplies(bodyFormat, hasNewContent, opts.noVerify) {
 		storageBefore = bodyValue(existingPage, bodyFormatXHTML)

--- a/tools/cfl/internal/cmd/page/edit.go
+++ b/tools/cfl/internal/cmd/page/edit.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/open-cli-collective/confluence-cli/api"
 	"github.com/open-cli-collective/confluence-cli/internal/cmd/root"
+	"github.com/open-cli-collective/confluence-cli/internal/pageview"
 	cflpresent "github.com/open-cli-collective/confluence-cli/internal/present"
 	"github.com/open-cli-collective/confluence-cli/pkg/md"
 )
@@ -191,43 +192,38 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	// opens. It is the lossy-format guard's evidence and the verification
 	// baseline both, and refusing after an editor session would discard work
 	// the operator had just done.
-	// A title- or parent-only edit still resends the body it just read, so
-	// it rewrites the page and is subject to the same loss.
-	writesBody := hasNewContent || opts.editor || opts.title != "" || opts.parent != ""
+	// A title- or parent-only edit resends the body it just read. That is a
+	// write, but only a lossy one if what gets resent is the lossy
+	// representation: getPageWithBodyFallback asks for storage first, so a
+	// page with a storage body is resent losslessly.
+	resendsExistingBody := !hasNewContent && !opts.editor && (opts.title != "" || opts.parent != "")
+	writesBody := hasNewContent || opts.editor || resendsExistingBody
+	currentStorage := func() (string, string) {
+		if body := bodyValue(existingPage, bodyFormatXHTML); body != "" {
+			return body, ""
+		}
+		return fetchStorageBody(ctx, client, opts.pageID)
+	}
+
 	var storageBefore, storageBeforeErr string
 	if writesBody && !opts.noVerify {
-		storageBefore = bodyValue(existingPage, bodyFormatXHTML)
-		if storageBefore == "" {
-			body, err := readStorageBody(ctx, client, opts.pageID)
-			switch {
-			case err != nil:
-				storageBeforeErr = err.Error()
-			case body == "":
-				storageBeforeErr = "the page returned no storage body"
-			default:
-				storageBefore = body
-			}
-		}
+		storageBefore, storageBeforeErr = currentStorage()
 	}
 
 	// Refuse before writing, and before the editor: once the ADF is written
 	// the content is gone, and the caller's own copy never had it to restore
 	// from.
-	if writesBody && bodyFormat == bodyFormatADF && !opts.allowLossy {
+	// A resend of an existing storage body carries no loss regardless of
+	// --body-format, so only an actual ADF payload is guarded.
+	writesADF := bodyFormat == bodyFormatADF &&
+		(!resendsExistingBody || !pageview.HasStorageContent(existingPage))
+	if writesBody && writesADF && !opts.allowLossy {
 		// --no-verify silences the readback, not this: skipping the check
 		// that reports damage is a different decision from consenting to
 		// cause it.
 		current, currentErr := storageBefore, storageBeforeErr
-		if current == "" && opts.noVerify {
-			body, err := readStorageBody(ctx, client, opts.pageID)
-			switch {
-			case err != nil:
-				currentErr = err.Error()
-			case body == "":
-				currentErr = "the page returned no storage body"
-			default:
-				current = body
-			}
+		if current == "" && currentErr == "" {
+			current, currentErr = currentStorage()
 		}
 		if current == "" {
 			return fmt.Errorf("cannot confirm this page is safe to write as %s: its current content could not be read (%s)\nUse --body-format xhtml, or --allow-lossy to write anyway", bodyFormat, orUnknown(currentErr))
@@ -274,11 +270,6 @@ func runEdit(ctx context.Context, opts *editOptions) error {
 	} else {
 		req.Body = existingPage.Body
 	}
-
-	// Captured before the write: the storage body is what reveals loss the
-	// caller inherited from a lossy read of their own.
-	// The page was already fetched above, and the non-editor path asks for
-	// the storage representation, so the baseline is usually in hand.
 
 	page, err := client.UpdatePage(ctx, opts.pageID, req)
 	if err != nil {

--- a/tools/cfl/internal/cmd/page/fetch.go
+++ b/tools/cfl/internal/cmd/page/fetch.go
@@ -108,3 +108,17 @@ func getPageVersionWithBodyFallback(ctx context.Context, client *api.Client, pag
 
 	return page, nil
 }
+
+// fetchStorageBody returns a page's storage body, or an explanation of why it
+// is unavailable. One place answers that question so callers cannot drift.
+func fetchStorageBody(ctx context.Context, client *api.Client, pageID string) (body, reason string) {
+	got, err := readStorageBody(ctx, client, pageID)
+	switch {
+	case err != nil:
+		return "", err.Error()
+	case got == "":
+		return "", "the page returned no storage body"
+	default:
+		return got, ""
+	}
+}

--- a/tools/cfl/internal/cmd/page/lossy.go
+++ b/tools/cfl/internal/cmd/page/lossy.go
@@ -1,12 +1,9 @@
 package page
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/open-cli-collective/confluence-cli/api"
 )
 
 // Confluence's ADF export does not carry everything its storage
@@ -50,6 +47,10 @@ var emphasisTagRE = regexp.MustCompile(`</?(strong|em|code)>`)
 // adjacent, so this tracks open tags rather than matching a shape: a regex
 // would either miss intervening markup or, with RE2's lack of lookahead,
 // match across unrelated elements.
+//
+// Depths are clamped at zero. Storage bodies are not guaranteed to be
+// balanced, and an unmatched closing tag would otherwise drive a counter
+// negative and blind the detector to every later nesting on the page.
 func countEmphasisedCode(markup string) int {
 	var depth struct{ emphasis, code int }
 	found := 0
@@ -58,7 +59,9 @@ func countEmphasisedCode(markup string) int {
 		switch m[1] {
 		case "code":
 			if closing {
-				depth.code--
+				if depth.code > 0 {
+					depth.code--
+				}
 			} else {
 				if depth.emphasis > 0 {
 					found++
@@ -67,7 +70,9 @@ func countEmphasisedCode(markup string) int {
 			}
 		default:
 			if closing {
-				depth.emphasis--
+				if depth.emphasis > 0 {
+					depth.emphasis--
+				}
 			} else {
 				if depth.code > 0 {
 					found++
@@ -137,19 +142,4 @@ func orUnknown(reason string) string {
 		return "cause unknown"
 	}
 	return reason
-}
-
-// fetchStorageBody returns the page's storage body, or an explanation of why
-// it is unavailable. One place answers that question so the two callers
-// cannot drift.
-func fetchStorageBody(ctx context.Context, client *api.Client, pageID string) (body, reason string) {
-	got, err := readStorageBody(ctx, client, pageID)
-	switch {
-	case err != nil:
-		return "", err.Error()
-	case got == "":
-		return "", "the page returned no storage body"
-	default:
-		return got, ""
-	}
 }

--- a/tools/cfl/internal/cmd/page/lossy.go
+++ b/tools/cfl/internal/cmd/page/lossy.go
@@ -38,11 +38,42 @@ var lossyConstructs = []lossyConstruct{
 		pattern: regexp.MustCompile(`<ac:link[\s>]`),
 		detail:  "anchor and page references become plain expanded URLs",
 	},
-	{
-		name:    "emphasis on code spans",
-		pattern: regexp.MustCompile(`(?s)<(?:strong|em)>(?:\s|<(?:strong|em)>)*<code>|<code>(?:\s|<(?:strong|em)>)*<(?:strong|em)>`),
-		detail:  "bold or italic wrapping inline code is dropped",
-	},
+}
+
+var emphasisTagRE = regexp.MustCompile(`</?(strong|em|code)>`)
+
+// countEmphasisedCode reports how many inline code spans sit inside bold or
+// italic, or vice versa. Nesting is what matters and the two need not be
+// adjacent, so this tracks open tags rather than matching a shape: a regex
+// would either miss intervening markup or, with RE2's lack of lookahead,
+// match across unrelated elements.
+func countEmphasisedCode(markup string) int {
+	var depth struct{ emphasis, code int }
+	found := 0
+	for _, m := range emphasisTagRE.FindAllStringSubmatch(markup, -1) {
+		closing := strings.HasPrefix(m[0], "</")
+		switch m[1] {
+		case "code":
+			if closing {
+				depth.code--
+			} else {
+				if depth.emphasis > 0 {
+					found++
+				}
+				depth.code++
+			}
+		default:
+			if closing {
+				depth.emphasis--
+			} else {
+				if depth.code > 0 {
+					found++
+				}
+				depth.emphasis++
+			}
+		}
+	}
+	return found
 }
 
 // lossyFinding names one construct a write would destroy.
@@ -71,6 +102,13 @@ func findLossyConstructs(storageBody string) []lossyFinding {
 		if n := len(c.pattern.FindAllString(markup, -1)); n > 0 {
 			found = append(found, lossyFinding{Construct: c.name, Detail: c.detail, Count: n})
 		}
+	}
+	if n := countEmphasisedCode(markup); n > 0 {
+		found = append(found, lossyFinding{
+			Construct: "emphasis on code spans",
+			Detail:    "bold or italic wrapping inline code is dropped",
+			Count:     n,
+		})
 	}
 	return found
 }

--- a/tools/cfl/internal/cmd/page/lossy.go
+++ b/tools/cfl/internal/cmd/page/lossy.go
@@ -1,9 +1,12 @@
 package page
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/open-cli-collective/confluence-cli/api"
 )
 
 // Confluence's ADF export does not carry everything its storage
@@ -134,4 +137,19 @@ func orUnknown(reason string) string {
 		return "cause unknown"
 	}
 	return reason
+}
+
+// fetchStorageBody returns the page's storage body, or an explanation of why
+// it is unavailable. One place answers that question so the two callers
+// cannot drift.
+func fetchStorageBody(ctx context.Context, client *api.Client, pageID string) (body, reason string) {
+	got, err := readStorageBody(ctx, client, pageID)
+	switch {
+	case err != nil:
+		return "", err.Error()
+	case got == "":
+		return "", "the page returned no storage body"
+	default:
+		return got, ""
+	}
 }

--- a/tools/cfl/internal/cmd/page/lossy.go
+++ b/tools/cfl/internal/cmd/page/lossy.go
@@ -1,0 +1,90 @@
+package page
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Confluence's ADF export does not carry everything its storage
+// representation does, so reading a page as ADF and writing it back destroys
+// content the caller never touched. Two losses are established by
+// experiment:
+//
+//   - Any mark paired with `code` is dropped. Sending code+strong stores
+//     correctly and reads back as code alone, while storage returns
+//     <code><strong>…</strong></code> intact. strong+em survives, so this is
+//     specific to code.
+//   - Internal link elements are not represented. <ac:link> anchors come back
+//     as plain links, and writing that back turns a short anchor reference
+//     into an expanded URL.
+//
+// A caller cannot see either of these: the ADF they hold is already missing
+// the marks, so comparing what they sent against what was stored agrees. The
+// only moment the loss is preventable is before the write, by looking at the
+// page as it exists now.
+
+// lossyConstruct is something the ADF representation cannot carry.
+type lossyConstruct struct {
+	name    string
+	pattern *regexp.Regexp
+	// detail explains the consequence in the operator's terms.
+	detail string
+}
+
+var lossyConstructs = []lossyConstruct{
+	{
+		name:    "internal links",
+		pattern: regexp.MustCompile(`<ac:link[\s>]`),
+		detail:  "anchor and page references become plain expanded URLs",
+	},
+	{
+		name:    "emphasis on code spans",
+		pattern: regexp.MustCompile(`(?s)<(strong|em)>\s*<code>|<code>\s*<(strong|em)>`),
+		detail:  "bold or italic wrapping inline code is dropped",
+	},
+	{
+		name:    "structured macros",
+		pattern: regexp.MustCompile(`<ac:structured-macro[\s>]`),
+		detail:  "macro bodies may not survive the conversion",
+	},
+}
+
+// lossyFinding names one construct a write would destroy.
+type lossyFinding struct {
+	Construct string
+	Detail    string
+	Count     int
+}
+
+// findLossyConstructs reports what an ADF write would destroy in the page as
+// it currently stands. It inspects the existing storage body rather than the
+// caller's content, because the caller's ADF has already lost these things —
+// that is the whole problem.
+func findLossyConstructs(storageBody string) []lossyFinding {
+	if strings.TrimSpace(storageBody) == "" {
+		return nil
+	}
+	var found []lossyFinding
+	for _, c := range lossyConstructs {
+		if n := len(c.pattern.FindAllString(storageBody, -1)); n > 0 {
+			found = append(found, lossyFinding{Construct: c.name, Detail: c.detail, Count: n})
+		}
+	}
+	return found
+}
+
+// lossyFormatError refuses a write that would silently degrade the page, and
+// says how to proceed deliberately. The escape hatch is a flag rather than a
+// format choice so that overwriting known-lossy content is visible in shell
+// history instead of implied.
+func lossyFormatError(findings []lossyFinding, bodyFormat string) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "refusing to write this page as %s: the %s representation cannot carry content it currently has, and writing would remove it\n", bodyFormat, bodyFormat)
+	for _, f := range findings {
+		fmt.Fprintf(&b, "  - %s (%d) — %s\n", f.Construct, f.Count, f.Detail)
+	}
+	b.WriteString("\nUse --body-format xhtml to edit this page without losing them.\n")
+	b.WriteString("Pass --allow-lossy to write it as " + bodyFormat + " anyway.")
+	return fmt.Errorf("%s", b.String())
+}

--- a/tools/cfl/internal/cmd/page/lossy.go
+++ b/tools/cfl/internal/cmd/page/lossy.go
@@ -40,13 +40,8 @@ var lossyConstructs = []lossyConstruct{
 	},
 	{
 		name:    "emphasis on code spans",
-		pattern: regexp.MustCompile(`(?s)<(strong|em)>\s*<code>|<code>\s*<(strong|em)>`),
+		pattern: regexp.MustCompile(`(?s)<(?:strong|em)>(?:\s|<(?:strong|em)>)*<code>|<code>(?:\s|<(?:strong|em)>)*<(?:strong|em)>`),
 		detail:  "bold or italic wrapping inline code is dropped",
-	},
-	{
-		name:    "structured macros",
-		pattern: regexp.MustCompile(`<ac:structured-macro[\s>]`),
-		detail:  "macro bodies may not survive the conversion",
 	},
 }
 
@@ -61,13 +56,19 @@ type lossyFinding struct {
 // it currently stands. It inspects the existing storage body rather than the
 // caller's content, because the caller's ADF has already lost these things —
 // that is the whole problem.
+//
+// Comment and CDATA spans are removed first, for the same reason
+// storageProfile removes them: storage carries macro bodies verbatim inside
+// CDATA, where angle brackets are content rather than markup, and a match
+// there would refuse a write over nothing.
 func findLossyConstructs(storageBody string) []lossyFinding {
 	if strings.TrimSpace(storageBody) == "" {
 		return nil
 	}
+	markup := storageInertRE.ReplaceAllString(storageBody, "")
 	var found []lossyFinding
 	for _, c := range lossyConstructs {
-		if n := len(c.pattern.FindAllString(storageBody, -1)); n > 0 {
+		if n := len(c.pattern.FindAllString(markup, -1)); n > 0 {
 			found = append(found, lossyFinding{Construct: c.name, Detail: c.detail, Count: n})
 		}
 	}
@@ -87,4 +88,12 @@ func lossyFormatError(findings []lossyFinding, bodyFormat string) error {
 	b.WriteString("\nUse --body-format xhtml to edit this page without losing them.\n")
 	b.WriteString("Pass --allow-lossy to write it as " + bodyFormat + " anyway.")
 	return fmt.Errorf("%s", b.String())
+}
+
+// orUnknown keeps a refusal honest when the cause could not be captured.
+func orUnknown(reason string) string {
+	if strings.TrimSpace(reason) == "" {
+		return "cause unknown"
+	}
+	return reason
 }

--- a/tools/cfl/internal/cmd/page/lossy_test.go
+++ b/tools/cfl/internal/cmd/page/lossy_test.go
@@ -220,9 +220,11 @@ func TestCountEmphasisedCodeToleratesInterveningMarkup(t *testing.T) {
 	}
 }
 
-// A title-only edit resends the body it just read, so it is a write and
-// carries the same loss.
-func TestRunEditRefusesLossyTitleOnlyEdit(t *testing.T) {
+// A title-only edit on a page with a storage body resends that storage
+// losslessly, whatever --body-format was asked for. Refusing it would be a
+// false positive, and a guard that fires on safe edits gets overridden by
+// reflex.
+func TestRunEditAllowsTitleOnlyEditOfStoragePage(t *testing.T) {
 	srv := storageServer(t, `<p><ac:link ac:anchor="a11"><ac:link-body>see</ac:link-body></ac:link></p>`)
 	defer srv.Close()
 
@@ -235,12 +237,8 @@ func TestRunEditRefusesLossyTitleOnlyEdit(t *testing.T) {
 		title:      "New Title",
 		bodyFormat: bodyFormatADF,
 	}
-	err := runEdit(context.Background(), opts)
-	if err == nil {
-		t.Fatal("a title-only edit rewrites the body and must be guarded")
-	}
-	if !strings.Contains(err.Error(), "internal links") {
-		t.Errorf("unexpected error: %v", err)
+	if err := runEdit(context.Background(), opts); err != nil {
+		t.Fatalf("a title-only edit resends storage and must not be refused: %v", err)
 	}
 }
 

--- a/tools/cfl/internal/cmd/page/lossy_test.go
+++ b/tools/cfl/internal/cmd/page/lossy_test.go
@@ -1,0 +1,155 @@
+package page
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// storageServer serves a page whose storage body is fixed from the outset,
+// including on the read that happens before a write. driftServer only
+// applies its body after a PUT, so it cannot exercise a guard that inspects
+// the page as it currently stands.
+func storageServer(t *testing.T, storage string) *httptest.Server {
+	t.Helper()
+	payload := `{"id":"12345","title":"Test","version":{"number":1},"body":{"storage":{"value":` +
+		mustJSON(t, storage) + `}},"_links":{"webui":"/pages/12345"}}`
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(payload))
+		case "PUT":
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(payload))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func mustJSON(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func TestFindLossyConstructs(t *testing.T) {
+	tests := []struct {
+		name    string
+		storage string
+		want    []string
+	}{
+		{
+			name:    "plain content is safe",
+			storage: `<p>hello <strong>world</strong> and <code>code</code></p>`,
+		},
+		{
+			name:    "internal link",
+			storage: `<p><ac:link ac:anchor="a11"><ac:link-body>see</ac:link-body></ac:link></p>`,
+			want:    []string{"internal links"},
+		},
+		{
+			name:    "emphasis wrapping code",
+			storage: `<p><em><strong><code>KEY</code></strong></em></p>`,
+			want:    []string{"emphasis on code spans"},
+		},
+		{
+			name:    "code wrapping emphasis",
+			storage: `<p><code><strong>KEY</strong></code></p>`,
+			want:    []string{"emphasis on code spans"},
+		},
+		{
+			name:    "macro",
+			storage: `<ac:structured-macro ac:name="info"><p>x</p></ac:structured-macro>`,
+			want:    []string{"structured macros"},
+		},
+		{
+			name:    "empty body reports nothing",
+			storage: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := findLossyConstructs(tc.storage)
+			if len(got) != len(tc.want) {
+				t.Fatalf("findings = %v, want %v", got, tc.want)
+			}
+			for i, w := range tc.want {
+				if got[i].Construct != w {
+					t.Errorf("finding[%d] = %q, want %q", i, got[i].Construct, w)
+				}
+			}
+		})
+	}
+}
+
+// Emphasis that does not touch a code span is not a loss and must not be
+// reported: a guard that fires on safe pages gets disabled.
+func TestFindLossyConstructsIgnoresPlainEmphasis(t *testing.T) {
+	if got := findLossyConstructs(`<p><strong><em>bold italic</em></strong></p>`); len(got) != 0 {
+		t.Errorf("plain emphasis reported as lossy: %v", got)
+	}
+}
+
+// The refusal has to name what would go and how to proceed; an error that
+// only says no gets worked around blindly.
+func TestLossyFormatErrorNamesLossAndRemedy(t *testing.T) {
+	err := lossyFormatError([]lossyFinding{
+		{Construct: "internal links", Detail: "anchor and page references become plain expanded URLs", Count: 8},
+	}, bodyFormatADF)
+	msg := err.Error()
+	for _, want := range []string{"internal links (8)", "expanded URLs", "--body-format xhtml", "--allow-lossy"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+// The guard must stop the write, not report it afterwards: once written, the
+// content is gone and the caller's copy never had it.
+func TestRunEditRefusesLossyAdfWrite(t *testing.T) {
+	srv := storageServer(t, `<p><ac:link ac:anchor="a11"><ac:link-body>see</ac:link-body></ac:link></p>`)
+	defer srv.Close()
+
+	opts := editOptsFor(t, srv, `{"type":"doc","version":1,"content":[]}`, true)
+	opts.bodyFormat = bodyFormatADF
+	err := runEdit(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected the lossy write to be refused")
+	}
+	if !strings.Contains(err.Error(), "internal links") {
+		t.Errorf("refusal should name the construct: %v", err)
+	}
+}
+
+func TestRunEditAllowLossyProceeds(t *testing.T) {
+	srv := storageServer(t, `<p><ac:link ac:anchor="a11"><ac:link-body>see</ac:link-body></ac:link></p>`)
+	defer srv.Close()
+
+	opts := editOptsFor(t, srv, `{"type":"doc","version":1,"content":[]}`, true)
+	opts.bodyFormat = bodyFormatADF
+	opts.allowLossy = true
+	if err := runEdit(context.Background(), opts); err != nil {
+		t.Fatalf("--allow-lossy should permit the write: %v", err)
+	}
+}
+
+// xhtml carries these constructs, so it is never refused.
+func TestRunEditDoesNotRefuseXhtml(t *testing.T) {
+	srv := storageServer(t, `<p><ac:link ac:anchor="a11"><ac:link-body>see</ac:link-body></ac:link></p>`)
+	defer srv.Close()
+
+	opts := editOptsFor(t, srv, `<p><ac:link ac:anchor="a11"><ac:link-body>see</ac:link-body></ac:link></p>`, true)
+	if err := runEdit(context.Background(), opts); err != nil {
+		t.Fatalf("xhtml write should not be refused: %v", err)
+	}
+}

--- a/tools/cfl/internal/cmd/page/lossy_test.go
+++ b/tools/cfl/internal/cmd/page/lossy_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/open-cli-collective/confluence-cli/api"
 )
 
 // storageServer serves a page whose storage body is fixed from the outset,
@@ -189,5 +191,73 @@ func TestRunEditRefusesWhenBaselineUnreadable(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "could not be read") {
 		t.Errorf("refusal should say the check could not run: %v", err)
+	}
+}
+
+// Emphasis and code are not always adjacent; a shape-matching regex missed
+// the case with markup in between, which is the common one in real pages.
+func TestCountEmphasisedCodeToleratesInterveningMarkup(t *testing.T) {
+	tests := []struct {
+		name   string
+		markup string
+		want   int
+	}{
+		{"adjacent", `<strong><code>K</code></strong>`, 1},
+		{"code outside", `<code><em>K</em></code>`, 1},
+		{"markup in between", `<strong>label <a href="x">link</a> <code>K</code></strong>`, 1},
+		{"two in one run", `<strong><code>A</code> and <code>B</code></strong>`, 2},
+		{"siblings, not nested", `<strong>bold</strong> <code>K</code>`, 0},
+		{"emphasis alone", `<strong><em>bold italic</em></strong>`, 0},
+		{"code alone", `<p><code>K</code></p>`, 0},
+		{"closed before code", `<strong>bold</strong><p><code>K</code></p>`, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countEmphasisedCode(tc.markup); got != tc.want {
+				t.Errorf("countEmphasisedCode(%q) = %d, want %d", tc.markup, got, tc.want)
+			}
+		})
+	}
+}
+
+// A title-only edit resends the body it just read, so it is a write and
+// carries the same loss.
+func TestRunEditRefusesLossyTitleOnlyEdit(t *testing.T) {
+	srv := storageServer(t, `<p><ac:link ac:anchor="a11"><ac:link-body>see</ac:link-body></ac:link></p>`)
+	defer srv.Close()
+
+	rootOpts := newEditTestRootOptions()
+	rootOpts.SetAPIClient(api.NewClient(srv.URL, "test@example.com", "token"))
+	rootOpts.Stdin = nil
+	opts := &editOptions{
+		Options:    rootOpts,
+		pageID:     "12345",
+		title:      "New Title",
+		bodyFormat: bodyFormatADF,
+	}
+	err := runEdit(context.Background(), opts)
+	if err == nil {
+		t.Fatal("a title-only edit rewrites the body and must be guarded")
+	}
+	if !strings.Contains(err.Error(), "internal links") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// --no-verify silences the readback. Consenting to skip the report is not
+// consenting to cause the damage.
+func TestNoVerifyDoesNotDisableTheGuard(t *testing.T) {
+	srv := storageServer(t, `<p><ac:link ac:anchor="a11"><ac:link-body>see</ac:link-body></ac:link></p>`)
+	defer srv.Close()
+
+	opts := editOptsFor(t, srv, `{"type":"doc","version":1,"content":[]}`, true)
+	opts.bodyFormat = bodyFormatADF
+	opts.noVerify = true
+	err := runEdit(context.Background(), opts)
+	if err == nil {
+		t.Fatal("--no-verify must not permit a lossy write")
+	}
+	if !strings.Contains(err.Error(), "internal links") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/tools/cfl/internal/cmd/page/lossy_test.go
+++ b/tools/cfl/internal/cmd/page/lossy_test.go
@@ -68,9 +68,12 @@ func TestFindLossyConstructs(t *testing.T) {
 			want:    []string{"emphasis on code spans"},
 		},
 		{
-			name:    "macro",
-			storage: `<ac:structured-macro ac:name="info"><p>x</p></ac:structured-macro>`,
-			want:    []string{"structured macros"},
+			// Verified against Confluence: a structured macro round-trips
+			// through ADF as a panel node and comes back intact, so
+			// refusing on it would block a great many pages over a loss
+			// that does not happen.
+			name:    "structured macro survives and is not refused",
+			storage: `<ac:structured-macro ac:name="info"><ac:rich-text-body><p>x</p></ac:rich-text-body></ac:structured-macro>`,
 		},
 		{
 			name:    "empty body reports nothing",
@@ -151,5 +154,40 @@ func TestRunEditDoesNotRefuseXhtml(t *testing.T) {
 	opts := editOptsFor(t, srv, `<p><ac:link ac:anchor="a11"><ac:link-body>see</ac:link-body></ac:link></p>`, true)
 	if err := runEdit(context.Background(), opts); err != nil {
 		t.Fatalf("xhtml write should not be refused: %v", err)
+	}
+}
+
+// Angle brackets inside CDATA are content, not markup; matching there would
+// refuse a write over nothing.
+func TestFindLossyConstructsIgnoresCDATA(t *testing.T) {
+	body := `<p>ok</p><ac:plain-text-body><![CDATA[<ac:link ac:anchor="x"/>]]></ac:plain-text-body>`
+	if got := findLossyConstructs(body); len(got) != 0 {
+		t.Errorf("matched inside CDATA: %v", got)
+	}
+}
+
+// A guard that cannot read the page must refuse, not wave the write through:
+// failing open is the behaviour it exists to prevent.
+func TestRunEditRefusesWhenBaselineUnreadable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			// A page whose body carries no storage representation.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"12345","title":"T","version":{"number":1},"body":{},"_links":{"webui":"/p"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"12345","title":"T","version":{"number":2},"_links":{"webui":"/p"}}`))
+	}))
+	defer srv.Close()
+
+	opts := editOptsFor(t, srv, `{"type":"doc","version":1,"content":[]}`, true)
+	opts.bodyFormat = bodyFormatADF
+	err := runEdit(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected a refusal when the page's current content cannot be read")
+	}
+	if !strings.Contains(err.Error(), "could not be read") {
+		t.Errorf("refusal should say the check could not run: %v", err)
 	}
 }

--- a/tools/cfl/internal/cmd/page/lossy_test.go
+++ b/tools/cfl/internal/cmd/page/lossy_test.go
@@ -259,3 +259,54 @@ func TestNoVerifyDoesNotDisableTheGuard(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+// Storage bodies are not guaranteed balanced. An unmatched closing tag must
+// not drive a counter negative and blind the detector to later nesting —
+// silently missing the thing it exists to find.
+func TestCountEmphasisedCodeSurvivesUnbalancedMarkup(t *testing.T) {
+	tests := []struct {
+		name   string
+		markup string
+		want   int
+	}{
+		{"stray close then real nesting", `</strong><p><strong><code>K</code></strong></p>`, 1},
+		{"stray code close first", `</code><p><em><code>K</code></em></p>`, 1},
+		{"many strays", `</strong></strong></em><strong><code>K</code></strong>`, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countEmphasisedCode(tc.markup); got != tc.want {
+				t.Errorf("countEmphasisedCode(%q) = %d, want %d", tc.markup, got, tc.want)
+			}
+		})
+	}
+}
+
+// A resend hands the page's own body straight back, so nothing is converted
+// and nothing can be lost — including on an ADF-native page, which has no
+// storage body to lose.
+func TestRunEditAllowsTitleOnlyEditOfAdfNativePage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":"12345","title":"T","version":{"number":1},"body":{"atlas_doc_format":{"value":"{\"type\":\"doc\",\"version\":1,\"content\":[]}"}},"_links":{"webui":"/p"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"12345","title":"T2","version":{"number":2},"_links":{"webui":"/p"}}`))
+	}))
+	defer srv.Close()
+
+	rootOpts := newEditTestRootOptions()
+	rootOpts.SetAPIClient(api.NewClient(srv.URL, "test@example.com", "token"))
+	rootOpts.Stdin = nil
+	opts := &editOptions{
+		Options:    rootOpts,
+		pageID:     "12345",
+		title:      "New Title",
+		bodyFormat: bodyFormatADF,
+	}
+	if err := runEdit(context.Background(), opts); err != nil {
+		t.Fatalf("a resend converts nothing and must not be refused: %v", err)
+	}
+}

--- a/tools/cfl/internal/cmd/page/view.go
+++ b/tools/cfl/internal/cmd/page/view.go
@@ -43,6 +43,10 @@ for exact Atlassian Document Format JSON or --body-format xhtml for exact
 Confluence storage XHTML.
 
 Markdown output is truncated to 5000 characters by default for concise display.
+ADF output is lossy: it does not carry emphasis wrapping inline code, nor
+internal link elements. Use --body-format xhtml when the output will be
+edited and written back.
+
 Exact ADF and XHTML output is never truncated. Use --no-truncate to show the
 complete Markdown page content without truncation.
 The --content-only flag implies --no-truncate since it is intended for piping.


### PR DESCRIPTION
## [INT-736]

`--body-format adf` is offered with nothing said about what it can't carry. Choosing it because a page is cloud-editor-native — which is exactly the reasoning that seems sensible — silently degrades the page and returns a success message.

### Established by experiment, not inference

Sent three mark combinations through the API and read them back both ways:

| sent | ADF read back | storage read back |
|---|---|---|
| `code`+`strong` | **`['code']`** | `<code><strong>…</strong></code>` |
| `strong`+`em` | `['em','strong']` | `<strong><em>…</em></strong>` |
| `code`+`em` | **`['code']`** | `<code><em>…</em></code>` |

**Confluence stores it correctly — the ADF export drops it.** `strong`+`em` survives; anything paired with `code` doesn't. `<ac:link>` isn't represented in ADF at all.

The caller can't detect this: their ADF is already missing the marks, so sent-vs-stored agrees. It happened to two real pages before anyone noticed, found only by comparing storage by hand.

### Change

A write is refused when the page **currently holds** content the requested format can't carry:

```
Error: refusing to write this page as adf: the adf representation cannot carry
content it currently has, and writing would remove it
  - internal links (8) — anchor and page references become plain expanded URLs

Use --body-format xhtml to edit this page without losing them.
Pass --allow-lossy to write it as adf anyway.
```

It inspects the page as it stands, not the caller's content — the caller's copy lost these things before they ever saw it. `--allow-lossy` keeps the escape hatch deliberate and visible in shell history rather than implied by a format choice.

INT-732's detection stays as the safety net for whatever this doesn't anticipate. Refusing the operation is the fix; noticing afterwards is the fallback.

### Dogfooded against real Confluence

The decisive one — replaying **the exact write that damaged a real page**:

```
$ cfl page view 3544285190 --body-format adf --content-only > p.json
$ cfl page edit 3544285190 --body-format adf --file p.json
Error: refusing to write this page as adf: ...
  - internal links (8) — anchor and page references become plain expanded URLs
```

That write previously succeeded and destroyed 8 anchor links. Also verified on scratch pages: a page with no lossy constructs round-trips fine (no false positive), a page with emphasis-on-code is refused, and `--allow-lossy` proceeds — with INT-732 then correctly reporting `em (1→0)`, `strong (1→0)`.

`make test` (61 packages) and `make lint` (3 modules) clean.

### Scope note

`page create` isn't guarded: there's no existing page to lose content from. The guard is inherently about overwriting something that already exists.