### PR TITLE
fix(cfl): stop macro parameter order failing a clean write

### DIFF
--- a/tools/cfl/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/cfl/internal/cmd/OUTPUT_SPEC.md
@@ -344,8 +344,9 @@ The page was updated, but it does not hold the content supplied. Re-read the pag
     - <node>.attrs.<name> (<before>→<after>)
   attributes added:
     + <node>.attrs.<name> (<before>→<after>)
-  macro parameters changed:
+  macro parameters dropped:
     - macro <n> parameter <name>=<value> (<before>→<after>)
+  macro parameters added:
     + macro <n> parameter <name>=<value> (<before>→<after>)
 ```
 

--- a/tools/cfl/internal/cmd/OUTPUT_SPEC.md
+++ b/tools/cfl/internal/cmd/OUTPUT_SPEC.md
@@ -312,6 +312,18 @@ Confluence added attributes that were not sent:
   + <node>.attrs.<name> (<before>→<after>)
 ```
 
+A storage-format write also compares each macro's parameters. Their order
+within a macro is the server's to choose and is not reported; a parameter that
+was added, dropped or edited is, and the command exits non-zero. `<n>` counts
+the macros opening before the parameter, so a value moving between two macros
+reads as a change rather than a reordering:
+
+```text
+Stored <format> body does not hold the macro parameters that were sent. Page text is intact; these parameters differ:
+  - macro <n> parameter <name>=<value> (<before>→<after>)
+  + macro <n> parameter <name>=<value> (<before>→<after>)
+```
+
 Content loss is reported the same way and the command exits non-zero. The
 first line names what moved in the document — one of three shapes:
 
@@ -332,6 +344,9 @@ The page was updated, but it does not hold the content supplied. Re-read the pag
     - <node>.attrs.<name> (<before>→<after>)
   attributes added:
     + <node>.attrs.<name> (<before>→<after>)
