### PR TITLE
fix(jtk): make config show reflect the shared store

### DIFF
--- a/tools/jtk/internal/cmd/configcmd/configcmd.go
+++ b/tools/jtk/internal/cmd/configcmd/configcmd.go
@@ -44,10 +44,9 @@ func newShowCmd(opts *root.Options) *cobra.Command {
 
 The API token is shown as a presence status only (its value lives in the
 OS keyring and is never displayed); token/keyring reporting is
-authoritative. The non-secret rows reflect environment variables and the
-legacy per-tool file ONLY — a value set solely in the shared
-~/.config/atlassian-cli/config.yml is shown as "-" here even though jtk
-resolves and uses it at runtime.`,
+authoritative. The non-secret rows reflect the same precedence the
+runtime uses: environment variables, then the shared
+~/.config/atlassian-cli/config.yml, then the legacy per-tool file.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cfg := config.GetValuesWithSources()
 

--- a/tools/jtk/internal/config/source.go
+++ b/tools/jtk/internal/config/source.go
@@ -64,8 +64,21 @@ func GetValuesWithSources() ValuesWithSources {
 		AuthMethodSrc:     authMethodSrc,
 		CloudID:           cloudID,
 		CloudIDSrc:        cloudIDSrc,
-		Path:              Path(),
+		Path:              activeConfigPath(),
 	}
+}
+
+// activeConfigPath returns the config file the resolvers actually read:
+// the shared store when it exists on disk, else the legacy per-tool
+// file. `config show` used to always print the legacy path, which is
+// misleading once `jtk init` has written the shared store.
+func activeConfigPath() string {
+	if sp, err := credstore.DefaultPath(); err == nil {
+		if _, statErr := os.Stat(sp); statErr == nil {
+			return sp
+		}
+	}
+	return Path()
 }
 
 // keyringBackendLabel renders the backend and how it was selected, e.g.
@@ -81,13 +94,16 @@ func keyringBackendLabel(kr keyring.Info) string {
 }
 
 // GetURLWithSource returns the URL and its source.
-// Precedence: JIRA_URL → ATLASSIAN_URL → config url → JIRA_DOMAIN (legacy) → config domain (legacy)
+// Precedence: JIRA_URL → ATLASSIAN_URL → shared default → config url → JIRA_DOMAIN (legacy) → config domain (legacy)
 func GetURLWithSource() (value, source string) {
 	if os.Getenv("JIRA_URL") != "" {
 		return GetURL(), "env (JIRA_URL)"
 	}
 	if os.Getenv("ATLASSIAN_URL") != "" {
 		return GetURL(), "env (ATLASSIAN_URL)"
+	}
+	if v, src := jtkSectionWithSource("url"); v != "" {
+		return GetURL(), string(src)
 	}
 	cfg, err := Load()
 	if err != nil {
@@ -107,13 +123,16 @@ func GetURLWithSource() (value, source string) {
 }
 
 // GetEmailWithSource returns the email and its source.
-// Precedence: JIRA_EMAIL → ATLASSIAN_EMAIL → config email
+// Precedence: JIRA_EMAIL → ATLASSIAN_EMAIL → shared default → config email
 func GetEmailWithSource() (value, source string) {
 	if os.Getenv("JIRA_EMAIL") != "" {
 		return GetEmail(), "env (JIRA_EMAIL)"
 	}
 	if os.Getenv("ATLASSIAN_EMAIL") != "" {
 		return GetEmail(), "env (ATLASSIAN_EMAIL)"
+	}
+	if v, src := jtkSectionWithSource("email"); v != "" {
+		return v, string(src)
 	}
 	cfg, err := Load()
 	if err != nil {
@@ -126,10 +145,13 @@ func GetEmailWithSource() (value, source string) {
 }
 
 // GetDefaultProjectWithSource returns the default project and its source.
-// Precedence: JIRA_DEFAULT_PROJECT → config default_project
+// Precedence: JIRA_DEFAULT_PROJECT → shared jtk.default_project → config default_project
 func GetDefaultProjectWithSource() (value, source string) {
 	if os.Getenv("JIRA_DEFAULT_PROJECT") != "" {
 		return GetDefaultProject(), "env (JIRA_DEFAULT_PROJECT)"
+	}
+	if v := loadShared().JTK.DefaultProject; v != "" {
+		return v, "shared jtk"
 	}
 	cfg, err := Load()
 	if err != nil {

--- a/tools/jtk/internal/config/source_test.go
+++ b/tools/jtk/internal/config/source_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/open-cli-collective/atlassian-go/credstore"
 	"github.com/open-cli-collective/atlassian-go/keyring"
 	"github.com/open-cli-collective/atlassian-go/testutil"
 )
@@ -149,6 +150,68 @@ func TestGetDefaultProjectWithSource_EnvPrecedence(t *testing.T) {
 	value, source = GetDefaultProjectWithSource()
 	testutil.Equal(t, value, "ENV-PROJ")
 	testutil.Equal(t, source, "env (JIRA_DEFAULT_PROJECT)")
+}
+
+// Values set only in the shared store must show up in `config show`
+// with the shared source label — they are what the runtime resolves
+// (this used to render as empty "-" rows, hiding a working config).
+func TestGetValuesWithSources_SharedStore(t *testing.T) {
+	sharedPath, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	store := &credstore.Store{
+		Default: credstore.Section{
+			URL:   "https://shared.atlassian.net",
+			Email: "shared@example.com",
+		},
+		JTK: credstore.ToolSection{DefaultProject: "MON"},
+	}
+	testutil.RequireNoError(t, store.Save(sharedPath))
+
+	result := GetValuesWithSources()
+
+	testutil.Equal(t, result.URL, "https://shared.atlassian.net")
+	testutil.Equal(t, result.URLSource, string(credstore.SourceDefault))
+
+	testutil.Equal(t, result.Email, "shared@example.com")
+	testutil.Equal(t, result.EmailSource, string(credstore.SourceDefault))
+
+	testutil.Equal(t, result.DefaultProject, "MON")
+	testutil.Equal(t, result.ProjectSource, "shared jtk")
+
+	// The path row names the file actually read.
+	testutil.Equal(t, result.Path, sharedPath)
+
+	// Env still outranks shared.
+	t.Setenv("JIRA_URL", "https://env.atlassian.net")
+	value, source := GetURLWithSource()
+	testutil.Equal(t, value, "https://env.atlassian.net")
+	testutil.Equal(t, source, "env (JIRA_URL)")
+}
+
+// Shared store outranks the legacy per-tool file in the source column,
+// matching runtime resolution.
+func TestGetValuesWithSources_SharedBeatsLegacy(t *testing.T) {
+	sharedPath, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	testutil.RequireNoError(t, Save(&Config{
+		URL:   "https://legacy.atlassian.net",
+		Email: "legacy@example.com",
+	}))
+	store := &credstore.Store{
+		Default: credstore.Section{URL: "https://shared.atlassian.net"},
+	}
+	testutil.RequireNoError(t, store.Save(sharedPath))
+
+	value, source := GetURLWithSource()
+	testutil.Equal(t, value, "https://shared.atlassian.net")
+	testutil.Equal(t, source, string(credstore.SourceDefault))
+
+	// Email is unset in shared, so the legacy file still supplies it.
+	value, source = GetEmailWithSource()
+	testutil.Equal(t, value, "legacy@example.com")
+	testutil.Equal(t, source, "config")
 }
 
 func TestGetValuesWithSources_AllFields(t *testing.T) {


### PR DESCRIPTION
## Problem

`jtk config show` skips the shared `~/.config/atlassian-cli/config.yml` that the runtime resolvers actually use. After `jtk init` writes the shared store, `config show` renders url/email/default_project as empty `-` rows and prints the legacy per-tool path (which may not even exist) as `Config file:`. A fully working configuration looks unconfigured:

```
KEY | VALUE | SOURCE
url |  | -
email |  | -
...
Config file: ~/Library/Application Support/jira-ticket-cli/config.json   # does not exist
```

while `jtk me` succeeds. The blind spot was documented in the command's help text, but as a diagnostic surface it misleads more than it explains — I hit it minutes after a successful `jtk init`.

## Fix

- `GetURLWithSource`, `GetEmailWithSource`, `GetDefaultProjectWithSource` now consult the shared store between env and the legacy file — the same precedence the runtime getters use (`auth_method` and `cloud_id` already did this via `jtkSectionWithSource`).
- The `Config file:` row names the file actually read: the shared store when it exists on disk, else the legacy path.
- The help-text paragraph documenting the old limitation is replaced by the actual precedence.

## After

```
KEY | VALUE | SOURCE
url | https://example.atlassian.net | shared default
email | user@example.com | shared default
api_token | configured | keyring (api_token)
...
Config file: ~/Library/Application Support/atlassian-cli/config.yml
```

## Tests

Two new tests: shared-store values surface with the shared source label and the path row names the shared file; shared beats legacy per field (url from shared, email falling through to legacy). `go test ./tools/jtk/...` green, `gofmt` clean.