+  macro parameters changed:
+    - macro <n> parameter <name>=<value> (<before>→<after>)
+    + macro <n> parameter <name>=<value> (<before>→<after>)
 ```
 
 The offset line is omitted when the visible text is identical and only

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -71,14 +71,21 @@ func compareStoredBody(sent, stored, bodyFormat string) (writeDrift, error) {
 		return compareADF(sent, stored)
 	case bodyFormatXHTML:
 		sentText, storedText := xhtmlText(sent), xhtmlText(stored)
+		// Reordering a macro's parameters is not a change; adding, dropping
+		// or editing one still is, and stays as fatal as it was when the
+		// parameter values were compared as part of the text. Naming the
+		// parameter beats the opaque text offset that reported it before.
+		dropped, added := diffAttrProfiles(macroParameterProfile(sent), macroParameterProfile(stored))
 		return writeDrift{
-			TextChanged:   sentText != storedText,
+			TextChanged:   sentText != storedText || len(dropped) > 0 || len(added) > 0,
 			SentText:      sentText,
 			StoredText:    storedText,
 			VisibleSent:   len([]rune(sentText)),
 			VisibleStored: len([]rune(storedText)),
 			SentVisible:   sentText,
 			StoredVisible: storedText,
+			DroppedAttrs:  dropped,
+			AddedAttrs:    added,
 		}, nil
 	default:
 		return writeDrift{}, fmt.Errorf("cannot verify %s input: it is converted before sending, so the stored body is not comparable to what was supplied", bodyFormat)
@@ -326,10 +333,38 @@ func diffAttrProfiles(sent, stored map[string]int) (dropped, added []string) {
 	return dropped, added
 }
 
+// acParameterRe matches a macro parameter element, capturing its attributes
+// and its value. (?s) so a value containing newlines is still one match.
+var acParameterRe = regexp.MustCompile(`(?s)<ac:parameter\b([^>]*)>(.*?)</ac:parameter>`)
+
+// acParameterNameRe pulls a parameter's name out of its attributes.
+var acParameterNameRe = regexp.MustCompile(`ac:name\s*=\s*"([^"]*)"`)
+
+// macroParameterProfile counts a body's macro parameters as name=value pairs.
+// Confluence returns a macro's parameters in an order of its own choosing, so
+// they are compared as a multiset rather than a sequence: a reordering is not
+// a change, while a parameter that is dropped, added or edited still is.
+func macroParameterProfile(s string) map[string]int {
+	profile := map[string]int{}
+	for _, m := range acParameterRe.FindAllStringSubmatch(s, -1) {
+		name := ""
+		if n := acParameterNameRe.FindStringSubmatch(m[1]); n != nil {
+			name = n[1]
+		}
+		profile["macro parameter "+name+"="+strings.TrimSpace(m[2])]++
+	}
+	return profile
+}
+
 // xhtmlText strips tags so storage-format bodies compare on their text.
 // Confluence rewrites storage markup freely, so element-level equality would
 // report drift on every write.
 func xhtmlText(s string) string {
+	// Macro parameter values are configuration, not text a reader sees, and
+	// Confluence reorders them within a macro. Left in the text stream, a
+	// reordering reads as rewritten content and fails an otherwise clean
+	// write; macroParameterProfile compares them order-independently instead.
+	s = acParameterRe.ReplaceAllString(s, "")
 	var b strings.Builder
 	depth := 0
 	for _, r := range s {

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -55,11 +55,18 @@ type writeDrift struct {
 	// occurrence counts fell or rose, in sorted order.
 	DroppedAttrs []string
 	AddedAttrs   []string
+
+	// ParamChanges names macro parameters the server did not store as they
+	// were sent. Their order within a macro is the server's to choose, so
+	// only an added, dropped or edited parameter appears here. It is kept
+	// apart from TextChanged because the page text is intact: saying
+	// otherwise would make the report assert something untrue.
+	ParamChanges []string
 }
 
 // Clean reports whether the stored body matched what was sent.
 func (d writeDrift) Clean() bool {
-	return !d.TextChanged && len(d.DroppedAttrs) == 0 && len(d.AddedAttrs) == 0
+	return !d.TextChanged && len(d.DroppedAttrs) == 0 && len(d.AddedAttrs) == 0 && len(d.ParamChanges) == 0
 }
 
 // compareStoredBody diffs a submitted body against the one Confluence stored.
@@ -71,21 +78,15 @@ func compareStoredBody(sent, stored, bodyFormat string) (writeDrift, error) {
 		return compareADF(sent, stored)
 	case bodyFormatXHTML:
 		sentText, storedText := xhtmlText(sent), xhtmlText(stored)
-		// Reordering a macro's parameters is not a change; adding, dropping
-		// or editing one still is, and stays as fatal as it was when the
-		// parameter values were compared as part of the text. Naming the
-		// parameter beats the opaque text offset that reported it before.
-		dropped, added := diffAttrProfiles(macroParameterProfile(sent), macroParameterProfile(stored))
 		return writeDrift{
-			TextChanged:   sentText != storedText || len(dropped) > 0 || len(added) > 0,
+			TextChanged:   sentText != storedText,
 			SentText:      sentText,
 			StoredText:    storedText,
 			VisibleSent:   len([]rune(sentText)),
 			VisibleStored: len([]rune(storedText)),
 			SentVisible:   sentText,
 			StoredVisible: storedText,
-			DroppedAttrs:  dropped,
-			AddedAttrs:    added,
+			ParamChanges:  diffMacroParameters(sent, stored),
 		}, nil
 	default:
 		return writeDrift{}, fmt.Errorf("cannot verify %s input: it is converted before sending, so the stored body is not comparable to what was supplied", bodyFormat)
@@ -333,27 +334,92 @@ func diffAttrProfiles(sent, stored map[string]int) (dropped, added []string) {
 	return dropped, added
 }
 
-// acParameterRe matches a macro parameter element, capturing its attributes
-// and its value. (?s) so a value containing newlines is still one match.
-var acParameterRe = regexp.MustCompile(`(?s)<ac:parameter\b([^>]*)>(.*?)</ac:parameter>`)
+// acParameterPairRE matches a macro parameter written as an open/close pair,
+// capturing its attributes and its value. The `[^/]` before the closing angle
+// bracket keeps it from starting on a self-closing tag, which has no value and
+// no closing tag: matching one would run the value capture on to the *next*
+// parameter's closing tag and swallow every element in between, including page
+// content. (?s) so a value containing newlines is still one match.
+var acParameterPairRE = regexp.MustCompile(`(?s)<ac:parameter\b([^>]*[^/])?>(.*?)</ac:parameter>`)
+
+// acParameterEmptyRE matches a self-closing parameter, which carries a name
+// but no value.
+var acParameterEmptyRE = regexp.MustCompile(`<ac:parameter\b([^>]*?)/>`)
+
+// acMacroOpenRE marks where each macro begins, so a parameter can be attributed
+// to the macro that contains it.
+var acMacroOpenRE = regexp.MustCompile(`<ac:structured-macro\b`)
 
 // acParameterNameRe pulls a parameter's name out of its attributes.
 var acParameterNameRe = regexp.MustCompile(`ac:name\s*=\s*"([^"]*)"`)
 
-// macroParameterProfile counts a body's macro parameters as name=value pairs.
-// Confluence returns a macro's parameters in an order of its own choosing, so
-// they are compared as a multiset rather than a sequence: a reordering is not
-// a change, while a parameter that is dropped, added or edited still is.
+// macroParameterProfile counts a body's macro parameters. Confluence returns a
+// macro's parameters in an order of its own choosing, so they are compared as a
+// multiset rather than a sequence: a reordering within one macro is not a
+// change, while a parameter that is dropped, added or edited still is.
+//
+// Each key is scoped to the macro that holds the parameter, identified by how
+// many macros open before it. Without that scope a parameter moving between two
+// macros carrying the same name and value would read as a reordering, and the
+// swap this guard exists to catch would pass.
+//
+// Comment and CDATA spans are removed first, matching storageProfile: storage
+// format carries macro bodies verbatim inside CDATA, so markup quoted in a code
+// block is content rather than page configuration.
 func macroParameterProfile(s string) map[string]int {
+	s = storageInertRE.ReplaceAllString(s, "")
+	macroOpens := acMacroOpenRE.FindAllStringIndex(s, -1)
+	// macroAt reports how many macros have opened before position i, which
+	// identifies the macro a parameter sits in.
+	macroAt := func(i int) int {
+		n := 0
+		for _, m := range macroOpens {
+			if m[0] < i {
+				n++
+			}
+		}
+		return n
+	}
+
 	profile := map[string]int{}
-	for _, m := range acParameterRe.FindAllStringSubmatch(s, -1) {
+	record := func(start int, attrs, value string) {
 		name := ""
-		if n := acParameterNameRe.FindStringSubmatch(m[1]); n != nil {
+		if n := acParameterNameRe.FindStringSubmatch(attrs); n != nil {
 			name = n[1]
 		}
-		profile["macro parameter "+name+"="+strings.TrimSpace(m[2])]++
+		// Collapse whitespace exactly as the surrounding text comparison
+		// does, so a value that only had its spacing normalized is not
+		// reported as an edit.
+		value = strings.Join(strings.Fields(value), " ")
+		profile[fmt.Sprintf("macro %d parameter %s=%s", macroAt(start), name, value)]++
+	}
+	for _, m := range acParameterPairRE.FindAllStringSubmatchIndex(s, -1) {
+		attrs := ""
+		if m[2] >= 0 {
+			attrs = s[m[2]:m[3]]
+		}
+		record(m[0], attrs, s[m[4]:m[5]])
+	}
+	for _, m := range acParameterEmptyRE.FindAllStringSubmatchIndex(s, -1) {
+		record(m[0], s[m[2]:m[3]], "")
 	}
 	return profile
+}
+
+// diffMacroParameters names the macro parameters that did not survive the
+// write as they were sent, in sorted order. An empty result means every
+// parameter came back, whatever order the server chose to return them in.
+func diffMacroParameters(sent, stored string) []string {
+	dropped, added := diffAttrProfiles(macroParameterProfile(sent), macroParameterProfile(stored))
+	changes := make([]string, 0, len(dropped)+len(added))
+	for _, d := range dropped {
+		changes = append(changes, "- "+d)
+	}
+	for _, a := range added {
+		changes = append(changes, "+ "+a)
+	}
+	sort.Strings(changes)
+	return changes
 }
 
 // xhtmlText strips tags so storage-format bodies compare on their text.
@@ -364,7 +430,7 @@ func xhtmlText(s string) string {
 	// Confluence reorders them within a macro. Left in the text stream, a
 	// reordering reads as rewritten content and fails an otherwise clean
 	// write; macroParameterProfile compares them order-independently instead.
-	s = acParameterRe.ReplaceAllString(s, "")
+	s = acParameterPairRE.ReplaceAllString(s, "")
 	var b strings.Builder
 	depth := 0
 	for _, r := range s {
@@ -461,6 +527,7 @@ func verifyStoredBody(ctx context.Context, req verifyRequest) error {
 		SentExcerpt:         readableExcerpt(drift.SentVisible, off),
 		StoredExcerpt:       readableExcerpt(drift.StoredVisible, off),
 		AtomChanges:         drift.AtomChanges,
+		ParamChanges:        drift.ParamChanges,
 		DroppedAttrs:        drift.DroppedAttrs,
 		AddedAttrs:          drift.AddedAttrs,
 		LostElements:        storage.Lost,
@@ -473,6 +540,12 @@ func verifyStoredBody(ctx context.Context, req verifyRequest) error {
 	}
 	if drift.TextChanged {
 		return fmt.Errorf("stored page content does not match what was sent")
+	}
+	// A parameter the server did not store as sent is a failed write too. It
+	// was fatal before macro parameters were excluded from the text compare,
+	// and nothing about excluding them makes it safe to pass.
+	if len(drift.ParamChanges) > 0 {
+		return fmt.Errorf("stored page does not hold the macro parameters that were sent")
 	}
 	return nil
 }

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -56,17 +56,20 @@ type writeDrift struct {
 	DroppedAttrs []string
 	AddedAttrs   []string
 
-	// ParamChanges names macro parameters the server did not store as they
-	// were sent. Their order within a macro is the server's to choose, so
-	// only an added, dropped or edited parameter appears here. It is kept
-	// apart from TextChanged because the page text is intact: saying
-	// otherwise would make the report assert something untrue.
-	ParamChanges []string
+	// ParamsDropped and ParamsAdded name macro parameters whose occurrence
+	// counts fell or rose, in sorted order. Their order within a macro is
+	// the server's to choose, so only an added, dropped or edited parameter
+	// appears here. They are kept apart from TextChanged because the page
+	// text is intact: saying otherwise would make the report assert
+	// something untrue.
+	ParamsDropped []string
+	ParamsAdded   []string
 }
 
 // Clean reports whether the stored body matched what was sent.
 func (d writeDrift) Clean() bool {
-	return !d.TextChanged && len(d.DroppedAttrs) == 0 && len(d.AddedAttrs) == 0 && len(d.ParamChanges) == 0
+	return !d.TextChanged && len(d.DroppedAttrs) == 0 && len(d.AddedAttrs) == 0 &&
+		len(d.ParamsDropped) == 0 && len(d.ParamsAdded) == 0
 }
 
 // compareStoredBody diffs a submitted body against the one Confluence stored.
@@ -78,6 +81,7 @@ func compareStoredBody(sent, stored, bodyFormat string) (writeDrift, error) {
 		return compareADF(sent, stored)
 	case bodyFormatXHTML:
 		sentText, storedText := xhtmlText(sent), xhtmlText(stored)
+		paramsDropped, paramsAdded := diffMacroParameters(sent, stored)
 		return writeDrift{
 			TextChanged:   sentText != storedText,
 			SentText:      sentText,
@@ -86,7 +90,8 @@ func compareStoredBody(sent, stored, bodyFormat string) (writeDrift, error) {
 			VisibleStored: len([]rune(storedText)),
 			SentVisible:   sentText,
 			StoredVisible: storedText,
-			ParamChanges:  diffMacroParameters(sent, stored),
+			ParamsDropped: paramsDropped,
+			ParamsAdded:   paramsAdded,
 		}, nil
 	default:
 		return writeDrift{}, fmt.Errorf("cannot verify %s input: it is converted before sending, so the stored body is not comparable to what was supplied", bodyFormat)
@@ -334,6 +339,23 @@ func diffAttrProfiles(sent, stored map[string]int) (dropped, added []string) {
 	return dropped, added
 }
 
+// stripMacroParameters removes parameter elements from a storage body, leaving
+// comment and CDATA spans untouched. macroParameterProfile skips those spans
+// because markup quoted in a macro body is content; if this scan did not skip
+// them too, a quoted parameter would be dropped from the compared text and
+// absent from the profile, so a server edit to it would be caught by neither.
+func stripMacroParameters(s string) string {
+	var b strings.Builder
+	last := 0
+	for _, span := range storageInertRE.FindAllStringIndex(s, -1) {
+		b.WriteString(acParameterPairRE.ReplaceAllString(s[last:span[0]], ""))
+		b.WriteString(s[span[0]:span[1]])
+		last = span[1]
+	}
+	b.WriteString(acParameterPairRE.ReplaceAllString(s[last:], ""))
+	return b.String()
+}
+
 // acParameterPairRE matches a macro parameter written as an open/close pair,
 // capturing its attributes and its value. The `[^/]` before the closing angle
 // bracket keeps it from starting on a self-closing tag, which has no value and
@@ -407,19 +429,11 @@ func macroParameterProfile(s string) map[string]int {
 }
 
 // diffMacroParameters names the macro parameters that did not survive the
-// write as they were sent, in sorted order. An empty result means every
-// parameter came back, whatever order the server chose to return them in.
-func diffMacroParameters(sent, stored string) []string {
-	dropped, added := diffAttrProfiles(macroParameterProfile(sent), macroParameterProfile(stored))
-	changes := make([]string, 0, len(dropped)+len(added))
-	for _, d := range dropped {
-		changes = append(changes, "- "+d)
-	}
-	for _, a := range added {
-		changes = append(changes, "+ "+a)
-	}
-	sort.Strings(changes)
-	return changes
+// write as they were sent, dropped and added kept apart so the presenter owns
+// how they are marked. Two empty results mean every parameter came back,
+// whatever order the server chose to return them in.
+func diffMacroParameters(sent, stored string) (dropped, added []string) {
+	return diffAttrProfiles(macroParameterProfile(sent), macroParameterProfile(stored))
 }
 
 // xhtmlText strips tags so storage-format bodies compare on their text.
@@ -430,7 +444,7 @@ func xhtmlText(s string) string {
 	// Confluence reorders them within a macro. Left in the text stream, a
 	// reordering reads as rewritten content and fails an otherwise clean
 	// write; macroParameterProfile compares them order-independently instead.
-	s = acParameterPairRE.ReplaceAllString(s, "")
+	s = stripMacroParameters(s)
 	var b strings.Builder
 	depth := 0
 	for _, r := range s {
@@ -527,7 +541,8 @@ func verifyStoredBody(ctx context.Context, req verifyRequest) error {
 		SentExcerpt:         readableExcerpt(drift.SentVisible, off),
 		StoredExcerpt:       readableExcerpt(drift.StoredVisible, off),
 		AtomChanges:         drift.AtomChanges,
-		ParamChanges:        drift.ParamChanges,
+		ParamsDropped:       drift.ParamsDropped,
+		ParamsAdded:         drift.ParamsAdded,
 		DroppedAttrs:        drift.DroppedAttrs,
 		AddedAttrs:          drift.AddedAttrs,
 		LostElements:        storage.Lost,
@@ -544,7 +559,7 @@ func verifyStoredBody(ctx context.Context, req verifyRequest) error {
 	// A parameter the server did not store as sent is a failed write too. It
 	// was fatal before macro parameters were excluded from the text compare,
 	// and nothing about excluding them makes it safe to pass.
-	if len(drift.ParamChanges) > 0 {
+	if len(drift.ParamsDropped) > 0 || len(drift.ParamsAdded) > 0 {
 		return fmt.Errorf("stored page does not hold the macro parameters that were sent")
 	}
 	return nil

--- a/tools/cfl/internal/cmd/page/verify.go
+++ b/tools/cfl/internal/cmd/page/verify.go
@@ -339,20 +339,44 @@ func diffAttrProfiles(sent, stored map[string]int) (dropped, added []string) {
 	return dropped, added
 }
 
+// blankInert masks comment and CDATA spans with spaces, preserving every
+// offset. Storage format carries macro bodies verbatim inside CDATA, so markup
+// quoted there is content rather than page configuration.
+//
+// Both parameter scans match against this one masked view and then index back
+// into the original, so they cannot disagree about where a parameter is: a
+// single notion of what counts as markup serves the text comparison and the
+// parameter profile alike.
+func blankInert(s string) string {
+	spans := storageInertRE.FindAllStringIndex(s, -1)
+	if len(spans) == 0 {
+		return s
+	}
+	b := []byte(s)
+	for _, span := range spans {
+		for i := span[0]; i < span[1]; i++ {
+			b[i] = ' '
+		}
+	}
+	return string(b)
+}
+
 // stripMacroParameters removes parameter elements from a storage body, leaving
-// comment and CDATA spans untouched. macroParameterProfile skips those spans
-// because markup quoted in a macro body is content; if this scan did not skip
-// them too, a quoted parameter would be dropped from the compared text and
-// absent from the profile, so a server edit to it would be caught by neither.
+// comment and CDATA spans as the content they are. Matching happens on the
+// masked view while the text is cut from the original, so a parameter quoted
+// inside a macro body stays in the compared text and a real one does not.
 func stripMacroParameters(s string) string {
+	matches := acParameterPairRE.FindAllStringIndex(blankInert(s), -1)
+	if len(matches) == 0 {
+		return s
+	}
 	var b strings.Builder
 	last := 0
-	for _, span := range storageInertRE.FindAllStringIndex(s, -1) {
-		b.WriteString(acParameterPairRE.ReplaceAllString(s[last:span[0]], ""))
-		b.WriteString(s[span[0]:span[1]])
-		last = span[1]
+	for _, m := range matches {
+		b.WriteString(s[last:m[0]])
+		last = m[1]
 	}
-	b.WriteString(acParameterPairRE.ReplaceAllString(s[last:], ""))
+	b.WriteString(s[last:])
 	return b.String()
 }
 
@@ -385,11 +409,11 @@ var acParameterNameRe = regexp.MustCompile(`ac:name\s*=\s*"([^"]*)"`)
 // macros carrying the same name and value would read as a reordering, and the
 // swap this guard exists to catch would pass.
 //
-// Comment and CDATA spans are removed first, matching storageProfile: storage
-// format carries macro bodies verbatim inside CDATA, so markup quoted in a code
-// block is content rather than page configuration.
+// Comment and CDATA spans are masked first by blankInert, the same view
+// stripMacroParameters matches against, so the text comparison and this profile
+// agree on which parameters are real and which are quoted content.
 func macroParameterProfile(s string) map[string]int {
-	s = storageInertRE.ReplaceAllString(s, "")
+	s = blankInert(s)
 	macroOpens := acMacroOpenRE.FindAllStringIndex(s, -1)
 	// macroAt reports how many macros have opened before position i, which
 	// identifies the macro a parameter sits in.

--- a/tools/cfl/internal/cmd/page/verify_test.go
+++ b/tools/cfl/internal/cmd/page/verify_test.go
@@ -194,8 +194,8 @@ func TestCompareStoredBodyXHTMLMacroParameterOrder(t *testing.T) {
 			if d.TextChanged {
 				t.Errorf("TextChanged = true; the page text is identical, only parameters differ")
 			}
-			if len(d.ParamChanges) != tc.wantChanges {
-				t.Errorf("ParamChanges = %v, want %d entries", d.ParamChanges, tc.wantChanges)
+			if got := len(d.ParamsDropped) + len(d.ParamsAdded); got != tc.wantChanges {
+				t.Errorf("parameter changes = %v/%v, want %d entries", d.ParamsDropped, d.ParamsAdded, tc.wantChanges)
 			}
 			if d.Clean() != (tc.wantChanges == 0) {
 				t.Errorf("Clean() = %v, want %v", d.Clean(), tc.wantChanges == 0)
@@ -246,8 +246,53 @@ func TestMacroParameterProfileIsScopedPerMacro(t *testing.T) {
 	}
 	sent := macro("none") + macro("dark")
 	stored := macro("dark") + macro("none")
-	if changes := diffMacroParameters(sent, stored); len(changes) == 0 {
+	if dropped, added := diffMacroParameters(sent, stored); len(dropped)+len(added) == 0 {
 		t.Error("a parameter swapped between two macros reported as an in-macro reordering")
+	}
+}
+
+// A parameter-only mismatch has to fail the command, not just set a field on
+// a struct. Without this the fatal branch and its wording could be deleted and
+// every other test would still pass.
+func TestRunEditFailsWhenStoredMacroParametersDiffer(t *testing.T) {
+	const sent = `<ac:structured-macro ac:name="code">` +
+		`<ac:parameter ac:name="theme">none</ac:parameter>` +
+		`<ac:plain-text-body><![CDATA[echo hi]]></ac:plain-text-body></ac:structured-macro>`
+	srv, _ := driftServer(t, func(map[string]any) string {
+		// Same page text, one parameter value changed by the server.
+		return `{"storage":{"value":"` + strings.ReplaceAll(
+			strings.Replace(sent, ">none<", ">dark<", 1), `"`, `\"`) + `"}}`
+	})
+	defer srv.Close()
+
+	err := runEdit(context.Background(), editOptsFor(t, srv, sent, false))
+	if err == nil {
+		t.Fatal("expected an error when a stored macro parameter differs from what was sent")
+	}
+	if !strings.Contains(err.Error(), "macro parameters") {
+		t.Errorf("error should name the macro parameters, got: %v", err)
+	}
+}
+
+// The parameter scan and the text scan have to agree on what a parameter is.
+// The profile skips CDATA because markup quoted in a macro body is content, so
+// the text scan must keep it: otherwise a server edit to a documented sample is
+// dropped from the text and absent from the profile, and nothing catches it.
+func TestQuotedParameterMarkupStaysInComparedText(t *testing.T) {
+	sample := func(inner string) string {
+		return `<ac:structured-macro ac:name="code"><ac:plain-text-body><![CDATA[if (a > b) {}` + "\n" +
+			inner + "\n" + `tail]]></ac:plain-text-body></ac:structured-macro>`
+	}
+	sent := sample(`<ac:parameter ac:name="x">DOCUMENTED SAMPLE</ac:parameter>`)
+	stored := sample(`<ac:parameter ac:name="x">SERVER MANGLED IT</ac:parameter>`)
+
+	d, err := compareStoredBody(sent, stored, bodyFormatXHTML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Clean() {
+		t.Errorf("a server edit inside a quoted code sample went unreported\n sent  %q\n stored %q",
+			xhtmlText(sent), xhtmlText(stored))
 	}
 }
 

--- a/tools/cfl/internal/cmd/page/verify_test.go
+++ b/tools/cfl/internal/cmd/page/verify_test.go
@@ -807,6 +807,53 @@ func TestVerificationApplies(t *testing.T) {
 	}
 }
 
+// The dropped-before-added ordering is a claim about rendered output, so it is
+// asserted against rendered output. An edit has to read old value then new.
+func TestPresentedMacroParametersReadOldThenNew(t *testing.T) {
+	render := func(d cflpresent.WriteDrift) string {
+		var b strings.Builder
+		for _, sec := range (cflpresent.PagePresenter{}).PresentWriteDrift(d).Sections {
+			if msg, ok := sec.(*sharedpresent.MessageSection); ok {
+				b.WriteString(msg.Message)
+			}
+		}
+		return b.String()
+	}
+	drift := cflpresent.WriteDrift{
+		BodyFormat:    bodyFormatXHTML,
+		ParamsDropped: []string{"macro 1 parameter breakoutWidth=760 (1→0)"},
+		ParamsAdded:   []string{"macro 1 parameter breakoutWidth=500 (0→1)"},
+	}
+
+	out := render(drift)
+	if !strings.Contains(out, "macro parameters that were sent") {
+		t.Errorf("report should say the parameters did not survive:\n%s", out)
+	}
+	if !strings.Contains(out, "Page text is intact") {
+		t.Errorf("report should say the text survived, not that it changed:\n%s", out)
+	}
+	dropped, added := strings.Index(out, "- macro 1 parameter breakoutWidth=760"), strings.Index(out, "+ macro 1 parameter breakoutWidth=500")
+	if dropped < 0 || added < 0 {
+		t.Fatalf("report missing one of the parameter lines:\n%s", out)
+	}
+	if dropped > added {
+		t.Errorf("an edit reads backwards: the new value is printed above the one it replaced:\n%s", out)
+	}
+
+	// The same ordering has to hold in the text-loss branch, which renders
+	// through a different code path.
+	drift.TextChanged = true
+	drift.DiffOffset = -1
+	out = render(drift)
+	dropped, added = strings.Index(out, "macro parameters dropped:"), strings.Index(out, "macro parameters added:")
+	if dropped < 0 || added < 0 {
+		t.Fatalf("text-loss branch missing a parameter header:\n%s", out)
+	}
+	if dropped > added {
+		t.Errorf("text-loss branch prints added before dropped:\n%s", out)
+	}
+}
+
 func TestPresentedStorageLossExplainsTheCause(t *testing.T) {
 	model := cflpresent.PagePresenter{}.PresentWriteDrift(cflpresent.WriteDrift{
 		BodyFormat:   bodyFormatADF,

--- a/tools/cfl/internal/cmd/page/verify_test.go
+++ b/tools/cfl/internal/cmd/page/verify_test.go
@@ -153,28 +153,34 @@ func TestCompareStoredBodyXHTMLMacroParameterOrder(t *testing.T) {
 	theme := `<ac:parameter ac:name="theme">none</ac:parameter>`
 
 	tests := []struct {
-		name            string
-		sent, stored    string
-		wantTextChanged bool
-		wantClean       bool
+		name         string
+		sent, stored string
+		wantChanges  int
 	}{
 		{
-			name:      "parameters reordered by the server",
-			sent:      macro(theme, mode, width),
-			stored:    macro(mode, width, theme),
-			wantClean: true,
+			name:   "parameters reordered by the server",
+			sent:   macro(theme, mode, width),
+			stored: macro(mode, width, theme),
 		},
 		{
-			name:            "a parameter value edited",
-			sent:            macro(mode, width),
-			stored:          macro(mode, `<ac:parameter ac:name="breakoutWidth">500</ac:parameter>`),
-			wantTextChanged: true,
+			name:        "a parameter value edited",
+			sent:        macro(mode, width),
+			stored:      macro(mode, `<ac:parameter ac:name="breakoutWidth">500</ac:parameter>`),
+			wantChanges: 2, // the old value dropped, the new one added
 		},
 		{
-			name:            "a parameter dropped",
-			sent:            macro(mode, width),
-			stored:          macro(mode),
-			wantTextChanged: true,
+			name:        "a parameter dropped",
+			sent:        macro(mode, width),
+			stored:      macro(mode),
+			wantChanges: 1,
+		},
+		{
+			// Only the whitespace inside a value moved. It travelled in a
+			// whitespace-collapsed text stream before, so collapsing it here
+			// keeps the comparison exactly as strict as it was.
+			name:   "a parameter value respaced",
+			sent:   macro(`<ac:parameter ac:name="t">a  b</ac:parameter>`),
+			stored: macro(`<ac:parameter ac:name="t">a b</ac:parameter>`),
 		},
 	}
 	for _, tc := range tests {
@@ -183,15 +189,65 @@ func TestCompareStoredBodyXHTMLMacroParameterOrder(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// A reordering must not fail the write; a parameter that was
-			// edited or dropped must still fail it, as it did before.
-			if d.TextChanged != tc.wantTextChanged {
-				t.Errorf("TextChanged = %v, want %v", d.TextChanged, tc.wantTextChanged)
+			// The page text is identical in every case here, so claiming the
+			// text changed would make the report assert something untrue.
+			if d.TextChanged {
+				t.Errorf("TextChanged = true; the page text is identical, only parameters differ")
 			}
-			if d.Clean() != tc.wantClean {
-				t.Errorf("Clean() = %v, want %v (dropped %v, added %v)", d.Clean(), tc.wantClean, d.DroppedAttrs, d.AddedAttrs)
+			if len(d.ParamChanges) != tc.wantChanges {
+				t.Errorf("ParamChanges = %v, want %d entries", d.ParamChanges, tc.wantChanges)
+			}
+			if d.Clean() != (tc.wantChanges == 0) {
+				t.Errorf("Clean() = %v, want %v", d.Clean(), tc.wantChanges == 0)
 			}
 		})
+	}
+}
+
+// A self-closing parameter is valid storage XHTML and the sent body is the
+// caller's own markup. Matching it as if it opened a pair runs the value
+// capture on to the next closing tag and swallows the page content in between,
+// which would hide exactly the loss this guard exists to catch.
+func TestMacroParameterSelfClosingDoesNotSwallowContent(t *testing.T) {
+	body := `<ac:structured-macro ac:name="m"><ac:parameter ac:name="e"/></ac:structured-macro>` +
+		`<p>IMPORTANT PARAGRAPH</p>` +
+		`<ac:structured-macro ac:name="code"><ac:parameter ac:name="f">v</ac:parameter></ac:structured-macro>`
+	if got := xhtmlText(body); !strings.Contains(got, "IMPORTANT PARAGRAPH") {
+		t.Errorf("page text was swallowed by a self-closing parameter: xhtmlText = %q", got)
+	}
+	// Losing that paragraph must still read as a failed write.
+	d, err := compareStoredBody(body, strings.Replace(body, "<p>IMPORTANT PARAGRAPH</p>", "", 1), bodyFormatXHTML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.TextChanged {
+		t.Error("dropping a paragraph next to a self-closing parameter reported as unchanged")
+	}
+}
+
+// Storage format carries macro bodies verbatim inside CDATA, so markup quoted
+// in a code block is content and not page configuration. storageProfile
+// already strips those spans; the parameter scan has to agree with it.
+func TestMacroParameterProfileIgnoresQuotedMarkup(t *testing.T) {
+	body := `<ac:structured-macro ac:name="code"><ac:plain-text-body>` +
+		`<![CDATA[<ac:parameter ac:name="x">1</ac:parameter>]]></ac:plain-text-body></ac:structured-macro>`
+	if got := macroParameterProfile(body); len(got) != 0 {
+		t.Errorf("markup quoted inside CDATA read as configuration: %v", got)
+	}
+}
+
+// A parameter is scoped to the macro holding it, so a value moving between two
+// macros is a change rather than a reordering. Without that scope the two
+// bodies share one document-wide multiset and the swap passes silently.
+func TestMacroParameterProfileIsScopedPerMacro(t *testing.T) {
+	macro := func(theme string) string {
+		return `<ac:structured-macro ac:name="code"><ac:parameter ac:name="theme">` + theme +
+			`</ac:parameter></ac:structured-macro>`
+	}
+	sent := macro("none") + macro("dark")
+	stored := macro("dark") + macro("none")
+	if changes := diffMacroParameters(sent, stored); len(changes) == 0 {
+		t.Error("a parameter swapped between two macros reported as an in-macro reordering")
 	}
 }
 

--- a/tools/cfl/internal/cmd/page/verify_test.go
+++ b/tools/cfl/internal/cmd/page/verify_test.go
@@ -139,6 +139,62 @@ func TestCompareStoredBodyXHTMLComparesText(t *testing.T) {
 	}
 }
 
+// Confluence returns a macro's parameters in an order of its own choosing. The
+// guard exists to stop a write that lost content, so it must not fail a write
+// that lost nothing: a reordering has to read as clean, while an edited or
+// missing parameter still has to surface.
+func TestCompareStoredBodyXHTMLMacroParameterOrder(t *testing.T) {
+	macro := func(params ...string) string {
+		return `<ac:structured-macro ac:name="code">` + strings.Join(params, "") +
+			`<ac:plain-text-body><![CDATA[echo hi]]></ac:plain-text-body></ac:structured-macro>`
+	}
+	mode := `<ac:parameter ac:name="breakoutMode">wide</ac:parameter>`
+	width := `<ac:parameter ac:name="breakoutWidth">760</ac:parameter>`
+	theme := `<ac:parameter ac:name="theme">none</ac:parameter>`
+
+	tests := []struct {
+		name            string
+		sent, stored    string
+		wantTextChanged bool
+		wantClean       bool
+	}{
+		{
+			name:      "parameters reordered by the server",
+			sent:      macro(theme, mode, width),
+			stored:    macro(mode, width, theme),
+			wantClean: true,
+		},
+		{
+			name:            "a parameter value edited",
+			sent:            macro(mode, width),
+			stored:          macro(mode, `<ac:parameter ac:name="breakoutWidth">500</ac:parameter>`),
+			wantTextChanged: true,
+		},
+		{
+			name:            "a parameter dropped",
+			sent:            macro(mode, width),
+			stored:          macro(mode),
+			wantTextChanged: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := compareStoredBody(tc.sent, tc.stored, bodyFormatXHTML)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// A reordering must not fail the write; a parameter that was
+			// edited or dropped must still fail it, as it did before.
+			if d.TextChanged != tc.wantTextChanged {
+				t.Errorf("TextChanged = %v, want %v", d.TextChanged, tc.wantTextChanged)
+			}
+			if d.Clean() != tc.wantClean {
+				t.Errorf("Clean() = %v, want %v (dropped %v, added %v)", d.Clean(), tc.wantClean, d.DroppedAttrs, d.AddedAttrs)
+			}
+		})
+	}
+}
+
 // Markdown is converted before it is sent, so there is nothing to compare it
 // against; saying so is better than reporting a false mismatch.
 func TestCompareStoredBodyRejectsMarkdown(t *testing.T) {

--- a/tools/cfl/internal/present/mutation.go
+++ b/tools/cfl/internal/present/mutation.go
@@ -144,6 +144,9 @@ type WriteDrift struct {
 	AtomChanges  []string
 	DroppedAttrs []string
 	AddedAttrs   []string
+	// ParamChanges names macro parameters the server did not store as sent,
+	// each already prefixed with - or + for dropped or added.
+	ParamChanges []string
 	// LostElements names storage element types that became less frequent
 	// across the write.
 	LostElements []string
@@ -175,6 +178,12 @@ func attrLines(d WriteDrift) []string {
 		lines = append(lines, "  attributes added:")
 		for _, a := range d.AddedAttrs {
 			lines = append(lines, "    + "+a)
+		}
+	}
+	if len(d.ParamChanges) > 0 {
+		lines = append(lines, "  macro parameters changed:")
+		for _, p := range d.ParamChanges {
+			lines = append(lines, "    "+p)
 		}
 	}
 	return lines
@@ -239,6 +248,12 @@ func (PagePresenter) PresentWriteDrift(d WriteDrift) *sharedpresent.OutputModel 
 			lines = append(lines, "Confluence added attributes that were not sent:")
 			for _, a := range d.AddedAttrs {
 				lines = append(lines, "  + "+a)
+			}
+		}
+		if len(d.ParamChanges) > 0 {
+			lines = append(lines, fmt.Sprintf("Stored %s body does not hold the macro parameters that were sent. Page text is intact; these parameters differ:", d.BodyFormat))
+			for _, p := range d.ParamChanges {
+				lines = append(lines, "  "+p)
 			}
 		}
 	}

--- a/tools/cfl/internal/present/mutation.go
+++ b/tools/cfl/internal/present/mutation.go
@@ -144,9 +144,10 @@ type WriteDrift struct {
 	AtomChanges  []string
 	DroppedAttrs []string
 	AddedAttrs   []string
-	// ParamChanges names macro parameters the server did not store as sent,
-	// each already prefixed with - or + for dropped or added.
-	ParamChanges []string
+	// ParamsDropped and ParamsAdded name macro parameters the server did not
+	// store as sent, marker-free so the wording stays owned here.
+	ParamsDropped []string
+	ParamsAdded   []string
 	// LostElements names storage element types that became less frequent
 	// across the write.
 	LostElements []string
@@ -180,10 +181,16 @@ func attrLines(d WriteDrift) []string {
 			lines = append(lines, "    + "+a)
 		}
 	}
-	if len(d.ParamChanges) > 0 {
-		lines = append(lines, "  macro parameters changed:")
-		for _, p := range d.ParamChanges {
-			lines = append(lines, "    "+p)
+	if len(d.ParamsDropped) > 0 {
+		lines = append(lines, "  macro parameters dropped:")
+		for _, p := range d.ParamsDropped {
+			lines = append(lines, "    - "+p)
+		}
+	}
+	if len(d.ParamsAdded) > 0 {
+		lines = append(lines, "  macro parameters added:")
+		for _, p := range d.ParamsAdded {
+			lines = append(lines, "    + "+p)
 		}
 	}
 	return lines
@@ -250,10 +257,13 @@ func (PagePresenter) PresentWriteDrift(d WriteDrift) *sharedpresent.OutputModel 
 				lines = append(lines, "  + "+a)
 			}
 		}
-		if len(d.ParamChanges) > 0 {
+		if len(d.ParamsDropped) > 0 || len(d.ParamsAdded) > 0 {
 			lines = append(lines, fmt.Sprintf("Stored %s body does not hold the macro parameters that were sent. Page text is intact; these parameters differ:", d.BodyFormat))
-			for _, p := range d.ParamChanges {
-				lines = append(lines, "  "+p)
+			for _, p := range d.ParamsDropped {
+				lines = append(lines, "  - "+p)
+			}
+			for _, p := range d.ParamsAdded {
+				lines = append(lines, "  + "+p)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Confluence returns a macro's parameters in an order of its own choosing. The post-write verification strips tags and compares the remaining text, so a parameter's value counted as reader-visible text and a server-side reordering read as rewritten content.

The result was a write refused with a same-length "content differs" mismatch, whose excerpt showed only the parameter values transposed:

```
sent   "nonewide760... which should produce"
stored "wide760none... which should produce"
```

The page was stored correctly. Nothing was lost.

## Change

Macro parameters are removed from the compared text and diffed as a multiset instead:

- **Reordered** parameters now compare equal, so the write passes.
- **Added, dropped or edited** parameters still fail the write, exactly as before.
- The report now names the parameter (`macro parameter theme=none (1→0)`) instead of pointing at a text offset in a string the caller never wrote.

The strictness is deliberately unchanged. Only the reordering case is newly tolerated; a test covers each of the three outcomes, and each of them fails without the fix.

## Why it matters

This guard exists to refuse a write that silently lost content. A guard that also fails correct writes is one people learn to work around, which costs more than the loss it was built to catch.

## Testing

`go build`, `go vet`, full `go test ./...` and `golangci-lint run` all pass. The new test fails without the change:

```
--- FAIL: TestCompareStoredBodyXHTMLMacroParameterOrder/parameters_reordered_by_the_server
    TextChanged = true, want false
    Clean() = false, want true
```
